### PR TITLE
fix(core): fixed nested components & updated syntax

### DIFF
--- a/docs/content/guide/components.rst
+++ b/docs/content/guide/components.rst
@@ -135,11 +135,11 @@ Put a single file next to your pages tree, for example ``myapp/pages/_components
 
    <article class="card">{{ title }}</article>
 
-Call it from a template in scope (``template.djx``, ``layout.djx``, or another component) using the block form:
+Call it from a template in scope (``template.djx``, ``layout.djx``, or another component) using the **void** form (no closing tag):
 
 .. code-block:: django
 
-   {% component "card" title="Hello" %}{% endcomponent %}
+   {% component "card" title="Hello" %}
 
 The first argument is the component name (file stem). Remaining bits on the opening tag are static ``key="value"`` props (see :ref:`components-props-literals`).
 
@@ -225,28 +225,37 @@ Template syntax
 Props are literal strings
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Everything after the component name on ``{% component %}`` is parsed as ``name="value"`` tokens with **static** string values. You cannot pass a template variable there (for example ``title={{ post.title }}`` is not supported). Pass dynamic page data through **slots**, nested template content that the component template renders with ``{% set_slot %}``, or through variables added by ``@context`` in ``component.py``. The ``examples/components/`` project uses slots for list-driven content (see :ref:`components-example-project`).
+Everything after the component name on ``{% component %}`` / ``{% #component %}`` is parsed as ``name="value"`` tokens with **static** string values. You cannot pass a template variable there (for example ``title={{ post.title }}`` is not supported). Pass dynamic page data through **slots**, nested template content that the component template renders with ``{% #set_slot %}``, or through variables added by ``@context`` in ``component.py``. The ``examples/components/`` project uses slots for list-driven content (see :ref:`components-example-project`).
 
 **Invoking a component**
 
-- Without body: ``{% component "card" title="Post 1" description="First post" %} {% endcomponent %}``
-- With slots: put ``{% slot "name" %} ... {% endslot %}`` inside the component block. The component template can render them with ``{% set_slot "name" %} ... {% endset_slot %}`` (with optional default content between the tags).
+- **Void** (no inner markup): ``{% component "card" title="Post 1" description="First post" %}`` — the line ends the tag; there is **no** closing tag.
+- **Block** (slots or nested components): open with ``{% #component "name" ... %}`` and close with ``{% /component %}``. Inside, use:
 
-Components are available in ``template.djx`` and ``layout.djx`` without a ``{% load %}`` (they are in builtins). Use the same block form (with ``{% endcomponent %}``) even when there is no body.
+  - ``{% #slot "name" %}`` … ``{% /slot %}`` for slot bodies with markup, or
+  - ``{% slot "name" %}`` as a **short** form for an **empty** slot (name only).
 
-**Defining slots in the component template**
+- In the component template, define insertion points with ``{% #set_slot "name" %}`` … ``{% /set_slot %}``. Content between the tags is the default when the caller does not pass that slot. If there is **no** default body, use the void form ``{% set_slot "name" %}`` (same idea as short ``{% slot "name" %}`` at the call site).
 
-- ``{% set_slot "avatar" %}`` … ``{% endset_slot %}`` — place where slot content is inserted. The content between the tags is the default if the slot is not provided.
+Components are available in ``template.djx`` and ``layout.djx`` without a ``{% load %}`` (they are in builtins).
+
+**Nesting**
+
+You may nest void and block components without a fixed depth limit. Resolution uses ``current_template_path`` from the page (and is forwarded while rendering inner components) so **scope** matches the page tree (see Scope above).
 
 Example (call site):
 
 .. code-block:: html
 
    {% component "profile" username="Admin" %}
-     {% slot "avatar" %}
-       <img src="/avatar.png" alt="Avatar" />
-     {% endslot %}
-   {% endcomponent %}
+   <div class="card-list">
+     {% #component "card" title="Post 1" description="First" %}
+       {% #slot "image" %}
+         <img src="/x.png" alt="" />
+       {% /slot %}
+       {% slot "footer" %}
+     {% /component %}
+   </div>
 
 Example (component template ``_components/profile/component.djx``):
 
@@ -254,9 +263,9 @@ Example (component template ``_components/profile/component.djx``):
 
    <div class="profile">
      <div class="avatar">
-       {% set_slot "avatar" %}
+       {% #set_slot "avatar" %}
          <span class="badge">{{ username.0 }}</span>
-       {% endset_slot %}
+       {% /set_slot %}
      </div>
      <div class="info">{{ username }}</div>
    </div>
@@ -284,4 +293,4 @@ Checks
 Example project
 ----------------
 
-The ``examples/components/`` project shows a realistic setup: composite **header** with ``@context("user")`` and navigation, **footer** as a simple ``.djx`` file, **post cards** with slots inside a loop, and root versus branch-scoped ``_components``. See its ``README.md`` and ``tests.py`` in the repository.
+The ``examples/components/`` project shows a realistic setup: composite **header** with ``@context("user")`` and navigation, **footer** as a simple ``.djx`` file, **post cards** with ``{% #component %}`` / ``{% #slot %}`` inside a loop, a reusable **card** component, **recommendations** with ``@context``, and root versus branch-scoped ``_components``. See its ``README.md`` and ``tests.py`` in the repository.

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,7 +57,7 @@ A **blog** sample (English UI) built on next-dj components: simple and composite
 - Simple `.djx` components and composite folders (`component.djx` + optional `component.py` with `@context` decorator from `next.components`)
 - Slots for list-driven UI where `{% component %}` only accepts literal props
 - Root `root_components/` vs app `pages/_components/` scope. `NEXT_FRAMEWORK` (`DEFAULT_COMPONENT_BACKENDS`, `COMPONENTS_DIR`) so the file router skips the components folder
-- Template tags `{% component %}`, `{% slot %}`, `{% set_slot %}` (builtins. No `{% load %}` for these)
+- Template tags: void `{% component %}`, block `{% #component %}` / `{% /component %}`, `{% #slot %}` / `{% /slot %}`, short `{% slot %}`, `{% #set_slot %}` / `{% /set_slot %}`, short void `{% set_slot %}` (builtins; no `{% load %}` for these)
 - Optional: middleware protecting `/posts/create/` and `/posts/<id>/edit/`, `LogoutView`, pytest suite
 
 **Best for:** Reusable UI fragments, slots, component scope, and combining components with forms and file-based routing

--- a/examples/components/README.md
+++ b/examples/components/README.md
@@ -13,14 +13,15 @@ This example demonstrates next-dj **components** in a small **blog** app (Englis
 | Inline `component = "..."` (no `component.djx`) | `root_components/version_stamp/component.py` (in footer) |
 | Branch scope (`pages/.../_components/` only under that subtree) | `pages/posts/_components/draft_banner.djx` on create/edit |
 | Root `layout.djx` as call site | `root_scope_badge` (`pages/_components/`) and `dirs_root_note` (`root_components/` via ``DIRS``). Use the layout for nested `{% component %}` so ``current_template_path`` is set. |
-| Slots + nested `{% component %}` | Home `template.djx` (`author_chip` inside `post_card`) |
+| Slots + nested components | Home `template.djx` (`#component` / `#slot`; `author_chip` inside `post_card`) |
+| Generic card + recommendations | `pages/_components/card/`, `recommendations/` (`@context` + nested `#component "card"`) |
 
 ## What This Example Demonstrates
 
 - **Simple components** — single `.djx` file (e.g. footer).
 - **Composite components** — folder with `component.djx` and/or `component.py`. `component.py` can register **component context** via `from next.components import context` and `@context` / `@context("key")` (similar to `next.pages.context`).
-- **Slots** — `{% component "post_card" %} ... {% slot "title" %} ... {% endslot %} ...` because `{% component %}` props are string literals only. Slots carry dynamic values from loops.
-- **author_chip** — small composite: default circular avatar (first letter of login) via `{% set_slot "avatar" %}`, plus a `login` slot for the username. Used inside `post_card` meta and on the post detail header.
+- **Slots** — Block `{% #component "post_card" %} ... {% #slot "title" %} ... {% /slot %} ... {% /component %}`. Void `{% component "header" %}` for components without inner markup. Props on the opening tag are string literals only; slots carry dynamic values from loops.
+- **author_chip** — small composite: default circular avatar (first letter of login) via `{% #set_slot "avatar" %}`, plus a `login` slot for the username. Used inside `post_card` meta and on the post detail header.
 - **Root components** (`root_components/`) are wired through ``NEXT_FRAMEWORK["DEFAULT_COMPONENT_BACKENDS"][0]["DIRS"]``. Simple **dirs_root_note** only exists to show that this tree is not under ``myapp/pages/``. Other files there (header, footer, version_stamp, server_time) are the real demo. Everything in that folder is visible from every template. **`pages/_components/`** is shared across all templates under `pages/`. **`root_scope_badge`** lives there and renders from **`layout.djx`** in the same directory as `page.py`, which matches the “root template + root `_components` subtree” case. **`pages/posts/_components/`** is only for templates under the `posts/` branch (see `draft_banner`).
 - **Layout** — `layout.djx` wraps pages. Global **header** is a composite with `@context("user")`, merged branding keys, and a nested **server_time** component using `render()`.
 - **Forms** — `@forms.action()` for register, login, create post, update post. ModelForm + `get_initial()` for edit.
@@ -42,10 +43,12 @@ components/
 │   └── pages/
 │       ├── layout.djx           # HTML shell, {% component header/footer %}
 │       ├── page.py              # Home: @context page_obj + Paginator
-│       ├── template.djx         # Article list + post_card slots + pagination
+│       ├── template.djx         # Article list + post_card slots + pagination + recommendations
 │       ├── _components/
 │       │   ├── root_scope_badge/  # Composite: layout.djx uses this from pages root (corner case)
 │       │   ├── post_card/       # Composite: title, meta (author + date), actions
+│       │   ├── card/            # Generic card (title, body, actions slots)
+│       │   ├── recommendations/ # @context + nested card components
 │       │   └── author_chip/     # Avatar (initial) + login slot
 │       ├── account/login/       # LoginForm + @forms.action("login")
 │       ├── account/register/

--- a/examples/components/myapp/pages/_components/author_chip/component.djx
+++ b/examples/components/myapp/pages/_components/author_chip/component.djx
@@ -3,9 +3,9 @@
 {% else %}
     <span class="d-inline-flex align-items-center gap-2">
 {% endif %}
-    {% set_slot "avatar" %}
+    {% #set_slot "avatar" %}
         <span aria-hidden="true" class="rounded-circle bg-secondary text-white d-inline-flex align-items-center justify-content-center fw-semibold user-select-none" style="width: 2rem; height: 2rem; font-size: 0.8rem;">{{ login|default:"?"|slice:":1"|upper }}</span>
-    {% endset_slot %}
+    {% /set_slot %}
     <span class="fw-medium text-body">{{ login }}</span>
 {% if profile_url %}
     </a>

--- a/examples/components/myapp/pages/_components/card/component.djx
+++ b/examples/components/myapp/pages/_components/card/component.djx
@@ -1,0 +1,7 @@
+<div class="card h-100 border-0 shadow-sm">
+    <div class="card-body d-flex flex-column">
+        <h2 class="card-title h5">{% set_slot "title" %}</h2>
+        <div class="flex-grow-1 small">{% set_slot "body" %}</div>
+        <div class="mt-auto pt-1">{% set_slot "actions" %}</div>
+    </div>
+</div>

--- a/examples/components/myapp/pages/_components/recommendations/component.djx
+++ b/examples/components/myapp/pages/_components/recommendations/component.djx
@@ -1,0 +1,14 @@
+<section class="mt-5 pt-4 border-top" aria-labelledby="rec-heading">
+    <h2 id="rec-heading" class="h5 mb-3">Recommended</h2>
+    <div class="row g-3">
+        {% for item in recommendation_items %}
+            <div class="col-md-6 col-lg-4">
+                {% #component "card" %}
+                    {% #slot "title" %}<a href="{{ item.get_absolute_url }}" class="text-decoration-none text-reset">{{ item.title }}</a>{% /slot %}
+                    {% #slot "body" %}<p class="text-muted small mb-0">{{ item.created_at|date:"M j, Y" }}</p>{% /slot %}
+                    {% #slot "actions" %}<a class="btn btn-outline-primary btn-sm" href="{{ item.get_absolute_url }}">View</a>{% /slot %}
+                {% /component %}
+            </div>
+        {% endfor %}
+    </div>
+</section>

--- a/examples/components/myapp/pages/_components/recommendations/component.py
+++ b/examples/components/myapp/pages/_components/recommendations/component.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from myapp.models import Post
+
+from next.components import context
+
+
+@context("recommendation_items")
+def recommendation_items() -> list[Post]:
+    """Latest posts for the recommendations strip (detail page and home)."""
+    return list(Post.objects.select_related("author").order_by("-created_at")[:3])

--- a/examples/components/myapp/pages/authors/[int:id]/template.djx
+++ b/examples/components/myapp/pages/authors/[int:id]/template.djx
@@ -9,25 +9,25 @@
     <p class="text-muted small mb-0">@{{ author_user.username }}</p>
 </div>
 <div class="d-flex align-items-start gap-3 mb-4">
-    {% component "author_chip" %}
-        {% slot "login" %}{{ author_user.username }}{% endslot %}
-    {% endcomponent %}
+    {% #component "author_chip" %}
+        {% #slot "login" %}{{ author_user.username }}{% /slot %}
+    {% /component %}
 </div>
 <h2 class="h5 mb-3">Posts</h2>
 <div class="row g-3">
     {% for post in author_posts %}
         <div class="col-md-6">
-            {% component "post_card" %}
-                {% slot "title" %}{{ post.title }}{% endslot %}
-                {% slot "meta" %}
+            {% #component "post_card" %}
+                {% #slot "title" %}{{ post.title }}{% /slot %}
+                {% #slot "meta" %}
                     <div class="text-muted small">
                         <time datetime="{{ post.created_at|date:'c' }}">{{ post.created_at|date:"M j, Y" }}</time>
                     </div>
-                {% endslot %}
-                {% slot "actions" %}
+                {% /slot %}
+                {% #slot "actions" %}
                     <a href="{{ post.get_absolute_url }}" class="btn btn-outline-primary btn-sm align-self-start">View</a>
-                {% endslot %}
-            {% endcomponent %}
+                {% /slot %}
+            {% /component %}
         </div>
     {% empty %}
         <p class="text-muted">No posts yet.</p>

--- a/examples/components/myapp/pages/layout.djx
+++ b/examples/components/myapp/pages/layout.djx
@@ -7,16 +7,16 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body class="bg-light d-flex flex-column min-vh-100">
-    {% component "header" %}{% endcomponent %}
+    {% component "header" %}
     <main class="container py-4 flex-grow-1">
         <aside class="alert alert-secondary py-2 small mb-3" role="note" data-testid="root-scope-corner">
-            {% component "root_scope_badge" %}{% endcomponent %}
+            {% component "root_scope_badge" %}
             <span class="ms-2 align-middle" data-testid="dirs-root-note">
-                {% component "dirs_root_note" %}{% endcomponent %}
+                {% component "dirs_root_note" %}
             </span>
         </aside>
         {% block template %}{% endblock %}
     </main>
-    {% component "footer" %}{% endcomponent %}
+    {% component "footer" %}
 </body>
 </html>

--- a/examples/components/myapp/pages/posts/[int:id]/details/template.djx
+++ b/examples/components/myapp/pages/posts/[int:id]/details/template.djx
@@ -6,10 +6,10 @@
         {% endif %}
     </div>
     <div class="d-flex flex-wrap align-items-center gap-3 mb-4 text-muted small">
-        {% component "author_chip" %}
-            {% slot "profile_url" %}/authors/{{ post.author.id }}/{% endslot %}
-            {% slot "login" %}{{ post.author.username }}{% endslot %}
-        {% endcomponent %}
+        {% #component "author_chip" %}
+            {% #slot "profile_url" %}/authors/{{ post.author.id }}/{% /slot %}
+            {% #slot "login" %}{{ post.author.username }}{% /slot %}
+        {% /component %}
         <time datetime="{{ post.created_at|date:'c' }}">Published {{ post.created_at|date:"F j, Y, P" }}</time>
     </div>
     <div class="post-content mb-5">
@@ -21,21 +21,21 @@
     <div class="row g-3">
         {% for item in recommended %}
             <div class="col-md-4">
-                {% component "post_card" %}
-                    {% slot "title" %}{{ item.title }}{% endslot %}
-                    {% slot "meta" %}
+                {% #component "post_card" %}
+                    {% #slot "title" %}{{ item.title }}{% /slot %}
+                    {% #slot "meta" %}
                         <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 text-muted">
-                            {% component "author_chip" %}
-                                {% slot "profile_url" %}/authors/{{ item.author.id }}/{% endslot %}
-                                {% slot "login" %}{{ item.author.username }}{% endslot %}
-                            {% endcomponent %}
+                            {% #component "author_chip" %}
+                                {% #slot "profile_url" %}/authors/{{ item.author.id }}/{% /slot %}
+                                {% #slot "login" %}{{ item.author.username }}{% /slot %}
+                            {% /component %}
                             <time datetime="{{ item.created_at|date:'c' }}">{{ item.created_at|date:"M j, Y" }}</time>
                         </div>
-                    {% endslot %}
-                    {% slot "actions" %}
+                    {% /slot %}
+                    {% #slot "actions" %}
                         <a href="{{ item.get_absolute_url }}" class="btn btn-outline-primary btn-sm align-self-start">View</a>
-                    {% endslot %}
-                {% endcomponent %}
+                    {% /slot %}
+                {% /component %}
             </div>
         {% empty %}
             <p class="text-muted small">No other posts.</p>

--- a/examples/components/myapp/pages/posts/[int:id]/edit/template.djx
+++ b/examples/components/myapp/pages/posts/[int:id]/edit/template.djx
@@ -1,5 +1,5 @@
 <h1 class="h3 mb-4">Edit post</h1>
-{% component "draft_banner" %}{% endcomponent %}
+{% component "draft_banner" %}
 {% form @action="update_post" %}
     <div class="mb-3">
         <label class="form-label" for="id_title">Title</label>

--- a/examples/components/myapp/pages/posts/create/template.djx
+++ b/examples/components/myapp/pages/posts/create/template.djx
@@ -1,5 +1,5 @@
 <h1 class="h3 mb-4">New post</h1>
-{% component "draft_banner" %}{% endcomponent %}
+{% component "draft_banner" %}
 {% form @action="create_post" %}
     <div class="mb-3">
         <label class="form-label" for="id_title">Title</label>

--- a/examples/components/myapp/pages/template.djx
+++ b/examples/components/myapp/pages/template.djx
@@ -7,21 +7,21 @@
 <div class="row g-3">
     {% for post in page %}
         <div class="col-md-6">
-            {% component "post_card" %}
-                {% slot "title" %}{{ post.title }}{% endslot %}
-                {% slot "meta" %}
+            {% #component "post_card" %}
+                {% #slot "title" %}{{ post.title }}{% /slot %}
+                {% #slot "meta" %}
                     <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 text-muted">
-                        {% component "author_chip" %}
-                            {% slot "profile_url" %}/authors/{{ post.author.id }}/{% endslot %}
-                            {% slot "login" %}{{ post.author.username }}{% endslot %}
-                        {% endcomponent %}
+                        {% #component "author_chip" %}
+                            {% #slot "profile_url" %}/authors/{{ post.author.id }}/{% /slot %}
+                            {% #slot "login" %}{{ post.author.username }}{% /slot %}
+                        {% /component %}
                         <time datetime="{{ post.created_at|date:'c' }}">{{ post.created_at|date:"M j, Y" }}</time>
                     </div>
-                {% endslot %}
-                {% slot "actions" %}
+                {% /slot %}
+                {% #slot "actions" %}
                     <a href="{{ post.get_absolute_url }}" class="btn btn-outline-primary btn-sm align-self-start">View</a>
-                {% endslot %}
-            {% endcomponent %}
+                {% /slot %}
+            {% /component %}
         </div>
     {% empty %}
         <p class="text-muted">No posts yet.</p>
@@ -46,3 +46,4 @@
         </ul>
     </nav>
 {% endif %}
+{% component "recommendations" %}

--- a/examples/components/root_components/footer.djx
+++ b/examples/components/root_components/footer.djx
@@ -1,7 +1,11 @@
-<footer class="border-top mt-auto py-3 bg-white">
-    <div class="container text-muted small d-flex flex-wrap align-items-center gap-3">
-        <span>&copy; {% now "Y" %} Blog</span>
-        {% component "newsletter_subscribe" %}{% endcomponent %}
-        {% component "version_stamp" %}{% endcomponent %}
+<footer class="border-top bg-white mt-auto py-4">
+    <div class="container">
+        <div class="d-flex flex-wrap justify-content-between align-items-center gap-3 small text-muted">
+            <span>© {% now "Y" %} Blog</span>
+            <div class="d-flex flex-wrap gap-3 align-items-center">
+                {% component "newsletter_subscribe" %}
+                {% component "version_stamp" %}
+            </div>
+        </div>
     </div>
 </footer>

--- a/examples/components/root_components/header/component.djx
+++ b/examples/components/root_components/header/component.djx
@@ -2,7 +2,7 @@
     <nav class="container py-3 d-flex flex-wrap justify-content-between align-items-center gap-2">
         <a href="/" class="text-decoration-none fs-5 {% if request.path == '/' %}fw-bold text-primary{% else %}fw-semibold text-body{% endif %}">{{ site_brand_title }}</a>
         <span class="small text-muted align-self-center d-none d-sm-inline">{{ site_brand_subtitle }}</span>
-        {% component "server_time" %}{% endcomponent %}
+        {% component "server_time" %}
         <div class="d-flex flex-wrap gap-2 align-items-center">
             {% if user.is_authenticated %}
                 <a href="/account/profile/" class="btn btn-sm {% if request.path == '/account/profile/' %}btn-primary{% else %}btn-outline-primary{% endif %}">Profile</a>

--- a/examples/components/tests/tests.py
+++ b/examples/components/tests/tests.py
@@ -84,6 +84,7 @@ def test_home_lists_posts_and_header(client) -> None:
     assert "writer" in text
     assert "/authors/" in text
     assert "View" in text
+    assert "Recommended" in text
 
 
 @pytest.mark.django_db()
@@ -687,30 +688,3 @@ def test_render_root_scope_badge_from_layout_path(layout_template: Path) -> None
     assert info is not None
     html = render_component(info, {})
     assert "Root scope badge" in html
-
-
-def test_example_includes_expected_component_artifacts() -> None:
-    """Stable disk layout for documented demos (simple, composite, branch scope)."""
-    assert (
-        example_root
-        / "myapp"
-        / "pages"
-        / "_components"
-        / "root_scope_badge"
-        / "component.djx"
-    ).exists()
-    assert (example_root / "root_components" / "dirs_root_note.djx").exists()
-    assert (
-        example_root / "myapp" / "pages" / "_components" / "post_card" / "component.djx"
-    ).exists()
-    assert (
-        example_root / "myapp" / "pages" / "posts" / "_components" / "draft_banner.djx"
-    ).exists()
-    assert (example_root / "root_components" / "header" / "component.py").exists()
-    assert (example_root / "root_components" / "server_time" / "component.py").exists()
-    assert (
-        example_root / "root_components" / "version_stamp" / "component.py"
-    ).exists()
-    assert not (
-        example_root / "root_components" / "version_stamp" / "component.djx"
-    ).exists()

--- a/next/templatetags/components.py
+++ b/next/templatetags/components.py
@@ -1,20 +1,28 @@
-"""Template tags for next-dj components (``{% component %}``, slots).
+"""Template tags for next-dj components (void/block ``{% component %}``, slots).
 
-Resolve from ``current_template_path``, collect nested ``{% slot %}`` blocks, and
-pass props and slot HTML to the renderer.
+Resolve from ``current_template_path``, collect nested ``{% #slot %}`` /
+``{% slot %}`` blocks, and pass props and slot HTML to the renderer.
+
+In component templates, use ``{% #set_slot %}`` … ``{% /set_slot %}`` or the
+short void ``{% set_slot "name" %}`` when there is no default slot body.
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
 from django import template
+from django.template import base as template_base
 from django.template.base import Node, NodeList, Parser, Token
 
 from next.components import get_component, render_component
 
+
+# Allow line breaks inside ``{% ... %}`` (multiline tag bodies).
+template_base.tag_re = re.compile(template_base.tag_re.pattern, re.DOTALL)
 
 register = template.Library()
 
@@ -22,11 +30,14 @@ _COMPONENT_NAME_INDEX = 1
 _SLOT_ARG_COUNT = 2
 _COMPONENT_MIN_BITS = 2
 
-_END_COMPONENT = ("endcomponent", "/component")
-_END_SLOT = ("endslot", "/slot")
-_END_SET_SLOT = ("endset_slot", "/set_slot")
+_END_BLOCK_COMPONENT = ("/component",)
+_END_BLOCK_SLOT = ("/slot",)
+_END_BLOCK_SET_SLOT = ("/set_slot",)
 
-# Slot collection uses this key during parent `{% component %}` body render
+_SHORT_SLOT_EMPTY_NAME = "{% slot %} tag requires a quoted slot name"
+_SHORT_SET_SLOT_EMPTY_NAME = "{% set_slot %} tag requires a quoted slot name"
+
+# Slot collection uses this key during parent ``{% #component %}`` body render
 _INTERNAL_CONTEXT_KEYS = frozenset({"_component_slots"})
 
 
@@ -34,9 +45,20 @@ def _strip_quotes(raw: str) -> str:
     return raw.strip("'\"").strip()
 
 
+def _parse_literal_props(bits: list[str], start: int) -> dict[str, str]:
+    """Parse ``key="value"`` pairs from tag bits starting at *start*."""
+    props: dict[str, str] = {}
+    for part in bits[start:]:
+        if "=" not in part:
+            continue
+        key, _, val = part.partition("=")
+        props[key.strip()] = _strip_quotes(val)
+    return props
+
+
 @dataclass(frozen=True, slots=True)
 class _NamedBlockSpec:
-    """Arguments shared by ``{% slot %}`` and ``{% set_slot %}`` compilation."""
+    """Arguments shared by ``{% #slot %}`` and ``{% #set_slot %}`` compilation."""
 
     end_tokens: tuple[str, ...]
     expected_bits: int
@@ -49,7 +71,7 @@ def _parse_one_named_block(
     token: Token,
     spec: _NamedBlockSpec,
 ) -> tuple[str, NodeList]:
-    """Parse ``tag "name"`` … ``end`` into a name and inner node list."""
+    """Parse ``tag "name"`` … ``/end`` into a name and inner node list."""
     bits = token.split_contents()
     if len(bits) != spec.expected_bits:
         raise template.TemplateSyntaxError(spec.wrong_arity_message)
@@ -62,7 +84,7 @@ def _parse_one_named_block(
 
 
 class SlotNode(Node):
-    """Renders the slot body and records it by name when under ``{% component %}``."""
+    """Renders the slot body and records it by name when under ``{% #component %}``."""
 
     def __init__(self, name: str, nodelist: NodeList) -> None:
         """Remember the slot name and nested nodes."""
@@ -128,6 +150,7 @@ class ComponentNode(Node):
         for key in _INTERNAL_CONTEXT_KEYS:
             parent_flat.pop(key, None)
         render_ctx: dict[str, Any] = {**parent_flat, **self.props}
+        render_ctx["current_template_path"] = path
         render_ctx["children"] = "".join(child_chunks)
 
         for slot_name, content in slots.items():
@@ -157,8 +180,8 @@ class SetSlotNode(Node):
 
 
 @register.tag(name="component")
-def do_component(parser: Parser, token: Token) -> ComponentNode:
-    """Compile ``{% component "name" … %}`` … ``{% endcomponent %}``."""
+def do_component(_parser: Parser, token: Token) -> ComponentNode:
+    """Compile void ``{% component "name" … %}`` (no body, no closing tag)."""
     bits = token.split_contents()
     if len(bits) < _COMPONENT_MIN_BITS:
         msg = "{% component %} tag requires at least a component name"
@@ -167,41 +190,79 @@ def do_component(parser: Parser, token: Token) -> ComponentNode:
     if not name:
         msg = "{% component %} tag requires a quoted component name"
         raise template.TemplateSyntaxError(msg)
-    props: dict[str, str] = {}
-    for part in bits[2:]:
-        if "=" not in part:
-            continue
-        key, _, val = part.partition("=")
-        props[key.strip()] = _strip_quotes(val)
-    nodelist = parser.parse(_END_COMPONENT)
+    props = _parse_literal_props(bits, 2)
+    return ComponentNode(name=name, props=props, nodelist=NodeList())
+
+
+@register.tag(name="#component")
+def do_block_component(parser: Parser, token: Token) -> ComponentNode:
+    """Compile ``{% #component "name" … %}`` … ``{% /component %}``."""
+    bits = token.split_contents()
+    if len(bits) < _COMPONENT_MIN_BITS:
+        msg = "{% #component %} tag requires at least a component name"
+        raise template.TemplateSyntaxError(msg)
+    name = _strip_quotes(bits[_COMPONENT_NAME_INDEX])
+    if not name:
+        msg = "{% #component %} tag requires a quoted component name"
+        raise template.TemplateSyntaxError(msg)
+    props = _parse_literal_props(bits, 2)
+    nodelist = parser.parse(_END_BLOCK_COMPONENT)
     parser.delete_first_token()
     return ComponentNode(name=name, props=props, nodelist=nodelist)
 
 
-_SLOT_SPEC = _NamedBlockSpec(
-    end_tokens=_END_SLOT,
+_BLOCK_SLOT_SPEC = _NamedBlockSpec(
+    end_tokens=_END_BLOCK_SLOT,
     expected_bits=_SLOT_ARG_COUNT,
-    empty_name_message="{% slot %} tag requires a quoted slot name",
-    wrong_arity_message="{% slot %} tag requires exactly one argument: slot name",
+    empty_name_message="{% #slot %} tag requires a quoted slot name",
+    wrong_arity_message="{% #slot %} tag requires exactly one argument: slot name",
 )
 
 _SET_SLOT_SPEC = _NamedBlockSpec(
-    end_tokens=_END_SET_SLOT,
+    end_tokens=_END_BLOCK_SET_SLOT,
     expected_bits=_SLOT_ARG_COUNT,
-    empty_name_message="{% set_slot %} tag requires a quoted slot name",
-    wrong_arity_message=("{% set_slot %} tag requires exactly one argument: slot name"),
+    empty_name_message="{% #set_slot %} tag requires a quoted slot name",
+    wrong_arity_message=(
+        "{% #set_slot %} tag requires exactly one argument: slot name"
+    ),
 )
 
 
-@register.tag(name="slot")
-def do_slot(parser: Parser, token: Token) -> SlotNode:
-    """Compile ``{% slot "name" %}`` … ``{% endslot %}``."""
-    name, nodelist = _parse_one_named_block(parser, token, _SLOT_SPEC)
+@register.tag(name="#slot")
+def do_block_slot(parser: Parser, token: Token) -> SlotNode:
+    """Compile ``{% #slot "name" %}`` … ``{% /slot %}``."""
+    name, nodelist = _parse_one_named_block(parser, token, _BLOCK_SLOT_SPEC)
     return SlotNode(name=name, nodelist=nodelist)
 
 
-@register.tag(name="set_slot")
-def do_set_slot(parser: Parser, token: Token) -> SetSlotNode:
-    """Compile ``{% set_slot "name" %}`` … ``{% endset_slot %}``."""
+@register.tag(name="slot")
+def do_short_slot(_parser: Parser, token: Token) -> SlotNode:
+    """Compile empty ``{% slot "name" %}`` (short slot, no body)."""
+    bits = token.split_contents()
+    if len(bits) != _SLOT_ARG_COUNT:
+        msg = "{% slot %} short form requires exactly one quoted slot name"
+        raise template.TemplateSyntaxError(msg)
+    name = _strip_quotes(bits[_COMPONENT_NAME_INDEX])
+    if not name:
+        raise template.TemplateSyntaxError(_SHORT_SLOT_EMPTY_NAME)
+    return SlotNode(name=name, nodelist=NodeList())
+
+
+@register.tag(name="#set_slot")
+def do_block_set_slot(parser: Parser, token: Token) -> SetSlotNode:
+    """Compile ``{% #set_slot "name" %}`` … ``{% /set_slot %}``."""
     name, nodelist = _parse_one_named_block(parser, token, _SET_SLOT_SPEC)
     return SetSlotNode(name=name, nodelist=nodelist)
+
+
+@register.tag(name="set_slot")
+def do_short_set_slot(_parser: Parser, token: Token) -> SetSlotNode:
+    """Compile empty ``{% set_slot "name" %}`` (no default body, no closing tag)."""
+    bits = token.split_contents()
+    if len(bits) != _SLOT_ARG_COUNT:
+        msg = "{% set_slot %} short form requires exactly one quoted slot name"
+        raise template.TemplateSyntaxError(msg)
+    name = _strip_quotes(bits[_COMPONENT_NAME_INDEX])
+    if not name:
+        raise template.TemplateSyntaxError(_SHORT_SET_SLOT_EMPTY_NAME)
+    return SetSlotNode(name=name, nodelist=NodeList())

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -696,7 +696,7 @@ class TestComponentContextManager:
 
 
 class TestComponentTag:
-    """Tests for {% component %} and {% endcomponent %} tags."""
+    """Tests for void ``{% component %}`` and block ``{% #component %}`` tags."""
 
     def test_component_tag_requires_name(self) -> None:
         """{% component %} without name raises TemplateSyntaxError."""
@@ -706,27 +706,38 @@ class TestComponentTag:
     def test_component_tag_requires_quoted_name(self) -> None:
         """{% component %} with empty quoted name raises."""
         with pytest.raises(TemplateSyntaxError, match="quoted"):
-            Template('{% load components %}{% component "" %}{% endcomponent %}')
+            Template('{% load components %}{% component "" %}')
+
+    def test_legacy_endcomponent_is_invalid(self) -> None:
+        """{% endcomponent %} is not a registered tag."""
+        with pytest.raises(TemplateSyntaxError, match="endcomponent"):
+            Template("{% load components %}{% endcomponent %}")
+
+    def test_block_component_requires_name_token(self) -> None:
+        """{% #component %} without a name raises."""
+        with pytest.raises(TemplateSyntaxError, match="#component"):
+            Template("{% load components %}{% #component %}")
+
+    def test_block_component_requires_non_empty_quoted_name(self) -> None:
+        """{% #component %} with empty quoted name raises."""
+        with pytest.raises(TemplateSyntaxError, match="quoted"):
+            Template('{% load components %}{% #component "" %}{% /component %}')
 
     def test_component_tag_renders_empty_without_path_in_context(self) -> None:
         """When current_template_path is missing, component renders empty."""
-        t = Template(
-            '{% load components %}{% component "card" title="Hi" %}{% endcomponent %}'
-        )
+        t = Template('{% load components %}{% component "card" title="Hi" %}')
         result = t.render(Context({}))
         assert result == ""
 
     def test_component_tag_renders_empty_when_path_not_str_or_path(self) -> None:
         """When current_template_path is not str/Path (e.g. int), component renders empty."""
-        t = Template('{% load components %}{% component "card" %}{% endcomponent %}')
+        t = Template('{% load components %}{% component "card" %}')
         result = t.render(Context({"current_template_path": 42}))
         assert result == ""
 
     def test_component_tag_renders_empty_when_component_not_found(self) -> None:
         """When component is not resolved, renders empty."""
-        t = Template(
-            '{% load components %}{% component "nonexistent" %}{% endcomponent %}'
-        )
+        t = Template('{% load components %}{% component "nonexistent" %}')
         with patch("next.templatetags.components.get_component", return_value=None):
             result = t.render(
                 Context({"current_template_path": "/app/pages/home/template.djx"}),
@@ -748,10 +759,7 @@ class TestComponentTag:
                 is_simple=True,
             ),
         ):
-            t = Template(
-                "{% load components %}"
-                '{% component "card" title="Hello" %}{% endcomponent %}'
-            )
+            t = Template('{% load components %}{% component "card" title="Hello" %}')
             result = t.render(
                 Context({"current_template_path": str(tmp_path / "template.djx")}),
             )
@@ -777,9 +785,7 @@ class TestComponentTag:
                 is_simple=True,
             ),
         ):
-            t = Template(
-                '{% load components %}{% component "banner" %}{% endcomponent %}'
-            )
+            t = Template('{% load components %}{% component "banner" %}')
             result = t.render(
                 Context(
                     {
@@ -808,8 +814,7 @@ class TestComponentTag:
             ),
         ):
             t = Template(
-                "{% load components %}"
-                '{% component "chip" title="from_prop" %}{% endcomponent %}'
+                '{% load components %}{% component "chip" title="from_prop" %}'
             )
             result = t.render(
                 Context(
@@ -829,11 +834,13 @@ class TestComponentTag:
             "get_component",
             return_value=None,
         ):
-            t = Template('{% load components %}{% component "c" %}{% endcomponent %}')
+            t = Template('{% load components %}{% component "c" %}')
             t.render(Context({"current_template_path": tmp_path / "t.djx"}))
 
-    def test_component_tag_with_slots_passes_slot_content(self, tmp_path: Path) -> None:
-        """When component body has {% slot %}, content is passed to component."""
+    def test_block_component_with_slots_passes_slot_content(
+        self, tmp_path: Path
+    ) -> None:
+        """When #component body has #slot, content is passed to component."""
         (tmp_path / "box.djx").write_text(
             '<div class="box">{{ slot_image }} {{ children }}</div>',
         )
@@ -851,10 +858,10 @@ class TestComponentTag:
         ):
             t = Template(
                 "{% load components %}"
-                '{% component "box" %}'
-                '{% slot "image" %}<img src="x"/>{% endslot %}'
+                '{% #component "box" %}'
+                '{% #slot "image" %}<img src="x"/>{% /slot %}'
                 "kids"
-                "{% endcomponent %}"
+                "{% /component %}"
             )
             result = t.render(
                 Context({"current_template_path": str(tmp_path / "template.djx")}),
@@ -877,10 +884,7 @@ class TestComponentTag:
                 is_simple=True,
             ),
         ):
-            t = Template(
-                "{% load components %}"
-                '{% component "card" title="My Title" %}{% endcomponent %}'
-            )
+            t = Template('{% load components %}{% component "card" title="My Title" %}')
             result = t.render(
                 Context({"current_template_path": str(tmp_path / "t.djx")}),
             )
@@ -902,89 +906,172 @@ class TestComponentTag:
             ),
         ):
             t = Template(
-                "{% load components %}"
-                '{% component "card" orphan title="Kept" %}{% endcomponent %}'
+                '{% load components %}{% component "card" orphan title="Kept" %}'
             )
             result = t.render(
                 Context({"current_template_path": str(tmp_path / "t.djx")}),
             )
         assert "Kept" in result
 
+    def test_nested_components_three_levels(self, tmp_path: Path) -> None:
+        """{% #component %} inside component.djx resolves nested names."""
+        (tmp_path / "inner.djx").write_text("<i>inner</i>")
+        (tmp_path / "mid.djx").write_text(
+            '{% #component "inner" %}{% /component %}',
+        )
+        (tmp_path / "outer.djx").write_text(
+            '{% #component "mid" %}{% /component %}',
+        )
 
-class TestSlotTag:
-    """Tests for {% slot %} and {% endslot %} tags."""
-
-    def test_slot_tag_requires_name(self) -> None:
-        """{% slot %} without name raises TemplateSyntaxError."""
-        with pytest.raises(TemplateSyntaxError, match="slot"):
-            Template(
-                "{% load components %}"
-                '{% component "c" %}{% slot %}{% endslot %}{% endcomponent %}'
+        def fake_get(name: str, _: Path) -> ComponentInfo | None:
+            mapping = {
+                "outer": tmp_path / "outer.djx",
+                "mid": tmp_path / "mid.djx",
+                "inner": tmp_path / "inner.djx",
+            }
+            p = mapping.get(name)
+            if p is None:
+                return None
+            return ComponentInfo(
+                name=name,
+                scope_root=tmp_path,
+                scope_relative="",
+                template_path=p,
+                module_path=None,
+                is_simple=True,
             )
 
-    def test_slot_tag_requires_exactly_one_arg(self) -> None:
-        """{% slot %} with 0 or 3 args raises."""
+        with patch.object(components_manager, "get_component", side_effect=fake_get):
+            t = Template(
+                "{% load components %}{% #component 'outer' %}{% /component %}",
+            )
+            result = t.render(
+                Context({"current_template_path": str(tmp_path / "page.djx")}),
+            )
+        assert "<i>inner</i>" in result
+
+    def test_orphan_slash_component_raises(self) -> None:
+        """{% /component %} without opening #component raises."""
+        with pytest.raises(TemplateSyntaxError, match="/component"):
+            Template("{% load components %}{% /component %}")
+
+
+class TestSlotTag:
+    """Tests for ``{% #slot %}``, ``{% /slot %}``, and short ``{% slot %}``."""
+
+    def test_block_slot_tag_requires_name(self) -> None:
+        """{% #slot %} without name raises TemplateSyntaxError."""
+        with pytest.raises(TemplateSyntaxError, match="#slot"):
+            Template(
+                "{% load components %}"
+                '{% #component "c" %}{% #slot %}{% /slot %}{% /component %}'
+            )
+
+    def test_block_slot_tag_requires_exactly_one_arg(self) -> None:
+        """{% #slot %} with wrong arity raises."""
         with pytest.raises(TemplateSyntaxError, match="exactly one"):
             Template(
                 "{% load components %}"
-                '{% component "c" %}{% slot "a" "b" %}{% endslot %}{% endcomponent %}'
+                '{% #component "c" %}{% #slot "a" "b" %}{% /slot %}{% /component %}'
             )
 
-    def test_slot_tag_requires_quoted_name(self) -> None:
-        """{% slot %} with empty name raises."""
+    def test_short_slot_requires_quoted_name(self) -> None:
+        """{% slot %} short form with empty name raises."""
         with pytest.raises(TemplateSyntaxError, match="quoted slot name"):
             Template(
-                "{% load components %}"
-                '{% component "c" %}{% slot "" %}{% endslot %}{% endcomponent %}'
+                '{% load components %}{% #component "c" %}{% slot "" %}{% /component %}'
             )
 
-    def test_slot_tag_parses(self) -> None:
-        r"""{% slot "x" %} ... {% endslot %} parses inside component."""
+    def test_short_slot_requires_exactly_one_name(self) -> None:
+        """{% slot %} short form with two names raises."""
+        with pytest.raises(TemplateSyntaxError, match="exactly one"):
+            Template(
+                "{% load components %}"
+                '{% #component "c" %}{% slot "a" "b" %}{% /component %}'
+            )
+
+    def test_block_slot_parses_inside_block_component(self) -> None:
+        """{% #slot %} … {% /slot %} parses inside {% #component %}."""
         t = Template(
             "{% load components %}"
-            '{% component "c" %}'
-            '{% slot "image" %}<img/>{% endslot %}'
-            "{% endcomponent %}"
+            '{% #component "c" %}'
+            '{% #slot "image" %}<img/>{% /slot %}'
+            "{% /component %}"
         )
         t.render(Context({"current_template_path": "/x"}))
 
-
-class TestSetSlotTag:
-    """Tests for {% set_slot %} and {% endset_slot %} tags."""
-
-    def test_set_slot_requires_name(self) -> None:
-        """{% set_slot %} without name raises TemplateSyntaxError."""
-        with pytest.raises(TemplateSyntaxError, match="set_slot"):
-            Template("{% load components %}{% set_slot %}fallback{% endset_slot %}")
-
-    def test_set_slot_requires_quoted_name(self) -> None:
-        """{% set_slot %} with empty quoted name raises."""
-        with pytest.raises(TemplateSyntaxError, match="quoted slot name"):
-            Template('{% load components %}{% set_slot "" %}x{% endset_slot %}')
-
-    def test_set_slot_renders_fallback_when_slot_empty(self) -> None:
-        r"""{% set_slot "x" %}fallback{% endset_slot %} renders fallback when slot not in context."""
+    def test_short_slot_parses_inside_block_component(self) -> None:
+        """{% slot "name" %} short form compiles inside {% #component %}."""
         t = Template(
             "{% load components %}"
-            '{% set_slot "avatar" %}<span>default</span>{% endset_slot %}'
+            '{% #component "c" %}{% slot "footer" %}{% /component %}'
+        )
+        t.render(Context({"current_template_path": "/x"}))
+
+    def test_orphan_slash_slot_raises(self) -> None:
+        """{% /slot %} without opening #slot raises."""
+        with pytest.raises(TemplateSyntaxError, match="/slot"):
+            Template("{% load components %}{% /slot %}")
+
+
+class TestSetSlotTag:
+    """Tests for ``{% #set_slot %}``, ``{% /set_slot %}``, and short ``{% set_slot %}``."""
+
+    def test_set_slot_requires_name(self) -> None:
+        """{% #set_slot %} without name raises TemplateSyntaxError."""
+        with pytest.raises(TemplateSyntaxError, match="#set_slot"):
+            Template("{% load components %}{% #set_slot %}fallback{% /set_slot %}")
+
+    def test_set_slot_requires_quoted_name(self) -> None:
+        """{% #set_slot %} with empty quoted name raises."""
+        with pytest.raises(TemplateSyntaxError, match="quoted slot name"):
+            Template('{% load components %}{% #set_slot "" %}x{% /set_slot %}')
+
+    def test_set_slot_renders_fallback_when_slot_empty(self) -> None:
+        r"""{% #set_slot %} renders fallback when slot not in context."""
+        t = Template(
+            "{% load components %}"
+            '{% #set_slot "avatar" %}<span>default</span>{% /set_slot %}'
         )
         result = t.render(Context({}))
         assert "<span>default</span>" in result
 
     def test_set_slot_renders_slot_content_when_in_context(self) -> None:
-        """{% set_slot %} renders slot_xxx from context when present."""
+        """{% #set_slot %} renders slot_xxx from context when present."""
         t = Template(
             "{% load components %}"
-            '{% set_slot "avatar" %}<span>default</span>{% endset_slot %}'
+            '{% #set_slot "avatar" %}<span>default</span>{% /set_slot %}'
         )
         result = t.render(Context({"slot_avatar": '<img src="x"/>'}))
         assert '<img src="x"/>' in result
 
-    def test_set_slot_uses_slash_end_tag(self) -> None:
-        """{% set_slot %} can be closed with {% /set_slot %}."""
-        t = Template('{% load components %}{% set_slot "x" %}fallback{% /set_slot %}')
-        result = t.render(Context({}))
-        assert "fallback" in result
+    def test_orphan_slash_set_slot_raises(self) -> None:
+        """{% /set_slot %} without opening #set_slot raises."""
+        with pytest.raises(TemplateSyntaxError, match="/set_slot"):
+            Template("{% load components %}{% /set_slot %}")
+
+    def test_short_set_slot_renders_empty_when_slot_missing(self) -> None:
+        """{% set_slot "x" %} void form has no default; empty when slot absent."""
+        t = Template('{% load components %}{% set_slot "label" %}')
+        assert t.render(Context({})) == ""
+
+    def test_short_set_slot_renders_slot_from_context(self) -> None:
+        """Short {% set_slot %} prefers injected slot HTML from context."""
+        t = Template('{% load components %}{% set_slot "avatar" %}')
+        result = t.render(Context({"slot_avatar": "<b>ok</b>"}))
+        assert "<b>ok</b>" in result
+
+    def test_short_set_slot_requires_exactly_one_name(self) -> None:
+        """{% set_slot %} short form with two names raises."""
+        with pytest.raises(TemplateSyntaxError, match="exactly one"):
+            Template(
+                '{% load components %}{% set_slot "a" "b" %}',
+            )
+
+    def test_short_set_slot_empty_name_raises(self) -> None:
+        """{% set_slot "" %} raises."""
+        with pytest.raises(TemplateSyntaxError, match="quoted slot name"):
+            Template('{% load components %}{% set_slot "" %}')
 
 
 class TestModuleCache:


### PR DESCRIPTION
## Summary

**Main goal:** make **nested components work reliably** — any depth of `{% component %}` / `{% #component %}` inside `component.djx` (and other templates), with resolution consistent with the **page’s** component scope.

Previously, nested calls from a component template could fail to resolve or render correctly because the inner render context did not reliably carry **`current_template_path`**. This PR **sets that path explicitly** on the render context passed into each component so inner tags see the same visibility rules as the outer page (`FileComponentsBackend` / `ComponentVisibilityResolver`).

The **syntax overhaul** (void `{% component %}`, block `{% #component %}` / `{% /component %}`, `#slot` / `slot`, `#set_slot` / `set_slot`, removal of `endcomponent` / `endslot` / `endset_slot`) is the **packaging** for that behavior: clearer call sites, optional `re.DOTALL` on `tag_re` for multiline tags (see django-simple-components), and docs/examples updated end-to-end.

## What changed (high level)

1. **Nested components** — explicit `current_template_path` on render context + tests for multi-level nesting.
2. **New component tag surface** — as above; **breaking** for anyone still on `{% endcomponent %}` etc.
3. **Docs + `examples/components`** — migrated; added **card** and **recommendations** to show nesting + `@context`.

## Breaking changes

*(unchanged table / bullets — legacy closing tags removed)*

Full guidelines: [CONTRIBUTING.md](https://github.com/next-dj/next-dj/blob/main/CONTRIBUTING.md)
