### PR TITLE
fix(core): fixed forms in components with context

### DIFF
--- a/docs/content/guide/forms.rst
+++ b/docs/content/guide/forms.rst
@@ -8,12 +8,12 @@ Overview
 
 The forms system in next.dj allows you to:
 
-- **Register form actions** using the ``@forms.action()`` decorator
-- **Automatically handle CSRF protection** - tokens are inserted automatically
-- **Integrate with file routing** - URL parameters are automatically passed to forms
-- **Use Django forms** - Full support for ``Form`` and ``ModelForm``
-- **Handle validation errors** - Forms are re-rendered with errors automatically
-- **Support multiple response types** - Redirects, HTTP responses, or None
+- **Register form actions** using the ``@forms.action()`` decorator (names must be unique project-wide)
+- **Automatically handle CSRF protection** — tokens are inserted automatically
+- **Integrate with file routing** — URL parameters are passed into ``get_initial``, handlers, and hidden fields
+- **Use Django forms** — full support for ``Form`` and ``ModelForm`` with ``get_initial()``
+- **Re-render invalid submissions** — the originating page is chosen from POST ``_next_form_page`` (see below)
+- **Lazy bound forms in templates** — if the context does not already expose ``<action_name>.form``, it is built from the action registry and the request
 
 Key Concepts
 ------------
@@ -66,7 +66,14 @@ Here's a minimal example of a form in next.dj:
        <button type="submit">Send Message</button>
    {% endform %}
 
-That's it! The form automatically includes CSRF protection and handles validation errors.
+That's it! The form automatically includes CSRF protection, the origin field ``_next_form_page``, and validation error re-rendering when the submission is invalid.
+
+Page context and ``{% form %}``
+--------------------------------
+
+File-based rendering sets **``current_page_module_path``** in the template context (absolute path to the current ``page.py``). The ``{% form %}`` tag **requires** this value. It emits a hidden field **``_next_form_page``** so that if validation fails, the framework can reload that page’s template and show errors. If **``_next_form_page``** is missing or does not point to a ``page.py`` under ``BASE_DIR``, the dispatcher responds with **400 Bad Request**.
+
+Register **``@forms.action``** in ``page.py`` or in a **``component.py``** next to ``component.djx``. Component modules under your configured component roots are imported during app startup so actions are registered without manual ``importlib`` hacks.
 
 Basic Usage
 -----------
@@ -171,12 +178,12 @@ Use the ``@forms.action()`` decorator to register form action handlers:
        # Process form data
        return HttpResponseRedirect("/success/")
 
-**Decorator Parameters:**
+**Decorator parameters:**
 
-- **``name``** (required): Unique action name used in templates
-- **``form_class``** (optional): Form class for validation. If omitted, handler receives only request
+- **``name``** (required): Unique action name used in templates and to build a stable form endpoint. Must not collide with another action in the project.
+- **``form_class``** (optional): Django form class implementing ``get_initial``. If omitted, the handler is invoked without a bound form (useful for non-form POST actions).
 
-**Handler Function Signature:**
+**Handler function signature:**
 
 Handlers receive only the arguments they declare (dependency injection). Declare
 ``request: HttpRequest``, ``form: MyForm`` (when using ``form_class``), and any
@@ -235,14 +242,15 @@ Use the ``{% form %}`` template tag to render forms:
        <button type="submit">Submit</button>
    {% endform %}
 
-**Automatic Features:**
+**Automatic behavior:**
 
-- **CSRF Token**: Automatically included as hidden field
-- **Method**: Always POST
-- **Action URL**: Automatically generated from action name
-- **URL Parameters**: Automatically included as hidden fields (from file routing)
+- **CSRF token** — included as a hidden field
+- **Method** — always POST
+- **Action URL** — resolved from the registered action (``/_next/form/<uid>/``)
+- **Origin** — hidden **``_next_form_page``** set from **``current_page_module_path``**
+- **URL parameters** — when the page URL has dynamic segments, matching kwargs are echoed as **``_url_param_<name>``** hidden fields (the ``uid`` used by the form endpoint is skipped)
 
-**Accessing Form in Template:**
+**Accessing the form in the template:**
 
 The form instance is available inside the ``{% form %}`` tag:
 
@@ -303,9 +311,9 @@ Handlers can return different types of responses:
        obj = form.save()
        return obj  # If obj has .url attribute, it's converted to redirect
 
-**Invalid Form Handling:**
+**Invalid form handling:**
 
-If the form is invalid, the handler is **not called**. Instead, the form is automatically re-rendered with validation errors using the same template and context as the original page.
+If the form is invalid, the handler is **not** called. The framework reads **``_next_form_page``** from POST, validates that path, rebuilds the page render context, injects the bound form and errors, and returns **200** with the full page HTML. A missing or untrusted **``_next_form_page``** yields **400**.
 
 Working with ModelForm
 ----------------------
@@ -439,38 +447,17 @@ Forms automatically receive URL parameters from file routing:
 
 **How URL Parameters Work:**
 
-1. URL parameters are extracted from ``request.resolver_match.kwargs``
-2. They are included as hidden fields in the form (``_url_param_<name>``)
-3. They are passed to ``get_initial()`` and handler functions
-4. They are available in context functions when re-rendering errors
+1. URL parameters are taken from ``request.resolver_match.kwargs`` on GET
+2. They are echoed as hidden fields (``_url_param_<name>``) on the form
+3. On POST they are merged from those hidden fields when the resolver has no kwargs
+4. They are passed into ``get_initial()`` and into dependency-injected handler parameters
 
-Context System
-~~~~~~~~~~~~~~
+Context and the bound form
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Forms are automatically registered in the context system:
+Form actions **do not** register extra entries on the page context registry. Inside ``{% form %}``, if the template context already contains **``create_todo``** (or your action name) as a namespace with a **``.form``** attribute, that instance is used. Otherwise the framework calls **``build_form_namespace_for_action``** for the action name and current request, which runs **``get_initial``** with URL parameters from the resolver or from **``_url_param_*``** on POST.
 
-**Automatic Context Registration:**
-
-When you register a form action with ``form_class``, the form is automatically available in templates:
-
-.. code-block:: python
-
-   @forms.action("create_todo", form_class=TodoForm)
-   def create_todo_handler(request: HttpRequest, form: TodoForm) -> HttpResponseRedirect:
-       form.save()
-       return HttpResponseRedirect("/")
-
-The form is available in templates as ``create_todo.form``:
-
-.. code-block:: html
-
-   {% form @action="create_todo" %}
-       {{ form.as_p }}
-   {% endform %}
-
-**Using Forms with Context Functions:**
-
-You can combine forms with context functions:
+You can combine forms with **``@context``** functions as usual:
 
 .. code-block:: python
 
@@ -580,129 +567,40 @@ Display messages in templates:
 Internal Architecture
 ---------------------
 
-Action Registration
-~~~~~~~~~~~~~~~~~~~
+Registration and UID
+~~~~~~~~~~~~~~~~~~~~
 
-When you use ``@forms.action()``, the following happens:
+When a module defining ``@forms.action`` is imported:
 
-1. **UID Generation**: A unique identifier (UID) is created from the file path and action name using SHA256 hash (first 16 characters)
+1. **UID** — A short stable id is derived from the action **name** (SHA-256 of a fixed prefix and the name; first 16 hex characters). The name must be unique across the project.
+2. **Registry** — ``RegistryFormActionBackend`` stores the handler, optional ``form_class``, and UID. Metadata does **not** include the declaring file path for dispatch or error rendering.
 
-2. **Registry Storage**: The action is stored in ``FormActionManager`` with:
-   - Handler function
-   - Form class (if provided)
-   - File path
-   - UID
+There is no automatic ``register_context`` for form actions on ``page.py``; bound forms for GET come from **``build_form_namespace_for_action``** inside ``{% form %}`` unless you provide the namespace yourself.
 
-3. **Context Registration**: If ``form_class`` is provided, a context function is automatically registered that:
-   - Calls ``form_class.get_initial()`` with request and URL parameters
-   - Creates form instance with initial data or model instance
-   - Returns form in a ``SimpleNamespace`` object
+URL pattern
+~~~~~~~~~~~
 
-**Example Registration Flow:**
-
-.. code-block:: python
-
-   # File: pages/contact/page.py
-   @forms.action("contact", form_class=ContactForm)
-   def contact_handler(request: HttpRequest, form: ContactForm) -> HttpResponseRedirect:
-       # This action is registered with:
-       # - name: "contact"
-       # - uid: hash("pages/contact/page.py:contact")[:16]
-       # - handler: contact_handler
-       # - form_class: ContactForm
-       # - file_path: Path("pages/contact/page.py")
-       pass
-
-URL Generation
-~~~~~~~~~~~~~~
-
-Form actions generate URL patterns automatically:
-
-**URL Pattern Format:**
-
-All form actions use a single URL pattern:
+All actions share one route shape:
 
 .. code-block:: text
 
    /_next/form/<str:uid>/
 
-**URL Resolution:**
+``form_action_manager.get_action_url("contact")`` resolves the correct path for a registered name.
 
-1. ``FormActionManager.generate_urls()`` creates URL patterns from all registered backends
-2. Each backend's ``generate_urls()`` returns a list of URL patterns
-3. The default backend (``RegistryFormActionBackend``) creates one pattern for all actions
-4. Actions are dispatched by UID, not by name
-
-**Getting Action URLs:**
-
-Use ``form_action_manager.get_action_url(action_name)`` to get the URL for an action:
-
-.. code-block:: python
-
-   from next.forms import form_action_manager
-
-   url = form_action_manager.get_action_url("contact")
-   # Returns: "/_next/form/abc123def4567890/"
-
-Request Handling
+Request handling
 ~~~~~~~~~~~~~~~~
 
-**GET Requests:**
+**GET** to ``/_next/form/<uid>/`` returns **405 Method Not Allowed**. Users never open that URL for browsing; the browser POSTs to it from your page.
 
-GET requests to form action URLs return ``405 Method Not Allowed``. Forms are displayed through the normal page rendering process using context functions.
+**POST** flow:
 
-**POST Request Flow:**
+1. Read URL-related kwargs from **``_url_param_*``** fields.
+2. Resolve **``get_initial``**, bind POST/FILES, run **``is_valid()``**.
+3. If **invalid**: validate **``_next_form_page``** in POST (must be an existing ``page.py`` under ``BASE_DIR``), load that page’s template, merge **``Page.build_render_context``** with the bound form and errors, return **200**. If **``_next_form_page``** is missing or invalid, return **400**.
+4. If **valid**: call the handler with dependency-injected arguments and normalize the return value (**``None``** → 204 when appropriate, strings and redirect-like objects coerced as documented in the code).
 
-1. **Extract URL Parameters**: URL parameters are extracted from hidden form fields (``_url_param_<name>``)
-
-2. **Get Initial Data**: If ``form_class`` is provided:
-   - Call ``form_class.get_initial(request, **url_kwargs)``
-   - Check if result is a model instance (has ``_meta.model`` attribute)
-   - If model instance: create form with ``instance=initial_data`` (ModelForm only)
-   - If dictionary: create form with ``initial=initial_data``
-
-3. **Validate Form**: Call ``form.is_valid()``
-
-4. **Handle Invalid Form**: If form is invalid:
-   - Load template from registry (same template as original page)
-   - Build context with form errors
-   - Pass URL parameters to context functions
-   - Render full page with errors
-   - Return 200 with rendered HTML
-
-5. **Handle Valid Form**: If form is valid:
-   - Call handler function with ``request, form, **url_kwargs``
-   - Normalize handler response
-   - Return appropriate HTTP response
-
-**Response Normalization:**
-
-Handler responses are normalized through ``_normalize_handler_response()``:
-
-- **None**: Returns 204 No Content (or re-renders form if backend/request available)
-- **HttpResponse**: Returns as-is
-- **str**: Wraps in HttpResponse
-- **Object with .url**: Converts to HttpResponseRedirect
-
-**Error Rendering:**
-
-When form validation fails:
-
-1. **Template Loading**: Load full template from ``page._template_registry`` using file_path
-
-2. **Context Building**: Build context with:
-   - All context functions (with URL parameters)
-   - Form instance with errors (under action name and as ``form``)
-   - Request object
-
-3. **Rendering**: Render template with context, showing form errors
-
-**Component Architecture:**
-
-- **``FormActionBackend``**: Abstract base class for form action backends
-- **``RegistryFormActionBackend``**: In-memory registry implementation (default)
-- **``FormActionManager``**: Manages multiple backends, aggregates URL patterns
-- **``_FormActionDispatch``**: Internal class handling dispatch logic and response normalization
+**Roles:** ``FormActionBackend`` / ``RegistryFormActionBackend``, ``FormActionManager``, and ``_FormActionDispatch`` implement the above.
 
 Examples
 --------
@@ -1056,7 +954,8 @@ Common Issues
 
 - Ensure ``next`` is in ``INSTALLED_APPS`` (the app registers the ``{% form %}`` tag as a template builtin). For a custom engine, add ``next.templatetags.forms`` to ``OPTIONS['builtins']`` or use ``{% load forms %}`` in the template.
 - Check that action name matches ``@action`` parameter
-- Verify form action is registered (check for import errors)
+- Verify the action module is imported (``page.py`` or ``component.py`` under configured roots)
+- Ensure **``current_page_module_path``** is in the template context; without it ``{% form %}`` raises **``django.core.exceptions.ImproperlyConfigured``**
 
 **CSRF token missing:**
 
@@ -1073,7 +972,8 @@ Common Issues
 
 - Check that form validation is working (add ``print(form.errors)``)
 - Verify template has error display (``{{ form.errors }}`` or ``{{ form.<field>.errors }}``)
-- Ensure form is re-rendered (check response status is 200, not redirect)
+- Ensure the POST includes a valid **``_next_form_page``** hidden field (same origin as when the page was rendered); otherwise you may get **400** instead of a 200 error page
+- Ensure response status is **200** for invalid submissions (not a redirect)
 
 **Handler not called:**
 

--- a/examples/components/root_components/footer.djx
+++ b/examples/components/root_components/footer.djx
@@ -1,6 +1,7 @@
 <footer class="border-top mt-auto py-3 bg-white">
-    <div class="container text-muted small d-flex flex-wrap align-items-center">
+    <div class="container text-muted small d-flex flex-wrap align-items-center gap-3">
         <span>&copy; {% now "Y" %} Blog</span>
+        {% component "newsletter_subscribe" %}{% endcomponent %}
         {% component "version_stamp" %}{% endcomponent %}
     </div>
 </footer>

--- a/examples/components/root_components/newsletter_subscribe/component.djx
+++ b/examples/components/root_components/newsletter_subscribe/component.djx
@@ -1,0 +1,7 @@
+<div class="newsletter-subscribe d-flex flex-wrap align-items-center gap-2 ms-md-auto" data-testid="newsletter-subscribe">
+    <span class="text-muted">Newsletter</span>
+    {% form @action="newsletter_subscribe" class="d-flex flex-wrap gap-1 align-items-center mb-0" %}
+        {{ form.email }}
+        <button type="submit" class="btn btn-sm btn-outline-primary">Subscribe</button>
+    {% endform %}
+</div>

--- a/examples/components/root_components/newsletter_subscribe/component.py
+++ b/examples/components/root_components/newsletter_subscribe/component.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from django.contrib import messages
+from django.http import HttpRequest, HttpResponseRedirect
+
+from next import forms
+
+
+class NewsletterForm(forms.Form):
+    """Footer newsletter signup."""
+
+    email = forms.EmailField(
+        label="Enter your email to subscribe to our newsletter",
+        max_length=254,
+        widget=forms.EmailInput(
+            attrs={
+                "class": "form-control form-control-sm",
+                "placeholder": "Your email",
+                "autocomplete": "email",
+            },
+        ),
+    )
+
+    @classmethod
+    def get_initial(cls, _request: HttpRequest) -> dict:
+        """Return empty initial data."""
+        return {}
+
+
+@forms.action("newsletter_subscribe", form_class=NewsletterForm)
+def newsletter_subscribe_handler(
+    request: HttpRequest,
+    form: NewsletterForm,
+) -> HttpResponseRedirect:
+    _ = form.cleaned_data["email"]
+    messages.success(request, "Thanks — you're on the list.")
+    return HttpResponseRedirect(request.META.get("HTTP_REFERER", "/"))

--- a/examples/components/tests/conftest.py
+++ b/examples/components/tests/conftest.py
@@ -30,6 +30,12 @@ def _eager_load_example_pages() -> None:
     if _ExamplePagesLoadedState["done"]:
         return
 
+    home_page = example_root / "myapp" / "pages" / "page.py"
+    spec_home = importlib.util.spec_from_file_location("myapp_pages_home", home_page)
+    home_mod = importlib.util.module_from_spec(spec_home)
+    assert spec_home.loader is not None
+    spec_home.loader.exec_module(home_mod)
+
     authors_page = example_root / "myapp" / "pages" / "authors" / "[int:id]" / "page.py"
     spec = importlib.util.spec_from_file_location("myapp_authors_page", authors_page)
     authors_mod = importlib.util.module_from_spec(spec)

--- a/examples/components/tests/tests.py
+++ b/examples/components/tests/tests.py
@@ -19,6 +19,13 @@ User = get_user_model()
 
 example_root = Path(__file__).resolve().parent.parent
 
+LOGIN_PAGE_PY = (
+    example_root / "myapp" / "pages" / "account" / "login" / "page.py"
+).resolve()
+REGISTER_PAGE_PY = (
+    example_root / "myapp" / "pages" / "account" / "register" / "page.py"
+).resolve()
+
 
 @pytest.fixture()
 def home_template() -> Path:
@@ -309,7 +316,11 @@ def test_login_invalid_password_returns_layout(client) -> None:
     login_action = form_action_manager.get_action_url("login")
     response = client.post(
         login_action,
-        {"username": "eve", "password": "wrong"},
+        {
+            "username": "eve",
+            "password": "wrong",
+            "_next_form_page": str(LOGIN_PAGE_PY),
+        },
     )
     assert response.status_code == 200
     body = response.content.decode()
@@ -411,6 +422,7 @@ def test_register_form_password_mismatch(client) -> None:
             "username": "test",
             "password1": "pass123",
             "password2": "different",
+            "_next_form_page": str(REGISTER_PAGE_PY),
         },
     )
     assert response.status_code == 200
@@ -479,6 +491,7 @@ def test_register_form_username_exists(client) -> None:
             "username": "existing",
             "password1": "newpass123",
             "password2": "newpass123",
+            "_next_form_page": str(REGISTER_PAGE_PY),
         },
     )
     assert response.status_code == 200

--- a/next/apps.py
+++ b/next/apps.py
@@ -34,3 +34,10 @@ class NextFrameworkConfig(AppConfig):
                 sender.watch_dir(path, glob)  # type: ignore[attr-defined]
 
         autoreload_started.connect(watch_next_filesystem)
+
+        from next.components import components_manager  # noqa: PLC0415
+
+        components_manager._ensure_backends()
+        for backend in components_manager._backends:
+            if hasattr(backend, "import_all_component_modules"):
+                backend.import_all_component_modules()

--- a/next/components.py
+++ b/next/components.py
@@ -881,6 +881,17 @@ class FileComponentsBackend(ComponentsBackend):
         for comp_root in self._extra_component_roots:
             self._registry.mark_as_root(comp_root)
             self._discover_in_component_root(comp_root)
+        self.import_all_component_modules()
+
+    def import_all_component_modules(self) -> None:
+        """Load each ``component.py`` so decorators such as ``@forms.action`` run."""
+        seen: set[Path] = set()
+        for info in self._registry.get_all():
+            mp = info.module_path
+            if mp is None or mp in seen:
+                continue
+            seen.add(mp)
+            self._module_loader.load(mp)
 
     def _discover_in_component_root(self, component_root: Path) -> None:
         components = self._scanner.scan_directory(component_root, component_root, "")
@@ -921,6 +932,9 @@ def register_components_folder_from_router_walk(
         if isinstance(backend, FileComponentsBackend):
             found = backend._scanner.scan_directory(folder, pages_root, scope_relative)
             backend._registry.register_many(found)
+            for info in found:
+                if info.module_path:
+                    backend._module_loader.load(info.module_path)
             return
 
 

--- a/next/deps.py
+++ b/next/deps.py
@@ -127,6 +127,7 @@ class DependencyResolver:
         self._dependency_callables: dict[str, Callable[..., Any]] = {}
         self._providers: list[ParameterProvider] = list(providers)
         self._providers_loaded = bool(providers)
+        self._resolve_call_stack: list[Callable[..., Any]] = []
 
     def _get_providers(self) -> list[ParameterProvider]:
         """Instantiate registered ``RegisteredParameterProvider`` subclasses."""
@@ -246,20 +247,24 @@ class DependencyResolver:
         """Keyword args for calling ``func`` from ``context``."""
         self._ensure_providers()
 
+        self._resolve_call_stack.append(func)
         try:
-            sig = inspect.signature(func)
-        except (ValueError, TypeError):
-            return {}
+            try:
+                sig = inspect.signature(func)
+            except (ValueError, TypeError):
+                return {}
 
-        result: dict[str, Any] = {}
-        for name, param in sig.parameters.items():
-            if self._should_skip_parameter(param):
-                continue
+            result: dict[str, Any] = {}
+            for name, param in sig.parameters.items():
+                if self._should_skip_parameter(param):
+                    continue
 
-            value = self._resolve_parameter(param, context)
-            result[name] = value
+                value = self._resolve_parameter(param, context)
+                result[name] = value
 
-        return result
+            return result
+        finally:
+            self._resolve_call_stack.pop()
 
     def resolve_dependencies(
         self, func: Callable[..., Any], **context: object

--- a/next/forms.py
+++ b/next/forms.py
@@ -15,11 +15,13 @@ from pathlib import Path
 from typing import Any, TypedDict, TypeVar, cast, get_args, get_origin
 
 from django import forms as django_forms
+from django.conf import settings
 from django.forms.forms import BaseForm as DjangoBaseForm, DeclarativeFieldsMetaclass
 from django.forms.models import BaseModelForm as DjangoBaseModelForm, ModelFormMetaclass
 from django.http import (
     HttpRequest,
     HttpResponse,
+    HttpResponseBadRequest,
     HttpResponseNotAllowed,
     HttpResponseNotFound,
     HttpResponseRedirect,
@@ -29,7 +31,12 @@ from django.urls import URLPattern, path, reverse
 from django.urls.exceptions import NoReverseMatch
 from django.views.decorators.http import require_http_methods
 
-from .deps import DDependencyBase, RegisteredParameterProvider, resolver
+from .deps import (
+    RESERVED_KEYS,
+    DDependencyBase,
+    RegisteredParameterProvider,
+    resolver,
+)
 from .pages import page
 from .utils import caller_source_path
 
@@ -174,20 +181,18 @@ FORM_ACTION_REVERSE_NAME = "next:form_action"
 
 
 class ActionMeta(TypedDict, total=False):
-    """Per-action data."""
+    """Per-action data stored in the registry backend."""
 
     handler: Callable[..., Any]
     form_class: type[django_forms.Form] | None
-    file_path: Path
     uid: str
 
 
 @dataclass
 class FormActionOptions:
-    """Options for @action decorator."""
+    """Options passed to ``register_action`` (used by the ``@action`` decorator)."""
 
     form_class: type[django_forms.Form] | None = None
-    file_path: Path | None = None
 
 
 class FormActionBackend(ABC):
@@ -225,15 +230,43 @@ class FormActionBackend(ABC):
         action_name: str,  # noqa: ARG002
         form: django_forms.Form | None,  # noqa: ARG002
         template_fragment: str | None = None,  # noqa: ARG002
+        *,
+        page_file_path: Path | None = None,  # noqa: ARG002
     ) -> str:
         """Override this method to provide custom HTML for validation errors."""
         return ""
 
 
-def _make_uid(file_path: Path, action_name: str) -> str:
-    """Stable short id from file path and action name."""
-    raw = f"{file_path!s}:{action_name}".encode()
+def _make_uid(action_name: str) -> str:
+    """Stable short id from the action name (must be unique across the project)."""
+    raw = f"next.form.action:{action_name}".encode()
     return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def validated_next_form_page_path(request: HttpRequest) -> Path | None:  # noqa: PLR0911
+    """Return a trusted ``page.py`` path from POST ``_next_form_page``, or None."""
+    if not hasattr(request, "POST"):
+        return None
+    raw = request.POST.get("_next_form_page")
+    if not raw or not isinstance(raw, str):
+        return None
+    raw_stripped = raw.strip()
+    if not raw_stripped:
+        return None
+    try:
+        p = Path(raw_stripped).resolve()
+    except OSError:
+        return None
+    if p.name != "page.py" or not p.is_file():
+        return None
+    base = getattr(settings, "BASE_DIR", None)
+    if base is None:
+        return None
+    try:
+        p.relative_to(Path(base).resolve())
+    except ValueError:
+        return None
+    return p
 
 
 def _get_caller_path(back_count: int = 1) -> Path:
@@ -245,6 +278,11 @@ def _get_caller_path(back_count: int = 1) -> Path:
     )
 
 
+def _filter_reserved_url_kwargs(url_kwargs: dict[str, object]) -> dict[str, object]:
+    """Drop keys that collide with DI names used by ``resolve_dependencies``."""
+    return {k: v for k, v in url_kwargs.items() if k not in RESERVED_KEYS}
+
+
 def _url_kwargs_from_post(request: HttpRequest) -> dict[str, object]:
     """Parse ``_url_param_*`` hidden fields from POST."""
     out: dict[str, object] = {}
@@ -254,6 +292,8 @@ def _url_kwargs_from_post(request: HttpRequest) -> dict[str, object]:
         if not key.startswith("_url_param_"):
             continue
         param_name = key.replace("_url_param_", "")
+        if param_name in RESERVED_KEYS:
+            continue
         if isinstance(value, str):
             try:
                 out[param_name] = int(value)
@@ -268,7 +308,7 @@ def _url_kwargs_from_resolver_or_post(request: HttpRequest) -> dict[str, object]
     """URL kwargs from resolver match, else from POST hidden fields."""
     resolver_match = getattr(request, "resolver_match", None)
     if resolver_match and getattr(resolver_match, "kwargs", None):
-        return dict(resolver_match.kwargs)
+        return _filter_reserved_url_kwargs(dict(resolver_match.kwargs))
     if getattr(request, "method", None) == "POST" and hasattr(request, "POST"):
         return _url_kwargs_from_post(request)
     return {}
@@ -355,24 +395,15 @@ class RegistryFormActionBackend(FormActionBackend):
         *,
         options: FormActionOptions | None = None,
     ) -> None:
-        """Store action and form/initial. Registers context when form set."""
+        """Store handler, optional form class, and stable uid for the action name."""
         opts = options or FormActionOptions()
-        fp = opts.file_path or _get_caller_path(2)
-        uid = _make_uid(fp, name)
+        uid = _make_uid(name)
         self._uid_to_name[uid] = name
         self._registry[name] = {
             "handler": handler,
             "form_class": opts.form_class,
-            "file_path": fp,
             "uid": uid,
         }
-        if opts.form_class is not None:
-            page._context_manager.register_context(
-                fp,
-                name,
-                _form_action_context_callable(opts.form_class),
-                inherit_context=False,
-            )
 
     def get_action_url(self, action_name: str) -> str:
         """Reverse URL for a registered name."""
@@ -413,10 +444,22 @@ class RegistryFormActionBackend(FormActionBackend):
         action_name: str,
         form: django_forms.Form | None,
         template_fragment: str | None = None,
+        *,
+        page_file_path: Path | None = None,
     ) -> str:
-        """Default fragment renderer."""
+        """Render validation-error HTML for a page module path."""
+        path = page_file_path
+        if path is None:
+            path = validated_next_form_page_path(request)
+        if path is None:
+            return ""
         return _FormActionDispatch.render_form_fragment(
-            self, request, action_name, form, template_fragment
+            self,
+            request,
+            action_name,
+            form,
+            template_fragment,
+            path,
         )
 
 
@@ -543,9 +586,16 @@ class _FormActionDispatch:
         form: django_forms.Form | None,
         template_fragment: str | None,
     ) -> HttpResponse:
-        """``HttpResponse`` around the error fragment."""
+        """Full-page HTML for invalid form submission."""
+        page_path = validated_next_form_page_path(request)
+        if page_path is None:
+            return HttpResponseBadRequest("Missing or invalid _next_form_page")
         html = backend.render_form_fragment(
-            request, action_name, form, template_fragment
+            request,
+            action_name,
+            form,
+            template_fragment,
+            page_file_path=page_path,
         )
         return HttpResponse(html)
 
@@ -571,21 +621,21 @@ class _FormActionDispatch:
         return HttpResponse(response)
 
     @staticmethod
-    def render_form_fragment(
+    def render_form_fragment(  # noqa: PLR0913
         backend: FormActionBackend,
         request: HttpRequest,
         action_name: str,
         form: django_forms.Form | None,
         template_fragment: str | None,  # noqa: ARG004
+        page_file_path: Path,
     ) -> str:
-        """Full page template with bound form errors."""
+        """Full page template with bound form errors for ``page_file_path``."""
         meta = backend.get_meta(action_name)
         if not meta:
             return form.as_p() if form else ""
 
-        file_path = meta["file_path"]
+        file_path = page_file_path
 
-        # Load full template with layout
         if file_path not in page._template_registry:
             page._load_template_for_file(file_path)
         template_str = page._template_registry.get(file_path)
@@ -650,10 +700,16 @@ class FormActionManager:
         action_name: str,
         form: django_forms.Form | None,
         template_fragment: str | None = None,
+        *,
+        page_file_path: Path | None = None,
     ) -> str:
         """Delegate to first backend."""
         return self._backends[0].render_form_fragment(
-            request, action_name, form, template_fragment
+            request,
+            action_name,
+            form,
+            template_fragment,
+            page_file_path=page_file_path,
         )
 
     @property
@@ -670,14 +726,27 @@ def action(
     *,
     form_class: type[django_forms.Form] | None = None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Register form action handler."""
+    """Register a named form action. Action names must be unique in the project."""
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        opts = FormActionOptions(
-            form_class=form_class,
-            file_path=_get_caller_path(2),
-        )
+        opts = FormActionOptions(form_class=form_class)
         form_action_manager.register_action(name, func, options=opts)
         return func
 
     return decorator
+
+
+def build_form_namespace_for_action(
+    action_name: str,
+    request: HttpRequest,
+) -> types.SimpleNamespace | None:
+    """Build the ``SimpleNamespace(form=...)`` used by ``{% form %}`` when lazy."""
+    for backend in form_action_manager._backends:
+        meta = backend.get_meta(action_name)
+        if meta is None:
+            continue
+        fc = meta.get("form_class")
+        if fc is None:
+            return None
+        return _form_action_context_callable(fc)(request)
+    return None

--- a/next/pages.py
+++ b/next/pages.py
@@ -622,6 +622,7 @@ class Page:
         context_data["current_template_path"] = (
             str(template_djx) if template_djx.exists() else str(file_path)
         )
+        context_data["current_page_module_path"] = str(file_path.resolve())
         context_data.update(kwargs)
         context_data.update(
             self._context_manager.collect_context(file_path, *args, **kwargs),

--- a/next/templatetags/components.py
+++ b/next/templatetags/components.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, cast
 
 from django import template
 from django.template.base import Node, NodeList, Parser, Token
@@ -25,41 +26,12 @@ _END_COMPONENT = ("endcomponent", "/component")
 _END_SLOT = ("endslot", "/slot")
 _END_SET_SLOT = ("endset_slot", "/set_slot")
 
+# Slot collection uses this key during parent `{% component %}` body render
+_INTERNAL_CONTEXT_KEYS = frozenset({"_component_slots"})
+
 
 def _strip_quotes(raw: str) -> str:
     return raw.strip("'\"").strip()
-
-
-def _parse_literal_props(bits: list[str], start: int = 2) -> dict[str, str]:
-    """Turn ``key="value"`` tokens from the tag into a flat string dict."""
-    props: dict[str, str] = {}
-    for part in bits[start:]:
-        if "=" not in part:
-            continue
-        key, _, val = part.partition("=")
-        props[key.strip()] = _strip_quotes(val)
-    return props
-
-
-def _template_path_from_context(context: template.Context) -> Path | None:
-    """Return a resolved path from ``current_template_path``, or ``None``."""
-    raw = context.get("current_template_path")
-    if raw is None:
-        return None
-    if isinstance(raw, Path):
-        path = raw
-    elif isinstance(raw, str):
-        path = Path(raw)
-    else:
-        return None
-    return path.resolve()
-
-
-def _merge_slots_into_context(base: dict[str, str], slots: dict[str, str]) -> None:
-    """Add ``slot_<name>`` and ``<name>`` keys for each slot body."""
-    for slot_name, content in slots.items():
-        base[f"slot_{slot_name}"] = content
-        base[slot_name] = content
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,9 +92,22 @@ class ComponentNode(Node):
         self.props = props
         self.nodelist = nodelist
 
+    def _template_path_from_context(self, context: template.Context) -> Path | None:
+        """Return a resolved path from ``current_template_path``, or ``None``."""
+        raw = context.get("current_template_path")
+        if raw is None:
+            return None
+        if isinstance(raw, Path):
+            path = raw
+        elif isinstance(raw, str):
+            path = Path(raw)
+        else:
+            return None
+        return path.resolve()
+
     def render(self, context: template.Context) -> str:
         """Merge props, slots, and children, then render the component."""
-        path = _template_path_from_context(context)
+        path = self._template_path_from_context(context)
         if path is None:
             return ""
 
@@ -139,11 +124,19 @@ class ComponentNode(Node):
                 else:
                     child_chunks.append(node.render(context))
 
-        render_ctx: dict[str, str] = dict(self.props)
+        parent_flat = dict(cast("dict[str, Any]", context.flatten()))
+        for key in _INTERNAL_CONTEXT_KEYS:
+            parent_flat.pop(key, None)
+        render_ctx: dict[str, Any] = {**parent_flat, **self.props}
         render_ctx["children"] = "".join(child_chunks)
-        _merge_slots_into_context(render_ctx, slots)
 
-        request = context.get("request")
+        for slot_name, content in slots.items():
+            render_ctx[f"slot_{slot_name}"] = content
+            render_ctx[slot_name] = content
+
+        request = render_ctx.get("request")
+        if request is None:
+            request = context.get("request")
         return render_component(info, render_ctx, request=request)
 
 
@@ -174,7 +167,12 @@ def do_component(parser: Parser, token: Token) -> ComponentNode:
     if not name:
         msg = "{% component %} tag requires a quoted component name"
         raise template.TemplateSyntaxError(msg)
-    props = _parse_literal_props(bits)
+    props: dict[str, str] = {}
+    for part in bits[2:]:
+        if "=" not in part:
+            continue
+        key, _, val = part.partition("=")
+        props[key.strip()] = _strip_quotes(val)
     nodelist = parser.parse(_END_COMPONENT)
     parser.delete_first_token()
     return ComponentNode(name=name, props=props, nodelist=nodelist)

--- a/next/templatetags/forms.py
+++ b/next/templatetags/forms.py
@@ -14,7 +14,11 @@ from django.core.exceptions import ImproperlyConfigured
 from django.middleware.csrf import get_token
 from django.utils.html import escape, format_html
 
-from next.forms import form_action_manager
+from next.deps import RESERVED_KEYS
+from next.forms import build_form_namespace_for_action, form_action_manager
+
+
+_NEXT_FORM_PAGE = "_next_form_page"
 
 
 if TYPE_CHECKING:
@@ -140,21 +144,32 @@ class FormNode(template.Node):
             raise ImproperlyConfigured(msg)
         return cast("HttpRequest", request)
 
-    def _build_hidden_inputs(self, request: HttpRequest) -> str:
-        """Build CSRF hidden input and URL parameter inputs."""
+    def _build_hidden_inputs(
+        self,
+        request: HttpRequest,
+        *,
+        next_form_page: str | None,
+    ) -> str:
+        """Build CSRF, origin page, and URL parameter hidden inputs."""
         inputs = [
             format_html(
                 '<input type="hidden" name="csrfmiddlewaretoken" value="{}">',
                 get_token(request),
             )
         ]
+        if next_form_page:
+            inputs.append(
+                format_html(
+                    '<input type="hidden" name="{}" value="{}">',
+                    _NEXT_FORM_PAGE,
+                    escape(next_form_page),
+                )
+            )
 
-        # Add hidden inputs for URL parameters (from file routing)
-        # These will be passed to form handlers via POST data
         if request.resolver_match and request.resolver_match.kwargs:
             for key, value in request.resolver_match.kwargs.items():
-                # Skip uid parameter used by form action system
-                if key != "uid":
+                # Skip uid (form action URL) and names reserved for DI
+                if key != "uid" and key not in RESERVED_KEYS:
                     inputs.append(
                         format_html(
                             '<input type="hidden" name="_url_param_{}" value="{}">',
@@ -170,17 +185,28 @@ class FormNode(template.Node):
         request = self._get_request(context)
         builder = FormAttrsBuilder.from_config(self.config)
 
-        # Get form from context by action name
+        raw_page = context.get("current_page_module_path")
+        if not raw_page:
+            msg = (
+                "{% form %} requires 'current_page_module_path' in template context "
+                "(set when rendering file-based pages)."
+            )
+            raise ImproperlyConfigured(msg)
+        next_form_page = str(raw_page)
+
         form_obj = context.get(self.config.action_name)
         if form_obj and hasattr(form_obj, "form"):
             form_instance = form_obj.form
         else:
-            form_instance = None
+            built = build_form_namespace_for_action(self.config.action_name, request)
+            form_instance = built.form if built is not None else None
 
         opening_tag = builder.build_opening_tag()
-        hidden_inputs = self._build_hidden_inputs(request)
+        hidden_inputs = self._build_hidden_inputs(
+            request,
+            next_form_page=next_form_page,
+        )
 
-        # Push form as local variable (only available inside {% form %} tag)
         with context.push(form=form_instance):
             content = self.nodelist.render(context)
 

--- a/next/urls.py
+++ b/next/urls.py
@@ -85,7 +85,13 @@ class HttpRequestProvider(RegisteredParameterProvider):
                 if hints.get(param.name) is HttpRequest:
                     return True
             except (NameError, TypeError, AttributeError, ValueError):
-                pass
+                logger.debug(
+                    "Failed to resolve type hints for %r "
+                    "when checking HttpRequest parameter %s",
+                    func,
+                    param.name,
+                    exc_info=True,
+                )
         origin = get_origin(param.annotation)
         return origin is None and param.annotation is HttpRequest
 

--- a/next/urls.py
+++ b/next/urls.py
@@ -13,7 +13,16 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterable, Iterator
 from pathlib import Path
-from typing import Any, ClassVar, SupportsIndex, TypeVar, get_args, get_origin, overload
+from typing import (
+    Any,
+    ClassVar,
+    SupportsIndex,
+    TypeVar,
+    get_args,
+    get_origin,
+    get_type_hints,
+    overload,
+)
 
 from django.conf import settings
 from django.http import HttpRequest
@@ -68,6 +77,15 @@ class HttpRequestProvider(RegisteredParameterProvider):
         """Return True when the parameter is ``HttpRequest`` and a request exists."""
         if getattr(context, "request", None) is None:
             return False
+        stack = getattr(self.resolver, "_resolve_call_stack", ())
+        if stack:
+            func = stack[-1]
+            try:
+                hints = get_type_hints(func)
+                if hints.get(param.name) is HttpRequest:
+                    return True
+            except (NameError, TypeError, AttributeError, ValueError):
+                pass
         origin = get_origin(param.annotation)
         return origin is None and param.annotation is HttpRequest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ if not settings.configured:
         ],
         ROOT_URLCONF="next.urls",
         SECRET_KEY="test-secret-key",  # noqa: S106
+        BASE_DIR=project_root,
         USE_TZ=True,
         TIME_ZONE="UTC",
         NEXT_FRAMEWORK={

--- a/tests/pages/template.djx
+++ b/tests/pages/template.djx
@@ -1,0 +1,1 @@
+{% block template %}<p>test page</p>{{ form }}{% endblock %}

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -307,6 +307,45 @@ class TestRegisterComponentsFolderFromRouterWalk:
         register_components_folder_from_router_walk(folder, tmp_path, "")
         assert len(list(backend._registry.get_all())) == 1
 
+    def test_loads_component_py_when_composite_has_module(self, tmp_path: Path) -> None:
+        """Router walk loads ``component.py`` for composite components (coverage)."""
+        components_manager._walk_registered_folders.clear()
+        components_manager._backends.clear()
+        backend = FileComponentsBackend(dict(_MIN_FILE_COMPONENTS))
+        components_manager._backends.append(backend)
+        comp_dir = tmp_path / "_components" / "news"
+        comp_dir.mkdir(parents=True)
+        (comp_dir / "component.djx").write_text("<span>news</span>")
+        (comp_dir / "component.py").write_text("# module for news\n")
+        register_components_folder_from_router_walk(
+            tmp_path / "_components",
+            tmp_path,
+            "",
+        )
+        infos = [i for i in backend._registry.get_all() if i.name == "news"]
+        assert len(infos) == 1
+        assert infos[0].module_path is not None
+
+    def test_import_all_component_modules_loads_each_module_path(
+        self, tmp_path: Path
+    ) -> None:
+        """``import_all_component_modules`` executes ``module_loader.load`` per path."""
+        comp_py = tmp_path / "component.py"
+        comp_py.write_text("# registered component module\n")
+        djx = tmp_path / "c.djx"
+        djx.write_text("<div/>")
+        info = ComponentInfo(
+            name="c",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=djx,
+            module_path=comp_py,
+            is_simple=False,
+        )
+        backend = FileComponentsBackend(dict(_MIN_FILE_COMPONENTS))
+        backend._registry.register(info)
+        backend.import_all_component_modules()
+
 
 class TestGetComponent:
     """Tests for get_component()."""
@@ -718,6 +757,70 @@ class TestComponentTag:
             )
         assert 'class="card"' in result
         assert "Hello" in result
+
+    def test_component_tag_inherits_parent_template_context(
+        self, tmp_path: Path
+    ) -> None:
+        """Parent page context keys are visible inside the component template."""
+        (tmp_path / "banner.djx").write_text(
+            '<span class="banner">{{ page_var }}</span>'
+        )
+        with patch.object(
+            components_manager,
+            "get_component",
+            return_value=ComponentInfo(
+                name="banner",
+                scope_root=tmp_path,
+                scope_relative="",
+                template_path=tmp_path / "banner.djx",
+                module_path=None,
+                is_simple=True,
+            ),
+        ):
+            t = Template(
+                '{% load components %}{% component "banner" %}{% endcomponent %}'
+            )
+            result = t.render(
+                Context(
+                    {
+                        "current_template_path": str(tmp_path / "template.djx"),
+                        "page_var": "from_parent_page",
+                    },
+                ),
+            )
+        assert "from_parent_page" in result
+
+    def test_component_tag_prop_overrides_parent_context_key(
+        self, tmp_path: Path
+    ) -> None:
+        """Explicit tag props shadow parent context keys of the same name."""
+        (tmp_path / "chip.djx").write_text("<em>{{ title }}</em>")
+        with patch.object(
+            components_manager,
+            "get_component",
+            return_value=ComponentInfo(
+                name="chip",
+                scope_root=tmp_path,
+                scope_relative="",
+                template_path=tmp_path / "chip.djx",
+                module_path=None,
+                is_simple=True,
+            ),
+        ):
+            t = Template(
+                "{% load components %}"
+                '{% component "chip" title="from_prop" %}{% endcomponent %}'
+            )
+            result = t.render(
+                Context(
+                    {
+                        "current_template_path": str(tmp_path / "t.djx"),
+                        "title": "from_parent",
+                    },
+                ),
+            )
+        assert "from_prop" in result
+        assert "from_parent" not in result
 
     def test_component_tag_accepts_path_object_in_context(self, tmp_path: Path) -> None:
         """current_template_path in context can be a Path object."""

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,4 +1,6 @@
+import importlib.util
 import inspect
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -107,6 +109,34 @@ class TestHttpRequestProvider:
         param = inspect_parameter("request", HttpRequest)
         ctx = _ctx(request=request)
         assert provider.resolve(param, ctx) is request
+
+    def test_can_handle_when_get_type_hints_raises_falls_back(
+        self, tmp_path: Path
+    ) -> None:
+        """If ``get_type_hints`` raises, the except branch runs and fallback applies."""
+        mod_path = tmp_path / "bad_ann.py"
+        mod_path.write_text(
+            "from __future__ import annotations\n"
+            "def handler(request: DoesNotExist):\n"
+            "    pass\n",
+            encoding="utf-8",
+        )
+        spec = importlib.util.spec_from_file_location("bad_ann", mod_path)
+        assert spec is not None
+        assert spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        handler = mod.handler
+
+        provider = HttpRequestProvider()
+        req = HttpRequest()
+        ctx = _ctx(request=req)
+        param = inspect.signature(handler).parameters["request"]
+        resolver._resolve_call_stack.append(handler)
+        try:
+            assert provider.can_handle(param, ctx) is False
+        finally:
+            resolver._resolve_call_stack.pop()
 
 
 class TestUrlKwargsProvider:

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,4 +1,5 @@
 import inspect
+import pathlib
 import types
 from pathlib import Path
 from typing import ClassVar
@@ -10,6 +11,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.middleware.csrf import get_token
 from django.template import Context, TemplateSyntaxError
+from django.test import Client
 
 from next.forms import (
     BaseModelForm,
@@ -18,13 +20,28 @@ from next.forms import (
     FormActionOptions,
     ModelForm,
     RegistryFormActionBackend,
+    _form_action_context_callable,
     _FormActionDispatch,
     _get_caller_path,
+    _url_kwargs_from_post,
     action,
+    build_form_namespace_for_action,
     form_action_manager,
     page,
+    validated_next_form_page_path,
 )
 from next.templatetags.forms import _parse_form_tag_args
+
+
+PAGE_MODULE_FOR_FORM_TESTS = (
+    Path(__file__).resolve().parent / "pages" / "page.py"
+).resolve()
+
+
+@pytest.fixture()
+def client_no_csrf():
+    """Test client without CSRF checks (form action POSTs supply fields manually)."""
+    return Client(enforce_csrf_checks=False)
 
 
 class SimpleForm(Form):
@@ -106,29 +123,41 @@ class TestRenderFormFragment:
         assert html == ""
 
     def test_with_template_fragment(self, mock_http_request) -> None:
-        """Render form with given template fragment."""
+        """Render form using the page template for ``page_file_path``."""
         request = mock_http_request(method="GET")
         form = SimpleForm(initial={"name": "test"})
-        fragment = "{{ form.name }}"
         html = form_action_manager.render_form_fragment(
-            request, "test_submit", form, template_fragment=fragment
+            request,
+            "test_submit",
+            form,
+            template_fragment=None,
+            page_file_path=PAGE_MODULE_FOR_FORM_TESTS,
         )
         assert "test" in html or "name" in html
 
     def test_with_form_only_no_template(self, mock_http_request) -> None:
-        """Render form without template returns string."""
+        """Render form via registry template for ``page_file_path`` returns HTML."""
         request = mock_http_request(method="GET")
         form = SimpleForm(initial={"name": "x"})
         html = form_action_manager.render_form_fragment(
-            request, "test_submit", form, template_fragment=None
+            request,
+            "test_submit",
+            form,
+            template_fragment=None,
+            page_file_path=PAGE_MODULE_FOR_FORM_TESTS,
         )
         assert isinstance(html, str)
+        assert html.strip() != ""
 
     def test_form_none_no_template_returns_string(self, mock_http_request) -> None:
-        """Form None and no template still returns a string."""
+        """Form None still returns a string when a page template exists."""
         request = mock_http_request(method="GET")
         html = form_action_manager.render_form_fragment(
-            request, "test_submit", form=None, template_fragment=None
+            request,
+            "test_submit",
+            form=None,
+            template_fragment=None,
+            page_file_path=PAGE_MODULE_FOR_FORM_TESTS,
         )
         assert isinstance(html, str)
 
@@ -143,22 +172,28 @@ class TestRenderFormFragment:
     def test_renders_from_registry_template(
         self, mock_http_request, registry_template: str, output_mode: str
     ) -> None:
-        """Render fragment using template stored in page registry for the action file."""
+        """Render fragment using template stored in page registry for ``page_file_path``."""
         request = mock_http_request(method="GET")
         form = SimpleForm(initial={"name": "a"})
         backend = form_action_manager.default_backend
         assert isinstance(backend, RegistryFormActionBackend)
-        meta = backend.get_meta("test_submit")
-        assert meta is not None
-        file_path = meta["file_path"]
+        file_path = PAGE_MODULE_FOR_FORM_TESTS
         original_registry = page._template_registry.copy()
         page._template_registry[file_path] = registry_template
         try:
             html = backend.render_form_fragment(
-                request, "test_submit", form, template_fragment=None
+                request,
+                "test_submit",
+                form,
+                template_fragment=None,
+                page_file_path=file_path,
             )
             if output_mode == "path":
-                assert str(file_path) in html
+                template_djx = file_path.parent / "template.djx"
+                expected_path = (
+                    str(template_djx) if template_djx.is_file() else str(file_path)
+                )
+                assert expected_path in html
             else:
                 assert "a" in html or "name" in html
         finally:
@@ -275,9 +310,9 @@ class TestFormActionDispatch:
 class TestDispatchViaClient:
     """Form action dispatch via Django test client."""
 
-    def test_unknown_uid_returns_404(self, client) -> None:
+    def test_unknown_uid_returns_404(self, client_no_csrf) -> None:
         """Unknown form uid returns 404."""
-        resp = client.get("/_next/form/unknown_uid_12345/")
+        resp = client_no_csrf.get("/_next/form/unknown_uid_12345/")
         assert resp.status_code == 404
 
     @pytest.mark.parametrize(
@@ -285,41 +320,66 @@ class TestDispatchViaClient:
         ["test_submit", "test_no_form"],
         ids=("with_form_class", "without_form_class"),
     )
-    def test_get_returns_405(self, client, action_name: str) -> None:
+    def test_get_returns_405(self, client_no_csrf, action_name: str) -> None:
         """GET form action URL returns 405 Method Not Allowed."""
         url = form_action_manager.get_action_url(action_name)
-        resp = client.get(url)
+        resp = client_no_csrf.get(url)
         assert resp.status_code == 405
 
-    def test_invalid_form_returns_200_with_errors(self, client) -> None:
-        """Invalid POST returns 200 with validation errors."""
+    def test_invalid_form_returns_200_with_errors(self, client_no_csrf) -> None:
+        """Invalid POST returns 200 with validation errors when _next_form_page is valid."""
         url = form_action_manager.get_action_url("test_submit")
-        resp = client.post(url, data={"name": ""}, follow=False)
+        resp = client_no_csrf.post(
+            url,
+            data={
+                "name": "",
+                "_next_form_page": str(PAGE_MODULE_FOR_FORM_TESTS),
+            },
+            follow=False,
+        )
         assert resp.status_code == 200
         c = resp.content
         assert b"error" in c.lower() or b"required" in c.lower() or b"name" in c
 
-    def test_valid_form_calls_handler(self, client) -> None:
+    def test_invalid_form_without_next_page_returns_400(self, client_no_csrf) -> None:
+        """Invalid POST without _next_form_page returns 400."""
+        url = form_action_manager.get_action_url("test_submit")
+        resp = client_no_csrf.post(url, data={"name": ""}, follow=False)
+        assert resp.status_code == 400
+
+    def test_valid_form_calls_handler(self, client_no_csrf) -> None:
         """Valid POST calls handler and returns 200/204."""
         url = form_action_manager.get_action_url("test_submit")
-        resp = client.post(url, data={"name": "Alice", "email": ""}, follow=False)
+        resp = client_no_csrf.post(
+            url,
+            data={
+                "name": "Alice",
+                "email": "",
+                "_next_form_page": str(PAGE_MODULE_FOR_FORM_TESTS),
+            },
+            follow=False,
+        )
         assert resp.status_code in (200, 204)
 
-    def test_redirect_action_returns_redirect(self, client) -> None:
+    def test_redirect_action_returns_redirect(self, client_no_csrf) -> None:
         """Redirect action returns 302 redirect."""
         url = form_action_manager.get_action_url("test_redirect")
-        resp = client.post(
+        resp = client_no_csrf.post(
             url,
-            data={"name": "Bob", "email": ""},
+            data={
+                "name": "Bob",
+                "email": "",
+                "_next_form_page": str(PAGE_MODULE_FOR_FORM_TESTS),
+            },
             follow=False,
         )
         assert resp.status_code == 302
         assert resp.url == "/done/"
 
-    def test_no_form_action_post_returns_200(self, client) -> None:
+    def test_no_form_action_post_returns_200(self, client_no_csrf) -> None:
         """Action without form_class POST returns 200 and body."""
         url = form_action_manager.get_action_url("test_no_form")
-        resp = client.post(url, data={})
+        resp = client_no_csrf.post(url, data={})
         assert resp.status_code == 200
         assert b"ok" in resp.content
 
@@ -366,7 +426,14 @@ class TestFormTagRender:
         t = form_engine.from_string(
             '{% form @action="test_submit" %}{{ form.as_p }}{% endform %}'
         )
-        html = t.render(Context({"request": csrf_request}))
+        html = t.render(
+            Context(
+                {
+                    "request": csrf_request,
+                    "current_page_module_path": str(PAGE_MODULE_FOR_FORM_TESTS),
+                }
+            )
+        )
         assert "<form" in html
         assert "action=" in html
         assert 'method="post"' in html
@@ -377,7 +444,14 @@ class TestFormTagRender:
         t = form_engine.from_string(
             '{% form @action="test_submit" class="my-form" id="f1" %}x{% endform %}'
         )
-        html = t.render(Context({"request": csrf_request}))
+        html = t.render(
+            Context(
+                {
+                    "request": csrf_request,
+                    "current_page_module_path": str(PAGE_MODULE_FOR_FORM_TESTS),
+                }
+            )
+        )
         assert 'class="my-form"' in html
         assert 'id="f1"' in html
 
@@ -386,8 +460,35 @@ class TestFormTagRender:
     ) -> None:
         """Form includes csrfmiddlewaretoken when request in context."""
         t = form_engine.from_string('{% form @action="test_submit" %}x{% endform %}')
-        html = t.render(Context({"request": csrf_request}))
+        html = t.render(
+            Context(
+                {
+                    "request": csrf_request,
+                    "current_page_module_path": str(PAGE_MODULE_FOR_FORM_TESTS),
+                }
+            )
+        )
         assert "csrfmiddlewaretoken" in html
+
+    def test_includes_next_form_page_hidden(self, form_engine, csrf_request) -> None:
+        """Form includes _next_form_page from current_page_module_path."""
+        t = form_engine.from_string('{% form @action="test_submit" %}x{% endform %}')
+        html = t.render(
+            Context(
+                {
+                    "request": csrf_request,
+                    "current_page_module_path": str(PAGE_MODULE_FOR_FORM_TESTS),
+                }
+            )
+        )
+        assert "_next_form_page" in html
+        assert str(PAGE_MODULE_FOR_FORM_TESTS) in html
+
+    def test_requires_current_page_module_path(self, form_engine, csrf_request) -> None:
+        """Without current_page_module_path, {% form %} raises ImproperlyConfigured."""
+        t = form_engine.from_string('{% form @action="test_submit" %}x{% endform %}')
+        with pytest.raises(ImproperlyConfigured, match="current_page_module_path"):
+            t.render(Context({"request": csrf_request}))
 
     def test_unknown_action_renders_empty_action_url(
         self, form_engine, csrf_request
@@ -396,7 +497,14 @@ class TestFormTagRender:
         t = form_engine.from_string(
             '{% form @action="nonexistent_action_xyz" %}z{% endform %}'
         )
-        html = t.render(Context({"request": csrf_request}))
+        html = t.render(
+            Context(
+                {
+                    "request": csrf_request,
+                    "current_page_module_path": str(PAGE_MODULE_FOR_FORM_TESTS),
+                }
+            )
+        )
         assert 'action=""' in html or "action=''" in html
         assert "<form" in html
 
@@ -417,6 +525,7 @@ class TestFormTagRender:
         context = Context(
             {
                 "request": csrf_request,
+                "current_page_module_path": str(PAGE_MODULE_FOR_FORM_TESTS),
                 "test_submit": types.SimpleNamespace(form=form_instance),
             }
         )
@@ -435,6 +544,7 @@ class TestFormTagRender:
         context = Context(
             {
                 "request": csrf_request,
+                "current_page_module_path": str(PAGE_MODULE_FOR_FORM_TESTS),
                 "test_submit": types.SimpleNamespace(form=form_instance),
             }
         )
@@ -467,6 +577,7 @@ class TestFormTagRender:
         context = Context(
             {
                 "request": request,
+                "current_page_module_path": str(PAGE_MODULE_FOR_FORM_TESTS),
                 "test_submit": types.SimpleNamespace(form=SimpleForm()),
             }
         )
@@ -533,7 +644,7 @@ class TestBaseFormGetInitial:
         assert result == {}
 
     def test_form_class_without_get_initial_raises_error_in_context(self) -> None:
-        """Test that form class without get_initial raises TypeError when context is accessed."""
+        """Form class without get_initial raises TypeError when lazy context runs."""
         backend = RegistryFormActionBackend()
 
         # Create a form class that doesn't inherit from BaseForm
@@ -545,25 +656,17 @@ class TestBaseFormGetInitial:
         ) -> HttpResponseRedirect:
             return HttpResponseRedirect("/")
 
-        # Register action with form class that doesn't have get_initial
         backend.register_action(
             "test_action",
             handler,
             options=FormActionOptions(form_class=CustomDjangoForm),
         )
 
-        # The error should occur when context_func is called via page context
         request = HttpRequest()
-        meta = backend.get_meta("test_action")
-        assert meta is not None
-        file_path = meta["file_path"]
+        assert backend.get_meta("test_action") is not None
 
-        # Try to get context through page context manager - this will trigger the error
-        # The context_func was registered, so calling collect_context will trigger it
         with pytest.raises(TypeError, match="must have get_initial method"):
-            page._context_manager.collect_context(
-                file_path, request, action_name="test_action"
-            )
+            _form_action_context_callable(CustomDjangoForm)(request)
 
     def test_form_with_model_instance_but_not_modelform_raises_error(self) -> None:
         """Test that using instance parameter with non-ModelForm raises TypeError."""
@@ -587,23 +690,13 @@ class TestBaseFormGetInitial:
             "test_action", handler, options=FormActionOptions(form_class=CustomForm)
         )
 
-        # Try to get context - this will trigger the error when trying to use instance
         request = HttpRequest()
-        meta = backend.get_meta("test_action")
-        assert meta is not None
-        file_path = meta["file_path"]
+        assert backend.get_meta("test_action") is not None
 
-        # Real call to collect_context - this will trigger the error in context_func
-        # context_func is registered with key="test_action", so it will be called
-        # when collect_context runs and processes registered context functions
-        # Access the context key to trigger the function
-        context_registry = page._context_manager._context_registry.get(file_path, {})
-        assert "test_action" in context_registry
-        func, _ = context_registry["test_action"]
         with pytest.raises(
             TypeError, match="instance parameter only supported for ModelForm"
         ):
-            func(request)  # This will trigger the error
+            _form_action_context_callable(CustomForm)(request)
 
     def test_post_with_non_string_value_in_dispatch(self, mock_http_request) -> None:
         """Test that POST values that are not strings are handled correctly in dispatch."""
@@ -677,19 +770,12 @@ class TestBaseFormGetInitial:
             "test_action", handler, options=FormActionOptions(form_class=TestModelForm)
         )
 
-        # Get context - this will call context_func which creates form with instance
         request = HttpRequest()
-        meta = backend.get_meta("test_action")
-        assert meta is not None
-        file_path = meta["file_path"]
+        assert backend.get_meta("test_action") is not None
 
-        # Call collect_context to trigger context_func
-        context_registry = page._context_manager._context_registry.get(file_path, {})
-        if "test_action" in context_registry:
-            func, _ = context_registry["test_action"]
-            result = func(request)  # This should create form with instance (line 255)
-            assert hasattr(result, "form")
-            assert result.form is not None
+        result = _form_action_context_callable(TestModelForm)(request)
+        assert hasattr(result, "form")
+        assert result.form is not None
 
     def test_context_func_gets_url_kwargs_from_post_when_no_resolver_match(
         self,
@@ -712,16 +798,11 @@ class TestBaseFormGetInitial:
             handler,
             options=FormActionOptions(form_class=FormWithId),
         )
-        meta = backend.get_meta("post_params_action")
-        assert meta is not None
-        file_path = meta["file_path"]
+        assert backend.get_meta("post_params_action") is not None
         request = HttpRequest()
         request.method = "POST"
         request.POST = {"_url_param_id": "42"}
-        context_registry = page._context_manager._context_registry.get(file_path, {})
-        assert "post_params_action" in context_registry
-        func, _ = context_registry["post_params_action"]
-        result = func(request)
+        result = _form_action_context_callable(FormWithId)(request)
         assert hasattr(result, "form")
         assert result.form.initial.get("name") == "from-42"
 
@@ -744,16 +825,11 @@ class TestBaseFormGetInitial:
             handler,
             options=FormActionOptions(form_class=FormWithId),
         )
-        meta = backend.get_meta("resolver_params_action")
-        assert meta is not None
-        file_path = meta["file_path"]
+        assert backend.get_meta("resolver_params_action") is not None
         request = HttpRequest()
         request.resolver_match = MagicMock()
         request.resolver_match.kwargs = {"id": 7}
-        context_registry = page._context_manager._context_registry.get(file_path, {})
-        assert "resolver_params_action" in context_registry
-        func, _ = context_registry["resolver_params_action"]
-        result = func(request)
+        result = _form_action_context_callable(FormWithId)(request)
         assert result.form.initial.get("name") == "resolver-7"
 
     def test_context_func_post_url_param_non_digit_string(self) -> None:
@@ -775,15 +851,11 @@ class TestBaseFormGetInitial:
             handler,
             options=FormActionOptions(form_class=FormWithSlug),
         )
-        meta = backend.get_meta("slug_action")
-        assert meta is not None
-        file_path = meta["file_path"]
+        assert backend.get_meta("slug_action") is not None
         request = HttpRequest()
         request.method = "POST"
         request.POST = {"_url_param_slug": "my-slug"}
-        context_registry = page._context_manager._context_registry.get(file_path, {})
-        func, _ = context_registry["slug_action"]
-        result = func(request)
+        result = _form_action_context_callable(FormWithSlug)(request)
         assert result.form.initial.get("slug") == "my-slug"
 
     def test_dispatch_with_modelform_returning_instance(
@@ -909,11 +981,10 @@ class TestBaseFormGetInitial:
         def handler(_request: HttpRequest, _form: TestForm) -> HttpResponseRedirect:
             return HttpResponseRedirect("/")
 
-        test_file = Path(__file__).parent / "test_file.py"
         backend.register_action(
             "test_action",
             handler,
-            options=FormActionOptions(form_class=TestForm, file_path=test_file),
+            options=FormActionOptions(form_class=TestForm),
         )
 
         mock_post = MagicMock()
@@ -922,18 +993,22 @@ class TestBaseFormGetInitial:
         ]
         request = mock_http_request(POST=mock_post)
 
-        # Pre-populate template registry
-        meta = backend.get_meta("test_action")
-        assert meta is not None
-        file_path = meta["file_path"]
+        file_path = PAGE_MODULE_FOR_FORM_TESTS
+        original_registry = page._template_registry.copy()
         page._template_registry[file_path] = "{{ form.name }}"
-
-        # Real call to render_form_fragment - this will cover lines 478-479 (non-string branch)
-        form = TestForm(initial={"name": "test"})
-        html = backend.render_form_fragment(
-            request, "test_action", form, template_fragment=None
-        )
-        assert isinstance(html, str)
+        try:
+            form = TestForm(initial={"name": "test"})
+            html = backend.render_form_fragment(
+                request,
+                "test_action",
+                form,
+                template_fragment=None,
+                page_file_path=file_path,
+            )
+            assert isinstance(html, str)
+        finally:
+            page._template_registry.clear()
+            page._template_registry.update(original_registry)
 
     def test_render_form_fragment_with_string_post_value_not_int(
         self, mock_http_request
@@ -947,11 +1022,10 @@ class TestBaseFormGetInitial:
         def handler(_request: HttpRequest, _form: TestForm) -> HttpResponseRedirect:
             return HttpResponseRedirect("/")
 
-        test_file = Path(__file__).parent / "test_file.py"
         backend.register_action(
             "test_action",
             handler,
-            options=FormActionOptions(form_class=TestForm, file_path=test_file),
+            options=FormActionOptions(form_class=TestForm),
         )
 
         mock_post = MagicMock()
@@ -960,18 +1034,22 @@ class TestBaseFormGetInitial:
         ]
         request = mock_http_request(POST=mock_post)
 
-        # Pre-populate template registry
-        meta = backend.get_meta("test_action")
-        assert meta is not None
-        file_path = meta["file_path"]
+        file_path = PAGE_MODULE_FOR_FORM_TESTS
+        original_registry = page._template_registry.copy()
         page._template_registry[file_path] = "{{ form.name }}"
-
-        # Real call to render_form_fragment - this will cover lines 474-477 (ValueError branch)
-        form = TestForm(initial={"name": "test"})
-        html = backend.render_form_fragment(
-            request, "test_action", form, template_fragment=None
-        )
-        assert isinstance(html, str)
+        try:
+            form = TestForm(initial={"name": "test"})
+            html = backend.render_form_fragment(
+                request,
+                "test_action",
+                form,
+                template_fragment=None,
+                page_file_path=file_path,
+            )
+            assert isinstance(html, str)
+        finally:
+            page._template_registry.clear()
+            page._template_registry.update(original_registry)
 
     def test_dispatch_with_form_without_get_initial(self, mock_http_request) -> None:
         """Test that dispatch raises TypeError when form class doesn't have get_initial."""
@@ -1052,26 +1130,186 @@ class TestBaseFormGetInitial:
         def handler(_request: HttpRequest, _form: TestForm) -> HttpResponseRedirect:
             return HttpResponseRedirect("/")
 
-        test_file = Path(__file__).parent / "test_file.py"
         backend.register_action(
             "test_action",
             handler,
-            options=FormActionOptions(form_class=TestForm, file_path=test_file),
+            options=FormActionOptions(form_class=TestForm),
         )
 
         mock_post = MagicMock()
         mock_post.items.return_value = [("_url_param_test", ["list", "value"])]
         request = mock_http_request(POST=mock_post)
 
-        # Pre-populate template registry
-        meta = backend.get_meta("test_action")
-        assert meta is not None
-        file_path = meta["file_path"]
+        file_path = PAGE_MODULE_FOR_FORM_TESTS
+        original_registry = page._template_registry.copy()
         page._template_registry[file_path] = "{{ form.name }}"
+        try:
+            form = TestForm(initial={"name": "test"})
+            html = backend.render_form_fragment(
+                request,
+                "test_action",
+                form,
+                template_fragment=None,
+                page_file_path=file_path,
+            )
+            assert isinstance(html, str)
+        finally:
+            page._template_registry.clear()
+            page._template_registry.update(original_registry)
 
-        # Real call to render_form_fragment - this will cover the non-string handling code
-        form = TestForm(initial={"name": "test"})
-        html = backend.render_form_fragment(
-            request, "test_action", form, template_fragment=None
+
+class TestValidatedNextFormPagePath:
+    """``validated_next_form_page_path`` edge cases."""
+
+    def test_no_post_attr(self) -> None:
+        """Missing ``POST`` yields None."""
+
+        class NoPost:
+            pass
+
+        assert validated_next_form_page_path(NoPost()) is None  # type: ignore[arg-type]
+
+    def test_next_page_not_str(self) -> None:
+        """Non-string ``_next_form_page`` yields None."""
+        req = HttpRequest()
+        req.method = "POST"
+
+        class WeirdPost:
+            def get(self, _key: str, _default: object = None) -> object:
+                return 42
+
+        req.POST = WeirdPost()  # type: ignore[assignment]
+        assert validated_next_form_page_path(req) is None
+
+    def test_next_page_empty_after_strip(self) -> None:
+        """Whitespace-only ``_next_form_page`` yields None."""
+        req = HttpRequest()
+        req.method = "POST"
+        req.POST = {"_next_form_page": "   \n  "}
+        assert validated_next_form_page_path(req) is None
+
+    def test_resolve_raises_oserror(self, monkeypatch) -> None:
+        """``Path.resolve`` raising ``OSError`` yields None."""
+
+        def boom(self: pathlib.Path, *args: object, **kwargs: object) -> pathlib.Path:
+            msg = "boom"
+            raise OSError(msg)
+
+        monkeypatch.setattr(pathlib.Path, "resolve", boom)
+        req = HttpRequest()
+        req.method = "POST"
+        req.POST = {"_next_form_page": str(PAGE_MODULE_FOR_FORM_TESTS)}
+        assert validated_next_form_page_path(req) is None
+
+    def test_not_page_py(self, tmp_path) -> None:
+        """Filename other than ``page.py`` yields None."""
+        p = tmp_path / "foo.py"
+        p.write_text("x=1")
+        req = HttpRequest()
+        req.method = "POST"
+        req.POST = {"_next_form_page": str(p.resolve())}
+        assert validated_next_form_page_path(req) is None
+
+    def test_base_dir_none(self, monkeypatch) -> None:
+        """Missing ``settings.BASE_DIR`` yields None."""
+        req = HttpRequest()
+        req.method = "POST"
+        req.POST = {"_next_form_page": str(PAGE_MODULE_FOR_FORM_TESTS)}
+        monkeypatch.setattr("django.conf.settings.BASE_DIR", None)
+        assert validated_next_form_page_path(req) is None
+
+    def test_outside_base_dir(self, tmp_path, monkeypatch) -> None:
+        """Path outside ``BASE_DIR`` yields None."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        page_py = outside / "page.py"
+        page_py.write_text("# x")
+        req = HttpRequest()
+        req.method = "POST"
+        req.POST = {"_next_form_page": str(page_py.resolve())}
+        monkeypatch.setattr("django.conf.settings.BASE_DIR", tmp_path / "project")
+        assert validated_next_form_page_path(req) is None
+
+
+class TestUrlKwargsFromPostReserved:
+    """``_url_kwargs_from_post`` skips DI-reserved param names."""
+
+    def test_skips_url_param_request(self) -> None:
+        """``_url_param_request`` is not forwarded as ``request``."""
+        req = HttpRequest()
+        req.method = "POST"
+        req.POST = {"_url_param_request": "x", "_url_param_id": "7"}
+        out = _url_kwargs_from_post(req)
+        assert "request" not in out
+        assert out["id"] == 7
+
+
+class TestBuildFormNamespaceForAction:
+    """``build_form_namespace_for_action`` when action has no form class."""
+
+    def test_returns_none_for_action_without_form_class(
+        self, mock_http_request
+    ) -> None:
+        """Actions without ``form_class`` return None."""
+        req = mock_http_request(method="GET")
+        assert build_form_namespace_for_action("test_no_form", req) is None
+
+
+class TestFormDispatchRenderFragmentBranches:
+    """``_FormActionDispatch.render_form_fragment`` fallbacks."""
+
+    def test_unknown_action_uses_form_as_p(self, mock_http_request) -> None:
+        """Unknown action meta falls back to ``form.as_p()``."""
+        backend = RegistryFormActionBackend()
+
+        class F(Form):
+            name = forms.CharField(max_length=10)
+
+        def h(_request: HttpRequest, _form: F) -> HttpResponseRedirect:
+            return HttpResponseRedirect("/")
+
+        backend.register_action(
+            "only", handler=h, options=FormActionOptions(form_class=F)
         )
-        assert isinstance(html, str)
+        req = mock_http_request(method="GET")
+        form = F()
+        html = _FormActionDispatch.render_form_fragment(
+            backend,
+            req,
+            "missing_action",
+            form,
+            None,
+            PAGE_MODULE_FOR_FORM_TESTS,
+        )
+        assert html == form.as_p()
+
+    def test_empty_template_string_uses_form_as_p(self, mock_http_request) -> None:
+        """Empty template string in registry falls back to ``form.as_p()``."""
+        backend = RegistryFormActionBackend()
+
+        class F(Form):
+            name = forms.CharField(max_length=10)
+
+        def h(_request: HttpRequest, _form: F) -> HttpResponseRedirect:
+            return HttpResponseRedirect("/")
+
+        backend.register_action(
+            "frag", handler=h, options=FormActionOptions(form_class=F)
+        )
+        req = mock_http_request(method="GET")
+        form = F()
+        original = page._template_registry.copy()
+        page._template_registry[PAGE_MODULE_FOR_FORM_TESTS] = ""
+        try:
+            html = _FormActionDispatch.render_form_fragment(
+                backend,
+                req,
+                "frag",
+                form,
+                None,
+                PAGE_MODULE_FOR_FORM_TESTS,
+            )
+            assert html == form.as_p()
+        finally:
+            page._template_registry.clear()
+            page._template_registry.update(original)

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -423,6 +423,15 @@ class TestPageHasTemplateAndLazyRender:
         assert page_file in page_instance._template_registry
         assert "Lazy" in result
 
+    def test_load_template_for_file_false_when_no_usable_template_source(
+        self, page_instance, tmp_path
+    ) -> None:
+        """_load_template_for_file skips loaders that yield no content and returns False."""
+        page_file = tmp_path / "page.py"
+        page_file.write_text("y = 1")
+        assert not page_instance._load_template_for_file(page_file)
+        assert page_file not in page_instance._template_registry
+
     def test_render_invalidates_cache_when_template_stale(
         self, page_instance, tmp_path
     ) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,15 @@
+from unittest.mock import patch
+
 import pytest
 
-from next.utils import caller_source_path
+from next.utils import caller_source_path, resolve_base_dir
+
+
+def test_resolve_base_dir_non_path_non_str_returns_none() -> None:
+    """When ``BASE_DIR`` is neither Path nor str, return None."""
+    with patch("next.utils.settings") as mock_settings:
+        mock_settings.BASE_DIR = object()
+        assert resolve_base_dir() is None
 
 
 def test_caller_source_path_requires_one_mode() -> None:


### PR DESCRIPTION
## Summary

Fixes form handling for pages and root components so form actions work reliably when forms are declared in component templates, dependency injection resolves `HttpRequest` correctly (including with postponed annotations), and invalid submissions re-render using a validated `_next_form_page` origin.

## Motivation

- Forms embedded in components need the same wiring as page-level forms: correct context, fragment/page rendering, and safe resolution of the originating `page.py`.
- `HttpRequest` typing with `from __future__ import annotations` previously broke naive annotation checks; URL kwargs could also shadow injected `request`.
- Documentation and examples should match the current architecture (lazy `{% form %}`, no manual `register_context_paths` for form actions where applicable).

## What changed

- **Core (`next/`)**
  - **`forms.py` / `templatetags/forms.py`**: Align form building and rendering with action names, lazy form construction, and hidden `_next_form_page` derived from the current page module path.
  - **`deps.py`**: Resolve parameter types via `get_type_hints` and stack-aware resolution so `HttpRequest` and similar annotations work with string annotations.
  - **`urls.py`**: Reserve URL parameter names that collide with injected providers (e.g. `request`).
  - **`apps.py` / `components.py`**: Ensure component modules are imported on startup so form actions and routers are registered consistently.
  - **`pages.py`**: Pass through `current_page_module_path` for render context where needed.
  - **`templatetags/components.py`**: Adjustments for component rendering in line with the form/context changes.

- **Docs**
  - **`docs/content/guide/forms.rst`**: Rewritten to describe the current form-actions flow and usage.

- **Examples**
  - **`newsletter_subscribe`**: Component template + handler under `root_components/`.
  - **`tests/tests.py`**: Example POSTs that simulate validation failures now include `_next_form_page` (matching real browser submissions), fixing 400 vs expected 200 on error re-renders.

- **Tests**
  - Expanded coverage in `tests/test_forms.py`, `test_components.py`, `test_deps.py`, `test_pages.py`, `test_utils.py`, plus small fixture/template updates.

---

Full guidelines: [CONTRIBUTING.md](https://github.com/next-dj/next-dj/blob/main/CONTRIBUTING.md)
