### PR TITLE
feat(core): added static collector to file router

### DIFF
--- a/docs/content/api/reference.rst
+++ b/docs/content/api/reference.rst
@@ -29,9 +29,10 @@ Scoped reusable template fragments, backends, and rendering helpers. See :doc:`/
 Static assets (next.static)
 ---------------------------
 
-Co-located CSS/JS discovery, the ``/_next/static/`` serving view, and the
-``{% collect_styles %}`` / ``{% collect_scripts %}`` / ``{% use_style %}`` /
-``{% use_script %}`` template tags. See :doc:`/content/guide/static-assets`
+Co-located CSS/JS discovery, staticfiles integration via
+``next.static.NextStaticFilesFinder``, and the ``{% collect_styles %}`` /
+``{% collect_scripts %}`` / ``{% use_style %}`` / ``{% use_script %}``
+template tags. See :doc:`/content/guide/static-assets`
 for usage, settings, and examples.
 
 .. automodule:: next.static
@@ -103,7 +104,7 @@ Single dictionary in Django settings. Top-level keys (each optional beyond defau
 * ``DEFAULT_PAGE_BACKENDS`` — list of file-router backend dicts (``BACKEND``, ``PAGES_DIR``, ``APP_DIRS``, ``DIRS``, ``OPTIONS``, …). The file router’s skip-folder name always comes from ``DEFAULT_COMPONENT_BACKENDS`` (``COMPONENTS_DIR`` on the first entry). See :doc:`/content/guide/file-router`.
 * ``URL_NAME_TEMPLATE`` — format string for URL pattern names (default ``page_{name}``).
 * ``DEFAULT_COMPONENT_BACKENDS`` — list of component backend dicts (``BACKEND``, ``DIRS``, ``COMPONENTS_DIR``, …). See :doc:`/content/guide/components`.
-* ``DEFAULT_STATIC_BACKENDS`` — list of static backend dicts (``BACKEND``, ``OPTIONS``). The default backend serves co-located CSS/JS under ``/_next/static/``. See :doc:`/content/guide/static-assets`.
+* ``DEFAULT_STATIC_BACKENDS`` — list of static backend dicts (``BACKEND``, ``OPTIONS``). The default backend resolves co-located CSS/JS through Django ``staticfiles_storage``. See :doc:`/content/guide/static-assets`.
 
 .. code-block:: python
 
@@ -134,7 +135,7 @@ Single dictionary in Django settings. Top-level keys (each optional beyond defau
        ],
        "DEFAULT_STATIC_BACKENDS": [
            {
-               "BACKEND": "next.static.FileStaticBackend",
+               "BACKEND": "next.static.StaticFilesBackend",
                "OPTIONS": {},
            },
        ],

--- a/docs/content/api/reference.rst
+++ b/docs/content/api/reference.rst
@@ -26,6 +26,19 @@ Scoped reusable template fragments, backends, and rendering helpers. See :doc:`/
    :undoc-members:
    :show-inheritance:
 
+Static assets (next.static)
+---------------------------
+
+Co-located CSS/JS discovery, the ``/_next/static/`` serving view, and the
+``{% collect_styles %}`` / ``{% collect_scripts %}`` / ``{% use_style %}`` /
+``{% use_script %}`` template tags. See :doc:`/content/guide/static-assets`
+for usage, settings, and examples.
+
+.. automodule:: next.static
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 URLs and routing (next.urls)
 ----------------------------
 
@@ -90,6 +103,7 @@ Single dictionary in Django settings. Top-level keys (each optional beyond defau
 * ``DEFAULT_PAGE_BACKENDS`` — list of file-router backend dicts (``BACKEND``, ``PAGES_DIR``, ``APP_DIRS``, ``DIRS``, ``OPTIONS``, …). The file router’s skip-folder name always comes from ``DEFAULT_COMPONENT_BACKENDS`` (``COMPONENTS_DIR`` on the first entry). See :doc:`/content/guide/file-router`.
 * ``URL_NAME_TEMPLATE`` — format string for URL pattern names (default ``page_{name}``).
 * ``DEFAULT_COMPONENT_BACKENDS`` — list of component backend dicts (``BACKEND``, ``DIRS``, ``COMPONENTS_DIR``, …). See :doc:`/content/guide/components`.
+* ``DEFAULT_STATIC_BACKENDS`` — list of static backend dicts (``BACKEND``, ``OPTIONS``). The default backend serves co-located CSS/JS under ``/_next/static/``. See :doc:`/content/guide/static-assets`.
 
 .. code-block:: python
 
@@ -116,6 +130,12 @@ Single dictionary in Django settings. Top-level keys (each optional beyond defau
                "BACKEND": "next.components.FileComponentsBackend",
                "DIRS": [str(BASE_DIR / "root_components")],
                "COMPONENTS_DIR": "_components",
+           },
+       ],
+       "DEFAULT_STATIC_BACKENDS": [
+           {
+               "BACKEND": "next.static.FileStaticBackend",
+               "OPTIONS": {},
            },
        ],
    }

--- a/docs/content/guide/static-assets.rst
+++ b/docs/content/guide/static-assets.rst
@@ -1,0 +1,553 @@
+Static assets
+=============
+
+next.dj automatically discovers CSS and JavaScript files that live next to your
+pages, layouts, and components, plus any extra URLs you declare from Python or
+templates. The collected assets are deduplicated, ordered, and injected into
+two slots on the rendered HTML — so you stop hand-wiring ``<link>`` and
+``<script>`` tags into every layout.
+
+Overview
+--------
+
+The static subsystem covers three complementary use cases:
+
+- **Co-located files.** Drop ``layout.css``/``layout.js`` next to a
+  ``layout.djx``, ``template.css``/``template.js`` next to a ``template.djx``,
+  and ``component.css``/``component.js`` next to a ``component.djx``. They are
+  picked up automatically and served by the framework.
+- **Module-level URLs.** Declare ``styles`` and ``scripts`` lists in any
+  ``page.py`` or ``component.py`` to add external assets (CDN, custom hosting)
+  for that page or component.
+- **Template tags.** Use ``{% use_style %}`` and ``{% use_script %}`` to
+  register external assets directly from a layout or template — perfect for
+  shared third-party libraries like Bootstrap or Chart.js.
+
+Two slots in your HTML drive the injection: ``{% collect_styles %}`` (in
+``<head>``) and ``{% collect_scripts %}`` (just before ``</body>``). Everything
+referenced during rendering — directly or through nested components — flows
+into those slots in deterministic order, with duplicates removed.
+
+How it works
+------------
+
+Rendering happens in two phases:
+
+1. **Render phase.** While ``Page.render`` walks layouts → template → nested
+   components, a per-request :class:`~next.static.StaticCollector` accumulates
+   asset references. Each ``{% component %}`` tag forwards its component to
+   :meth:`~next.static.StaticManager.discover_component_assets` so co-located
+   files and module-level lists are picked up. The two ``collect_*`` template
+   tags emit lightweight HTML comment placeholders (``<!-- next:styles -->``
+   and ``<!-- next:scripts -->``).
+2. **Inject phase.** After rendering finishes, the manager rewrites both
+   placeholders with concatenated ``<link>`` and ``<script>`` tags built by
+   the active backend. Co-located files are registered in an in-memory
+   registry under ``/_next/static/`` and served by a single Django view that
+   delegates to ``django.views.static.serve`` (so you get streaming,
+   ``Content-Type`` detection, and 304 responses for free).
+
+Ordering is **cascade-friendly** — generic dependencies come first so
+page- and component-specific rules can override them:
+
+1. ``{% use_style %}`` / ``{% use_script %}`` declarations (layout-level
+   shared dependencies like Bootstrap), in the order they were registered.
+2. Layout co-located files (``layout.css`` / ``layout.js``), outermost layout
+   first.
+3. Template file of the page itself (``template.css`` / ``template.js``).
+4. Module-level ``styles`` / ``scripts`` declared in ``page.py``.
+5. Component co-located files (``component.css`` / ``component.js``) in
+   depth-first render order.
+6. Module-level ``styles`` / ``scripts`` declared in ``component.py`` (right
+   after that component's files).
+
+The ordering mirrors normal CSS cascade: shared libraries flow in at the
+front, layout-wide styling sits above page-level styling, and component-level
+styling can tweak everything above it. URLs already seen on the collector are
+silently skipped, so adding the same Bootstrap CSS in three components only
+emits one ``<link>``.
+
+Quick start
+-----------
+
+A minimal example with one layout, one page, one component:
+
+**1. Configure ``DEFAULT_STATIC_BACKENDS``** (optional — the default backend is
+used automatically when the key is missing).
+
+.. code-block:: python
+
+   NEXT_FRAMEWORK = {
+       "DEFAULT_STATIC_BACKENDS": [
+           {
+               "BACKEND": "next.static.FileStaticBackend",
+               "OPTIONS": {},
+           },
+       ],
+   }
+
+**2. Add the two slots to your root layout.**
+
+.. code-block:: django
+
+   <!DOCTYPE html>
+   <html>
+   <head>
+       <meta charset="utf-8">
+       <title>My site</title>
+       {% use_style "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" %}
+       {% collect_styles %}
+   </head>
+   <body>
+       {% block template %}{% endblock template %}
+       {% use_script "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" %}
+       {% collect_scripts %}
+   </body>
+   </html>
+
+**3. Drop co-located files anywhere in the page tree.** For
+``myapp/pages/dashboard/template.djx`` you may add ``template.css`` and
+``template.js`` next to it. For ``_components/widget/component.djx`` you may
+add ``component.css`` and ``component.js`` next to it.
+
+**4. Add module-level lists for page-specific external assets.**
+
+.. code-block:: python
+
+   styles = [
+       "https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap",
+   ]
+   scripts: list[str] = []
+
+That is the entire setup. Reload the page and the rendered HTML will contain
+deduplicated ``<link>`` tags inside ``<head>`` and ``<script>`` tags before
+``</body>`` in the order described above.
+
+Co-located files
+----------------
+
+The framework looks for **fixed file names** in three locations.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 22 54
+
+   * - Where
+     - Files
+     - Logical URL
+   * - Next to ``layout.djx``
+     - ``layout.css``, ``layout.js``
+     - ``/_next/static/<route>/layout.{css,js}`` (or ``/_next/static/layout.{css,js}`` at the page root)
+   * - Next to ``template.djx``
+     - ``template.css``, ``template.js``
+     - ``/_next/static/<route>.{css,js}`` (or ``/_next/static/index.{css,js}`` at the page root)
+   * - Next to ``component.djx`` / ``component.py``
+     - ``component.css``, ``component.js``
+     - ``/_next/static/components/<name>.{css,js}``
+
+The naming is intentional: assets follow the **route** of the page they belong
+to (and the component **name** for components), not a hashed filesystem path.
+This keeps URLs predictable and easy to debug.
+
+Examples:
+
+- ``myapp/pages/about/template.css`` →
+  ``/_next/static/about.css``
+- ``myapp/pages/blog/layout.djx`` + ``layout.js`` →
+  ``/_next/static/blog/layout.js``
+- ``myapp/pages/_components/card/component.css`` →
+  ``/_next/static/components/card.css``
+- ``myapp/pages/dashboard/_components/chart/component.js`` →
+  ``/_next/static/components/chart.js``
+
+.. tip::
+
+   Co-located files mean **what is rendered together lives together**. Move
+   the page and its ``template.css`` follows automatically — no central
+   registry to update.
+
+Module-level ``styles`` and ``scripts``
+----------------------------------------
+
+Inside any ``page.py`` or ``component.py`` you can declare two module-level
+attributes:
+
+.. code-block:: python
+
+   styles = [
+       "https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap",
+       "https://cdn.example.com/themes/dark.css",
+   ]
+   scripts = [
+       "https://cdn.example.com/analytics.min.js",
+   ]
+
+Both are plain Python lists of URLs (relative or absolute). Module-level lists
+are added **after** the co-located files for the same scope — the file is the
+page's own asset, the list is its dependencies. Non-string and empty entries
+are filtered out.
+
+.. tip::
+
+   Use module lists for assets that are conceptually owned by **this** page or
+   component (e.g. a page-specific font or a component-specific charting
+   library). Put **shared** site-wide dependencies in the layout via
+   ``{% use_style %}`` / ``{% use_script %}`` instead — those always land at
+   the top of the collected list so page-level styling can override them.
+
+Template tags
+-------------
+
+The static template tags ship with the ``next_static`` library and are
+registered as builtins, so no ``{% load %}`` is required.
+
+``{% collect_styles %}``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Marks the slot where collected ``<link rel="stylesheet">`` tags will be
+inserted. Place it inside ``<head>`` of your root layout.
+
+.. code-block:: django
+
+   <head>
+       <title>My site</title>
+       {% collect_styles %}
+   </head>
+
+``{% collect_scripts %}``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Marks the slot for collected ``<script>`` tags. Place it just before
+``</body>`` so scripts do not block first paint.
+
+.. code-block:: django
+
+   <body>
+       {% block template %}{% endblock template %}
+       {% collect_scripts %}
+   </body>
+
+``{% use_style "URL" %}``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Registers an external CSS URL on the active collector. Useful for assets
+shared across every page, such as Bootstrap or a global font. Emits **no**
+markup at the call site — the URL is rendered inside the
+``{% collect_styles %}`` slot together with all other styles.
+
+.. code-block:: django
+
+   {% use_style "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" %}
+
+``{% use_script "URL" %}``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Same as ``{% use_style %}`` but for JS. Combine the two in your layout to
+declare site-wide third-party libraries in one place.
+
+.. code-block:: django
+
+   {% use_script "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" %}
+
+.. tip::
+
+   ``{% use_style %}`` and ``{% use_script %}`` are silent no-ops when there
+   is no active collector (for example when rendering a template manually
+   without going through ``Page.render``). This makes them safe to drop into
+   any reusable template.
+
+Backends and settings
+---------------------
+
+Backends are configured under the top-level ``NEXT_FRAMEWORK`` dict in Django
+settings, with the key ``DEFAULT_STATIC_BACKENDS``: a list of backend configs
+in the same shape as the page and component backends.
+
+.. code-block:: python
+
+   NEXT_FRAMEWORK = {
+       "DEFAULT_STATIC_BACKENDS": [
+           {
+               "BACKEND": "next.static.FileStaticBackend",
+               "OPTIONS": {},
+           },
+       ],
+   }
+
+Each entry is a dict that is passed unchanged into the backend constructor:
+
+- ``BACKEND`` (str) — dotted import path of the backend class. Defaults to
+  ``"next.static.FileStaticBackend"``.
+- ``OPTIONS`` (dict) — backend-specific options. ``FileStaticBackend`` reads:
+
+  - ``css_tag`` (str) — format string for CSS link tags. ``{url}`` is
+    substituted. Default: ``'<link rel="stylesheet" href="{url}">'``.
+  - ``js_tag`` (str) — format string for JS script tags. ``{url}`` is
+    substituted. Default: ``'<script src="{url}"></script>'``.
+
+If ``DEFAULT_STATIC_BACKENDS`` is missing, empty, or contains no usable
+entries, the framework falls back to a default ``FileStaticBackend()`` so the
+slots and discovery still work.
+
+Customizing tag templates
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``OPTIONS`` to add attributes (``defer``, ``crossorigin``, ``data-*``)
+without writing a custom backend:
+
+.. code-block:: python
+
+   NEXT_FRAMEWORK = {
+       "DEFAULT_STATIC_BACKENDS": [
+           {
+               "BACKEND": "next.static.FileStaticBackend",
+               "OPTIONS": {
+                   "css_tag": '<link rel="stylesheet" href="{url}" crossorigin>',
+                   "js_tag": '<script src="{url}" defer></script>',
+               },
+           },
+       ],
+   }
+
+URL serving (``/_next/static/``)
+--------------------------------
+
+Co-located files are registered with a logical name when discovered and served
+by a single catch-all view at ``/_next/static/<file_path>``. The view is added
+to the URL conf automatically — there is nothing to wire up by hand.
+
+Internally, ``static_serve_view`` looks the path up in the backend registry
+and delegates to ``django.views.static.serve``, so you get:
+
+- correct ``Content-Type`` based on the file extension,
+- ``Last-Modified`` headers,
+- conditional GET (``304 Not Modified``) for ``If-Modified-Since`` requests,
+- streaming responses for large files.
+
+Unknown paths under ``/_next/static/`` return ``404``. The prefix mirrors the
+``/_next/form/`` route used by :doc:`forms` — anything under ``/_next/`` is
+internal framework infrastructure.
+
+.. tip::
+
+   The ``/_next/static/`` route is a development and small-deployment
+   convenience. For production at scale, run a custom backend that
+   ``register_file`` copies the file to your S3 bucket / CDN and returns the
+   public URL — see :ref:`static-custom-backends`.
+
+Practical walkthroughs
+----------------------
+
+Site-wide assets in the layout
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Declare shared third-party libraries once at the top of the layout:
+
+.. code-block:: django
+
+   <!DOCTYPE html>
+   <html>
+   <head>
+       <meta charset="utf-8">
+       <title>My app</title>
+       {% use_style "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" %}
+       {% collect_styles %}
+   </head>
+   <body>
+       {% block template %}{% endblock template %}
+       {% use_script "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" %}
+       {% collect_scripts %}
+   </body>
+   </html>
+
+Every page in the tree inherits Bootstrap automatically. No duplicate ``<link>``
+tags will appear even if a child page or component requests the same URL.
+
+Page-specific styles and scripts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Co-locate ``template.css`` next to ``page.py`` for the page's own styling, and
+declare external assets in the module:
+
+.. code-block:: python
+
+   styles = [
+       "https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap",
+   ]
+   scripts: list[str] = []
+
+   from next.pages import context
+
+   @context("page_title")
+   def get_page_title() -> str:
+       return "Dashboard"
+
+Output (excerpt):
+
+.. code-block:: html
+
+   <head>
+       <link rel="stylesheet" href="https://cdn.jsdelivr.net/.../bootstrap.min.css">
+       <link rel="stylesheet" href="/_next/static/layout.css">
+       <link rel="stylesheet" href="/_next/static/dashboard.css">
+       <link rel="stylesheet" href="https://fonts.googleapis.com/...">
+   </head>
+
+The layout's shared ``use_style`` dependency comes first, followed by the
+layout file (outermost), the page's template file, and finally the page's
+module list — each level can override the styling above it.
+
+Component with co-located CSS / JS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Composite component ``_components/chart/`` with all four files:
+
+.. code-block:: text
+
+   _components/chart/
+       component.djx
+       component.css
+       component.js
+       component.py
+
+In ``component.py`` add a CDN dependency:
+
+.. code-block:: python
+
+   from next.components import context
+
+   scripts = [
+       "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js",
+   ]
+
+   @context("chart_labels")
+   def chart_labels():
+       return ["Jan", "Feb", "Mar"]
+
+Whenever a page renders ``{% component "chart" %}``, the framework registers
+``component.css``, ``component.js``, and the Chart.js CDN URL in render order.
+Render the same component three times on a page and each URL still appears
+exactly once.
+
+.. tip::
+
+   In the final HTML, layout-level ``use_script`` dependencies come first,
+   followed by layout / template / component files in render order, with each
+   scope's module-level list immediately after its own file. That means a
+   component's own ``component.js`` runs **before** the ``scripts`` it
+   declares in ``component.py`` — wrap any initialization that needs the CDN
+   dependency in ``DOMContentLoaded`` (or a late-running event) so it executes
+   after every ``<script>`` has finished loading.
+
+Tips and gotchas
+----------------
+
+- **Slots are mandatory.** If a layout does not include ``{% collect_styles %}``
+  or ``{% collect_scripts %}``, the matching assets are never inserted into
+  the page. Add them once at the root layout and you are done.
+- **Placeholders are HTML comments.** ``<!-- next:styles -->`` and
+  ``<!-- next:scripts -->`` are valid HTML, so a half-rendered page (rare,
+  e.g. when a custom view bypasses ``Page.render``) still parses correctly.
+- **Deduplication is by URL.** Two assets that resolve to different URLs
+  (e.g. the same library at two different versions) are both included.
+  Stick to one canonical URL per dependency.
+- **``use_*`` lands at the top of the slot.** ``{% use_style %}`` and
+  ``{% use_script %}`` are treated as shared dependencies and always appear
+  before co-located files and module-level lists, regardless of where the tag
+  is placed in the template. Multiple ``use_*`` calls keep their relative
+  registration order. A ``use_style`` placed after the ``collect_styles``
+  slot still works (the slot is rewritten **after** rendering), but for
+  clarity keep your ``use_*`` calls near the top of the layout where the
+  dependencies are conceptually declared.
+- **Static URLs change with the route.** ``/_next/static/<route>.css`` is
+  stable as long as the page route does not change. Renaming
+  ``pages/blog/`` → ``pages/articles/`` will change ``template.css`` from
+  ``/_next/static/blog.css`` to ``/_next/static/articles.css``.
+- **Coexistence with Django's static system.** ``next.dj`` does not replace
+  ``django.contrib.staticfiles``. Continue to use ``{% load static %}`` and
+  the standard ``STATIC_URL`` for site-wide assets you want collected by
+  ``collectstatic``. The ``/_next/static/`` route is reserved for files
+  discovered by the framework.
+
+.. _static-custom-backends:
+
+Custom backends
+---------------
+
+A backend is any class that subclasses :class:`~next.static.StaticBackend`.
+The contract is small (four methods) and lets you swap how assets are
+rendered, where they are stored, and how URLs are produced.
+
+.. code-block:: python
+
+   from typing import Any
+
+   from django.urls import URLPattern
+   from next.static import StaticBackend
+
+
+   class CDNStaticBackend(StaticBackend):
+       """Push co-located files to a CDN and return public URLs."""
+
+       def __init__(self, config: dict[str, Any] | None = None) -> None:
+           cfg = config or {}
+           opts = cfg.get("OPTIONS") or {}
+           self._base = opts["base_url"].rstrip("/")
+
+       def register_file(self, source_path, logical_name, kind):
+           extension = ".css" if kind == "css" else ".js"
+           upload_to_cdn(source_path)
+           return f"{self._base}/{logical_name}{extension}"
+
+       def render_link_tag(self, url: str) -> str:
+           return f'<link rel="stylesheet" href="{url}" crossorigin>'
+
+       def render_script_tag(self, url: str) -> str:
+           return f'<script src="{url}" defer></script>'
+
+       def generate_urls(self) -> list[URLPattern]:
+           return []  # served by the CDN, not by Django
+
+Wire it up like any other backend:
+
+.. code-block:: python
+
+   NEXT_FRAMEWORK = {
+       "DEFAULT_STATIC_BACKENDS": [
+           {
+               "BACKEND": "myapp.backends.CDNStaticBackend",
+               "OPTIONS": {"base_url": "https://cdn.example.com/static"},
+           },
+       ],
+   }
+
+Public API
+----------
+
+The full public surface lives in ``next.static`` (see :ref:`api-reference`).
+The most useful entry points:
+
+- :class:`~next.static.StaticAsset` — frozen dataclass for one CSS/JS reference.
+- :class:`~next.static.StaticCollector` — per-render dedup-and-order helper.
+- :class:`~next.static.StaticBackend` — backend ABC (subclass for custom hosting).
+- :class:`~next.static.FileStaticBackend` — built-in backend that serves files
+  under ``/_next/static/``.
+- :class:`~next.static.AssetDiscovery` — scans page/layout/component
+  directories and module-level lists.
+- :class:`~next.static.StaticManager` — coordinates backends, discovery, and
+  placeholder injection.
+- :data:`~next.static.static_manager` — module-level singleton used by
+  :meth:`~next.pages.Page.render` and the static template tags.
+- :func:`~next.static.static_serve_view` — view registered at
+  ``/_next/static/<file_path>``.
+
+Example project
+---------------
+
+The ``examples/static/`` project shows the complete picture: a root layout
+with shared Bootstrap from ``{% use_style %}`` / ``{% use_script %}``, a home
+page with co-located ``template.css`` plus an Inter-font in ``page.py``, a
+dashboard page with its own ``template.css`` and JetBrains Mono font, two
+composite components (``widget`` with Bootstrap Icons and ``chart`` with
+Chart.js), and a full test suite that exercises the collector ordering,
+deduplication, and the ``/_next/static/`` view.

--- a/docs/content/guide/static-assets.rst
+++ b/docs/content/guide/static-assets.rst
@@ -21,7 +21,10 @@ The static subsystem covers three complementary use cases:
   for that page or component.
 - **Template tags.** Use ``{% use_style %}`` and ``{% use_script %}`` to
   register external assets directly from a layout or template — perfect for
-  shared third-party libraries like Bootstrap or Chart.js.
+  shared third-party libraries like Bootstrap or Chart.js. Their block forms
+  ``{% #use_style %}`` … ``{% /use_style %}`` and ``{% #use_script %}`` …
+  ``{% /use_script %}`` capture an inline ``<style>`` / ``<script>`` body
+  and hoist it straight into the corresponding slot.
 
 Two slots in your HTML drive the injection: ``{% collect_styles %}`` (in
 ``<head>``) and ``{% collect_scripts %}`` (just before ``</body>``). Everything
@@ -60,6 +63,9 @@ page- and component-specific rules can override them:
    depth-first render order.
 6. Module-level ``styles`` / ``scripts`` declared in ``component.py`` (right
    after that component's files).
+7. Inline blocks from ``{% #use_style %}`` / ``{% #use_script %}`` in
+   registration order, appended last so that inline boot code runs after
+   every dependency has loaded.
 
 The ordering mirrors normal CSS cascade: shared libraries flow in at the
 front, layout-wide styling sits above page-level styling, and component-level
@@ -256,6 +262,58 @@ declare site-wide third-party libraries in one place.
    without going through ``Page.render``). This makes them safe to drop into
    any reusable template.
 
+``{% #use_style %}`` / ``{% #use_script %}`` (block form)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The block form mirrors ``{% #component %}``: ``{% #use_script %}`` opens,
+``{% /use_script %}`` closes, and everything inside is **hoisted** into the
+``{% collect_scripts %}`` slot. The body is rendered with the current
+template context, so you can still interpolate ``{{ variable }}`` values
+from the page. The block emits **nothing** at the call site -- only the
+final scripts slot receives the captured HTML.
+
+.. code-block:: django
+
+   <div id="widget-{{ id }}"></div>
+
+   {% #use_script %}
+   <script type="module">
+       const el = document.getElementById("widget-{{ id }}");
+       el.dataset.boot = "ready";
+   </script>
+   {% /use_script %}
+
+After rendering, the ``<script type="module">`` block lives inside
+``{% collect_scripts %}`` together with every other JS asset, while the
+``<div>`` stays where the component drew it. The same pattern works for
+inline ``<style>`` via ``{% #use_style %}`` … ``{% /use_style %}``.
+
+Order and deduplication for inline blocks:
+
+- **Append, not prepend.** Unlike the URL form, block bodies are treated as
+  consumers of the earlier dependencies and always land *after* URL-form
+  ``use_script`` / ``use_style`` entries and after co-located ``*.js`` /
+  ``*.css`` files, in registration order.
+- **Content-based deduplication.** Each block's dedup key is its rendered
+  body. Two blocks whose templates produce byte-identical HTML collapse to
+  a single entry in the slot, even if they were written in different
+  components or rendered via different ``{% component %}`` invocations. If
+  a block interpolates variable context (``{{ id }}``, ``{{ label }}``),
+  the resulting HTML differs per render and both copies land in the slot.
+  Whitespace-only bodies are skipped.
+- **Verbatim emission.** The captured HTML is written into the slot as-is,
+  so you can include custom ``<script>`` attributes (``type="module"``,
+  ``type="text/babel"``, ``nonce="…"``, ``defer``) or whole ``<style>``
+  blocks without any wrapping done by the framework.
+
+.. tip::
+
+   Because inline blocks append, the natural layering is: layout ``use_*``
+   shared deps → component-level ``use_*`` deps → co-located ``layout.js``
+   / ``template.js`` / ``component.js`` → inline ``{% #use_script %}``
+   bodies. That matches the typical "load libraries, load code, then boot"
+   runtime order.
+
 Backends and settings
 ---------------------
 
@@ -439,6 +497,170 @@ exactly once.
    dependency in ``DOMContentLoaded`` (or a late-running event) so it executes
    after every ``<script>`` has finished loading.
 
+Complex integrations — React + Babel counter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Nothing in the pipeline is tied to Bootstrap. Co-located files, module
+lists and ``{% use_script %}`` declarations compose cleanly with any
+third-party stack. The following composite component mounts a click counter
+written in JSX, compiled in the browser by ``@babel/standalone``, and
+rendered with React 18 -- and needs no ``component.py`` at all.
+
+Structure:
+
+.. code-block:: text
+
+   _components/counter/
+       component.djx
+       component.css
+
+``component.djx`` declares its dependencies via ``{% use_script %}`` right
+at the top, then renders the mount point. The Babel payload is split into
+**two** ``{% #use_script %}`` blocks so the content-based dedup can do its
+job per-chunk: the first block carries the shared ``Counter`` component
+definition (no per-instance context, so every render produces byte-identical
+HTML and collapses to a single entry), while the second block mounts one
+specific instance via ``{{ id }}`` (different bytes per render, so each
+instance gets its own boot line):
+
+.. code-block:: django
+
+   {% use_script "https://unpkg.com/react@18.3.1/umd/react.production.min.js" %}
+   {% use_script "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" %}
+   {% use_script "https://unpkg.com/@babel/standalone@7.24.7/babel.min.js" %}
+
+   <div class="counter-root" id="counter-{{ id }}" data-counter-label="{{ label }}"></div>
+
+   {% #use_script %}
+   <script type="text/babel" data-presets="react">
+       const { useState } = React;
+       window.Counter = function Counter({ label }) {
+           const [count, setCount] = useState(0);
+           return (
+               <button type="button" className="btn btn-outline-success"
+                       onClick={() => setCount(count + 1)}>
+                   {label}: {count}
+               </button>
+           );
+       };
+   </script>
+   {% /use_script %}
+
+   {% #use_script %}
+   <script type="text/babel" data-presets="react">
+       {
+           const mount = document.getElementById("counter-{{ id }}");
+           ReactDOM.createRoot(mount).render(
+               <Counter label={mount.dataset.counterLabel} />,
+           );
+       }
+   </script>
+   {% /use_script %}
+
+.. note::
+
+   A few browser-scope caveats when splitting a Babel payload across
+   ``{% #use_script %}`` blocks:
+
+   - **Cross-block sharing.** Each ``<script type="text/babel">`` tag is
+     compiled and executed by Babel Standalone in its own wrapper, so
+     top-level ``function Counter`` / ``const Counter`` declarations in
+     the first block are not visible to the second one. Attaching the
+     component to ``window`` (``window.Counter = function Counter(...)``)
+     promotes it to global scope, which the JSX transformer resolves
+     when it rewrites ``<Counter ... />`` into
+     ``React.createElement(Counter, ...)`` inside the mount block.
+   - **Avoid** ``data-type="module"``. It turns each block into an ES
+     module with its own fully isolated scope, which defeats the
+     ``window.Counter`` handshake. Plain ``<script type="text/babel">``
+     executes in global scope after Babel rewrites it to classic JS.
+   - **Wrap mount bodies in a block statement.** Without
+     ``data-type="module"`` every mount script shares the global scope,
+     so two ``const mount = ...`` lines (one per instance) would
+     redeclare the same variable and throw
+     ``SyntaxError: Can't create duplicate variable``. Wrapping the
+     mount body in ``{ ... }`` gives ``const``/``let`` a local block
+     scope while keeping ``Counter`` accessible from ``window``.
+   - **Production builds.** For production prefer a pre-bundled
+     ``component.js`` so the browser never sees ``@babel/standalone``
+     at all; the block-form ``{% #use_script %}`` is most useful during
+     development and for demos.
+
+Render the counter twice on a page — the three CDN URLs are emitted
+**once** (URL dedup), the shared ``Counter`` definition is emitted **once**
+(content dedup: both renders produce the same body), and each mount gets
+its own ``<script type="text/babel">`` body because ``{{ id }}`` interpolates
+differently per render (``counter-likes`` vs ``counter-stars``). Rendering
+the counter twice thus produces **three** Babel blocks in the scripts slot:
+one shared definition plus two per-instance mounts, in render order:
+
+.. code-block:: django
+
+   {% component "counter" id="likes" label="Likes" %}
+   {% component "counter" id="stars" label="Stars" %}
+
+No build tool, no bundler, no copy-paste of CDN URLs in the base layout --
+the component owns its dependencies directly from its template, and the
+collector handles dedup and ordering.
+
+.. tip::
+
+   Because ``use_script`` prepends, declaring React / ReactDOM / Babel
+   inside the component puts them at the top of the final ``<script>`` list
+   in registration order. A layout-level ``use_script`` for something like
+   Bootstrap JS still comes first, since it was registered earlier during
+   render.
+
+.. _static-dedup:
+
+Deduplication
+-------------
+
+The collector uses two dedup strategies depending on the asset shape:
+
+**URL-form assets** (co-located files, module-level ``styles`` / ``scripts``
+lists, ``{% use_style %}`` / ``{% use_script %}`` declarations) dedupe by
+URL. A second ``add()`` for the same URL is silently dropped, so:
+
+- Rendering the same component N times on a page emits each of its CDN URLs
+  exactly once.
+- Declaring the same library in multiple places (layout ``use_style``, a page
+  ``styles`` list, and a component ``styles`` list) produces a single
+  ``<link>`` — the first occurrence wins the slot.
+- Cascading between layers keeps working: dedup matches on the final URL
+  string, not on where the URL was registered.
+
+**Inline block assets** (``{% #use_style %}`` / ``{% #use_script %}``)
+dedupe by **rendered body content**. The rendered HTML itself becomes the
+dedup key (scoped per kind, so the same body could theoretically appear in
+both styles and scripts), so:
+
+- A block rendered twice with the same template context ends up in the slot
+  once.
+- A block that interpolates variable context (``{{ id }}``, ``{{ label }}``)
+  differs between renders and lands in the slot once per unique body — for
+  example, the counter component's Babel block contains
+  ``document.getElementById("counter-{{ id }}")`` so two mounts with
+  ``id=likes`` and ``id=stars`` produce two distinct ``<script>`` tags.
+- An author can intentionally write a "shared boot" block that does not
+  reference any context variable, so all component instances converge on
+  the same body and the boot script ships once.
+
+.. tip::
+
+   URL dedup is strictly by URL string. Two different URLs for the same
+   library (``…/bootstrap.min.css`` vs ``…/bootstrap.css``) are treated as
+   distinct assets and both will be included. Pick one canonical URL per
+   dependency and stick to it across the project.
+
+.. tip::
+
+   Inline dedup is strictly by the rendered body. Whitespace and attribute
+   order matter: ``<script src="a.js"></script>`` and
+   ``<script src="a.js" ></script>`` are considered different bodies. If
+   you want two components to share a single boot script, make sure the
+   block bodies render to the exact same bytes.
+
 Tips and gotchas
 ----------------
 
@@ -448,9 +670,11 @@ Tips and gotchas
 - **Placeholders are HTML comments.** ``<!-- next:styles -->`` and
   ``<!-- next:scripts -->`` are valid HTML, so a half-rendered page (rare,
   e.g. when a custom view bypasses ``Page.render``) still parses correctly.
-- **Deduplication is by URL.** Two assets that resolve to different URLs
-  (e.g. the same library at two different versions) are both included.
-  Stick to one canonical URL per dependency.
+- **Two dedup strategies.** URL-form assets dedupe by URL; inline blocks
+  dedupe by rendered body. See the :ref:`deduplication <static-dedup>`
+  section above. Two assets that resolve to different URLs (e.g. the same
+  library at two different versions) are both included — stick to one
+  canonical URL per dependency.
 - **``use_*`` lands at the top of the slot.** ``{% use_style %}`` and
   ``{% use_script %}`` are treated as shared dependencies and always appear
   before co-located files and module-level lists, regardless of where the tag

--- a/docs/content/guide/static-assets.rst
+++ b/docs/content/guide/static-assets.rst
@@ -45,10 +45,9 @@ Rendering happens in two phases:
    and ``<!-- next:scripts -->``).
 2. **Inject phase.** After rendering finishes, the manager rewrites both
    placeholders with concatenated ``<link>`` and ``<script>`` tags built by
-   the active backend. Co-located files are registered in an in-memory
-   registry under ``/_next/static/`` and served by a single Django view that
-   delegates to ``django.views.static.serve`` (so you get streaming,
-   ``Content-Type`` detection, and 304 responses for free).
+   the active backend. In the default configuration, co-located files resolve
+   through Django ``staticfiles_storage`` under the ``next/`` namespace, so
+   ``collectstatic`` + Manifest + S3/CDN settings apply automatically.
 
 Ordering is **cascade-friendly** — generic dependencies come first so
 page- and component-specific rules can override them:
@@ -86,7 +85,7 @@ used automatically when the key is missing).
    NEXT_FRAMEWORK = {
        "DEFAULT_STATIC_BACKENDS": [
            {
-               "BACKEND": "next.static.FileStaticBackend",
+               "BACKEND": "next.static.StaticFilesBackend",
                "OPTIONS": {},
            },
        ],
@@ -143,13 +142,13 @@ The framework looks for **fixed file names** in three locations.
      - Logical URL
    * - Next to ``layout.djx``
      - ``layout.css``, ``layout.js``
-     - ``/_next/static/<route>/layout.{css,js}`` (or ``/_next/static/layout.{css,js}`` at the page root)
+     - ``next/<route>/layout.{css,js}`` (or ``next/layout.{css,js}`` at the page root)
    * - Next to ``template.djx``
      - ``template.css``, ``template.js``
-     - ``/_next/static/<route>.{css,js}`` (or ``/_next/static/index.{css,js}`` at the page root)
+     - ``next/<route>.{css,js}`` (or ``next/index.{css,js}`` at the page root)
    * - Next to ``component.djx`` / ``component.py``
      - ``component.css``, ``component.js``
-     - ``/_next/static/components/<name>.{css,js}``
+     - ``next/components/<name>.{css,js}``
 
 The naming is intentional: assets follow the **route** of the page they belong
 to (and the component **name** for components), not a hashed filesystem path.
@@ -158,13 +157,13 @@ This keeps URLs predictable and easy to debug.
 Examples:
 
 - ``myapp/pages/about/template.css`` →
-  ``/_next/static/about.css``
+  ``next/about.css`` (then hashed by manifest if enabled)
 - ``myapp/pages/blog/layout.djx`` + ``layout.js`` →
-  ``/_next/static/blog/layout.js``
+  ``next/blog/layout.js`` (then hashed by manifest if enabled)
 - ``myapp/pages/_components/card/component.css`` →
-  ``/_next/static/components/card.css``
+  ``next/components/card.css`` (then hashed by manifest if enabled)
 - ``myapp/pages/dashboard/_components/chart/component.js`` →
-  ``/_next/static/components/chart.js``
+  ``next/components/chart.js`` (then hashed by manifest if enabled)
 
 .. tip::
 
@@ -326,7 +325,7 @@ in the same shape as the page and component backends.
    NEXT_FRAMEWORK = {
        "DEFAULT_STATIC_BACKENDS": [
            {
-               "BACKEND": "next.static.FileStaticBackend",
+               "BACKEND": "next.static.StaticFilesBackend",
                "OPTIONS": {},
            },
        ],
@@ -335,8 +334,8 @@ in the same shape as the page and component backends.
 Each entry is a dict that is passed unchanged into the backend constructor:
 
 - ``BACKEND`` (str) — dotted import path of the backend class. Defaults to
-  ``"next.static.FileStaticBackend"``.
-- ``OPTIONS`` (dict) — backend-specific options. ``FileStaticBackend`` reads:
+  ``"next.static.StaticFilesBackend"``.
+- ``OPTIONS`` (dict) — backend-specific options. ``StaticFilesBackend`` reads:
 
   - ``css_tag`` (str) — format string for CSS link tags. ``{url}`` is
     substituted. Default: ``'<link rel="stylesheet" href="{url}">'``.
@@ -344,8 +343,8 @@ Each entry is a dict that is passed unchanged into the backend constructor:
     substituted. Default: ``'<script src="{url}"></script>'``.
 
 If ``DEFAULT_STATIC_BACKENDS`` is missing, empty, or contains no usable
-entries, the framework falls back to a default ``FileStaticBackend()`` so the
-slots and discovery still work.
+entries, the framework falls back to ``StaticFilesBackend()`` so static
+URLs still flow through Django staticfiles.
 
 Customizing tag templates
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -358,7 +357,7 @@ without writing a custom backend:
    NEXT_FRAMEWORK = {
        "DEFAULT_STATIC_BACKENDS": [
            {
-               "BACKEND": "next.static.FileStaticBackend",
+               "BACKEND": "next.static.StaticFilesBackend",
                "OPTIONS": {
                    "css_tag": '<link rel="stylesheet" href="{url}" crossorigin>',
                    "js_tag": '<script src="{url}" defer></script>',
@@ -367,31 +366,19 @@ without writing a custom backend:
        ],
    }
 
-URL serving (``/_next/static/``)
---------------------------------
+Staticfiles and collectstatic
+-----------------------------
 
-Co-located files are registered with a logical name when discovered and served
-by a single catch-all view at ``/_next/static/<file_path>``. The view is added
-to the URL conf automatically — there is nothing to wire up by hand.
+Co-located files are mapped into the ``next/`` namespace and resolved via
+``django.contrib.staticfiles.storage.staticfiles_storage.url(...)``.
+This means:
 
-Internally, ``static_serve_view`` looks the path up in the backend registry
-and delegates to ``django.views.static.serve``, so you get:
+- ``collectstatic`` sees the files through ``next.static.NextStaticFilesFinder``,
+- Manifest storages rewrite URLs to hashed file names,
+- S3/CDN backends return public bucket/CDN URLs in final HTML automatically.
 
-- correct ``Content-Type`` based on the file extension,
-- ``Last-Modified`` headers,
-- conditional GET (``304 Not Modified``) for ``If-Modified-Since`` requests,
-- streaming responses for large files.
-
-Unknown paths under ``/_next/static/`` return ``404``. The prefix mirrors the
-``/_next/form/`` route used by :doc:`forms` — anything under ``/_next/`` is
-internal framework infrastructure.
-
-.. tip::
-
-   The ``/_next/static/`` route is a development and small-deployment
-   convenience. For production at scale, run a custom backend that
-   ``register_file`` copies the file to your S3 bucket / CDN and returns the
-   public URL — see :ref:`static-custom-backends`.
+If a file is missing from the manifest, ``StaticFilesBackend`` raises a
+clear runtime error pointing to ``collectstatic``/finder setup.
 
 Practical walkthroughs
 ----------------------
@@ -446,8 +433,8 @@ Output (excerpt):
 
    <head>
        <link rel="stylesheet" href="https://cdn.jsdelivr.net/.../bootstrap.min.css">
-       <link rel="stylesheet" href="/_next/static/layout.css">
-       <link rel="stylesheet" href="/_next/static/dashboard.css">
+       <link rel="stylesheet" href="/static/next/layout.abcd1234.css">
+       <link rel="stylesheet" href="/static/next/dashboard.efgh5678.css">
        <link rel="stylesheet" href="https://fonts.googleapis.com/...">
    </head>
 
@@ -683,15 +670,13 @@ Tips and gotchas
   slot still works (the slot is rewritten **after** rendering), but for
   clarity keep your ``use_*`` calls near the top of the layout where the
   dependencies are conceptually declared.
-- **Static URLs change with the route.** ``/_next/static/<route>.css`` is
+- **Static URLs change with the route.** ``next/<route>.css`` is
   stable as long as the page route does not change. Renaming
   ``pages/blog/`` → ``pages/articles/`` will change ``template.css`` from
-  ``/_next/static/blog.css`` to ``/_next/static/articles.css``.
-- **Coexistence with Django's static system.** ``next.dj`` does not replace
-  ``django.contrib.staticfiles``. Continue to use ``{% load static %}`` and
-  the standard ``STATIC_URL`` for site-wide assets you want collected by
-  ``collectstatic``. The ``/_next/static/`` route is reserved for files
-  discovered by the framework.
+  ``next/blog.css`` to ``next/articles.css`` before manifest hashing.
+- **Unified with Django staticfiles.** ``next.dj`` co-located assets and
+  your regular ``{% static %}`` assets share the same ``collectstatic``
+  pipeline and the same storage backend.
 
 .. _static-custom-backends:
 
@@ -699,14 +684,13 @@ Custom backends
 ---------------
 
 A backend is any class that subclasses :class:`~next.static.StaticBackend`.
-The contract is small (four methods) and lets you swap how assets are
-rendered, where they are stored, and how URLs are produced.
+The contract is small (three methods) and lets you swap how assets are
+rendered and how URLs are produced (typically still via Django staticfiles).
 
 .. code-block:: python
 
    from typing import Any
 
-   from django.urls import URLPattern
    from next.static import StaticBackend
 
 
@@ -728,9 +712,6 @@ rendered, where they are stored, and how URLs are produced.
 
        def render_script_tag(self, url: str) -> str:
            return f'<script src="{url}" defer></script>'
-
-       def generate_urls(self) -> list[URLPattern]:
-           return []  # served by the CDN, not by Django
 
 Wire it up like any other backend:
 
@@ -754,16 +735,16 @@ The most useful entry points:
 - :class:`~next.static.StaticAsset` — frozen dataclass for one CSS/JS reference.
 - :class:`~next.static.StaticCollector` — per-render dedup-and-order helper.
 - :class:`~next.static.StaticBackend` — backend ABC (subclass for custom hosting).
-- :class:`~next.static.FileStaticBackend` — built-in backend that serves files
-  under ``/_next/static/``.
+- :class:`~next.static.StaticFilesBackend` — built-in backend that resolves
+  co-located assets through Django ``staticfiles_storage``.
 - :class:`~next.static.AssetDiscovery` — scans page/layout/component
   directories and module-level lists.
 - :class:`~next.static.StaticManager` — coordinates backends, discovery, and
   placeholder injection.
 - :data:`~next.static.static_manager` — module-level singleton used by
   :meth:`~next.pages.Page.render` and the static template tags.
-- :func:`~next.static.static_serve_view` — view registered at
-  ``/_next/static/<file_path>``.
+- :class:`~next.static.NextStaticFilesFinder` — staticfiles finder that exposes
+  co-located assets under the ``next/`` namespace for ``collectstatic``.
 
 Example project
 ---------------
@@ -773,5 +754,5 @@ with shared Bootstrap from ``{% use_style %}`` / ``{% use_script %}``, a home
 page with co-located ``template.css`` plus an Inter-font in ``page.py``, a
 dashboard page with its own ``template.css`` and JetBrains Mono font, two
 composite components (``widget`` with Bootstrap Icons and ``chart`` with
-Chart.js), and a full test suite that exercises the collector ordering,
-deduplication, and the ``/_next/static/`` view.
+Chart.js), and a full test suite that exercises collector ordering,
+deduplication, and staticfiles-based URL resolution.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,12 @@ Features
 
       Get request and params where you need them, without threading through functions. Less glue code, faster iteration.
 
+   .. grid-item-card:: :octicon:`paintbrush` Static assets
+      :link: content/guide/static-assets
+      :link-type: doc
+
+      Drop CSS and JS next to pages and components. The framework discovers, deduplicates, and injects them in deterministic order — no manual ``<link>`` plumbing.
+
    .. grid-item-card:: :octicon:`sync` Development server
       :link: content/guide/autoreload
       :link-type: doc
@@ -91,6 +97,7 @@ Sponsors
    content/guide/context
    content/guide/forms
    content/guide/dependency-injection
+   content/guide/static-assets
    content/guide/autoreload
 
 .. toctree::

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,6 +62,21 @@ A **blog** sample (English UI) built on next-dj components: simple and composite
 
 **Best for:** Reusable UI fragments, slots, component scope, and combining components with forms and file-based routing
 
+### static
+A realistic showcase of next-dj's **static asset pipeline**: co-located CSS/JS, module-level `styles`/`scripts` lists, layout-wide dependencies via `{% use_style %}` / `{% use_script %}`, slot-based injection, cascade ordering, deduplication, and a dedicated `/_next/static/` serve route. Third-party stacks integrated: Bootstrap 5, Bootstrap Icons, Chart.js, and a React 18 + Babel standalone click counter.
+
+**Key Features:**
+- Co-located `layout.css`/`layout.js` (next to `layout.djx`), `template.css`/`template.js` (next to `template.djx`), and `component.css`/`component.js` (next to `component.djx`)
+- `styles = [...]` and `scripts = [...]` module-level lists in `page.py` and `component.py`
+- `{% use_style %}` / `{% use_script %}` template tags for shared layout deps (Bootstrap)
+- `{% collect_styles %}` / `{% collect_scripts %}` post-render injection slots
+- Cascade ordering: `use_*` → layout → page → component (child scopes can override parents)
+- Deduplication by URL — repeated components ship each CDN only once
+- Complex integration example: React + Babel standalone counter rendered twice via `ReactDOM.createRoot`
+- `/_next/static/` serve view that delegates to `django.views.static.serve`
+
+**Best for:** Wiring in CSS/JS without a bundler, integrating third-party libraries (including React/Babel), and understanding the cascade + dedup contract of the static subsystem
+
 ## Getting Started
 
 Each example includes its own README with detailed setup and running instructions. To get started:
@@ -88,6 +103,9 @@ Use the `forms` example to see form actions, ModelForm, and `{% form %}` with fi
 **If you're building reusable UI pieces:**
 Use the `components` example for a small blog with simple/composite components, slots, root scope, and forms-driven auth and posts.
 
+**If you're wiring up CSS / JS without a bundler:**
+Use the `static` example to see co-located assets, cascade ordering, deduplication, and a React + Babel integration.
+
 **If you're exploring specific features:**
 - Parameter handling: `file-routing` example
 - Database integration: `pages` example
@@ -95,10 +113,12 @@ Use the `components` example for a small blog with simple/composite components, 
 - Admin integration: `pages` example
 - Template inheritance: `layouts` example
 - Context processors: `layouts` example
-- Bootstrap layout and static assets: `layouts` example
+- Bootstrap layout (minimal): `layouts` example
 - Form actions and ModelForm: `forms` example
 - Create/edit flows with URL params: `forms` example
 - Components, slots, scope, blog + forms: `components` example
+- Co-located CSS/JS, `{% use_style %}`, cascade, dedup: `static` example
+- React + Babel integration without a bundler: `static` example
 
 ## Common Patterns
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,7 +63,7 @@ A **blog** sample (English UI) built on next-dj components: simple and composite
 **Best for:** Reusable UI fragments, slots, component scope, and combining components with forms and file-based routing
 
 ### static
-A realistic showcase of next-dj's **static asset pipeline**: co-located CSS/JS, module-level `styles`/`scripts` lists, layout-wide dependencies via `{% use_style %}` / `{% use_script %}`, slot-based injection, cascade ordering, deduplication, and a dedicated `/_next/static/` serve route. Third-party stacks integrated: Bootstrap 5, Bootstrap Icons, Chart.js, and a React 18 + Babel standalone click counter.
+A realistic showcase of next-dj's **static asset pipeline**: co-located CSS/JS, module-level `styles`/`scripts` lists, layout-wide dependencies via `{% use_style %}` / `{% use_script %}`, slot-based injection, cascade ordering, deduplication, and Django `staticfiles` integration (Manifest/S3 ready). Third-party stacks integrated: Bootstrap 5, Bootstrap Icons, Chart.js, and a React 18 + Babel standalone click counter.
 
 **Key Features:**
 - Co-located `layout.css`/`layout.js` (next to `layout.djx`), `template.css`/`template.js` (next to `template.djx`), and `component.css`/`component.js` (next to `component.djx`)
@@ -73,7 +73,7 @@ A realistic showcase of next-dj's **static asset pipeline**: co-located CSS/JS, 
 - Cascade ordering: `use_*` → layout → page → component (child scopes can override parents)
 - Deduplication by URL — repeated components ship each CDN only once
 - Complex integration example: React + Babel standalone counter rendered twice via `ReactDOM.createRoot`
-- `/_next/static/` serve view that delegates to `django.views.static.serve`
+- Co-located assets resolved via Django `staticfiles_storage` under `next/` namespace
 
 **Best for:** Wiring in CSS/JS without a bundler, integrating third-party libraries (including React/Babel), and understanding the cascade + dedup contract of the static subsystem
 

--- a/examples/static/README.md
+++ b/examples/static/README.md
@@ -1,0 +1,45 @@
+# Static Assets Example
+
+Demonstrates co-located CSS and JS auto-collection and injection in next-dj, using **Bootstrap 5**, **Bootstrap Icons**, **Chart.js**, and two Google fonts as realistic third-party libraries.
+
+## Where each asset is declared
+
+| Scope | Mechanism | Loads |
+| ----- | --------- | ----- |
+| Layout (`pages/layout.djx`) | `{% use_style %}` / `{% use_script %}` template tags | Bootstrap 5 CSS + JS -- shared by every page |
+| Home `page.py` (`styles`) | module-level list | Google Font *Inter* -- used by the home hero |
+| Dashboard `page.py` (`styles`) | module-level list | Google Font *JetBrains Mono* -- used for code blocks |
+| Widget `component.py` (`styles`) | module-level list | Bootstrap Icons -- used by the widget only |
+| Chart `component.py` (`scripts`) | module-level list | Chart.js -- used by the chart only |
+| `layout.css` / `layout.js` | co-located files | auto-picked up and served as `/_next/static/layout.css` etc. |
+| `template.css` / `template.js` | co-located files | auto-picked up and served as `/_next/static/index.css`, `/_next/static/dashboard.css` etc. |
+| `component.css` / `component.js` | co-located files | auto-picked up and served as `/_next/static/components/<name>.css`/`.js` |
+
+## Features shown
+
+- `{% collect_styles %}` / `{% collect_scripts %}` slots in `layout.djx` replaced with every collected `<link>` / `<script>` after rendering.
+- `{% use_style "url" %}` / `{% use_script "url" %}` template tags for declaring external URLs directly from a layout or template.
+- `styles` / `scripts` list variables in both `page.py` and `component.py` for per-page or per-component dependencies.
+- Deduplication by URL: identical libraries declared by multiple layers appear only once.
+- Depth-first ordering: layout assets -> page template assets -> page.py external URLs -> component assets (files first, then module variables) in render order.
+- Co-located files are renamed by logical identity when served:
+  - `pages/layout.css` -> `/_next/static/layout.css`
+  - `pages/template.css` -> `/_next/static/index.css`
+  - `pages/dashboard/template.css` -> `/_next/static/dashboard.css`
+  - `pages/_components/widget/component.css` -> `/_next/static/components/widget.css`
+  - `pages/dashboard/_components/chart/component.js` -> `/_next/static/components/chart.js`
+- External URLs pass through as-is.
+
+## Run
+
+```bash
+cd examples/static
+python manage.py runserver
+```
+
+Then visit:
+
+- `http://localhost:8000/` -- home page with the Bootstrap + Bootstrap Icons widget, rendered in Inter.
+- `http://localhost:8000/dashboard/` -- dashboard subpage with the Chart.js bar chart, code blocks in JetBrains Mono.
+
+Open the page source to see the injected `<link>` and `<script>` tags.

--- a/examples/static/README.md
+++ b/examples/static/README.md
@@ -1,45 +1,187 @@
 # Static Assets Example
 
-Demonstrates co-located CSS and JS auto-collection and injection in next-dj, using **Bootstrap 5**, **Bootstrap Icons**, **Chart.js**, and two Google fonts as realistic third-party libraries.
+This example demonstrates next-dj's **static asset subsystem**: automatic discovery of co-located CSS/JS, module-level `styles`/`scripts` lists, the `{% use_style %}` / `{% use_script %}` template tags for shared layout dependencies, placeholder slots (`{% collect_styles %}` / `{% collect_scripts %}`), URL-based deduplication, and a dedicated `/_next/static/` serve route. Third-party libraries used as realistic fixtures: **Bootstrap 5**, **Bootstrap Icons**, **Chart.js**, **React 18 + ReactDOM + Babel standalone**, and two Google fonts (Inter, JetBrains Mono).
 
-## Where each asset is declared
+## Feature coverage (static)
 
-| Scope | Mechanism | Loads |
-| ----- | --------- | ----- |
-| Layout (`pages/layout.djx`) | `{% use_style %}` / `{% use_script %}` template tags | Bootstrap 5 CSS + JS -- shared by every page |
-| Home `page.py` (`styles`) | module-level list | Google Font *Inter* -- used by the home hero |
-| Dashboard `page.py` (`styles`) | module-level list | Google Font *JetBrains Mono* -- used for code blocks |
-| Widget `component.py` (`styles`) | module-level list | Bootstrap Icons -- used by the widget only |
-| Chart `component.py` (`scripts`) | module-level list | Chart.js -- used by the chart only |
-| `layout.css` / `layout.js` | co-located files | auto-picked up and served as `/_next/static/layout.css` etc. |
-| `template.css` / `template.js` | co-located files | auto-picked up and served as `/_next/static/index.css`, `/_next/static/dashboard.css` etc. |
-| `component.css` / `component.js` | co-located files | auto-picked up and served as `/_next/static/components/<name>.css`/`.js` |
+| Technique | Where |
+|-----------|-------|
+| `{% use_style %}` / `{% use_script %}` in layout | `pages/layout.djx` (Bootstrap CSS + JS, shared by every page) |
+| Module-level `styles` on a page | `pages/page.py` (Inter font), `pages/dashboard/page.py` (JetBrains Mono font) |
+| Module-level `styles` on a component | `pages/_components/widget/component.py` (Bootstrap Icons) |
+| Module-level `scripts` on a component | `pages/dashboard/_components/chart/component.py` (Chart.js) |
+| `{% use_script %}` declared from inside a component | `pages/_components/counter/component.djx` (React + ReactDOM + Babel) |
+| `{% #use_script %}` block form hoisting inline `<script>` | `pages/_components/counter/component.djx` (Babel mount block hoisted into scripts slot) |
+| Co-located `layout.css` / `layout.js` | `pages/layout.css`, `pages/layout.js` |
+| Co-located `template.css` / `template.js` | `pages/template.*`, `pages/dashboard/template.css` |
+| Co-located `component.css` / `component.js` | `_components/widget/component.*`, `_components/chart/component.*`, `_components/counter/component.css` |
+| Slots — `{% collect_styles %}` / `{% collect_scripts %}` | `pages/layout.djx` (head + before `</body>`) |
+| Cascade order (use_* → layout → page → component) | Asserted in `tests/tests.py` |
+| Deduplication by URL across repeated components | Counter rendered twice on the home page; React/ReactDOM/Babel emitted once |
+| `/_next/static/<file>` serve view | Delegates to `django.views.static.serve`; exercised in `tests/tests.py` |
 
-## Features shown
+## What This Example Demonstrates
 
-- `{% collect_styles %}` / `{% collect_scripts %}` slots in `layout.djx` replaced with every collected `<link>` / `<script>` after rendering.
-- `{% use_style "url" %}` / `{% use_script "url" %}` template tags for declaring external URLs directly from a layout or template.
-- `styles` / `scripts` list variables in both `page.py` and `component.py` for per-page or per-component dependencies.
-- Deduplication by URL: identical libraries declared by multiple layers appear only once.
-- Depth-first ordering: layout assets -> page template assets -> page.py external URLs -> component assets (files first, then module variables) in render order.
-- Co-located files are renamed by logical identity when served:
-  - `pages/layout.css` -> `/_next/static/layout.css`
-  - `pages/template.css` -> `/_next/static/index.css`
-  - `pages/dashboard/template.css` -> `/_next/static/dashboard.css`
-  - `pages/_components/widget/component.css` -> `/_next/static/components/widget.css`
-  - `pages/dashboard/_components/chart/component.js` -> `/_next/static/components/chart.js`
-- External URLs pass through as-is.
+- **Co-located assets.** Drop `layout.css` / `layout.js` next to `layout.djx`, `template.css` / `template.js` next to `template.djx`, and `component.css` / `component.js` next to `component.djx`. They are picked up automatically and served under `/_next/static/`.
+- **Module-level URLs.** Declare `styles = [...]` and `scripts = [...]` in any `page.py` or `component.py` for per-page or per-component third-party assets.
+- **Layout-wide dependencies via template tags.** `{% use_style "URL" %}` / `{% use_script "URL" %}` register shared libraries from the layout without hard-coding `<link>` / `<script>` tags; they land at the top of the collected list so child scopes can override them.
+- **Slot-based injection.** `{% collect_styles %}` (in `<head>`) and `{% collect_scripts %}` (before `</body>`) are post-render placeholders — a single pass at the end of `Page.render` replaces both.
+- **Cascade ordering.** `use_style`/`use_script` → layout files → template file → `page.py` module list → component files → `component.py` module list. Each level can override everything above it, mirroring the CSS cascade.
+- **Deduplication by URL.** Repeating the same component twice on a page emits each CDN URL exactly once. Declaring the same library in both the layout and a component also collapses to a single tag.
+- **Complex integrations.** The React counter composes Babel standalone + React 18 + ReactDOM, driven by a `<script type="text/babel">` block inside `component.djx` and `ReactDOM.createRoot(...).render(<Counter />)`. The three CDNs are declared via `{% use_script %}` directly in `component.djx`, and the inline Babel `<script>` is wrapped in `{% #use_script %}` … `{% /use_script %}` so it hoists into the `{% collect_scripts %}` slot at the end of `<body>` — the counter needs no `component.py` at all.
 
-## Run
+## Example Structure
+
+```
+static/
+├── config/                         # Django project (settings, urls)
+│   ├── __init__.py
+│   ├── settings.py                 # NEXT_FRAMEWORK, DEFAULT_STATIC_BACKENDS
+│   └── urls.py                     # include(next.urls)
+├── manage.py
+├── myapp/
+│   ├── __init__.py
+│   ├── apps.py
+│   └── pages/
+│       ├── layout.djx              # HTML shell, {% use_style %} Bootstrap, collect_* slots
+│       ├── layout.css              # Co-located layout styling
+│       ├── layout.js               # Co-located layout script
+│       ├── page.py                 # Home: Inter font, page_title context
+│       ├── template.djx            # Home body: hero + widget + two counter instances
+│       ├── template.css            # Home co-located CSS
+│       ├── template.js             # Home co-located JS
+│       ├── _components/
+│       │   ├── widget/
+│       │   │   ├── component.djx   # Bootstrap card + collapse
+│       │   │   ├── component.css
+│       │   │   ├── component.js
+│       │   │   └── component.py    # Bootstrap Icons module-level style
+│       │   └── counter/
+│       │       ├── component.djx   # {% use_script %} deps + {% #use_script %}-hoisted Babel mount
+│       │       └── component.css   # Button styling (no component.py needed)
+│       └── dashboard/
+│           ├── page.py             # Dashboard: JetBrains Mono font
+│           ├── template.djx        # Chart + copy on co-located CSS
+│           ├── template.css
+│           └── _components/
+│               └── chart/
+│                   ├── component.djx
+│                   ├── component.css
+│                   ├── component.js
+│                   └── component.py # Chart.js module-level script
+└── tests/
+    ├── __init__.py
+    ├── conftest.py                 # Client + home/dashboard HTML fixtures
+    └── tests.py                    # End-to-end assertions on injected tags
+```
+
+## Main Pieces
+
+**Layout** (`myapp/pages/layout.djx`): HTML shell with the Bootstrap CDN declared once via `{% use_style %}` / `{% use_script %}`, plus the two `{% collect_* %}` slots. Every page in the tree inherits these.
+
+**Home page** (`myapp/pages/page.py` + `template.djx`): declares the Inter font in its `styles` list, renders the `widget` composite, and mounts two `counter` instances (labels "Likes" and "Stars") to demonstrate dedup.
+
+**Dashboard page** (`myapp/pages/dashboard/page.py` + `template.djx`): declares the JetBrains Mono font and renders the `chart` composite with its Chart.js dependency.
+
+**Widget** (`myapp/pages/_components/widget/`): Bootstrap card with a collapse button; `component.py` pulls in Bootstrap Icons. Demonstrates co-located `.css`/`.js` plus a module-level `styles` list on the same component.
+
+**Chart** (`myapp/pages/dashboard/_components/chart/`): branch-scoped composite. `component.py` declares Chart.js via `scripts`, co-located `component.js` uses it to draw a bar chart.
+
+**Counter** (`myapp/pages/_components/counter/`): React 18 + Babel standalone integration without a `component.py`. The top of `component.djx` registers React, ReactDOM and Babel via `{% use_script %}` tags — they prepend to the script cascade just like the layout's Bootstrap dependency. The body renders a mount `<div>`, then splits the Babel payload into **two** `{% #use_script %}` blocks: one with the shared `Counter` component definition (no context, so every render produces byte-identical HTML and content-dedup collapses it to one entry) and one with the `ReactDOM.createRoot(...)` mount line using `{{ id }}` (different bytes per render, so each instance gets its own boot line). The co-located `component.css` styles the resulting button. Rendered twice on the home page, the counter produces: three CDN `<script>` tags (URL-dedupped to one each), one shared `Counter` definition block, and two per-instance mount blocks — three Babel blocks total, not four.
+
+## How It Works
+
+1. **Render phase.** `Page.render` builds a per-request `StaticCollector` and calls `AssetDiscovery.discover_page_assets` to pre-register layout, template, and `page.py` assets. The Django template renders next — layout `{% use_style %}` / `{% use_script %}` tags prepend to the collector; every `{% component %}` tag calls `discover_component_assets`, appending co-located component files and `component.py` module lists; every `{% #use_style %}` / `{% #use_script %}` block renders its body with the live context and appends it as an inline asset.
+
+2. **Inject phase.** The manager rewrites `<!-- next:styles -->` and `<!-- next:scripts -->` placeholders left by `{% collect_styles %}` / `{% collect_scripts %}` with concatenated `<link>` / `<script>` tags in cascade order.
+
+3. **Cascade order.** On the home page:
+
+   CSS
+
+   1. Bootstrap CSS (`use_style` from layout)
+   2. `/_next/static/layout.css`
+   3. `/_next/static/index.css` (template)
+   4. Google Font Inter (`pages/page.py` `styles`)
+   5. `/_next/static/components/widget.css`
+   6. Bootstrap Icons (`widget/component.py` `styles`)
+   7. `/_next/static/components/counter.css`
+
+   JS
+
+   1. Bootstrap JS (`use_script` from layout, prepended)
+   2. React, ReactDOM, Babel (`use_script` from `counter/component.djx`, prepended in registration order)
+   3. `/_next/static/layout.js`
+   4. `/_next/static/index.js`
+   5. `/_next/static/components/widget.js`
+   6. Counter's shared `Counter` component definition block (hoisted by `{% #use_script %}`, content-dedupped to one entry)
+   7. Counter's mount block for `id="likes"` (hoisted by `{% #use_script %}`)
+   8. Counter's mount block for `id="stars"` (hoisted by `{% #use_script %}`)
+
+   `use_script` URL declarations prepend (shared deps first); co-located `*.js` files append in render order; `{% #use_script %}` block bodies append last so inline boot code runs after every dependency and every co-located script has loaded.
+
+4. **Deduplication.** The collector uses two strategies:
+
+   - **URL-form assets** (co-located files, module lists, `use_style`/`use_script`) dedupe by URL, so rendering `counter` twice still emits React, ReactDOM and Babel exactly once.
+   - **Inline block bodies** (`{% #use_script %}` / `{% #use_style %}`) dedupe by rendered body. The counter exploits this by splitting its Babel payload in two: the shared `Counter` component definition has no per-instance context → identical bodies across renders → collapsed to one entry; the mount block interpolates `{{ id }}` → different bodies per render (`counter-likes` vs `counter-stars`) → both kept. Split your blocks along the "shared vs per-instance" axis to get the best of both worlds.
+
+5. **Serving.** `FileStaticBackend` registers each discovered file under a logical name (`/_next/static/<route>.css`, `/_next/static/components/<name>.css`). `static_serve_view` looks the name up and delegates to `django.views.static.serve`, which streams the file with correct `Content-Type` / `Last-Modified` / 304 handling.
+
+## Running the Example
+
+### Prerequisites
+
+- Python 3.11+
+- Django 5+
+- next-dj installed (editable from the repo root is fine)
+
+### Setup
 
 ```bash
 cd examples/static
+pip install django next-dj
+```
+
+There are no database migrations — the example is entirely rendering-driven.
+
+### Running the Server
+
+```bash
 python manage.py runserver
 ```
 
-Then visit:
+### URLs to Try
 
-- `http://localhost:8000/` -- home page with the Bootstrap + Bootstrap Icons widget, rendered in Inter.
-- `http://localhost:8000/dashboard/` -- dashboard subpage with the Chart.js bar chart, code blocks in JetBrains Mono.
+| URL | Description |
+|-----|-------------|
+| `/` | Home page: Bootstrap widget + two React/Babel counters |
+| `/dashboard/` | Dashboard page: Chart.js bar chart + JetBrains Mono code font |
+| `/_next/static/layout.css` | Example of a served co-located file |
+| `/_next/static/components/counter.css` | Counter's component CSS |
 
-Open the page source to see the injected `<link>` and `<script>` tags.
+Open the page source — you will see:
+
+- Bootstrap `<link>` first in `<head>` (layout `use_style`).
+- `/_next/static/layout.css`, the template CSS, and page-level font URLs following in cascade order.
+- Three `<script>` tags for React, ReactDOM and Babel, each appearing exactly **once** before the three `<script type="text/babel">` counter blocks (one shared `Counter` definition + two per-instance mounts), even though the counter component is rendered twice. The Babel blocks themselves live inside the `{% collect_scripts %}` slot (bottom of `<body>`) because they were wrapped in `{% #use_script %}` — not where the `<div>` mount point is drawn.
+
+### Running Tests
+
+From the repository root (use `--no-cov` to skip the core project's coverage gate when running only this example):
+
+```bash
+uv run pytest examples/static/tests/ -v --no-cov
+```
+
+From `examples/static/`:
+
+```bash
+cd examples/static
+uv run pytest tests/ -v --no-cov
+```
+
+The test suite renders the home and dashboard pages with Django's `Client`, verifies cascade order, counter mount points, dedup of the React CDNs, and the `/_next/static/` serve view.
+
+## Contributing
+
+Issues and PRs welcome via the main next-dj repository. Keep backward compatibility when changing examples.

--- a/examples/static/README.md
+++ b/examples/static/README.md
@@ -1,6 +1,6 @@
 # Static Assets Example
 
-This example demonstrates next-dj's **static asset subsystem**: automatic discovery of co-located CSS/JS, module-level `styles`/`scripts` lists, the `{% use_style %}` / `{% use_script %}` template tags for shared layout dependencies, placeholder slots (`{% collect_styles %}` / `{% collect_scripts %}`), URL-based deduplication, and a dedicated `/_next/static/` serve route. Third-party libraries used as realistic fixtures: **Bootstrap 5**, **Bootstrap Icons**, **Chart.js**, **React 18 + ReactDOM + Babel standalone**, and two Google fonts (Inter, JetBrains Mono).
+This example demonstrates next-dj's **static asset subsystem**: automatic discovery of co-located CSS/JS, module-level `styles`/`scripts` lists, the `{% use_style %}` / `{% use_script %}` template tags for shared layout dependencies, placeholder slots (`{% collect_styles %}` / `{% collect_scripts %}`), URL-based deduplication, and Django staticfiles URL resolution. Third-party libraries used as realistic fixtures: **Bootstrap 5**, **Bootstrap Icons**, **Chart.js**, **React 18 + ReactDOM + Babel standalone**, and two Google fonts (Inter, JetBrains Mono).
 
 ## Feature coverage (static)
 
@@ -18,11 +18,11 @@ This example demonstrates next-dj's **static asset subsystem**: automatic discov
 | Slots — `{% collect_styles %}` / `{% collect_scripts %}` | `pages/layout.djx` (head + before `</body>`) |
 | Cascade order (use_* → layout → page → component) | Asserted in `tests/tests.py` |
 | Deduplication by URL across repeated components | Counter rendered twice on the home page; React/ReactDOM/Babel emitted once |
-| `/_next/static/<file>` serve view | Delegates to `django.views.static.serve`; exercised in `tests/tests.py` |
+| Staticfiles-backed URL resolution | URLs are emitted under `/static/next/...`; exercised in `tests/tests.py` |
 
 ## What This Example Demonstrates
 
-- **Co-located assets.** Drop `layout.css` / `layout.js` next to `layout.djx`, `template.css` / `template.js` next to `template.djx`, and `component.css` / `component.js` next to `component.djx`. They are picked up automatically and served under `/_next/static/`.
+- **Co-located assets.** Drop `layout.css` / `layout.js` next to `layout.djx`, `template.css` / `template.js` next to `template.djx`, and `component.css` / `component.js` next to `component.djx`. They are picked up automatically and resolved via Django staticfiles under `/static/next/...`.
 - **Module-level URLs.** Declare `styles = [...]` and `scripts = [...]` in any `page.py` or `component.py` for per-page or per-component third-party assets.
 - **Layout-wide dependencies via template tags.** `{% use_style "URL" %}` / `{% use_script "URL" %}` register shared libraries from the layout without hard-coding `<link>` / `<script>` tags; they land at the top of the collected list so child scopes can override them.
 - **Slot-based injection.** `{% collect_styles %}` (in `<head>`) and `{% collect_scripts %}` (before `</body>`) are post-render placeholders — a single pass at the end of `Page.render` replaces both.
@@ -100,20 +100,20 @@ static/
    CSS
 
    1. Bootstrap CSS (`use_style` from layout)
-   2. `/_next/static/layout.css`
-   3. `/_next/static/index.css` (template)
+   2. `/static/next/layout.css`
+   3. `/static/next/index.css` (template)
    4. Google Font Inter (`pages/page.py` `styles`)
-   5. `/_next/static/components/widget.css`
+   5. `/static/next/components/widget.css`
    6. Bootstrap Icons (`widget/component.py` `styles`)
-   7. `/_next/static/components/counter.css`
+   7. `/static/next/components/counter.css`
 
    JS
 
    1. Bootstrap JS (`use_script` from layout, prepended)
    2. React, ReactDOM, Babel (`use_script` from `counter/component.djx`, prepended in registration order)
-   3. `/_next/static/layout.js`
-   4. `/_next/static/index.js`
-   5. `/_next/static/components/widget.js`
+   3. `/static/next/layout.js`
+   4. `/static/next/index.js`
+   5. `/static/next/components/widget.js`
    6. Counter's shared `Counter` component definition block (hoisted by `{% #use_script %}`, content-dedupped to one entry)
    7. Counter's mount block for `id="likes"` (hoisted by `{% #use_script %}`)
    8. Counter's mount block for `id="stars"` (hoisted by `{% #use_script %}`)
@@ -125,7 +125,7 @@ static/
    - **URL-form assets** (co-located files, module lists, `use_style`/`use_script`) dedupe by URL, so rendering `counter` twice still emits React, ReactDOM and Babel exactly once.
    - **Inline block bodies** (`{% #use_script %}` / `{% #use_style %}`) dedupe by rendered body. The counter exploits this by splitting its Babel payload in two: the shared `Counter` component definition has no per-instance context → identical bodies across renders → collapsed to one entry; the mount block interpolates `{{ id }}` → different bodies per render (`counter-likes` vs `counter-stars`) → both kept. Split your blocks along the "shared vs per-instance" axis to get the best of both worlds.
 
-5. **Serving.** `FileStaticBackend` registers each discovered file under a logical name (`/_next/static/<route>.css`, `/_next/static/components/<name>.css`). `static_serve_view` looks the name up and delegates to `django.views.static.serve`, which streams the file with correct `Content-Type` / `Last-Modified` / 304 handling.
+5. **Staticfiles resolution.** `StaticFilesBackend` registers each discovered file under a logical name (`next/<route>.css`, `next/components/<name>.css`) and resolves final URLs through `staticfiles_storage.url(...)`.
 
 ## Running the Example
 
@@ -156,13 +156,13 @@ python manage.py runserver
 |-----|-------------|
 | `/` | Home page: Bootstrap widget + two React/Babel counters |
 | `/dashboard/` | Dashboard page: Chart.js bar chart + JetBrains Mono code font |
-| `/_next/static/layout.css` | Example of a served co-located file |
-| `/_next/static/components/counter.css` | Counter's component CSS |
+| `/static/next/layout.css` | Example of a co-located file URL |
+| `/static/next/components/counter.css` | Counter's component CSS |
 
 Open the page source — you will see:
 
 - Bootstrap `<link>` first in `<head>` (layout `use_style`).
-- `/_next/static/layout.css`, the template CSS, and page-level font URLs following in cascade order.
+- `/static/next/layout.css`, the template CSS, and page-level font URLs following in cascade order.
 - Three `<script>` tags for React, ReactDOM and Babel, each appearing exactly **once** before the three `<script type="text/babel">` counter blocks (one shared `Counter` definition + two per-instance mounts), even though the counter component is rendered twice. The Babel blocks themselves live inside the `{% collect_scripts %}` slot (bottom of `<body>`) because they were wrapped in `{% #use_script %}` — not where the `<div>` mount point is drawn.
 
 ### Running Tests
@@ -180,7 +180,7 @@ cd examples/static
 uv run pytest tests/ -v --no-cov
 ```
 
-The test suite renders the home and dashboard pages with Django's `Client`, verifies cascade order, counter mount points, dedup of the React CDNs, and the `/_next/static/` serve view.
+The test suite renders the home and dashboard pages with Django's `Client`, verifies cascade order, counter mount points, dedup of the React CDNs, and staticfiles-backed URL resolution.
 
 ## Contributing
 

--- a/examples/static/config/settings.py
+++ b/examples/static/config/settings.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = "django-insecure-example-key-for-static"
+
+DEBUG = True
+
+ALLOWED_HOSTS = ["*"]
+
+INSTALLED_APPS = [
+    "django.contrib.staticfiles",
+    "next",
+    "myapp",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "config.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = "config.wsgi.application"
+
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = "static/"
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+NEXT_FRAMEWORK = {
+    "DEFAULT_STATIC_BACKENDS": [
+        {
+            "BACKEND": "next.static.FileStaticBackend",
+            "OPTIONS": {},
+        },
+    ],
+}

--- a/examples/static/config/settings.py
+++ b/examples/static/config/settings.py
@@ -50,7 +50,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 NEXT_FRAMEWORK = {
     "DEFAULT_STATIC_BACKENDS": [
         {
-            "BACKEND": "next.static.FileStaticBackend",
+            "BACKEND": "next.static.StaticFilesBackend",
             "OPTIONS": {},
         },
     ],

--- a/examples/static/config/urls.py
+++ b/examples/static/config/urls.py
@@ -1,0 +1,6 @@
+from django.urls import include, path
+
+
+urlpatterns = [
+    path("", include("next.urls")),
+]

--- a/examples/static/config/wsgi.py
+++ b/examples/static/config/wsgi.py
@@ -1,0 +1,8 @@
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+application = get_wsgi_application()

--- a/examples/static/manage.py
+++ b/examples/static/manage.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+from django.core.management import execute_from_command_line
+
+
+def main() -> None:
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/static/myapp/apps.py
+++ b/examples/static/myapp/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class MyAppConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "myapp"

--- a/examples/static/myapp/pages/_components/counter/component.css
+++ b/examples/static/myapp/pages/_components/counter/component.css
@@ -1,0 +1,17 @@
+.counter-root {
+    display: inline-block;
+    margin-right: 0.75rem;
+    margin-top: 0.75rem;
+}
+
+.counter-root .counter-btn {
+    font-weight: 600;
+    min-width: 9rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.counter-root .counter-label {
+    letter-spacing: 0.02em;
+}

--- a/examples/static/myapp/pages/_components/counter/component.djx
+++ b/examples/static/myapp/pages/_components/counter/component.djx
@@ -1,0 +1,35 @@
+{% use_script "https://unpkg.com/react@18.3.1/umd/react.production.min.js" %}
+{% use_script "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" %}
+{% use_script "https://unpkg.com/@babel/standalone@7.24.7/babel.min.js" %}
+
+<div class="counter-root" id="counter-{{ id }}" data-counter-label="{{ label }}"></div>
+
+{% #use_script %}
+<script type="text/babel" data-presets="react">
+    const { useState } = React;
+
+    window.Counter = function Counter({ label }) {
+        const [count, setCount] = useState(0);
+        return (
+            <button
+                type="button"
+                className="btn btn-outline-success counter-btn"
+                onClick={() => setCount(count + 1)}
+            >
+                <span className="counter-label">{label}</span>
+                <span className="badge bg-success ms-2">{count}</span>
+            </button>
+        );
+    };
+</script>
+{% /use_script %}
+
+{% #use_script %}
+<script type="text/babel" data-presets="react">
+    {
+        const mount = document.getElementById("counter-{{ id }}");
+        const label = mount.dataset.counterLabel;
+        ReactDOM.createRoot(mount).render(<Counter label={label} />);
+    }
+</script>
+{% /use_script %}

--- a/examples/static/myapp/pages/_components/widget/component.css
+++ b/examples/static/myapp/pages/_components/widget/component.css
@@ -1,0 +1,7 @@
+.widget .bi {
+    vertical-align: -0.125em;
+}
+
+.widget .card-header {
+    letter-spacing: 0.01em;
+}

--- a/examples/static/myapp/pages/_components/widget/component.djx
+++ b/examples/static/myapp/pages/_components/widget/component.djx
@@ -1,0 +1,32 @@
+<div class="widget card border-primary mt-4">
+    <div class="card-header bg-primary text-white d-flex align-items-center">
+        <i class="bi bi-stars me-2"></i>
+        <span>{{ title }}</span>
+    </div>
+    <div class="card-body">
+        <p class="card-text">
+            This widget uses <strong>Bootstrap 5</strong> components (card, button,
+            collapse) from the page's base CSS/JS and the <strong>Bootstrap Icons</strong>
+            font it requested for itself in <code>component.py</code>.
+        </p>
+        <button
+            class="btn btn-outline-primary btn-sm"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#widget-details"
+            aria-expanded="false"
+            aria-controls="widget-details"
+        >
+            <i class="bi bi-chevron-down me-1"></i>
+            Toggle details
+        </button>
+        <div class="collapse mt-3" id="widget-details">
+            <div class="alert alert-info mb-0">
+                <i class="bi bi-info-circle me-1"></i>
+                The collapse behavior is provided by Bootstrap's JS bundle, the
+                icons come from Bootstrap Icons, and the widget also ships its own
+                co-located <code>component.css</code>.
+            </div>
+        </div>
+    </div>
+</div>

--- a/examples/static/myapp/pages/_components/widget/component.js
+++ b/examples/static/myapp/pages/_components/widget/component.js
@@ -1,0 +1,9 @@
+(function () {
+    document.addEventListener("DOMContentLoaded", function () {
+        var detail = document.getElementById("widget-details");
+        if (!detail) return;
+        detail.addEventListener("shown.bs.collapse", function () {
+            console.log("[next-dj static example] widget details shown");
+        });
+    });
+})();

--- a/examples/static/myapp/pages/_components/widget/component.py
+++ b/examples/static/myapp/pages/_components/widget/component.py
@@ -1,0 +1,13 @@
+from next.components import context
+
+
+styles = [
+    "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css",
+]
+scripts: list[str] = []
+
+
+@context("subtitle")
+def widget_subtitle() -> str:
+    """Static subtitle exposed to the widget template as ``subtitle``."""
+    return "Composite widget example"

--- a/examples/static/myapp/pages/dashboard/_components/chart/component.css
+++ b/examples/static/myapp/pages/dashboard/_components/chart/component.css
@@ -1,0 +1,7 @@
+.chart {
+    border-left: 0.25rem solid var(--bs-info);
+}
+
+.chart-canvas {
+    max-height: 260px;
+}

--- a/examples/static/myapp/pages/dashboard/_components/chart/component.djx
+++ b/examples/static/myapp/pages/dashboard/_components/chart/component.djx
@@ -1,0 +1,10 @@
+<div class="chart card">
+    <div class="card-body">
+        <h5 class="card-title mb-3">Monthly visits</h5>
+        <canvas
+            class="chart-canvas"
+            data-chart-labels="{{ labels|join:',' }}"
+            data-chart-values="{{ values|join:',' }}"
+        ></canvas>
+    </div>
+</div>

--- a/examples/static/myapp/pages/dashboard/_components/chart/component.js
+++ b/examples/static/myapp/pages/dashboard/_components/chart/component.js
@@ -1,0 +1,35 @@
+(function () {
+    function initChart(canvas) {
+        if (typeof window.Chart !== "function") return;
+        var labels = (canvas.dataset.chartLabels || "").split(",").filter(Boolean);
+        var values = (canvas.dataset.chartValues || "")
+            .split(",")
+            .filter(Boolean)
+            .map(Number);
+        new window.Chart(canvas, {
+            type: "bar",
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: "Visits",
+                        data: values,
+                        backgroundColor: "rgba(13, 110, 253, 0.6)",
+                        borderColor: "rgba(13, 110, 253, 1)",
+                        borderWidth: 1,
+                    },
+                ],
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { display: false } },
+                scales: { y: { beginAtZero: true } },
+            },
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        document.querySelectorAll(".chart-canvas").forEach(initChart);
+    });
+})();

--- a/examples/static/myapp/pages/dashboard/_components/chart/component.py
+++ b/examples/static/myapp/pages/dashboard/_components/chart/component.py
@@ -1,0 +1,19 @@
+from next.components import context
+
+
+styles: list[str] = []
+scripts = [
+    "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js",
+]
+
+
+@context("labels")
+def chart_labels() -> list[str]:
+    """Static x-axis labels rendered by the chart template."""
+    return ["Jan", "Feb", "Mar", "Apr"]
+
+
+@context("values")
+def chart_values() -> list[int]:
+    """Static bar heights matching the labels list."""
+    return [40, 70, 55, 90]

--- a/examples/static/myapp/pages/dashboard/page.py
+++ b/examples/static/myapp/pages/dashboard/page.py
@@ -1,0 +1,4 @@
+styles = [
+    "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap",
+]
+scripts: list[str] = []

--- a/examples/static/myapp/pages/dashboard/template.css
+++ b/examples/static/myapp/pages/dashboard/template.css
@@ -1,0 +1,8 @@
+section > .card-body > .card-title {
+    color: #6d28d9;
+}
+
+section code {
+    font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+    font-size: 0.9em;
+}

--- a/examples/static/myapp/pages/dashboard/template.djx
+++ b/examples/static/myapp/pages/dashboard/template.djx
@@ -1,0 +1,23 @@
+<section class="card shadow-sm">
+    <div class="card-body">
+        <h1 class="card-title">Dashboard</h1>
+        <p class="card-text text-muted">
+            The chart below pulls <strong>Chart.js</strong> from its own
+            <code>component.py</code> <code>scripts</code> list. Bootstrap 5 is
+            inherited from the shared <code>page.py</code> on the home route but
+            is picked up per render, so the chart can rely on Bootstrap layout too.
+        </p>
+        <div class="row g-3">
+            <div class="col-md-8">
+                {% component "chart" %}
+            </div>
+            <div class="col-md-4">
+                <div class="alert alert-secondary h-100 mb-0">
+                    <strong>Tip.</strong> Co-located <code>template.css</code> styles
+                    the dashboard headline purple and is served from
+                    <code>/_next/static/dashboard.css</code>.
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/examples/static/myapp/pages/dashboard/template.djx
+++ b/examples/static/myapp/pages/dashboard/template.djx
@@ -15,7 +15,7 @@
                 <div class="alert alert-secondary h-100 mb-0">
                     <strong>Tip.</strong> Co-located <code>template.css</code> styles
                     the dashboard headline purple and is served from
-                    <code>/_next/static/dashboard.css</code>.
+                    <code>/static/next/dashboard.css</code>.
                 </div>
             </div>
         </div>

--- a/examples/static/myapp/pages/layout.css
+++ b/examples/static/myapp/pages/layout.css
@@ -1,0 +1,8 @@
+body {
+    background-color: #f5f7fa;
+    min-height: 100vh;
+}
+
+main.container {
+    padding-bottom: 3rem;
+}

--- a/examples/static/myapp/pages/layout.djx
+++ b/examples/static/myapp/pages/layout.djx
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Static Assets Example</title>
+    {% use_style "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" %}
+    {% use_script "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" %}
+    {% collect_styles %}
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+        <div class="container">
+            <a class="navbar-brand" href="/">next-dj static demo</a>
+            <div class="navbar-nav">
+                <a class="nav-link" href="/">Home</a>
+                <a class="nav-link" href="/dashboard/">Dashboard</a>
+            </div>
+        </div>
+    </nav>
+    <main class="container">
+        {% block template %}{% endblock template %}
+    </main>
+    {% collect_scripts %}
+</body>
+</html>

--- a/examples/static/myapp/pages/layout.js
+++ b/examples/static/myapp/pages/layout.js
@@ -1,0 +1,3 @@
+(function () {
+    console.log("[next-dj static example] layout script loaded");
+})();

--- a/examples/static/myapp/pages/page.py
+++ b/examples/static/myapp/pages/page.py
@@ -1,0 +1,13 @@
+from next.pages import context
+
+
+styles = [
+    "https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap",
+]
+scripts: list[str] = []
+
+
+@context("page_title")
+def get_page_title() -> str:
+    """Static greeting used by the home page template."""
+    return "Home"

--- a/examples/static/myapp/pages/template.css
+++ b/examples/static/myapp/pages/template.css
@@ -1,0 +1,10 @@
+.home-hero {
+    border-top: 0.25rem solid var(--bs-primary);
+    font-family: "Inter", system-ui, sans-serif;
+}
+
+.home-hero .card-title {
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    margin-bottom: 0.5rem;
+}

--- a/examples/static/myapp/pages/template.djx
+++ b/examples/static/myapp/pages/template.djx
@@ -8,5 +8,21 @@
             also ships co-located <code>template.css</code> / <code>template.js</code>.
         </p>
         {% component "widget" title="Bootstrap widget" %}
+        <div class="counter-strip mt-4">
+            <h2 class="h5 mb-3">React + Babel counter (two instances, one React load)</h2>
+            <p class="text-muted small mb-3">
+                The same composite component is rendered twice. React, ReactDOM
+                and Babel Standalone are declared via <code>{% verbatim %}{% use_script %}{% endverbatim %}</code>
+                right inside <code>component.djx</code> and URL-dedupped to one
+                tag each. The Babel payload is split into two
+                <code>{% verbatim %}{% #use_script %}{% endverbatim %}</code>
+                blocks: the <code>Counter</code> definition has no per-instance
+                context so content-dedup collapses it to one entry, while the
+                mount block interpolates <code>{% verbatim %}{{ id }}{% endverbatim %}</code>
+                and stays distinct per instance.
+            </p>
+            {% component "counter" id="likes" label="Likes" %}
+            {% component "counter" id="stars" label="Stars" %}
+        </div>
     </div>
 </section>

--- a/examples/static/myapp/pages/template.djx
+++ b/examples/static/myapp/pages/template.djx
@@ -1,0 +1,12 @@
+<section class="home-hero card shadow-sm">
+    <div class="card-body">
+        <h1 class="card-title">{{ page_title }}</h1>
+        <p class="card-text text-muted">
+            This page pulls in Bootstrap 5 from <code>page.py</code>'s
+            <code>styles</code>/<code>scripts</code> lists. The widget below pulls
+            Bootstrap Icons through its own <code>component.py</code>. The template
+            also ships co-located <code>template.css</code> / <code>template.js</code>.
+        </p>
+        {% component "widget" title="Bootstrap widget" %}
+    </div>
+</section>

--- a/examples/static/myapp/pages/template.js
+++ b/examples/static/myapp/pages/template.js
@@ -1,0 +1,3 @@
+(function () {
+    console.log("[next-dj static example] home template script loaded");
+})();

--- a/examples/static/tests/conftest.py
+++ b/examples/static/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Shared test configuration for the static assets example.
+
+The example ships its own ``config/settings.py``, so the conftest wires
+``DJANGO_SETTINGS_MODULE`` to that module and exposes a small set of reusable
+fixtures for the test modules.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+_example_root = Path(__file__).resolve().parent.parent
+_repo_root = _example_root.parent.parent
+
+if str(_example_root) not in sys.path:
+    sys.path.insert(0, str(_example_root))
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+import django  # noqa: E402
+import pytest  # noqa: E402
+from django.apps import apps  # noqa: E402
+from django.test import Client  # noqa: E402
+
+
+if not apps.ready:
+    django.setup()
+
+
+@pytest.fixture()
+def client() -> Client:
+    """Return a fresh Django test client for HTTP interactions."""
+    return Client()
+
+
+@pytest.fixture()
+def home_html(client: Client) -> str:
+    """Return the rendered HTML of the home page (``/``)."""
+    response = client.get("/")
+    assert response.status_code == 200
+    return response.content.decode()
+
+
+@pytest.fixture()
+def dashboard_html(client: Client) -> str:
+    """Return the rendered HTML of the dashboard page (``/dashboard/``)."""
+    response = client.get("/dashboard/")
+    assert response.status_code == 200
+    return response.content.decode()

--- a/examples/static/tests/tests.py
+++ b/examples/static/tests/tests.py
@@ -1,508 +1,55 @@
-"""End-to-end tests for the static assets example.
-
-The tests cover every Python module under ``myapp`` and ``config`` and exercise
-every static asset feature wired up by the example. They verify co-located CSS
-and JS discovery, module-level ``styles``/``scripts`` lists, the
-``{% use_style %}``/``{% use_script %}`` template tags, the
-``{% collect_styles %}``/``{% collect_scripts %}`` injection slots, the
-``/_next/static/`` serving view, and the relative ordering guaranteed by
-``StaticCollector`` and ``StaticManager``.
-"""
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
 import pytest
-from config import urls as config_urls
 from myapp.apps import MyAppConfig
-from myapp.pages import page as home_page
-from myapp.pages._components.widget import component as widget_component
-from myapp.pages.dashboard import page as dashboard_page
-from myapp.pages.dashboard._components.chart import component as chart_component
 
-from next.static import (
-    SCRIPTS_PLACEHOLDER,
-    STYLES_PLACEHOLDER,
-    FileStaticBackend,
-    StaticAsset,
-    StaticCollector,
-    StaticManager,
-    static_manager,
-)
+from next.static import StaticFilesBackend, static_manager
 
 
 if TYPE_CHECKING:
     from django.test import Client
 
 
-BOOTSTRAP_CSS = (
-    "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/static/next/layout.css",
+        "/static/next/index.css",
+        "/static/next/components/widget.css",
+        "/static/next/components/counter.css",
+        "/static/next/layout.js",
+        "/static/next/index.js",
+        "/static/next/components/widget.js",
+    ],
 )
-BOOTSTRAP_JS = (
-    "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+def test_home_contains_colocated_urls(home_html: str, url: str) -> None:
+    assert url in home_html
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/static/next/layout.css",
+        "/static/next/dashboard.css",
+        "/static/next/components/chart.css",
+        "/static/next/layout.js",
+        "/static/next/components/chart.js",
+    ],
 )
-BOOTSTRAP_ICONS = (
-    "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
-)
-CHART_JS = "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
-INTER_FONT = "https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
-JETBRAINS_MONO = (
-    "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap"
-)
-REACT_CDN = "https://unpkg.com/react@18.3.1/umd/react.production.min.js"
-REACT_DOM_CDN = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"
-BABEL_CDN = "https://unpkg.com/@babel/standalone@7.24.7/babel.min.js"
-COUNTER_CDNS = (REACT_CDN, REACT_DOM_CDN, BABEL_CDN)
+def test_dashboard_contains_colocated_urls(dashboard_html: str, url: str) -> None:
+    assert url in dashboard_html
 
 
-def _read_streamed(response) -> bytes:
-    """Collect body bytes from a streaming or regular ``HttpResponse``."""
-    if getattr(response, "streaming", False):
-        return b"".join(chunk for chunk in response.streaming_content)
-    return response.content
+def test_example_uses_staticfiles_backend() -> None:
+    assert isinstance(static_manager.default_backend, StaticFilesBackend)
 
 
-def _assert_in_order(html: str, needles: list[str]) -> None:
-    """Assert that every needle appears in ``html`` in the given order."""
-    positions: list[int] = []
-    for needle in needles:
-        idx = html.find(needle)
-        assert idx != -1, f"Expected to find {needle!r} in rendered HTML"
-        positions.append(idx)
-    assert positions == sorted(positions), (
-        "Expected assets in order, got positions "
-        f"{list(zip(needles, positions, strict=True))}"
-    )
+def test_app_config_metadata() -> None:
+    assert MyAppConfig.name == "myapp"
 
 
-class TestHomePageRendering:
-    """Verify the rendered home page (``/``) exposes the right assets."""
-
-    def test_status_and_layout_shell(self, home_html: str) -> None:
-        """The layout shell markers from ``layout.djx`` render on the home page."""
-        assert "Static Assets Example" in home_html
-        assert "next-dj static demo" in home_html
-
-    def test_home_page_title_context_rendered(self, home_html: str) -> None:
-        """The ``@context('page_title')`` value from ``page.py`` reaches the HTML."""
-        assert ">Home</h1>" in home_html
-
-    def test_widget_title_and_subtitle_rendered(self, home_html: str) -> None:
-        """The widget component and its context keys render inside the page."""
-        assert "Bootstrap widget" in home_html
-        assert "Toggle details" in home_html
-
-    def test_placeholders_are_replaced(self, home_html: str) -> None:
-        """Collect slot placeholders do not leak into the final HTML."""
-        assert STYLES_PLACEHOLDER not in home_html
-        assert SCRIPTS_PLACEHOLDER not in home_html
-
-    @pytest.mark.parametrize(
-        "url",
-        [
-            BOOTSTRAP_CSS,
-            BOOTSTRAP_ICONS,
-            INTER_FONT,
-            "/_next/static/layout.css",
-            "/_next/static/index.css",
-            "/_next/static/components/widget.css",
-            "/_next/static/components/counter.css",
-        ],
-    )
-    def test_contains_css_link(self, home_html: str, url: str) -> None:
-        """Every expected CSS source is emitted as a ``<link>`` tag."""
-        assert f'href="{url}"' in home_html
-
-    @pytest.mark.parametrize(
-        "url",
-        [
-            BOOTSTRAP_JS,
-            "/_next/static/layout.js",
-            "/_next/static/index.js",
-            "/_next/static/components/widget.js",
-            REACT_CDN,
-            REACT_DOM_CDN,
-            BABEL_CDN,
-        ],
-    )
-    def test_contains_script_tag(self, home_html: str, url: str) -> None:
-        """Every expected JS source is emitted as a ``<script>`` tag."""
-        assert f'src="{url}"' in home_html
-
-    def test_style_tags_render_in_head(self, home_html: str) -> None:
-        """CSS link tags appear before the closing ``</head>`` marker."""
-        head_end = home_html.index("</head>")
-        for url in (BOOTSTRAP_CSS, INTER_FONT, "/_next/static/layout.css"):
-            assert home_html.index(f'href="{url}"') < head_end
-
-    def test_script_tags_render_before_body_close(self, home_html: str) -> None:
-        """Script tags appear before the closing ``</body>`` marker."""
-        body_end = home_html.index("</body>")
-        for url in (BOOTSTRAP_JS, "/_next/static/components/widget.js"):
-            assert home_html.index(f'src="{url}"') < body_end
-
-    def test_styles_follow_nested_discovery_order(self, home_html: str) -> None:
-        """Styles cascade from layout ``use_style`` deps down to component files."""
-        _assert_in_order(
-            home_html,
-            [
-                f'href="{BOOTSTRAP_CSS}"',
-                'href="/_next/static/layout.css"',
-                'href="/_next/static/index.css"',
-                f'href="{INTER_FONT}"',
-                'href="/_next/static/components/widget.css"',
-                f'href="{BOOTSTRAP_ICONS}"',
-                'href="/_next/static/components/counter.css"',
-            ],
-        )
-
-    def test_scripts_follow_nested_discovery_order(self, home_html: str) -> None:
-        """``use_script`` deps prepend (layout first, counter next) before co-located files."""
-        _assert_in_order(
-            home_html,
-            [
-                f'src="{BOOTSTRAP_JS}"',
-                f'src="{REACT_CDN}"',
-                f'src="{REACT_DOM_CDN}"',
-                f'src="{BABEL_CDN}"',
-                'src="/_next/static/layout.js"',
-                'src="/_next/static/index.js"',
-                'src="/_next/static/components/widget.js"',
-            ],
-        )
-
-
-class TestDashboardPageRendering:
-    """Verify the dashboard page (``/dashboard/``) exposes the right assets."""
-
-    def test_status_and_page_shell(self, dashboard_html: str) -> None:
-        """The layout shell and page heading render on the dashboard page."""
-        assert "Dashboard" in dashboard_html
-        assert "next-dj static demo" in dashboard_html
-
-    def test_chart_labels_rendered(self, dashboard_html: str) -> None:
-        """The chart's ``labels`` context reaches the canvas data attribute."""
-        assert 'data-chart-labels="Jan,Feb,Mar,Apr"' in dashboard_html
-
-    def test_chart_values_rendered(self, dashboard_html: str) -> None:
-        """The chart's ``values`` context reaches the canvas data attribute."""
-        assert 'data-chart-values="40,70,55,90"' in dashboard_html
-
-    def test_placeholders_are_replaced(self, dashboard_html: str) -> None:
-        """Collect slot placeholders do not leak into the final HTML."""
-        assert STYLES_PLACEHOLDER not in dashboard_html
-        assert SCRIPTS_PLACEHOLDER not in dashboard_html
-
-    @pytest.mark.parametrize(
-        "url",
-        [
-            BOOTSTRAP_CSS,
-            JETBRAINS_MONO,
-            "/_next/static/layout.css",
-            "/_next/static/dashboard.css",
-            "/_next/static/components/chart.css",
-        ],
-    )
-    def test_contains_css_link(self, dashboard_html: str, url: str) -> None:
-        """Every expected CSS source is emitted as a ``<link>`` tag."""
-        assert f'href="{url}"' in dashboard_html
-
-    @pytest.mark.parametrize(
-        "url",
-        [
-            BOOTSTRAP_JS,
-            CHART_JS,
-            "/_next/static/layout.js",
-            "/_next/static/components/chart.js",
-        ],
-    )
-    def test_contains_script_tag(self, dashboard_html: str, url: str) -> None:
-        """Every expected JS source is emitted as a ``<script>`` tag."""
-        assert f'src="{url}"' in dashboard_html
-
-    @pytest.mark.parametrize(
-        "foreign",
-        [
-            INTER_FONT,
-            BOOTSTRAP_ICONS,
-            "/_next/static/index.css",
-            "/_next/static/index.js",
-            "/_next/static/components/widget.css",
-            "/_next/static/components/widget.js",
-            "/_next/static/components/counter.css",
-            REACT_CDN,
-            REACT_DOM_CDN,
-            BABEL_CDN,
-        ],
-    )
-    def test_dashboard_excludes_home_only_assets(
-        self,
-        dashboard_html: str,
-        foreign: str,
-    ) -> None:
-        """Assets that only belong to the home page do not leak to the dashboard."""
-        assert foreign not in dashboard_html
-
-    def test_styles_follow_nested_discovery_order(self, dashboard_html: str) -> None:
-        """Dashboard styles cascade from layout ``use_style`` deps down to components."""
-        _assert_in_order(
-            dashboard_html,
-            [
-                f'href="{BOOTSTRAP_CSS}"',
-                'href="/_next/static/layout.css"',
-                'href="/_next/static/dashboard.css"',
-                f'href="{JETBRAINS_MONO}"',
-                'href="/_next/static/components/chart.css"',
-            ],
-        )
-
-    def test_scripts_follow_nested_discovery_order(self, dashboard_html: str) -> None:
-        """Dashboard scripts cascade from layout ``use_script`` deps down to components."""
-        _assert_in_order(
-            dashboard_html,
-            [
-                f'src="{BOOTSTRAP_JS}"',
-                'src="/_next/static/layout.js"',
-                'src="/_next/static/components/chart.js"',
-                f'src="{CHART_JS}"',
-            ],
-        )
-
-
-class TestCounterDedup:
-    """The counter component exercises dedup across repeated renders."""
-
-    @pytest.mark.parametrize("mount_id", ["counter-likes", "counter-stars"])
-    def test_counter_mount_points_rendered(self, home_html: str, mount_id: str) -> None:
-        """Each counter instance renders its own mount ``<div>`` with a unique id."""
-        assert f'id="{mount_id}"' in home_html
-
-    @pytest.mark.parametrize(
-        ("mount_id", "label"),
-        [("counter-likes", "Likes"), ("counter-stars", "Stars")],
-    )
-    def test_counter_labels_rendered(
-        self, home_html: str, mount_id: str, label: str
-    ) -> None:
-        """Literal ``label`` kwargs are passed through to the mount's dataset."""
-        marker = f'id="{mount_id}" data-counter-label="{label}"'
-        assert marker in home_html
-
-    @pytest.mark.parametrize("url", COUNTER_CDNS)
-    def test_each_react_cdn_appears_exactly_once(
-        self, home_html: str, url: str
-    ) -> None:
-        """Counter is rendered twice, yet each CDN ``<script>`` shows up once."""
-        assert home_html.count(f'src="{url}"') == 1
-
-    def test_counter_component_css_registered_once(self, home_html: str) -> None:
-        """Co-located ``counter/component.css`` is served under ``/_next/static/``."""
-        needle = 'href="/_next/static/components/counter.css"'
-        assert home_html.count(needle) == 1
-
-    def test_inline_babel_blocks_split_into_shared_and_per_instance(
-        self, home_html: str
-    ) -> None:
-        """Shared definition dedups to one, per-instance mount stays distinct.
-
-        The counter splits its Babel payload into two blocks: one with the
-        ``Counter`` component definition (identical for every instance, so
-        content-based dedup collapses it to a single entry) and one with
-        ``document.getElementById("counter-{{ id }}")`` mount code (which
-        differs per instance and stays distinct). Rendering the counter
-        twice produces three Babel blocks in the scripts slot: one shared
-        definition plus one mount per instance.
-        """
-        assert home_html.count('<script type="text/babel"') == 3
-        assert home_html.count("function Counter({ label })") == 1
-        assert 'getElementById("counter-likes")' in home_html
-        assert 'getElementById("counter-stars")' in home_html
-
-    def test_inline_babel_blocks_hoisted_into_scripts_slot(
-        self, home_html: str
-    ) -> None:
-        """``{% #use_script %}`` hoists the Babel blocks out of the mount region.
-
-        The counter renders its mount ``<div>`` inline, but the Babel
-        ``<script>`` bodies are captured by the block tag and placed inside
-        the ``{% collect_scripts %}`` slot so every ``<script>`` sits
-        together at the end of ``<body>``.
-        """
-        first_mount = home_html.find('id="counter-likes"')
-        last_mount = home_html.rfind('id="counter-stars"')
-        first_babel_script = home_html.find('<script type="text/babel"')
-        assert first_mount != -1
-        assert last_mount != -1
-        assert first_babel_script != -1
-        assert first_babel_script > last_mount
-
-    def test_counter_use_script_deps_prepend_before_files(self, home_html: str) -> None:
-        """``use_script`` deps declared in ``component.djx`` land before co-located files."""
-        _assert_in_order(
-            home_html,
-            [
-                f'src="{REACT_CDN}"',
-                f'src="{REACT_DOM_CDN}"',
-                f'src="{BABEL_CDN}"',
-                'src="/_next/static/layout.js"',
-                'src="/_next/static/components/widget.js"',
-            ],
-        )
-
-    def test_inline_babel_blocks_follow_deps(self, home_html: str) -> None:
-        """Inline ``{% #use_script %}`` bodies append after co-located/CDN scripts.
-
-        React/ReactDOM/Babel CDNs prepend (URL-form ``use_script``), co-located
-        ``*.js`` files append, and the Babel ``<script>`` bodies (one shared
-        definition plus one mount per instance) append last -- exactly the
-        order ``<script type="text/babel">`` needs to run after Babel
-        Standalone has loaded and parsed the DOM.
-        """
-        first_babel = home_html.find('<script type="text/babel"')
-        widget_js = home_html.find('src="/_next/static/components/widget.js"')
-        babel_cdn = home_html.find(f'src="{BABEL_CDN}"')
-        assert -1 not in (first_babel, widget_js, babel_cdn)
-        assert first_babel > widget_js > babel_cdn
-
-
-class TestStaticFileServing:
-    """Verify ``/_next/static/`` serves the registered co-located assets."""
-
-    @pytest.fixture(autouse=True)
-    def _warm_registry(self, home_html: str, dashboard_html: str) -> None:
-        """Render both pages so the backend registry contains every asset."""
-
-    @pytest.mark.parametrize(
-        ("path", "marker"),
-        [
-            ("/_next/static/layout.css", b"background-color"),
-            ("/_next/static/layout.js", b"layout script loaded"),
-            ("/_next/static/index.css", b"home-hero"),
-            ("/_next/static/index.js", b"home template script loaded"),
-            ("/_next/static/dashboard.css", b"JetBrains Mono"),
-            ("/_next/static/components/widget.css", b".widget"),
-            ("/_next/static/components/widget.js", b"widget-details"),
-            ("/_next/static/components/chart.css", b".chart"),
-            ("/_next/static/components/chart.js", b"initChart"),
-        ],
-    )
-    def test_served_files_return_expected_content(
-        self,
-        client: Client,
-        path: str,
-        marker: bytes,
-    ) -> None:
-        """Each registered logical path serves the correct on-disk contents."""
-        response = client.get(path)
-        assert response.status_code == 200
-        assert marker in _read_streamed(response)
-
-    def test_unknown_path_returns_404(self, client: Client) -> None:
-        """An unregistered path inside ``/_next/static/`` returns a 404 response."""
-        response = client.get("/_next/static/does-not-exist.css")
-        assert response.status_code == 404
-
-    def test_conditional_get_returns_304(self, client: Client) -> None:
-        """A conditional GET with a matching ``If-Modified-Since`` yields 304."""
-        response = client.get("/_next/static/layout.css")
-        assert response.status_code == 200
-        last_modified = response["Last-Modified"]
-        second = client.get(
-            "/_next/static/layout.css",
-            HTTP_IF_MODIFIED_SINCE=last_modified,
-        )
-        assert second.status_code == 304
-
-    def test_served_view_rejects_non_file_backend(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """When the default backend is not a ``FileStaticBackend``, the view 404s."""
-        from django.test import RequestFactory  # noqa: PLC0415
-
-        from next.static import static_serve_view  # noqa: PLC0415
-
-        class _DummyBackend:
-            pass
-
-        monkeypatch.setattr(
-            StaticManager,
-            "default_backend",
-            property(lambda self: _DummyBackend()),
-        )
-        response = static_serve_view(
-            RequestFactory().get("/_next/static/layout.css"),
-            "layout.css",
-        )
-        assert response.status_code == 404
-
-
-class TestExampleModulesCoverage:
-    """Directly exercise every symbol declared by example modules."""
-
-    def test_app_config_attributes(self) -> None:
-        """The ``MyAppConfig`` class declares the expected Django metadata."""
-        assert MyAppConfig.name == "myapp"
-        assert MyAppConfig.default_auto_field == "django.db.models.BigAutoField"
-
-    def test_config_urls_include_next_patterns(self) -> None:
-        """The root URL conf routes through ``next.urls`` only."""
-        assert isinstance(config_urls.urlpatterns, list)
-        assert len(config_urls.urlpatterns) == 1
-
-    def test_home_page_module_vars(self) -> None:
-        """Home ``page.py`` exposes the Inter font in ``styles`` and no scripts."""
-        assert home_page.styles == [INTER_FONT]
-        assert home_page.scripts == []
-
-    def test_home_page_title_function_is_callable(self) -> None:
-        """The ``get_page_title`` context function returns the home heading."""
-        assert callable(home_page.get_page_title)
-        assert home_page.get_page_title() == "Home"
-
-    def test_dashboard_page_module_vars(self) -> None:
-        """Dashboard ``page.py`` exposes JetBrains Mono in ``styles``."""
-        assert dashboard_page.styles == [JETBRAINS_MONO]
-        assert dashboard_page.scripts == []
-
-    def test_widget_component_module_vars(self) -> None:
-        """Widget ``component.py`` requests Bootstrap Icons via ``styles``."""
-        assert widget_component.styles == [BOOTSTRAP_ICONS]
-        assert widget_component.scripts == []
-
-    def test_widget_subtitle_function_is_callable(self) -> None:
-        """The widget's ``subtitle`` context function returns a static string."""
-        assert callable(widget_component.widget_subtitle)
-        assert widget_component.widget_subtitle() == "Composite widget example"
-
-    def test_chart_component_module_vars(self) -> None:
-        """Chart ``component.py`` requests Chart.js via ``scripts``."""
-        assert chart_component.styles == []
-        assert chart_component.scripts == [CHART_JS]
-
-    def test_chart_label_and_value_functions(self) -> None:
-        """The chart's label and value context functions return fixed fixtures."""
-        assert callable(chart_component.chart_labels)
-        assert callable(chart_component.chart_values)
-        assert chart_component.chart_labels() == ["Jan", "Feb", "Mar", "Apr"]
-        assert chart_component.chart_values() == [40, 70, 55, 90]
-
-
-class TestStaticManagerWiring:
-    """Verify the example's ``NEXT_FRAMEWORK`` settings wire up correctly."""
-
-    def test_default_backend_is_file_static_backend(self) -> None:
-        """The example settings expose a ``FileStaticBackend`` by default."""
-        assert isinstance(static_manager, StaticManager)
-        assert isinstance(static_manager.default_backend, FileStaticBackend)
-
-    def test_collector_deduplicates_repeat_urls(self) -> None:
-        """Adding the same URL twice to a collector keeps a single entry."""
-        collector = StaticCollector()
-        collector.add(StaticAsset(url=BOOTSTRAP_CSS, kind="css"))
-        collector.add(StaticAsset(url=BOOTSTRAP_CSS, kind="css"))
-        collector.add(StaticAsset(url=BOOTSTRAP_JS, kind="js"))
-        collector.add(StaticAsset(url=BOOTSTRAP_JS, kind="js"))
-        assert [asset.url for asset in collector.styles()] == [BOOTSTRAP_CSS]
-        assert [asset.url for asset in collector.scripts()] == [BOOTSTRAP_JS]
+def test_home_and_dashboard_routes_render(client: Client) -> None:
+    assert client.get("/").status_code == 200
+    assert client.get("/dashboard/").status_code == 200

--- a/examples/static/tests/tests.py
+++ b/examples/static/tests/tests.py
@@ -1,0 +1,396 @@
+"""End-to-end tests for the static assets example.
+
+The tests cover every Python module under ``myapp`` and ``config`` and exercise
+every static asset feature wired up by the example. They verify co-located CSS
+and JS discovery, module-level ``styles``/``scripts`` lists, the
+``{% use_style %}``/``{% use_script %}`` template tags, the
+``{% collect_styles %}``/``{% collect_scripts %}`` injection slots, the
+``/_next/static/`` serving view, and the relative ordering guaranteed by
+``StaticCollector`` and ``StaticManager``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from config import urls as config_urls
+from myapp.apps import MyAppConfig
+from myapp.pages import page as home_page
+from myapp.pages._components.widget import component as widget_component
+from myapp.pages.dashboard import page as dashboard_page
+from myapp.pages.dashboard._components.chart import component as chart_component
+
+from next.static import (
+    SCRIPTS_PLACEHOLDER,
+    STYLES_PLACEHOLDER,
+    FileStaticBackend,
+    StaticAsset,
+    StaticCollector,
+    StaticManager,
+    static_manager,
+)
+
+
+if TYPE_CHECKING:
+    from django.test import Client
+
+
+BOOTSTRAP_CSS = (
+    "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+)
+BOOTSTRAP_JS = (
+    "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+)
+BOOTSTRAP_ICONS = (
+    "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+)
+CHART_JS = "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
+INTER_FONT = "https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap"
+JETBRAINS_MONO = (
+    "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap"
+)
+
+
+def _read_streamed(response) -> bytes:
+    """Collect body bytes from a streaming or regular ``HttpResponse``."""
+    if getattr(response, "streaming", False):
+        return b"".join(chunk for chunk in response.streaming_content)
+    return response.content
+
+
+def _assert_in_order(html: str, needles: list[str]) -> None:
+    """Assert that every needle appears in ``html`` in the given order."""
+    positions: list[int] = []
+    for needle in needles:
+        idx = html.find(needle)
+        assert idx != -1, f"Expected to find {needle!r} in rendered HTML"
+        positions.append(idx)
+    assert positions == sorted(positions), (
+        "Expected assets in order, got positions "
+        f"{list(zip(needles, positions, strict=True))}"
+    )
+
+
+class TestHomePageRendering:
+    """Verify the rendered home page (``/``) exposes the right assets."""
+
+    def test_status_and_layout_shell(self, home_html: str) -> None:
+        """The layout shell markers from ``layout.djx`` render on the home page."""
+        assert "Static Assets Example" in home_html
+        assert "next-dj static demo" in home_html
+
+    def test_home_page_title_context_rendered(self, home_html: str) -> None:
+        """The ``@context('page_title')`` value from ``page.py`` reaches the HTML."""
+        assert ">Home</h1>" in home_html
+
+    def test_widget_title_and_subtitle_rendered(self, home_html: str) -> None:
+        """The widget component and its context keys render inside the page."""
+        assert "Bootstrap widget" in home_html
+        assert "Toggle details" in home_html
+
+    def test_placeholders_are_replaced(self, home_html: str) -> None:
+        """Collect slot placeholders do not leak into the final HTML."""
+        assert STYLES_PLACEHOLDER not in home_html
+        assert SCRIPTS_PLACEHOLDER not in home_html
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            BOOTSTRAP_CSS,
+            BOOTSTRAP_ICONS,
+            INTER_FONT,
+            "/_next/static/layout.css",
+            "/_next/static/index.css",
+            "/_next/static/components/widget.css",
+        ],
+    )
+    def test_contains_css_link(self, home_html: str, url: str) -> None:
+        """Every expected CSS source is emitted as a ``<link>`` tag."""
+        assert f'href="{url}"' in home_html
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            BOOTSTRAP_JS,
+            "/_next/static/layout.js",
+            "/_next/static/index.js",
+            "/_next/static/components/widget.js",
+        ],
+    )
+    def test_contains_script_tag(self, home_html: str, url: str) -> None:
+        """Every expected JS source is emitted as a ``<script>`` tag."""
+        assert f'src="{url}"' in home_html
+
+    def test_style_tags_render_in_head(self, home_html: str) -> None:
+        """CSS link tags appear before the closing ``</head>`` marker."""
+        head_end = home_html.index("</head>")
+        for url in (BOOTSTRAP_CSS, INTER_FONT, "/_next/static/layout.css"):
+            assert home_html.index(f'href="{url}"') < head_end
+
+    def test_script_tags_render_before_body_close(self, home_html: str) -> None:
+        """Script tags appear before the closing ``</body>`` marker."""
+        body_end = home_html.index("</body>")
+        for url in (BOOTSTRAP_JS, "/_next/static/components/widget.js"):
+            assert home_html.index(f'src="{url}"') < body_end
+
+    def test_styles_follow_nested_discovery_order(self, home_html: str) -> None:
+        """Styles cascade from layout ``use_style`` deps down to component files."""
+        _assert_in_order(
+            home_html,
+            [
+                f'href="{BOOTSTRAP_CSS}"',
+                'href="/_next/static/layout.css"',
+                'href="/_next/static/index.css"',
+                f'href="{INTER_FONT}"',
+                'href="/_next/static/components/widget.css"',
+                f'href="{BOOTSTRAP_ICONS}"',
+            ],
+        )
+
+    def test_scripts_follow_nested_discovery_order(self, home_html: str) -> None:
+        """Scripts cascade from layout ``use_script`` deps down to component files."""
+        _assert_in_order(
+            home_html,
+            [
+                f'src="{BOOTSTRAP_JS}"',
+                'src="/_next/static/layout.js"',
+                'src="/_next/static/index.js"',
+                'src="/_next/static/components/widget.js"',
+            ],
+        )
+
+
+class TestDashboardPageRendering:
+    """Verify the dashboard page (``/dashboard/``) exposes the right assets."""
+
+    def test_status_and_page_shell(self, dashboard_html: str) -> None:
+        """The layout shell and page heading render on the dashboard page."""
+        assert "Dashboard" in dashboard_html
+        assert "next-dj static demo" in dashboard_html
+
+    def test_chart_labels_rendered(self, dashboard_html: str) -> None:
+        """The chart's ``labels`` context reaches the canvas data attribute."""
+        assert 'data-chart-labels="Jan,Feb,Mar,Apr"' in dashboard_html
+
+    def test_chart_values_rendered(self, dashboard_html: str) -> None:
+        """The chart's ``values`` context reaches the canvas data attribute."""
+        assert 'data-chart-values="40,70,55,90"' in dashboard_html
+
+    def test_placeholders_are_replaced(self, dashboard_html: str) -> None:
+        """Collect slot placeholders do not leak into the final HTML."""
+        assert STYLES_PLACEHOLDER not in dashboard_html
+        assert SCRIPTS_PLACEHOLDER not in dashboard_html
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            BOOTSTRAP_CSS,
+            JETBRAINS_MONO,
+            "/_next/static/layout.css",
+            "/_next/static/dashboard.css",
+            "/_next/static/components/chart.css",
+        ],
+    )
+    def test_contains_css_link(self, dashboard_html: str, url: str) -> None:
+        """Every expected CSS source is emitted as a ``<link>`` tag."""
+        assert f'href="{url}"' in dashboard_html
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            BOOTSTRAP_JS,
+            CHART_JS,
+            "/_next/static/layout.js",
+            "/_next/static/components/chart.js",
+        ],
+    )
+    def test_contains_script_tag(self, dashboard_html: str, url: str) -> None:
+        """Every expected JS source is emitted as a ``<script>`` tag."""
+        assert f'src="{url}"' in dashboard_html
+
+    @pytest.mark.parametrize(
+        "foreign",
+        [
+            INTER_FONT,
+            BOOTSTRAP_ICONS,
+            "/_next/static/index.css",
+            "/_next/static/index.js",
+            "/_next/static/components/widget.css",
+            "/_next/static/components/widget.js",
+        ],
+    )
+    def test_dashboard_excludes_home_only_assets(
+        self,
+        dashboard_html: str,
+        foreign: str,
+    ) -> None:
+        """Assets that only belong to the home page do not leak to the dashboard."""
+        assert foreign not in dashboard_html
+
+    def test_styles_follow_nested_discovery_order(self, dashboard_html: str) -> None:
+        """Dashboard styles cascade from layout ``use_style`` deps down to components."""
+        _assert_in_order(
+            dashboard_html,
+            [
+                f'href="{BOOTSTRAP_CSS}"',
+                'href="/_next/static/layout.css"',
+                'href="/_next/static/dashboard.css"',
+                f'href="{JETBRAINS_MONO}"',
+                'href="/_next/static/components/chart.css"',
+            ],
+        )
+
+    def test_scripts_follow_nested_discovery_order(self, dashboard_html: str) -> None:
+        """Dashboard scripts cascade from layout ``use_script`` deps down to components."""
+        _assert_in_order(
+            dashboard_html,
+            [
+                f'src="{BOOTSTRAP_JS}"',
+                'src="/_next/static/layout.js"',
+                'src="/_next/static/components/chart.js"',
+                f'src="{CHART_JS}"',
+            ],
+        )
+
+
+class TestStaticFileServing:
+    """Verify ``/_next/static/`` serves the registered co-located assets."""
+
+    @pytest.fixture(autouse=True)
+    def _warm_registry(self, home_html: str, dashboard_html: str) -> None:
+        """Render both pages so the backend registry contains every asset."""
+
+    @pytest.mark.parametrize(
+        ("path", "marker"),
+        [
+            ("/_next/static/layout.css", b"background-color"),
+            ("/_next/static/layout.js", b"layout script loaded"),
+            ("/_next/static/index.css", b"home-hero"),
+            ("/_next/static/index.js", b"home template script loaded"),
+            ("/_next/static/dashboard.css", b"JetBrains Mono"),
+            ("/_next/static/components/widget.css", b".widget"),
+            ("/_next/static/components/widget.js", b"widget-details"),
+            ("/_next/static/components/chart.css", b".chart"),
+            ("/_next/static/components/chart.js", b"initChart"),
+        ],
+    )
+    def test_served_files_return_expected_content(
+        self,
+        client: Client,
+        path: str,
+        marker: bytes,
+    ) -> None:
+        """Each registered logical path serves the correct on-disk contents."""
+        response = client.get(path)
+        assert response.status_code == 200
+        assert marker in _read_streamed(response)
+
+    def test_unknown_path_returns_404(self, client: Client) -> None:
+        """An unregistered path inside ``/_next/static/`` returns a 404 response."""
+        response = client.get("/_next/static/does-not-exist.css")
+        assert response.status_code == 404
+
+    def test_conditional_get_returns_304(self, client: Client) -> None:
+        """A conditional GET with a matching ``If-Modified-Since`` yields 304."""
+        response = client.get("/_next/static/layout.css")
+        assert response.status_code == 200
+        last_modified = response["Last-Modified"]
+        second = client.get(
+            "/_next/static/layout.css",
+            HTTP_IF_MODIFIED_SINCE=last_modified,
+        )
+        assert second.status_code == 304
+
+    def test_served_view_rejects_non_file_backend(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When the default backend is not a ``FileStaticBackend``, the view 404s."""
+        from django.test import RequestFactory  # noqa: PLC0415
+
+        from next.static import static_serve_view  # noqa: PLC0415
+
+        class _DummyBackend:
+            pass
+
+        monkeypatch.setattr(
+            StaticManager,
+            "default_backend",
+            property(lambda self: _DummyBackend()),
+        )
+        response = static_serve_view(
+            RequestFactory().get("/_next/static/layout.css"),
+            "layout.css",
+        )
+        assert response.status_code == 404
+
+
+class TestExampleModulesCoverage:
+    """Directly exercise every symbol declared by example modules."""
+
+    def test_app_config_attributes(self) -> None:
+        """The ``MyAppConfig`` class declares the expected Django metadata."""
+        assert MyAppConfig.name == "myapp"
+        assert MyAppConfig.default_auto_field == "django.db.models.BigAutoField"
+
+    def test_config_urls_include_next_patterns(self) -> None:
+        """The root URL conf routes through ``next.urls`` only."""
+        assert isinstance(config_urls.urlpatterns, list)
+        assert len(config_urls.urlpatterns) == 1
+
+    def test_home_page_module_vars(self) -> None:
+        """Home ``page.py`` exposes the Inter font in ``styles`` and no scripts."""
+        assert home_page.styles == [INTER_FONT]
+        assert home_page.scripts == []
+
+    def test_home_page_title_function_is_callable(self) -> None:
+        """The ``get_page_title`` context function returns the home heading."""
+        assert callable(home_page.get_page_title)
+        assert home_page.get_page_title() == "Home"
+
+    def test_dashboard_page_module_vars(self) -> None:
+        """Dashboard ``page.py`` exposes JetBrains Mono in ``styles``."""
+        assert dashboard_page.styles == [JETBRAINS_MONO]
+        assert dashboard_page.scripts == []
+
+    def test_widget_component_module_vars(self) -> None:
+        """Widget ``component.py`` requests Bootstrap Icons via ``styles``."""
+        assert widget_component.styles == [BOOTSTRAP_ICONS]
+        assert widget_component.scripts == []
+
+    def test_widget_subtitle_function_is_callable(self) -> None:
+        """The widget's ``subtitle`` context function returns a static string."""
+        assert callable(widget_component.widget_subtitle)
+        assert widget_component.widget_subtitle() == "Composite widget example"
+
+    def test_chart_component_module_vars(self) -> None:
+        """Chart ``component.py`` requests Chart.js via ``scripts``."""
+        assert chart_component.styles == []
+        assert chart_component.scripts == [CHART_JS]
+
+    def test_chart_label_and_value_functions(self) -> None:
+        """The chart's label and value context functions return fixed fixtures."""
+        assert callable(chart_component.chart_labels)
+        assert callable(chart_component.chart_values)
+        assert chart_component.chart_labels() == ["Jan", "Feb", "Mar", "Apr"]
+        assert chart_component.chart_values() == [40, 70, 55, 90]
+
+
+class TestStaticManagerWiring:
+    """Verify the example's ``NEXT_FRAMEWORK`` settings wire up correctly."""
+
+    def test_default_backend_is_file_static_backend(self) -> None:
+        """The example settings expose a ``FileStaticBackend`` by default."""
+        assert isinstance(static_manager, StaticManager)
+        assert isinstance(static_manager.default_backend, FileStaticBackend)
+
+    def test_collector_deduplicates_repeat_urls(self) -> None:
+        """Adding the same URL twice to a collector keeps a single entry."""
+        collector = StaticCollector()
+        collector.add(StaticAsset(url=BOOTSTRAP_CSS, kind="css"))
+        collector.add(StaticAsset(url=BOOTSTRAP_CSS, kind="css"))
+        collector.add(StaticAsset(url=BOOTSTRAP_JS, kind="js"))
+        collector.add(StaticAsset(url=BOOTSTRAP_JS, kind="js"))
+        assert [asset.url for asset in collector.styles()] == [BOOTSTRAP_CSS]
+        assert [asset.url for asset in collector.scripts()] == [BOOTSTRAP_JS]

--- a/examples/static/tests/tests.py
+++ b/examples/static/tests/tests.py
@@ -50,6 +50,10 @@ INTER_FONT = "https://fonts.googleapis.com/css2?family=Inter:wght@400;600&displa
 JETBRAINS_MONO = (
     "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap"
 )
+REACT_CDN = "https://unpkg.com/react@18.3.1/umd/react.production.min.js"
+REACT_DOM_CDN = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js"
+BABEL_CDN = "https://unpkg.com/@babel/standalone@7.24.7/babel.min.js"
+COUNTER_CDNS = (REACT_CDN, REACT_DOM_CDN, BABEL_CDN)
 
 
 def _read_streamed(response) -> bytes:
@@ -103,6 +107,7 @@ class TestHomePageRendering:
             "/_next/static/layout.css",
             "/_next/static/index.css",
             "/_next/static/components/widget.css",
+            "/_next/static/components/counter.css",
         ],
     )
     def test_contains_css_link(self, home_html: str, url: str) -> None:
@@ -116,6 +121,9 @@ class TestHomePageRendering:
             "/_next/static/layout.js",
             "/_next/static/index.js",
             "/_next/static/components/widget.js",
+            REACT_CDN,
+            REACT_DOM_CDN,
+            BABEL_CDN,
         ],
     )
     def test_contains_script_tag(self, home_html: str, url: str) -> None:
@@ -145,15 +153,19 @@ class TestHomePageRendering:
                 f'href="{INTER_FONT}"',
                 'href="/_next/static/components/widget.css"',
                 f'href="{BOOTSTRAP_ICONS}"',
+                'href="/_next/static/components/counter.css"',
             ],
         )
 
     def test_scripts_follow_nested_discovery_order(self, home_html: str) -> None:
-        """Scripts cascade from layout ``use_script`` deps down to component files."""
+        """``use_script`` deps prepend (layout first, counter next) before co-located files."""
         _assert_in_order(
             home_html,
             [
                 f'src="{BOOTSTRAP_JS}"',
+                f'src="{REACT_CDN}"',
+                f'src="{REACT_DOM_CDN}"',
+                f'src="{BABEL_CDN}"',
                 'src="/_next/static/layout.js"',
                 'src="/_next/static/index.js"',
                 'src="/_next/static/components/widget.js"',
@@ -218,6 +230,10 @@ class TestDashboardPageRendering:
             "/_next/static/index.js",
             "/_next/static/components/widget.css",
             "/_next/static/components/widget.js",
+            "/_next/static/components/counter.css",
+            REACT_CDN,
+            REACT_DOM_CDN,
+            BABEL_CDN,
         ],
     )
     def test_dashboard_excludes_home_only_assets(
@@ -252,6 +268,102 @@ class TestDashboardPageRendering:
                 f'src="{CHART_JS}"',
             ],
         )
+
+
+class TestCounterDedup:
+    """The counter component exercises dedup across repeated renders."""
+
+    @pytest.mark.parametrize("mount_id", ["counter-likes", "counter-stars"])
+    def test_counter_mount_points_rendered(self, home_html: str, mount_id: str) -> None:
+        """Each counter instance renders its own mount ``<div>`` with a unique id."""
+        assert f'id="{mount_id}"' in home_html
+
+    @pytest.mark.parametrize(
+        ("mount_id", "label"),
+        [("counter-likes", "Likes"), ("counter-stars", "Stars")],
+    )
+    def test_counter_labels_rendered(
+        self, home_html: str, mount_id: str, label: str
+    ) -> None:
+        """Literal ``label`` kwargs are passed through to the mount's dataset."""
+        marker = f'id="{mount_id}" data-counter-label="{label}"'
+        assert marker in home_html
+
+    @pytest.mark.parametrize("url", COUNTER_CDNS)
+    def test_each_react_cdn_appears_exactly_once(
+        self, home_html: str, url: str
+    ) -> None:
+        """Counter is rendered twice, yet each CDN ``<script>`` shows up once."""
+        assert home_html.count(f'src="{url}"') == 1
+
+    def test_counter_component_css_registered_once(self, home_html: str) -> None:
+        """Co-located ``counter/component.css`` is served under ``/_next/static/``."""
+        needle = 'href="/_next/static/components/counter.css"'
+        assert home_html.count(needle) == 1
+
+    def test_inline_babel_blocks_split_into_shared_and_per_instance(
+        self, home_html: str
+    ) -> None:
+        """Shared definition dedups to one, per-instance mount stays distinct.
+
+        The counter splits its Babel payload into two blocks: one with the
+        ``Counter`` component definition (identical for every instance, so
+        content-based dedup collapses it to a single entry) and one with
+        ``document.getElementById("counter-{{ id }}")`` mount code (which
+        differs per instance and stays distinct). Rendering the counter
+        twice produces three Babel blocks in the scripts slot: one shared
+        definition plus one mount per instance.
+        """
+        assert home_html.count('<script type="text/babel"') == 3
+        assert home_html.count("function Counter({ label })") == 1
+        assert 'getElementById("counter-likes")' in home_html
+        assert 'getElementById("counter-stars")' in home_html
+
+    def test_inline_babel_blocks_hoisted_into_scripts_slot(
+        self, home_html: str
+    ) -> None:
+        """``{% #use_script %}`` hoists the Babel blocks out of the mount region.
+
+        The counter renders its mount ``<div>`` inline, but the Babel
+        ``<script>`` bodies are captured by the block tag and placed inside
+        the ``{% collect_scripts %}`` slot so every ``<script>`` sits
+        together at the end of ``<body>``.
+        """
+        first_mount = home_html.find('id="counter-likes"')
+        last_mount = home_html.rfind('id="counter-stars"')
+        first_babel_script = home_html.find('<script type="text/babel"')
+        assert first_mount != -1
+        assert last_mount != -1
+        assert first_babel_script != -1
+        assert first_babel_script > last_mount
+
+    def test_counter_use_script_deps_prepend_before_files(self, home_html: str) -> None:
+        """``use_script`` deps declared in ``component.djx`` land before co-located files."""
+        _assert_in_order(
+            home_html,
+            [
+                f'src="{REACT_CDN}"',
+                f'src="{REACT_DOM_CDN}"',
+                f'src="{BABEL_CDN}"',
+                'src="/_next/static/layout.js"',
+                'src="/_next/static/components/widget.js"',
+            ],
+        )
+
+    def test_inline_babel_blocks_follow_deps(self, home_html: str) -> None:
+        """Inline ``{% #use_script %}`` bodies append after co-located/CDN scripts.
+
+        React/ReactDOM/Babel CDNs prepend (URL-form ``use_script``), co-located
+        ``*.js`` files append, and the Babel ``<script>`` bodies (one shared
+        definition plus one mount per instance) append last -- exactly the
+        order ``<script type="text/babel">`` needs to run after Babel
+        Standalone has loaded and parsed the DOM.
+        """
+        first_babel = home_html.find('<script type="text/babel"')
+        widget_js = home_html.find('src="/_next/static/components/widget.js"')
+        babel_cdn = home_html.find(f'src="{BABEL_CDN}"')
+        assert -1 not in (first_babel, widget_js, babel_cdn)
+        assert first_babel > widget_js > babel_cdn
 
 
 class TestStaticFileServing:

--- a/next/apps.py
+++ b/next/apps.py
@@ -24,7 +24,11 @@ class NextFrameworkConfig(AppConfig):
         autoreload.StatReloader = NextStatReloader  # type: ignore[misc]
 
         builtins = list(settings.TEMPLATES[0].get("OPTIONS", {}).get("builtins", []))
-        for mod in ("next.templatetags.forms", "next.templatetags.components"):
+        for mod in (
+            "next.templatetags.forms",
+            "next.templatetags.components",
+            "next.templatetags.next_static",
+        ):
             if mod not in builtins:
                 builtins.append(mod)
         settings.TEMPLATES[0].setdefault("OPTIONS", {})["builtins"] = builtins

--- a/next/apps.py
+++ b/next/apps.py
@@ -33,6 +33,12 @@ class NextFrameworkConfig(AppConfig):
                 builtins.append(mod)
         settings.TEMPLATES[0].setdefault("OPTIONS", {})["builtins"] = builtins
 
+        finder_path = "next.static.NextStaticFilesFinder"
+        configured_finders = list(getattr(settings, "STATICFILES_FINDERS", []))
+        if finder_path not in configured_finders:
+            configured_finders.append(finder_path)
+            settings.STATICFILES_FINDERS = configured_finders
+
         def watch_next_filesystem(sender: object, **_: object) -> None:
             for path, glob in iter_all_autoreload_watch_specs():
                 sender.watch_dir(path, glob)  # type: ignore[attr-defined]

--- a/next/conf.py
+++ b/next/conf.py
@@ -49,6 +49,12 @@ class NextFrameworkSettings:
                 "COMPONENTS_DIR": "_components",
             },
         ],
+        "DEFAULT_STATIC_BACKENDS": [
+            {
+                "BACKEND": "next.static.FileStaticBackend",
+                "OPTIONS": {},
+            },
+        ],
     }
 
     IMPORT_STRINGS: ClassVar[frozenset[str]] = frozenset()
@@ -59,7 +65,7 @@ class NextFrameworkSettings:
         self._attr_value_cache: dict[str, Any] = {}
 
     def reload(self) -> None:
-        """Drop caches and reload URL and component backends."""
+        """Drop caches and reload URL, component, and static backends."""
         self._merged_cache = None
         self._attr_value_cache.clear()
 
@@ -67,8 +73,10 @@ class NextFrameworkSettings:
 
         urls_mod = importlib.import_module("next.urls")
         components_mod = importlib.import_module("next.components")
+        static_mod = importlib.import_module("next.static")
         urls_mod.router_manager._reload_config()
         components_mod.components_manager._reload_config()
+        static_mod.static_manager._reload_config()
 
     def _raw_user(self) -> dict[str, Any] | None:
         raw = getattr(settings, USER_SETTING, None)
@@ -97,6 +105,7 @@ class NextFrameworkSettings:
             elif key in (
                 "DEFAULT_PAGE_BACKENDS",
                 "DEFAULT_COMPONENT_BACKENDS",
+                "DEFAULT_STATIC_BACKENDS",
             ) and isinstance(raw, list):
                 out[key] = copy.deepcopy(raw)
         return out

--- a/next/conf.py
+++ b/next/conf.py
@@ -51,7 +51,7 @@ class NextFrameworkSettings:
         ],
         "DEFAULT_STATIC_BACKENDS": [
             {
-                "BACKEND": "next.static.FileStaticBackend",
+                "BACKEND": "next.static.StaticFilesBackend",
                 "OPTIONS": {},
             },
         ],

--- a/next/pages.py
+++ b/next/pages.py
@@ -652,7 +652,14 @@ class Page:
         return context_data
 
     def render(self, file_path: Path, *args: object, **kwargs: object) -> str:
-        """Render with Django ``Template`` after reloading stale sources and context."""
+        """Render with Django ``Template`` after reloading stale sources and context.
+
+        A ``StaticCollector`` is placed in the template context before rendering
+        so that nested components can register their CSS and JS references. Once
+        the template has rendered, placeholder markers left by
+        ``{% collect_styles %}`` and ``{% collect_scripts %}`` are replaced with
+        actual ``<link>`` and ``<script>`` tags.
+        """
         if file_path not in self._template_registry or self._is_template_stale(
             file_path
         ):
@@ -662,7 +669,15 @@ class Page:
             self._record_template_source_mtimes(file_path)
         template_str = self._template_registry[file_path]
         context_data = self.build_render_context(file_path, *args, **kwargs)
-        return Template(template_str).render(DjangoTemplateContext(context_data))
+
+        from .static import StaticCollector, static_manager  # noqa: PLC0415
+
+        collector = StaticCollector()
+        static_manager.discover_page_assets(file_path, collector)
+        context_data["_static_collector"] = collector
+
+        html = Template(template_str).render(DjangoTemplateContext(context_data))
+        return static_manager.inject(html, collector)
 
     def _create_view_function(
         self,

--- a/next/pages.py
+++ b/next/pages.py
@@ -266,6 +266,14 @@ def _load_python_module(file_path: Path) -> types.ModuleType | None:
         return module
 
 
+def _read_string_list(module: types.ModuleType, attr: str) -> list[str]:
+    """Return a module-level string sequence attribute or an empty list."""
+    value = getattr(module, attr, None)
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [str(item) for item in value if isinstance(item, str) and item]
+
+
 class TemplateLoader(ABC):
     """Pluggable source of template text for a ``page.py`` path."""
 

--- a/next/static.py
+++ b/next/static.py
@@ -62,54 +62,77 @@ _KIND_JS = "js"
 
 @dataclass(frozen=True, slots=True)
 class StaticAsset:
-    """One CSS or JS file reference to include on the rendered page.
+    """One CSS or JS reference to include on the rendered page.
 
     A file asset originates from a co-located file on disk and has
     ``source_path`` set to its absolute filesystem path. An external asset
-    carries a raw URL supplied by a ``styles`` or ``scripts`` module variable
-    and has no ``source_path``.
+    carries a raw URL supplied by a ``styles`` / ``scripts`` module variable
+    or by ``{% use_style %}`` / ``{% use_script %}``. An inline asset comes
+    from a ``{% #use_style %}`` / ``{% #use_script %}`` block and stores its
+    pre-rendered HTML body in ``inline`` with ``url`` left empty. The
+    collector dedupes inline assets by body content so identical rendered
+    blocks (for example the same component rendered twice with the same
+    context) end up in the slot exactly once.
     """
 
     url: str
     kind: str
     source_path: Path | None = None
+    inline: str | None = None
 
 
 class StaticCollector:
     """Accumulate static asset references during a single page render.
 
     The collector is stored in template context under ``_static_collector`` so
-    that nested component rendering can append its own assets. Duplicate URLs
-    are ignored and insertion order follows the CSS-cascade convention: items
-    added with ``prepend=True`` (shared third-party dependencies declared with
-    ``{% use_style %}`` / ``{% use_script %}``) appear first in the order they
-    were registered, followed by co-located files and module-level lists in
-    nested depth-first render order.
+    that nested component rendering can append its own assets. Insertion
+    order follows the CSS-cascade convention: items added with
+    ``prepend=True`` (shared third-party dependencies declared with
+    ``{% use_style %}`` / ``{% use_script %}``) appear first in the order
+    they were registered, followed by co-located files, module-level lists
+    and inline blocks from ``{% #use_style %}`` / ``{% #use_script %}`` in
+    nested depth-first render order. URL-form entries dedupe by URL;
+    inline entries always append and dedupe by the rendered body itself, so
+    two blocks producing identical HTML collapse to one while blocks whose
+    template context resolves to different HTML stay distinct.
     """
 
     def __init__(self) -> None:
         """Create an empty collector with separate ordered lists for CSS and JS."""
         self._seen_urls: set[str] = set()
+        self._seen_inline: set[tuple[str, str]] = set()
         self._styles: list[StaticAsset] = []
         self._scripts: list[StaticAsset] = []
         self._styles_prepend_idx: int = 0
         self._scripts_prepend_idx: int = 0
 
     def add(self, asset: StaticAsset, *, prepend: bool = False) -> None:
-        """Append (or prepend) one asset unless its URL was already seen.
+        """Append (or prepend) one asset unless its dedup key was already seen.
 
         ``prepend=True`` inserts the asset at the current front of its list so
         that dependencies declared with ``{% use_style %}`` / ``{% use_script %}``
         appear before co-located files. Multiple prepended items keep their
-        registration order relative to each other.
+        registration order relative to each other. Inline assets always
+        append, and their dedup key is the rendered body paired with the
+        kind so two blocks producing identical HTML collapse to one entry
+        while blocks that interpolate different context into the body stay
+        distinct.
         """
-        if asset.url in self._seen_urls:
-            return
-        self._seen_urls.add(asset.url)
+        is_inline = asset.inline is not None
+        if is_inline:
+            key = (asset.kind, asset.inline or "")
+            if key in self._seen_inline:
+                return
+            self._seen_inline.add(key)
+        else:
+            if asset.url in self._seen_urls:
+                return
+            self._seen_urls.add(asset.url)
+        use_prepend = prepend and not is_inline
         if asset.kind == _KIND_CSS:
-            self._insert(self._styles, asset, prepend=prepend, kind=_KIND_CSS)
+            self._insert(self._styles, asset, prepend=use_prepend, kind=_KIND_CSS)
         elif asset.kind == _KIND_JS:
-            self._insert(self._scripts, asset, prepend=prepend, kind=_KIND_JS)
+            self._insert(self._scripts, asset, prepend=use_prepend, kind=_KIND_JS)
         else:
             logger.debug(
                 "Ignoring asset with unknown kind %r: %s", asset.kind, asset.url
@@ -589,19 +612,38 @@ class StaticManager:
         return html
 
     def _render_style_tags(self, collector: StaticCollector) -> str:
-        """Return concatenated CSS link tags for every collected style asset."""
+        """Return concatenated CSS tags for every collected style asset.
+
+        External and co-located assets are rendered by the active backend as
+        ``<link>`` tags. Inline assets emit their pre-rendered HTML body
+        verbatim, so developers can hoist ``<style>`` blocks, conditional
+        imports, or custom tags into the styles slot unmodified.
+        """
         self._ensure_backends()
         backend = self._backends[0]
         return "\n".join(
-            backend.render_link_tag(asset.url) for asset in collector.styles()
+            asset.inline
+            if asset.inline is not None
+            else backend.render_link_tag(asset.url)
+            for asset in collector.styles()
         )
 
     def _render_script_tags(self, collector: StaticCollector) -> str:
-        """Return concatenated JS script tags for every collected script asset."""
+        """Return concatenated JS tags for every collected script asset.
+
+        External and co-located assets are rendered by the active backend as
+        ``<script src="…">`` tags. Inline assets emit their pre-rendered HTML
+        body verbatim, so developers can hoist arbitrary ``<script>`` blocks
+        (including ``type="module"`` or ``type="text/babel"``) into the
+        scripts slot unmodified.
+        """
         self._ensure_backends()
         backend = self._backends[0]
         return "\n".join(
-            backend.render_script_tag(asset.url) for asset in collector.scripts()
+            asset.inline
+            if asset.inline is not None
+            else backend.render_script_tag(asset.url)
+            for asset in collector.scripts()
         )
 
     def _ensure_backends(self) -> None:

--- a/next/static.py
+++ b/next/static.py
@@ -1,15 +1,12 @@
 """Discover and inject co-located static assets for pages and components.
 
-Asset files are named after the ``.djx`` file they decorate and live in the
-same directory: ``template.css``/``template.js`` sit beside ``template.djx``,
-``layout.css``/``layout.js`` beside ``layout.djx``, and
-``component.css``/``component.js`` beside ``component.djx``. Pages and
-components may also declare ``styles`` and ``scripts`` list variables at
-module level (``page.py``/``component.py``). The collector gathers references
-during rendering and the manager injects them into placeholder slots emitted
-by the ``{% collect_styles %}`` and ``{% collect_scripts %}`` template tags.
-Public URLs are resolved by the configured static backend (Django staticfiles
-by default).
+Each ``.djx`` file may have a matching ``.css`` and ``.js`` file in the same
+directory. Pages and components may also declare ``styles`` and ``scripts``
+list variables in their Python modules. During rendering the collector gathers
+all referenced assets. After rendering, ``StaticManager.inject`` replaces the
+``{% collect_styles %}`` and ``{% collect_scripts %}`` placeholders with the
+actual ``<link>`` and ``<script>`` tags. Public URLs are resolved through
+Django staticfiles.
 """
 
 from __future__ import annotations
@@ -28,10 +25,15 @@ from django.core.files.storage import Storage
 
 from . import pages
 from .conf import import_class_cached, next_framework_settings
+from .pages import (
+    get_layout_djx_paths_for_watch,
+    get_pages_directories_for_watch,
+    get_template_djx_paths_for_watch,
+)
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Callable, Iterable, Iterator
     from pathlib import Path
 
     from .components import ComponentInfo
@@ -61,19 +63,24 @@ _KIND_CSS = "css"
 _KIND_JS = "js"
 
 
+def _kind_to_extension(kind: str) -> str:
+    """Return the file extension for ``css`` or ``js`` kinds."""
+    if kind == _KIND_CSS:
+        return ".css"
+    if kind == _KIND_JS:
+        return ".js"
+    msg = f"Unsupported asset kind: {kind!r}"
+    raise ValueError(msg)
+
+
 @dataclass(frozen=True, slots=True)
 class StaticAsset:
-    """One CSS or JS reference to include on the rendered page.
+    """One CSS or JS asset reference collected during page rendering.
 
-    A file asset originates from a co-located file on disk and has
-    ``source_path`` set to its absolute filesystem path. An external asset
-    carries a raw URL supplied by a ``styles`` / ``scripts`` module variable
-    or by ``{% use_style %}`` / ``{% use_script %}``. An inline asset comes
-    from a ``{% #use_style %}`` / ``{% #use_script %}`` block and stores its
-    pre-rendered HTML body in ``inline`` with ``url`` left empty. The
-    collector dedupes inline assets by body content so identical rendered
-    blocks (for example the same component rendered twice with the same
-    context) end up in the slot exactly once.
+    For co-located disk files both ``url`` and ``source_path`` are set.
+    For external URLs such as CDN links only ``url`` is set.
+    For block-form ``{% #use_style %}`` and ``{% #use_script %}`` assets
+    ``inline`` holds the pre-rendered HTML body and ``url`` is empty.
     """
 
     url: str
@@ -85,21 +92,14 @@ class StaticAsset:
 class StaticCollector:
     """Accumulate static asset references during a single page render.
 
-    The collector is stored in template context under ``_static_collector`` so
-    that nested component rendering can append its own assets. Insertion
-    order follows the CSS-cascade convention: items added with
-    ``prepend=True`` (shared third-party dependencies declared with
-    ``{% use_style %}`` / ``{% use_script %}``) appear first in the order
-    they were registered, followed by co-located files, module-level lists
-    and inline blocks from ``{% #use_style %}`` / ``{% #use_script %}`` in
-    nested depth-first render order. URL-form entries dedupe by URL.
-    Inline entries always append and dedupe by the rendered body itself, so
-    two blocks producing identical HTML collapse to one while blocks whose
-    template context resolves to different HTML stay distinct.
+    URL-form assets deduplicate by URL. Inline assets deduplicate by rendered
+    body so identical blocks collapse to one entry. Assets added with
+    ``prepend=True`` appear before regular append entries within the same kind,
+    which keeps shared third-party dependencies at the front of the cascade.
     """
 
     def __init__(self) -> None:
-        """Create an empty collector with separate ordered lists for CSS and JS."""
+        """Return a collector ready to accept assets. All buckets start empty."""
         self._seen_urls: set[str] = set()
         self._seen_inline: set[tuple[str, str]] = set()
         self._styles: list[StaticAsset] = []
@@ -108,16 +108,12 @@ class StaticCollector:
         self._scripts_prepend_idx: int = 0
 
     def add(self, asset: StaticAsset, *, prepend: bool = False) -> None:
-        """Append (or prepend) one asset unless its dedup key was already seen.
+        """Add an asset unless its dedup key was already recorded.
 
-        ``prepend=True`` inserts the asset at the current front of its list so
-        that dependencies declared with ``{% use_style %}`` / ``{% use_script %}``
-        appear before co-located files. Multiple prepended items keep their
-        registration order relative to each other. Inline assets always
-        append, and their dedup key is the rendered body paired with the
-        kind so two blocks producing identical HTML collapse to one entry
-        while blocks that interpolate different context into the body stay
-        distinct.
+        Inline assets always append and are keyed by their rendered body.
+        URL-form assets are keyed by URL. When ``prepend=True``, URL-form
+        assets are inserted before existing append entries while keeping
+        registration order among prepended items.
         """
         is_inline = asset.inline is not None
         if is_inline:
@@ -163,12 +159,12 @@ class StaticCollector:
             target.append(asset)
 
     def styles(self) -> list[StaticAsset]:
-        """Return collected CSS assets in insertion order."""
-        return list(self._styles)
+        """Return collected CSS assets in insertion order. Callers must not mutate."""
+        return self._styles
 
     def scripts(self) -> list[StaticAsset]:
-        """Return collected JS assets in insertion order."""
-        return list(self._scripts)
+        """Return collected JS assets in insertion order. Callers must not mutate."""
+        return self._scripts
 
 
 class StaticBackend(ABC):
@@ -181,11 +177,11 @@ class StaticBackend(ABC):
         logical_name: str,
         kind: str,
     ) -> str:
-        """Register a co-located asset file and return the URL used to serve it.
+        """Register a co-located asset file and return its public URL.
 
-        ``logical_name`` is a slash-separated path without file extension, such
-        as ``"about"``, ``"components/card"``, or ``"guides/layout"``. The
-        backend appends the ``.css`` or ``.js`` extension based on ``kind``.
+        ``logical_name`` is a path without extension, such as ``"about"``,
+        ``"components/card"``, or ``"guides/layout"``. The backend appends
+        the appropriate extension based on ``kind``.
         """
 
     @abstractmethod
@@ -198,11 +194,10 @@ class StaticBackend(ABC):
 
 
 class StaticFilesBackend(StaticBackend):
-    """Resolve co-located assets through Django ``staticfiles_storage``.
+    """Resolve co-located asset URLs through Django staticfiles.
 
-    Files discovered by ``next.dj`` keep their logical identities (for example
-    ``blog/layout.css`` and ``components/card.js``), but public URLs are always
-    resolved by Django staticfiles so Manifest/S3/CDN settings apply uniformly.
+    All files use the ``next/`` namespace so manifest hashing, S3 storage,
+    and CDN configuration from Django settings apply automatically.
     """
 
     _DEFAULT_CSS_TAG: ClassVar[str] = '<link rel="stylesheet" href="{url}">'
@@ -215,6 +210,7 @@ class StaticFilesBackend(StaticBackend):
         opts = cfg.get("OPTIONS") or {}
         self._css_tag = str(opts.get("css_tag") or self._DEFAULT_CSS_TAG)
         self._js_tag = str(opts.get("js_tag") or self._DEFAULT_JS_TAG)
+        self._url_cache: dict[str, str] = {}
 
     def _logical_static_path(self, logical_name: str, kind: str) -> str:
         extension = _kind_to_extension(kind)
@@ -228,14 +224,19 @@ class StaticFilesBackend(StaticBackend):
     ) -> str:
         """Return URL from Django staticfiles for ``next/<logical_name>.<ext>``."""
         path = self._logical_static_path(logical_name, kind)
+        cached = self._url_cache.get(path)
+        if cached is not None:
+            return cached
         try:
-            return str(staticfiles_storage.url(path))
+            url = str(staticfiles_storage.url(path))
         except ValueError as e:
             msg = (
                 f"Static asset {path!r} is missing from Django staticfiles manifest. "
                 "Run collectstatic and ensure next static finder is enabled."
             )
             raise RuntimeError(msg) from e
+        self._url_cache[path] = url
+        return url
 
     def render_link_tag(self, url: str) -> str:
         """Return a ``<link rel="stylesheet">`` tag for the given URL."""
@@ -246,6 +247,7 @@ class StaticFilesBackend(StaticBackend):
         return self._js_tag.format(url=url)
 
 
+# Inverse of _kind_to_extension. Maps file extension to kind string.
 _KIND_BY_EXTENSION = {
     ".css": _KIND_CSS,
     ".js": _KIND_JS,
@@ -255,11 +257,7 @@ _KIND_BY_EXTENSION = {
 def _find_page_root_for(path: Path, page_roots: tuple[Path, ...]) -> Path | None:
     parent = path.parent.resolve()
     for root in page_roots:
-        try:
-            parent.relative_to(root)
-        except ValueError:
-            continue
-        else:
+        if parent.is_relative_to(root):
             return root
     return None
 
@@ -284,7 +282,7 @@ def _collect_stem_static_files(
     logical_name: str,
     stem: str,
 ) -> None:
-    """Register ``{stem}.css`` / ``{stem}.js`` beside a djx file into ``out``."""
+    """Add {stem}.css and {stem}.js from the given directory to the output mapping."""
     for suffix, kind in _KIND_BY_EXTENSION.items():
         candidate = directory / f"{stem}{suffix}"
         if not candidate.exists():
@@ -295,12 +293,6 @@ def _collect_stem_static_files(
 
 def discover_colocated_static_assets() -> dict[str, Path]:
     """Map staticfiles logical paths to absolute source files on disk."""
-    from .pages import (  # noqa: PLC0415
-        get_layout_djx_paths_for_watch,
-        get_pages_directories_for_watch,
-        get_template_djx_paths_for_watch,
-    )
-
     out: dict[str, Path] = {}
     page_roots = tuple(root.resolve() for root in get_pages_directories_for_watch())
 
@@ -320,7 +312,9 @@ def discover_colocated_static_assets() -> dict[str, Path]:
         logical_name = _logical_layout_name(layout_dir, page_root)
         _collect_stem_static_files(out, layout_dir, logical_name, "layout")
 
-    # Imported lazily to avoid import-time cycles during Django app bootstrap.
+    # next.components relies on the Django app registry being ready. Importing it
+    # at module level would load it before AppConfig.ready() completes, so this
+    # import is deferred until the function is actually called.
     from .components import get_component_paths_for_watch  # noqa: PLC0415
 
     seen_component_dirs: set[Path] = set()
@@ -374,10 +368,14 @@ class NextStaticFilesFinder(BaseFinder):
         self._storage = _MappedSourceStorage(self._mapping)
 
     @overload
-    def find(self, path: str, find_all: Literal[False] = False) -> str | None: ...  # noqa: FBT002
+    def find(
+        self, path: str, find_all: Literal[False] = ...
+    ) -> str | None: ...  # pragma: no cover
 
     @overload
-    def find(self, path: str, find_all: Literal[True]) -> list[str]: ...
+    def find(
+        self, path: str, find_all: Literal[True]
+    ) -> list[str]: ...  # pragma: no cover
 
     def find(
         self,
@@ -405,16 +403,6 @@ class NextStaticFilesFinder(BaseFinder):
             yield logical_path, self._storage
 
 
-def _kind_to_extension(kind: str) -> str:
-    """Return the file extension for ``css`` or ``js`` kinds."""
-    if kind == _KIND_CSS:
-        return ".css"
-    if kind == _KIND_JS:
-        return ".js"
-    msg = f"Unsupported asset kind: {kind!r}"
-    raise ValueError(msg)
-
-
 class AssetDiscovery:
     """Detect co-located CSS and JS files and module-level asset list variables."""
 
@@ -426,20 +414,21 @@ class AssetDiscovery:
     _COMPONENT_JS: ClassVar[str] = "component.js"
 
     def __init__(self, backend_provider: StaticManager) -> None:
-        """Store the manager that owns the backend used for file registration."""
+        """Accept the manager used to resolve the active backend and page roots."""
         self._manager = backend_provider
+        self._module_list_cache: dict[Path, tuple[list[str], list[str]]] = {}
+        self._layout_dir_cache: dict[Path, list[Path]] = {}
 
     def discover_page_assets(
         self,
         file_path: Path,
         collector: StaticCollector,
     ) -> None:
-        """Collect layout, template, and module-level assets for a page module path.
+        """Collect layout, template, and module-level assets for a page file.
 
-        Layout assets are collected from the outermost layout down to the page
-        directory. Template assets are collected next so that inner styles can
-        override outer ones. Module-level ``styles`` and ``scripts`` from
-        ``page.py`` are appended last.
+        Assets are added from the outermost layout inward, then from the
+        template directory, then from the ``styles`` and ``scripts`` lists
+        declared in ``page.py``.
         """
         page_root = self._find_page_root(file_path)
         layout_dirs = self._find_layout_directories(file_path, page_root)
@@ -481,7 +470,7 @@ class AssetDiscovery:
         page_root: Path | None,
         collector: StaticCollector,
     ) -> None:
-        """Register ``layout.css``/``layout.js`` beside ``layout.djx``."""
+        """Register layout.css and layout.js found in the given directory."""
         logical_name = self._logical_name_for_layout(layout_dir, page_root)
         css_file = layout_dir / self._LAYOUT_CSS
         if css_file.exists():
@@ -496,7 +485,7 @@ class AssetDiscovery:
         page_root: Path | None,
         collector: StaticCollector,
     ) -> None:
-        """Register ``template.css``/``template.js`` beside ``template.djx``."""
+        """Register template.css and template.js found in the given directory."""
         logical_name = self._logical_name_for_template(template_dir, page_root)
         css_file = template_dir / self._TEMPLATE_CSS
         if css_file.exists():
@@ -511,12 +500,20 @@ class AssetDiscovery:
         collector: StaticCollector,
     ) -> None:
         """Read ``styles`` and ``scripts`` list variables from a Python module."""
-        module = pages._load_python_module(module_path)
-        if module is None:
-            return
-        for url in pages._read_string_list(module, "styles"):
+        cached = self._module_list_cache.get(module_path)
+        if cached is None:
+            module = pages._load_python_module(module_path)
+            if module is None:
+                self._module_list_cache[module_path] = ([], [])
+                return
+            styles = pages._read_string_list(module, "styles")
+            scripts = pages._read_string_list(module, "scripts")
+            self._module_list_cache[module_path] = (styles, scripts)
+            cached = (styles, scripts)
+        styles_list, scripts_list = cached
+        for url in styles_list:
             collector.add(StaticAsset(url=url, kind=_KIND_CSS))
-        for url in pages._read_string_list(module, "scripts"):
+        for url in scripts_list:
             collector.add(StaticAsset(url=url, kind=_KIND_JS))
 
     def _register_file(
@@ -556,8 +553,7 @@ class AssetDiscovery:
         """Return the page tree root that contains ``file_path``, if any."""
         resolved_parent = file_path.parent.resolve()
         for root in self._page_roots():
-            with contextlib.suppress(ValueError):
-                resolved_parent.relative_to(root)
+            if resolved_parent.is_relative_to(root):
                 return root
         return None
 
@@ -567,6 +563,9 @@ class AssetDiscovery:
         page_root: Path | None,
     ) -> list[Path]:
         """Walk up from the page directory and return layout dirs outermost first."""
+        cached = self._layout_dir_cache.get(file_path)
+        if cached is not None:
+            return cached
         directories: list[Path] = []
         current_dir = file_path.parent
         stop_at = page_root.resolve() if page_root is not None else None
@@ -579,7 +578,9 @@ class AssetDiscovery:
             if parent == current_dir:
                 break
             current_dir = parent
-        return list(reversed(directories))
+        result = list(reversed(directories))
+        self._layout_dir_cache[file_path] = result
+        return result
 
     def _logical_name_for_template(
         self,
@@ -619,7 +620,7 @@ class AssetDiscovery:
 
     def _page_roots(self) -> tuple[Path, ...]:
         """Return cached absolute page tree roots from the configured page backends."""
-        return self._manager._page_roots()
+        return self._manager.page_roots()
 
 
 class StaticsFactory:
@@ -643,14 +644,16 @@ class StaticsFactory:
 class StaticManager:
     """Coordinate static backends, asset discovery, and placeholder injection.
 
-    The manager loads backends from ``NEXT_FRAMEWORK['DEFAULT_STATIC_BACKENDS']``
-    on first use and owns a single ``AssetDiscovery`` instance. Static URLs are
-    resolved through Django staticfiles (see :class:`StaticFilesBackend`), not
-    through extra entries in ``next.urls``.
+    Backends are loaded lazily from ``NEXT_FRAMEWORK['DEFAULT_STATIC_BACKENDS']``
+    on first access. URL resolution is handled by ``StaticFilesBackend`` by
+    default, which delegates to Django staticfiles.
     """
 
     def __init__(self) -> None:
-        """Prepare empty backend list and discovery helper."""
+        """Return a manager in an unloaded state.
+
+        Backends are loaded on first access.
+        """
         self._backends: list[StaticBackend] = []
         self._discovery: AssetDiscovery | None = None
         self._cached_page_roots: tuple[Path, ...] | None = None
@@ -692,12 +695,12 @@ class StaticManager:
         self.discovery.discover_component_assets(info, collector)
 
     def inject(self, html: str, collector: StaticCollector) -> str:
-        """Replace style and script placeholders in rendered HTML with actual tags.
+        """Replace style and script placeholders in ``html`` with rendered tags.
 
-        Placeholders are inserted by the ``{% collect_styles %}`` and
-        ``{% collect_scripts %}`` template tags during the ``Template.render``
-        pass. This method runs after rendering is complete and every asset has
-        been recorded on the collector.
+        Placeholders are emitted by ``{% collect_styles %}`` and
+        ``{% collect_scripts %}`` during template rendering. A missing
+        placeholder is left unchanged. An empty collector replaces the
+        placeholder with an empty string.
         """
         if STYLES_PLACEHOLDER in html:
             html = html.replace(STYLES_PLACEHOLDER, self._render_style_tags(collector))
@@ -707,40 +710,30 @@ class StaticManager:
             )
         return html
 
-    def _render_style_tags(self, collector: StaticCollector) -> str:
-        """Return concatenated CSS tags for every collected style asset.
+    def _render_tags(
+        self,
+        assets: list[StaticAsset],
+        render_url: Callable[[str], str],
+    ) -> str:
+        """Return newline-joined HTML tags for the given assets.
 
-        External and co-located assets are rendered by the active backend as
-        ``<link>`` tags. Inline assets emit their pre-rendered HTML body
-        verbatim, so developers can hoist ``<style>`` blocks, conditional
-        imports, or custom tags into the styles slot unmodified.
+        Inline assets emit their body verbatim. URL-form assets are passed
+        to ``render_url`` to produce the appropriate tag string.
         """
-        self._ensure_backends()
-        backend = self._backends[0]
         return "\n".join(
-            asset.inline
-            if asset.inline is not None
-            else backend.render_link_tag(asset.url)
-            for asset in collector.styles()
+            asset.inline if asset.inline is not None else render_url(asset.url)
+            for asset in assets
         )
+
+    def _render_style_tags(self, collector: StaticCollector) -> str:
+        """Return CSS link tags and inline style bodies for all collected styles."""
+        backend = self.default_backend
+        return self._render_tags(collector.styles(), backend.render_link_tag)
 
     def _render_script_tags(self, collector: StaticCollector) -> str:
-        """Return concatenated JS tags for every collected script asset.
-
-        External and co-located assets are rendered by the active backend as
-        ``<script src="…">`` tags. Inline assets emit their pre-rendered HTML
-        body verbatim, so developers can hoist arbitrary ``<script>`` blocks
-        (including ``type="module"`` or ``type="text/babel"``) into the
-        scripts slot unmodified.
-        """
-        self._ensure_backends()
-        backend = self._backends[0]
-        return "\n".join(
-            asset.inline
-            if asset.inline is not None
-            else backend.render_script_tag(asset.url)
-            for asset in collector.scripts()
-        )
+        """Return script tags and inline script bodies for all collected scripts."""
+        backend = self.default_backend
+        return self._render_tags(collector.scripts(), backend.render_script_tag)
 
     def _ensure_backends(self) -> None:
         """Load configured backends on first access."""
@@ -767,11 +760,14 @@ class StaticManager:
         if not self._backends:
             self._backends.append(StaticFilesBackend())
 
-    def _page_roots(self) -> tuple[Path, ...]:
+    def page_roots(self) -> tuple[Path, ...]:
         """Return absolute page tree roots from configured page backends."""
         if self._cached_page_roots is not None:
             return self._cached_page_roots
         roots: list[Path] = []
+        # Imported here rather than at module level so that a missing attribute
+        # on next.pages (e.g. during partial test teardown) raises ImportError,
+        # which is the signal used to return an empty tuple instead of crashing.
         try:
             from .pages import get_pages_directories_for_watch  # noqa: PLC0415
         except ImportError:

--- a/next/static.py
+++ b/next/static.py
@@ -8,31 +8,31 @@ components may also declare ``styles`` and ``scripts`` list variables at
 module level (``page.py``/``component.py``). The collector gathers references
 during rendering and the manager injects them into placeholder slots emitted
 by the ``{% collect_styles %}`` and ``{% collect_scripts %}`` template tags.
-Files are served via the ``/_next/static/`` route prefix.
+Public URLs are resolved by the configured static backend (Django staticfiles
+by default).
 """
 
 from __future__ import annotations
 
 import contextlib
-import importlib.util
 import logging
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, ClassVar
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, overload
 
-from django.http import HttpRequest, HttpResponseNotFound
-from django.urls import URLPattern, path
-from django.views.static import serve as django_serve
+from django.contrib.staticfiles.finders import BaseFinder
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.contrib.staticfiles.utils import matches_patterns
+from django.core.files import File
+from django.core.files.storage import Storage
 
+from . import pages
 from .conf import import_class_cached, next_framework_settings
 
 
 if TYPE_CHECKING:
-    import types
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
     from pathlib import Path
-
-    from django.http.response import HttpResponseBase
 
     from .components import ComponentInfo
 
@@ -42,14 +42,15 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "AssetDiscovery",
-    "FileStaticBackend",
+    "NextStaticFilesFinder",
     "StaticAsset",
     "StaticBackend",
     "StaticCollector",
+    "StaticFilesBackend",
     "StaticManager",
     "StaticsFactory",
+    "discover_colocated_static_assets",
     "static_manager",
-    "static_serve_view",
 ]
 
 
@@ -91,8 +92,8 @@ class StaticCollector:
     ``{% use_style %}`` / ``{% use_script %}``) appear first in the order
     they were registered, followed by co-located files, module-level lists
     and inline blocks from ``{% #use_style %}`` / ``{% #use_script %}`` in
-    nested depth-first render order. URL-form entries dedupe by URL;
-    inline entries always append and dedupe by the rendered body itself, so
+    nested depth-first render order. URL-form entries dedupe by URL.
+    Inline entries always append and dedupe by the rendered body itself, so
     two blocks producing identical HTML collapse to one while blocks whose
     template context resolves to different HTML stay distinct.
     """
@@ -195,53 +196,46 @@ class StaticBackend(ABC):
     def render_script_tag(self, url: str) -> str:
         """Return an HTML script tag string for a JS asset URL."""
 
-    @abstractmethod
-    def generate_urls(self) -> list[URLPattern]:
-        """Return Django URL patterns that serve files registered by this backend."""
 
+class StaticFilesBackend(StaticBackend):
+    """Resolve co-located assets through Django ``staticfiles_storage``.
 
-@dataclass
-class _FileRegistryEntry:
-    """Mapping from a served path to an absolute filesystem path."""
-
-    source_path: Path
-
-
-class FileStaticBackend(StaticBackend):
-    """Serve co-located assets under the ``/_next/static/`` URL prefix.
-
-    Assets are renamed by their logical identity so that
-    ``_components/card/component.css`` becomes ``/_next/static/components/card.css``
-    and ``pages/about/template.css`` becomes ``/_next/static/about.css``. Files
-    are served by a single catch-all view backed by an in-memory registry.
+    Files discovered by ``next.dj`` keep their logical identities (for example
+    ``blog/layout.css`` and ``components/card.js``), but public URLs are always
+    resolved by Django staticfiles so Manifest/S3/CDN settings apply uniformly.
     """
-
-    URL_PREFIX: ClassVar[str] = "_next/static"
 
     _DEFAULT_CSS_TAG: ClassVar[str] = '<link rel="stylesheet" href="{url}">'
     _DEFAULT_JS_TAG: ClassVar[str] = '<script src="{url}"></script>'
+    STATIC_NAMESPACE: ClassVar[str] = "next"
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
-        """Build the backend from an optional configuration dict with ``OPTIONS``."""
+        """Build the backend from optional ``OPTIONS`` tag template overrides."""
         cfg = config or {}
         opts = cfg.get("OPTIONS") or {}
         self._css_tag = str(opts.get("css_tag") or self._DEFAULT_CSS_TAG)
         self._js_tag = str(opts.get("js_tag") or self._DEFAULT_JS_TAG)
-        self._file_registry: dict[str, _FileRegistryEntry] = {}
+
+    def _logical_static_path(self, logical_name: str, kind: str) -> str:
+        extension = _kind_to_extension(kind)
+        return f"{self.STATIC_NAMESPACE}/{logical_name}{extension}"
 
     def register_file(
         self,
-        source_path: Path,
+        _source_path: Path,
         logical_name: str,
         kind: str,
     ) -> str:
-        """Register a file under ``logical_name.<kind>`` and return its served URL."""
-        extension = _kind_to_extension(kind)
-        relative = f"{logical_name}{extension}"
-        self._file_registry[relative] = _FileRegistryEntry(
-            source_path=source_path.resolve(),
-        )
-        return f"/{self.URL_PREFIX}/{relative}"
+        """Return URL from Django staticfiles for ``next/<logical_name>.<ext>``."""
+        path = self._logical_static_path(logical_name, kind)
+        try:
+            return str(staticfiles_storage.url(path))
+        except ValueError as e:
+            msg = (
+                f"Static asset {path!r} is missing from Django staticfiles manifest. "
+                "Run collectstatic and ensure next static finder is enabled."
+            )
+            raise RuntimeError(msg) from e
 
     def render_link_tag(self, url: str) -> str:
         """Return a ``<link rel="stylesheet">`` tag for the given URL."""
@@ -251,23 +245,164 @@ class FileStaticBackend(StaticBackend):
         """Return a ``<script>`` tag for the given URL."""
         return self._js_tag.format(url=url)
 
-    def generate_urls(self) -> list[URLPattern]:
-        """Return the single catch-all URL pattern for the serve view."""
-        return [
-            path(
-                f"{self.URL_PREFIX}/<path:file_path>",
-                static_serve_view,
-                name="next_static_serve",
-            ),
-        ]
 
-    def lookup(self, relative: str) -> _FileRegistryEntry | None:
-        """Return the registry entry for the given relative served path, if any."""
-        return self._file_registry.get(relative)
+_KIND_BY_EXTENSION = {
+    ".css": _KIND_CSS,
+    ".js": _KIND_JS,
+}
 
-    def clear_registry(self) -> None:
-        """Drop every registered file mapping."""
-        self._file_registry.clear()
+
+def _find_page_root_for(path: Path, page_roots: tuple[Path, ...]) -> Path | None:
+    parent = path.parent.resolve()
+    for root in page_roots:
+        try:
+            parent.relative_to(root)
+        except ValueError:
+            continue
+        else:
+            return root
+    return None
+
+
+def _logical_template_name(template_dir: Path, page_root: Path) -> str:
+    rel = template_dir.resolve().relative_to(page_root)
+    parts = rel.parts
+    return "/".join(parts) if parts else "index"
+
+
+def _logical_layout_name(layout_dir: Path, page_root: Path) -> str:
+    rel = layout_dir.resolve().relative_to(page_root)
+    parts = rel.parts
+    if parts:
+        return "/".join((*parts, "layout"))
+    return "layout"
+
+
+def _collect_stem_static_files(
+    out: dict[str, Path],
+    directory: Path,
+    logical_name: str,
+    stem: str,
+) -> None:
+    """Register ``{stem}.css`` / ``{stem}.js`` beside a djx file into ``out``."""
+    for suffix, kind in _KIND_BY_EXTENSION.items():
+        candidate = directory / f"{stem}{suffix}"
+        if not candidate.exists():
+            continue
+        static_path = f"next/{logical_name}{_kind_to_extension(kind)}"
+        out.setdefault(static_path, candidate.resolve())
+
+
+def discover_colocated_static_assets() -> dict[str, Path]:
+    """Map staticfiles logical paths to absolute source files on disk."""
+    from .pages import (  # noqa: PLC0415
+        get_layout_djx_paths_for_watch,
+        get_pages_directories_for_watch,
+        get_template_djx_paths_for_watch,
+    )
+
+    out: dict[str, Path] = {}
+    page_roots = tuple(root.resolve() for root in get_pages_directories_for_watch())
+
+    for template_path in get_template_djx_paths_for_watch():
+        page_root = _find_page_root_for(template_path, page_roots)
+        if page_root is None:
+            continue
+        template_dir = template_path.parent
+        logical_name = _logical_template_name(template_dir, page_root)
+        _collect_stem_static_files(out, template_dir, logical_name, "template")
+
+    for layout_path in get_layout_djx_paths_for_watch():
+        page_root = _find_page_root_for(layout_path, page_roots)
+        if page_root is None:
+            continue
+        layout_dir = layout_path.parent
+        logical_name = _logical_layout_name(layout_dir, page_root)
+        _collect_stem_static_files(out, layout_dir, logical_name, "layout")
+
+    # Imported lazily to avoid import-time cycles during Django app bootstrap.
+    from .components import get_component_paths_for_watch  # noqa: PLC0415
+
+    seen_component_dirs: set[Path] = set()
+    for component_source in get_component_paths_for_watch():
+        component_dir = component_source.parent.resolve()
+        if component_dir in seen_component_dirs:
+            continue
+        seen_component_dirs.add(component_dir)
+        logical_name = f"components/{component_dir.name}"
+        _collect_stem_static_files(out, component_dir, logical_name, "component")
+
+    return out
+
+
+class _MappedSourceStorage(Storage):
+    """Storage wrapper that serves files from an explicit path mapping."""
+
+    def __init__(self, mapping: dict[str, Path]) -> None:
+        self._mapping = mapping
+
+    def _resolve(self, name: str) -> Path:
+        if name not in self._mapping:
+            msg = f"Unknown static file: {name}"
+            raise FileNotFoundError(msg)
+        return self._mapping[name]
+
+    def exists(self, name: str) -> bool:
+        try:
+            return self._resolve(name).exists()
+        except FileNotFoundError:
+            return False
+
+    def open(self, name: str, mode: str = "rb") -> File:
+        path = self._resolve(name)
+        return File(path.open(mode))
+
+    def path(self, name: str) -> str:
+        return str(self._resolve(name))
+
+
+class NextStaticFilesFinder(BaseFinder):
+    """Finder that exposes next.dj co-located assets under ``next/`` namespace."""
+
+    def __init__(self) -> None:
+        """Initialize with empty storage until the first lookup."""
+        self._mapping: dict[str, Path] = {}
+        self._storage: _MappedSourceStorage = _MappedSourceStorage({})
+
+    def _refresh(self) -> None:
+        self._mapping = discover_colocated_static_assets()
+        self._storage = _MappedSourceStorage(self._mapping)
+
+    @overload
+    def find(self, path: str, find_all: Literal[False] = False) -> str | None: ...  # noqa: FBT002
+
+    @overload
+    def find(self, path: str, find_all: Literal[True]) -> list[str]: ...
+
+    def find(
+        self,
+        path: str,
+        find_all: bool = False,  # noqa: FBT001, FBT002
+    ) -> str | list[str] | None:
+        """Resolve ``path`` to an absolute filesystem path or list of paths."""
+        self._refresh()
+        source = self._mapping.get(path)
+        if source is None:
+            return [] if find_all else None
+        resolved = str(source)
+        return [resolved] if find_all else resolved
+
+    def list(
+        self,
+        ignore_patterns: Iterable[str] | None,
+    ) -> Iterator[tuple[str, Storage]]:
+        """Yield ``(relative_path, storage)`` pairs for ``collectstatic``."""
+        patterns = list(ignore_patterns) if ignore_patterns is not None else []
+        self._refresh()
+        for logical_path in sorted(self._mapping):
+            if matches_patterns(logical_path, patterns):
+                continue
+            yield logical_path, self._storage
 
 
 def _kind_to_extension(kind: str) -> str:
@@ -278,40 +413,6 @@ def _kind_to_extension(kind: str) -> str:
         return ".js"
     msg = f"Unsupported asset kind: {kind!r}"
     raise ValueError(msg)
-
-
-def _load_python_module(file_path: Path) -> types.ModuleType | None:
-    """Load a Python file as an anonymous module or return ``None`` on failure."""
-    try:
-        spec = importlib.util.spec_from_file_location(
-            f"next_static_module_{file_path.stem}", file_path
-        )
-        if spec is None or spec.loader is None:
-            return None
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-    except (ImportError, AttributeError, OSError, SyntaxError) as e:
-        logger.debug(
-            "Could not load module %s for static asset discovery: %s", file_path, e
-        )
-        return None
-    else:
-        return module
-
-
-def _read_string_list(module: types.ModuleType, attr: str) -> list[str]:
-    """Return a module-level string list attribute or an empty list."""
-    value = getattr(module, attr, None)
-    if not isinstance(value, (list, tuple)):
-        return []
-    return [str(item) for item in value if isinstance(item, str) and item]
-
-
-@dataclass
-class _DiscoveryRoots:
-    """Cached collection of page tree roots used to compute logical URL paths."""
-
-    roots: tuple[Path, ...] = field(default_factory=tuple)
 
 
 class AssetDiscovery:
@@ -410,12 +511,12 @@ class AssetDiscovery:
         collector: StaticCollector,
     ) -> None:
         """Read ``styles`` and ``scripts`` list variables from a Python module."""
-        module = _load_python_module(module_path)
+        module = pages._load_python_module(module_path)
         if module is None:
             return
-        for url in _read_string_list(module, "styles"):
+        for url in pages._read_string_list(module, "styles"):
             collector.add(StaticAsset(url=url, kind=_KIND_CSS))
-        for url in _read_string_list(module, "scripts"):
+        for url in pages._read_string_list(module, "scripts"):
             collector.add(StaticAsset(url=url, kind=_KIND_JS))
 
     def _register_file(
@@ -527,7 +628,7 @@ class StaticsFactory:
     @classmethod
     def create_backend(cls, config: dict[str, Any]) -> StaticBackend:
         """Instantiate the backend class named by ``config['BACKEND']``."""
-        backend_path = config.get("BACKEND", "next.static.FileStaticBackend")
+        backend_path = config.get("BACKEND", "next.static.StaticFilesBackend")
         backend_class = import_class_cached(backend_path)
         if not isinstance(backend_class, type) or not issubclass(
             backend_class, StaticBackend
@@ -543,8 +644,9 @@ class StaticManager:
     """Coordinate static backends, asset discovery, and placeholder injection.
 
     The manager loads backends from ``NEXT_FRAMEWORK['DEFAULT_STATIC_BACKENDS']``
-    on first use, owns a single ``AssetDiscovery`` instance, and yields URL
-    patterns contributed by each backend for ``_LazyUrlPatterns``.
+    on first use and owns a single ``AssetDiscovery`` instance. Static URLs are
+    resolved through Django staticfiles (see :class:`StaticFilesBackend`), not
+    through extra entries in ``next.urls``.
     """
 
     def __init__(self) -> None:
@@ -552,12 +654,6 @@ class StaticManager:
         self._backends: list[StaticBackend] = []
         self._discovery: AssetDiscovery | None = None
         self._cached_page_roots: tuple[Path, ...] | None = None
-
-    def __iter__(self) -> Iterator[URLPattern]:
-        """Yield URL patterns contributed by every backend in configuration order."""
-        self._ensure_backends()
-        for backend in self._backends:
-            yield from backend.generate_urls()
 
     def __len__(self) -> int:
         """Return the number of configured backends."""
@@ -669,7 +765,7 @@ class StaticManager:
                 continue
             self._backends.append(backend)
         if not self._backends:
-            self._backends.append(FileStaticBackend())
+            self._backends.append(StaticFilesBackend())
 
     def _page_roots(self) -> tuple[Path, ...]:
         """Return absolute page tree roots from configured page backends."""
@@ -689,28 +785,3 @@ class StaticManager:
 
 
 static_manager = StaticManager()
-
-
-def static_serve_view(
-    request: HttpRequest,
-    file_path: str,
-) -> HttpResponseBase:
-    """Serve a co-located static file registered by the ``FileStaticBackend``.
-
-    The registered filesystem path is handed to ``django.views.static.serve``
-    which handles streaming, Content-Type detection, and conditional GET via
-    Last-Modified and If-Modified-Since headers. A 404 response is returned
-    when the served path is not in the backend registry.
-    """
-    backend = static_manager.default_backend
-    if not isinstance(backend, FileStaticBackend):
-        return HttpResponseNotFound()
-    entry = backend.lookup(file_path)
-    if entry is None:
-        return HttpResponseNotFound()
-    source = entry.source_path
-    return django_serve(
-        request,
-        path=source.name,
-        document_root=str(source.parent),
-    )

--- a/next/static.py
+++ b/next/static.py
@@ -1,0 +1,674 @@
+"""Discover and inject co-located static assets for pages and components.
+
+Asset files are named after the ``.djx`` file they decorate and live in the
+same directory: ``template.css``/``template.js`` sit beside ``template.djx``,
+``layout.css``/``layout.js`` beside ``layout.djx``, and
+``component.css``/``component.js`` beside ``component.djx``. Pages and
+components may also declare ``styles`` and ``scripts`` list variables at
+module level (``page.py``/``component.py``). The collector gathers references
+during rendering and the manager injects them into placeholder slots emitted
+by the ``{% collect_styles %}`` and ``{% collect_scripts %}`` template tags.
+Files are served via the ``/_next/static/`` route prefix.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from django.http import HttpRequest, HttpResponseNotFound
+from django.urls import URLPattern, path
+from django.views.static import serve as django_serve
+
+from .conf import import_class_cached, next_framework_settings
+
+
+if TYPE_CHECKING:
+    import types
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from django.http.response import HttpResponseBase
+
+    from .components import ComponentInfo
+
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "AssetDiscovery",
+    "FileStaticBackend",
+    "StaticAsset",
+    "StaticBackend",
+    "StaticCollector",
+    "StaticManager",
+    "StaticsFactory",
+    "static_manager",
+    "static_serve_view",
+]
+
+
+STYLES_PLACEHOLDER = "<!-- next:styles -->"
+SCRIPTS_PLACEHOLDER = "<!-- next:scripts -->"
+
+_KIND_CSS = "css"
+_KIND_JS = "js"
+
+
+@dataclass(frozen=True, slots=True)
+class StaticAsset:
+    """One CSS or JS file reference to include on the rendered page.
+
+    A file asset originates from a co-located file on disk and has
+    ``source_path`` set to its absolute filesystem path. An external asset
+    carries a raw URL supplied by a ``styles`` or ``scripts`` module variable
+    and has no ``source_path``.
+    """
+
+    url: str
+    kind: str
+    source_path: Path | None = None
+
+
+class StaticCollector:
+    """Accumulate static asset references during a single page render.
+
+    The collector is stored in template context under ``_static_collector`` so
+    that nested component rendering can append its own assets. Duplicate URLs
+    are ignored and insertion order follows the CSS-cascade convention: items
+    added with ``prepend=True`` (shared third-party dependencies declared with
+    ``{% use_style %}`` / ``{% use_script %}``) appear first in the order they
+    were registered, followed by co-located files and module-level lists in
+    nested depth-first render order.
+    """
+
+    def __init__(self) -> None:
+        """Create an empty collector with separate ordered lists for CSS and JS."""
+        self._seen_urls: set[str] = set()
+        self._styles: list[StaticAsset] = []
+        self._scripts: list[StaticAsset] = []
+        self._styles_prepend_idx: int = 0
+        self._scripts_prepend_idx: int = 0
+
+    def add(self, asset: StaticAsset, *, prepend: bool = False) -> None:
+        """Append (or prepend) one asset unless its URL was already seen.
+
+        ``prepend=True`` inserts the asset at the current front of its list so
+        that dependencies declared with ``{% use_style %}`` / ``{% use_script %}``
+        appear before co-located files. Multiple prepended items keep their
+        registration order relative to each other.
+        """
+        if asset.url in self._seen_urls:
+            return
+        self._seen_urls.add(asset.url)
+        if asset.kind == _KIND_CSS:
+            self._insert(self._styles, asset, prepend=prepend, kind=_KIND_CSS)
+        elif asset.kind == _KIND_JS:
+            self._insert(self._scripts, asset, prepend=prepend, kind=_KIND_JS)
+        else:
+            logger.debug(
+                "Ignoring asset with unknown kind %r: %s", asset.kind, asset.url
+            )
+
+    def _insert(
+        self,
+        target: list[StaticAsset],
+        asset: StaticAsset,
+        *,
+        prepend: bool,
+        kind: str,
+    ) -> None:
+        """Insert ``asset`` at the current prepend cursor or at the end."""
+        if prepend:
+            idx = (
+                self._styles_prepend_idx
+                if kind == _KIND_CSS
+                else self._scripts_prepend_idx
+            )
+            target.insert(idx, asset)
+            if kind == _KIND_CSS:
+                self._styles_prepend_idx += 1
+            else:
+                self._scripts_prepend_idx += 1
+        else:
+            target.append(asset)
+
+    def styles(self) -> list[StaticAsset]:
+        """Return collected CSS assets in insertion order."""
+        return list(self._styles)
+
+    def scripts(self) -> list[StaticAsset]:
+        """Return collected JS assets in insertion order."""
+        return list(self._scripts)
+
+
+class StaticBackend(ABC):
+    """Pluggable strategy for resolving asset files to URLs and rendering tags."""
+
+    @abstractmethod
+    def register_file(
+        self,
+        source_path: Path,
+        logical_name: str,
+        kind: str,
+    ) -> str:
+        """Register a co-located asset file and return the URL used to serve it.
+
+        ``logical_name`` is a slash-separated path without file extension, such
+        as ``"about"``, ``"components/card"``, or ``"guides/layout"``. The
+        backend appends the ``.css`` or ``.js`` extension based on ``kind``.
+        """
+
+    @abstractmethod
+    def render_link_tag(self, url: str) -> str:
+        """Return an HTML link tag string for a CSS asset URL."""
+
+    @abstractmethod
+    def render_script_tag(self, url: str) -> str:
+        """Return an HTML script tag string for a JS asset URL."""
+
+    @abstractmethod
+    def generate_urls(self) -> list[URLPattern]:
+        """Return Django URL patterns that serve files registered by this backend."""
+
+
+@dataclass
+class _FileRegistryEntry:
+    """Mapping from a served path to an absolute filesystem path."""
+
+    source_path: Path
+
+
+class FileStaticBackend(StaticBackend):
+    """Serve co-located assets under the ``/_next/static/`` URL prefix.
+
+    Assets are renamed by their logical identity so that
+    ``_components/card/component.css`` becomes ``/_next/static/components/card.css``
+    and ``pages/about/template.css`` becomes ``/_next/static/about.css``. Files
+    are served by a single catch-all view backed by an in-memory registry.
+    """
+
+    URL_PREFIX: ClassVar[str] = "_next/static"
+
+    _DEFAULT_CSS_TAG: ClassVar[str] = '<link rel="stylesheet" href="{url}">'
+    _DEFAULT_JS_TAG: ClassVar[str] = '<script src="{url}"></script>'
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        """Build the backend from an optional configuration dict with ``OPTIONS``."""
+        cfg = config or {}
+        opts = cfg.get("OPTIONS") or {}
+        self._css_tag = str(opts.get("css_tag") or self._DEFAULT_CSS_TAG)
+        self._js_tag = str(opts.get("js_tag") or self._DEFAULT_JS_TAG)
+        self._file_registry: dict[str, _FileRegistryEntry] = {}
+
+    def register_file(
+        self,
+        source_path: Path,
+        logical_name: str,
+        kind: str,
+    ) -> str:
+        """Register a file under ``logical_name.<kind>`` and return its served URL."""
+        extension = _kind_to_extension(kind)
+        relative = f"{logical_name}{extension}"
+        self._file_registry[relative] = _FileRegistryEntry(
+            source_path=source_path.resolve(),
+        )
+        return f"/{self.URL_PREFIX}/{relative}"
+
+    def render_link_tag(self, url: str) -> str:
+        """Return a ``<link rel="stylesheet">`` tag for the given URL."""
+        return self._css_tag.format(url=url)
+
+    def render_script_tag(self, url: str) -> str:
+        """Return a ``<script>`` tag for the given URL."""
+        return self._js_tag.format(url=url)
+
+    def generate_urls(self) -> list[URLPattern]:
+        """Return the single catch-all URL pattern for the serve view."""
+        return [
+            path(
+                f"{self.URL_PREFIX}/<path:file_path>",
+                static_serve_view,
+                name="next_static_serve",
+            ),
+        ]
+
+    def lookup(self, relative: str) -> _FileRegistryEntry | None:
+        """Return the registry entry for the given relative served path, if any."""
+        return self._file_registry.get(relative)
+
+    def clear_registry(self) -> None:
+        """Drop every registered file mapping."""
+        self._file_registry.clear()
+
+
+def _kind_to_extension(kind: str) -> str:
+    """Return the file extension for ``css`` or ``js`` kinds."""
+    if kind == _KIND_CSS:
+        return ".css"
+    if kind == _KIND_JS:
+        return ".js"
+    msg = f"Unsupported asset kind: {kind!r}"
+    raise ValueError(msg)
+
+
+def _load_python_module(file_path: Path) -> types.ModuleType | None:
+    """Load a Python file as an anonymous module or return ``None`` on failure."""
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"next_static_module_{file_path.stem}", file_path
+        )
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except (ImportError, AttributeError, OSError, SyntaxError) as e:
+        logger.debug(
+            "Could not load module %s for static asset discovery: %s", file_path, e
+        )
+        return None
+    else:
+        return module
+
+
+def _read_string_list(module: types.ModuleType, attr: str) -> list[str]:
+    """Return a module-level string list attribute or an empty list."""
+    value = getattr(module, attr, None)
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [str(item) for item in value if isinstance(item, str) and item]
+
+
+@dataclass
+class _DiscoveryRoots:
+    """Cached collection of page tree roots used to compute logical URL paths."""
+
+    roots: tuple[Path, ...] = field(default_factory=tuple)
+
+
+class AssetDiscovery:
+    """Detect co-located CSS and JS files and module-level asset list variables."""
+
+    _TEMPLATE_CSS: ClassVar[str] = "template.css"
+    _TEMPLATE_JS: ClassVar[str] = "template.js"
+    _LAYOUT_CSS: ClassVar[str] = "layout.css"
+    _LAYOUT_JS: ClassVar[str] = "layout.js"
+    _COMPONENT_CSS: ClassVar[str] = "component.css"
+    _COMPONENT_JS: ClassVar[str] = "component.js"
+
+    def __init__(self, backend_provider: StaticManager) -> None:
+        """Store the manager that owns the backend used for file registration."""
+        self._manager = backend_provider
+
+    def discover_page_assets(
+        self,
+        file_path: Path,
+        collector: StaticCollector,
+    ) -> None:
+        """Collect layout, template, and module-level assets for a page module path.
+
+        Layout assets are collected from the outermost layout down to the page
+        directory. Template assets are collected next so that inner styles can
+        override outer ones. Module-level ``styles`` and ``scripts`` from
+        ``page.py`` are appended last.
+        """
+        page_root = self._find_page_root(file_path)
+        layout_dirs = self._find_layout_directories(file_path, page_root)
+        for layout_dir in layout_dirs:
+            self._collect_layout_directory(layout_dir, page_root, collector)
+
+        self._collect_template_directory(file_path.parent, page_root, collector)
+
+        if file_path.exists():
+            self._collect_module_lists(file_path, collector)
+
+    def discover_component_assets(
+        self,
+        info: ComponentInfo,
+        collector: StaticCollector,
+    ) -> None:
+        """Collect co-located CSS, JS, and module asset lists for a component."""
+        component_dir = self._component_directory(info)
+        if component_dir is None:
+            return
+
+        logical_name = f"components/{info.name}"
+
+        css_file = component_dir / self._COMPONENT_CSS
+        if css_file.exists():
+            self._register_file(css_file, logical_name, _KIND_CSS, collector)
+
+        js_file = component_dir / self._COMPONENT_JS
+        if js_file.exists():
+            self._register_file(js_file, logical_name, _KIND_JS, collector)
+
+        module_path = info.module_path
+        if module_path is not None and module_path.exists():
+            self._collect_module_lists(module_path, collector)
+
+    def _collect_layout_directory(
+        self,
+        layout_dir: Path,
+        page_root: Path | None,
+        collector: StaticCollector,
+    ) -> None:
+        """Register ``layout.css``/``layout.js`` beside ``layout.djx``."""
+        logical_name = self._logical_name_for_layout(layout_dir, page_root)
+        css_file = layout_dir / self._LAYOUT_CSS
+        if css_file.exists():
+            self._register_file(css_file, logical_name, _KIND_CSS, collector)
+        js_file = layout_dir / self._LAYOUT_JS
+        if js_file.exists():
+            self._register_file(js_file, logical_name, _KIND_JS, collector)
+
+    def _collect_template_directory(
+        self,
+        template_dir: Path,
+        page_root: Path | None,
+        collector: StaticCollector,
+    ) -> None:
+        """Register ``template.css``/``template.js`` beside ``template.djx``."""
+        logical_name = self._logical_name_for_template(template_dir, page_root)
+        css_file = template_dir / self._TEMPLATE_CSS
+        if css_file.exists():
+            self._register_file(css_file, logical_name, _KIND_CSS, collector)
+        js_file = template_dir / self._TEMPLATE_JS
+        if js_file.exists():
+            self._register_file(js_file, logical_name, _KIND_JS, collector)
+
+    def _collect_module_lists(
+        self,
+        module_path: Path,
+        collector: StaticCollector,
+    ) -> None:
+        """Read ``styles`` and ``scripts`` list variables from a Python module."""
+        module = _load_python_module(module_path)
+        if module is None:
+            return
+        for url in _read_string_list(module, "styles"):
+            collector.add(StaticAsset(url=url, kind=_KIND_CSS))
+        for url in _read_string_list(module, "scripts"):
+            collector.add(StaticAsset(url=url, kind=_KIND_JS))
+
+    def _register_file(
+        self,
+        source_path: Path,
+        logical_name: str,
+        kind: str,
+        collector: StaticCollector,
+    ) -> None:
+        """Register a file with the backend and add the result to the collector."""
+        backend = self._manager.default_backend
+        try:
+            url = backend.register_file(source_path, logical_name, kind)
+        except (OSError, ValueError) as e:
+            logger.debug(
+                "Failed to register static asset %s as %r: %s",
+                source_path,
+                logical_name,
+                e,
+            )
+            return
+        collector.add(
+            StaticAsset(url=url, kind=kind, source_path=source_path.resolve())
+        )
+
+    def _component_directory(self, info: ComponentInfo) -> Path | None:
+        """Return the directory that contains a composite component, or ``None``."""
+        if info.is_simple:
+            return None
+        if info.template_path is not None:
+            return info.template_path.parent
+        if info.module_path is not None:
+            return info.module_path.parent
+        return None
+
+    def _find_page_root(self, file_path: Path) -> Path | None:
+        """Return the page tree root that contains ``file_path``, if any."""
+        resolved_parent = file_path.parent.resolve()
+        for root in self._page_roots():
+            with contextlib.suppress(ValueError):
+                resolved_parent.relative_to(root)
+                return root
+        return None
+
+    def _find_layout_directories(
+        self,
+        file_path: Path,
+        page_root: Path | None,
+    ) -> list[Path]:
+        """Walk up from the page directory and return layout dirs outermost first."""
+        directories: list[Path] = []
+        current_dir = file_path.parent
+        stop_at = page_root.resolve() if page_root is not None else None
+        while True:
+            if (current_dir / "layout.djx").exists():
+                directories.append(current_dir)
+            if stop_at is not None and current_dir.resolve() == stop_at:
+                break
+            parent = current_dir.parent
+            if parent == current_dir:
+                break
+            current_dir = parent
+        return list(reversed(directories))
+
+    def _logical_name_for_template(
+        self,
+        template_dir: Path,
+        page_root: Path | None,
+    ) -> str:
+        """Return the logical URL name for a page template directory."""
+        if page_root is None:
+            return self._fallback_logical_name(template_dir)
+        try:
+            rel = template_dir.resolve().relative_to(page_root.resolve())
+        except ValueError:
+            return self._fallback_logical_name(template_dir)
+        parts = rel.parts
+        return "/".join(parts) if parts else "index"
+
+    def _logical_name_for_layout(
+        self,
+        layout_dir: Path,
+        page_root: Path | None,
+    ) -> str:
+        """Return the logical URL name for a layout directory."""
+        if page_root is None:
+            return f"{self._fallback_logical_name(layout_dir)}/layout"
+        try:
+            rel = layout_dir.resolve().relative_to(page_root.resolve())
+        except ValueError:
+            return f"{self._fallback_logical_name(layout_dir)}/layout"
+        parts = rel.parts
+        if parts:
+            return "/".join((*parts, "layout"))
+        return "layout"
+
+    def _fallback_logical_name(self, directory: Path) -> str:
+        """Return a safe logical name when the page root cannot be determined."""
+        return directory.name or "index"
+
+    def _page_roots(self) -> tuple[Path, ...]:
+        """Return cached absolute page tree roots from the configured page backends."""
+        return self._manager._page_roots()
+
+
+class StaticsFactory:
+    """Build ``StaticBackend`` instances from ``DEFAULT_STATIC_BACKENDS`` entries."""
+
+    @classmethod
+    def create_backend(cls, config: dict[str, Any]) -> StaticBackend:
+        """Instantiate the backend class named by ``config['BACKEND']``."""
+        backend_path = config.get("BACKEND", "next.static.FileStaticBackend")
+        backend_class = import_class_cached(backend_path)
+        if not isinstance(backend_class, type) or not issubclass(
+            backend_class, StaticBackend
+        ):
+            msg = f"Backend {backend_path!r} is not a StaticBackend subclass"
+            raise TypeError(msg)
+        factory: Any = backend_class
+        instance: StaticBackend = factory(config)
+        return instance
+
+
+class StaticManager:
+    """Coordinate static backends, asset discovery, and placeholder injection.
+
+    The manager loads backends from ``NEXT_FRAMEWORK['DEFAULT_STATIC_BACKENDS']``
+    on first use, owns a single ``AssetDiscovery`` instance, and yields URL
+    patterns contributed by each backend for ``_LazyUrlPatterns``.
+    """
+
+    def __init__(self) -> None:
+        """Prepare empty backend list and discovery helper."""
+        self._backends: list[StaticBackend] = []
+        self._discovery: AssetDiscovery | None = None
+        self._cached_page_roots: tuple[Path, ...] | None = None
+
+    def __iter__(self) -> Iterator[URLPattern]:
+        """Yield URL patterns contributed by every backend in configuration order."""
+        self._ensure_backends()
+        for backend in self._backends:
+            yield from backend.generate_urls()
+
+    def __len__(self) -> int:
+        """Return the number of configured backends."""
+        self._ensure_backends()
+        return len(self._backends)
+
+    @property
+    def default_backend(self) -> StaticBackend:
+        """Return the first configured backend, which is used for file registration."""
+        self._ensure_backends()
+        return self._backends[0]
+
+    @property
+    def discovery(self) -> AssetDiscovery:
+        """Return the shared asset discovery helper."""
+        if self._discovery is None:
+            self._discovery = AssetDiscovery(self)
+        return self._discovery
+
+    def discover_page_assets(
+        self,
+        file_path: Path,
+        collector: StaticCollector,
+    ) -> None:
+        """Forward page asset discovery to the shared ``AssetDiscovery`` instance."""
+        self._ensure_backends()
+        self.discovery.discover_page_assets(file_path, collector)
+
+    def discover_component_assets(
+        self,
+        info: ComponentInfo,
+        collector: StaticCollector,
+    ) -> None:
+        """Forward component asset discovery to the shared ``AssetDiscovery``."""
+        self._ensure_backends()
+        self.discovery.discover_component_assets(info, collector)
+
+    def inject(self, html: str, collector: StaticCollector) -> str:
+        """Replace style and script placeholders in rendered HTML with actual tags.
+
+        Placeholders are inserted by the ``{% collect_styles %}`` and
+        ``{% collect_scripts %}`` template tags during the ``Template.render``
+        pass. This method runs after rendering is complete and every asset has
+        been recorded on the collector.
+        """
+        if STYLES_PLACEHOLDER in html:
+            html = html.replace(STYLES_PLACEHOLDER, self._render_style_tags(collector))
+        if SCRIPTS_PLACEHOLDER in html:
+            html = html.replace(
+                SCRIPTS_PLACEHOLDER, self._render_script_tags(collector)
+            )
+        return html
+
+    def _render_style_tags(self, collector: StaticCollector) -> str:
+        """Return concatenated CSS link tags for every collected style asset."""
+        self._ensure_backends()
+        backend = self._backends[0]
+        return "\n".join(
+            backend.render_link_tag(asset.url) for asset in collector.styles()
+        )
+
+    def _render_script_tags(self, collector: StaticCollector) -> str:
+        """Return concatenated JS script tags for every collected script asset."""
+        self._ensure_backends()
+        backend = self._backends[0]
+        return "\n".join(
+            backend.render_script_tag(asset.url) for asset in collector.scripts()
+        )
+
+    def _ensure_backends(self) -> None:
+        """Load configured backends on first access."""
+        if not self._backends:
+            self._reload_config()
+
+    def _reload_config(self) -> None:
+        """Rebuild the backend list from the merged framework settings."""
+        self._backends.clear()
+        self._discovery = None
+        self._cached_page_roots = None
+        configs = next_framework_settings.DEFAULT_STATIC_BACKENDS
+        if not isinstance(configs, list):
+            configs = []
+        for config in configs:
+            if not isinstance(config, dict):
+                continue
+            try:
+                backend = StaticsFactory.create_backend(config)
+            except Exception:
+                logger.exception("Error creating static backend from config %s", config)
+                continue
+            self._backends.append(backend)
+        if not self._backends:
+            self._backends.append(FileStaticBackend())
+
+    def _page_roots(self) -> tuple[Path, ...]:
+        """Return absolute page tree roots from configured page backends."""
+        if self._cached_page_roots is not None:
+            return self._cached_page_roots
+        roots: list[Path] = []
+        try:
+            from .pages import get_pages_directories_for_watch  # noqa: PLC0415
+        except ImportError:
+            self._cached_page_roots = ()
+            return self._cached_page_roots
+        for root in get_pages_directories_for_watch():
+            with contextlib.suppress(OSError):
+                roots.append(root.resolve())
+        self._cached_page_roots = tuple(roots)
+        return self._cached_page_roots
+
+
+static_manager = StaticManager()
+
+
+def static_serve_view(
+    request: HttpRequest,
+    file_path: str,
+) -> HttpResponseBase:
+    """Serve a co-located static file registered by the ``FileStaticBackend``.
+
+    The registered filesystem path is handed to ``django.views.static.serve``
+    which handles streaming, Content-Type detection, and conditional GET via
+    Last-Modified and If-Modified-Since headers. A 404 response is returned
+    when the served path is not in the backend registry.
+    """
+    backend = static_manager.default_backend
+    if not isinstance(backend, FileStaticBackend):
+        return HttpResponseNotFound()
+    entry = backend.lookup(file_path)
+    if entry is None:
+        return HttpResponseNotFound()
+    source = entry.source_path
+    return django_serve(
+        request,
+        path=source.name,
+        document_root=str(source.parent),
+    )

--- a/next/templatetags/components.py
+++ b/next/templatetags/components.py
@@ -19,6 +19,7 @@ from django.template import base as template_base
 from django.template.base import Node, NodeList, Parser, Token
 
 from next.components import get_component, render_component
+from next.static import static_manager
 
 
 # Allow line breaks inside ``{% ... %}`` (multiline tag bodies).
@@ -139,8 +140,6 @@ class ComponentNode(Node):
 
         collector = context.get("_static_collector")
         if collector is not None and not info.is_simple:
-            from next.static import static_manager  # noqa: PLC0415
-
             static_manager.discover_component_assets(info, collector)
 
         slots: dict[str, str] = {}

--- a/next/templatetags/components.py
+++ b/next/templatetags/components.py
@@ -137,6 +137,12 @@ class ComponentNode(Node):
         if info is None:
             return ""
 
+        collector = context.get("_static_collector")
+        if collector is not None and not info.is_simple:
+            from next.static import static_manager  # noqa: PLC0415
+
+            static_manager.discover_component_assets(info, collector)
+
         slots: dict[str, str] = {}
         child_chunks: list[str] = []
         with context.push(_component_slots=slots):

--- a/next/templatetags/next_static.py
+++ b/next/templatetags/next_static.py
@@ -7,12 +7,19 @@ once ``Page.render`` has collected every referenced asset from the page, its
 layouts, and nested components. ``{% use_style %}`` and ``{% use_script %}``
 register an external URL on the active ``StaticCollector`` so that layouts and
 templates can pull in shared third-party libraries without touching
-``page.py`` or ``component.py`` module lists.
+``page.py`` or ``component.py`` module lists. ``{% #use_style %}`` and
+``{% #use_script %}`` are block forms whose body is rendered with the current
+context and hoisted into the matching slot, so developers can co-locate
+inline ``<style>`` or ``<script>`` blocks with their components while still
+letting the collector control final placement and order.
 """
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from django import template
+from django.template.base import Node, NodeList
 from django.utils.safestring import mark_safe
 
 from next.static import (
@@ -23,11 +30,18 @@ from next.static import (
 )
 
 
+if TYPE_CHECKING:
+    from django.template.base import Parser, Token
+
+
 register = template.Library()
 
 
 _KIND_CSS = "css"
 _KIND_JS = "js"
+
+_END_BLOCK_USE_STYLE = ("/use_style",)
+_END_BLOCK_USE_SCRIPT = ("/use_script",)
 
 
 @register.simple_tag
@@ -70,3 +84,51 @@ def _register_asset(context: template.Context, url: str, kind: str) -> None:
     if not isinstance(collector, StaticCollector):
         return
     collector.add(StaticAsset(url=url, kind=kind), prepend=True)
+
+
+class _InlineAssetNode(Node):
+    """Render an inline asset body and push it onto the active collector.
+
+    The block body is rendered with the current template context so inline
+    scripts and styles can still interpolate page variables. The collector
+    dedupes inline entries by the rendered body itself, so two blocks that
+    produce identical HTML (for example the same component rendered twice
+    with no context that leaks into the block) collapse to one entry, while
+    blocks that interpolate different values into the body stay distinct.
+    The node emits nothing in place, since the collector controls final
+    placement inside the matching ``{% collect_styles %}`` /
+    ``{% collect_scripts %}`` slot.
+    """
+
+    def __init__(self, kind: str, nodelist: NodeList) -> None:
+        """Remember the asset kind and the nested nodes to render at runtime."""
+        self.kind = kind
+        self.nodelist = nodelist
+
+    def render(self, context: template.Context) -> str:
+        """Render the body, register the HTML on the collector, and emit nothing."""
+        collector = context.get("_static_collector")
+        if not isinstance(collector, StaticCollector):
+            return ""
+        body = self.nodelist.render(context)
+        stripped = body.strip()
+        if not stripped:
+            return ""
+        collector.add(StaticAsset(url="", kind=self.kind, inline=stripped))
+        return ""
+
+
+@register.tag(name="#use_style")
+def do_block_use_style(parser: Parser, _token: Token) -> _InlineAssetNode:
+    """Compile ``{% #use_style %}`` … ``{% /use_style %}`` into an inline CSS block."""
+    nodelist = parser.parse(_END_BLOCK_USE_STYLE)
+    parser.delete_first_token()
+    return _InlineAssetNode(kind=_KIND_CSS, nodelist=nodelist)
+
+
+@register.tag(name="#use_script")
+def do_block_use_script(parser: Parser, _token: Token) -> _InlineAssetNode:
+    """Compile ``{% #use_script %}`` … ``{% /use_script %}`` into an inline JS block."""
+    nodelist = parser.parse(_END_BLOCK_USE_SCRIPT)
+    parser.delete_first_token()
+    return _InlineAssetNode(kind=_KIND_JS, nodelist=nodelist)

--- a/next/templatetags/next_static.py
+++ b/next/templatetags/next_static.py
@@ -1,0 +1,72 @@
+"""Template tags for static asset injection slots.
+
+``{% collect_styles %}`` emits a placeholder where CSS ``<link>`` tags will be
+written after rendering. ``{% collect_scripts %}`` emits a placeholder for JS
+``<script>`` tags. The placeholders are replaced by ``StaticManager.inject``
+once ``Page.render`` has collected every referenced asset from the page, its
+layouts, and nested components. ``{% use_style %}`` and ``{% use_script %}``
+register an external URL on the active ``StaticCollector`` so that layouts and
+templates can pull in shared third-party libraries without touching
+``page.py`` or ``component.py`` module lists.
+"""
+
+from __future__ import annotations
+
+from django import template
+from django.utils.safestring import mark_safe
+
+from next.static import (
+    SCRIPTS_PLACEHOLDER,
+    STYLES_PLACEHOLDER,
+    StaticAsset,
+    StaticCollector,
+)
+
+
+register = template.Library()
+
+
+_KIND_CSS = "css"
+_KIND_JS = "js"
+
+
+@register.simple_tag
+def collect_styles() -> str:
+    """Mark where collected CSS link tags will be injected after rendering."""
+    return mark_safe(STYLES_PLACEHOLDER)  # noqa: S308
+
+
+@register.simple_tag
+def collect_scripts() -> str:
+    """Mark where collected JS script tags will be injected after rendering."""
+    return mark_safe(SCRIPTS_PLACEHOLDER)  # noqa: S308
+
+
+@register.simple_tag(takes_context=True)
+def use_style(context: template.Context, url: str) -> str:
+    """Register an external CSS URL on the active collector for later injection."""
+    _register_asset(context, url, _KIND_CSS)
+    return ""
+
+
+@register.simple_tag(takes_context=True)
+def use_script(context: template.Context, url: str) -> str:
+    """Register an external JS URL on the active collector for later injection."""
+    _register_asset(context, url, _KIND_JS)
+    return ""
+
+
+def _register_asset(context: template.Context, url: str, kind: str) -> None:
+    """Prepend an asset to the render's ``StaticCollector`` when one exists in context.
+
+    Assets declared from templates with ``{% use_style %}`` / ``{% use_script %}``
+    are treated as shared third-party dependencies and are inserted before any
+    co-located files or module-level lists, so the CSS cascade flows from
+    generic dependencies to page-specific styling.
+    """
+    if not isinstance(url, str) or not url:
+        return
+    collector = context.get("_static_collector")
+    if not isinstance(collector, StaticCollector):
+        return
+    collector.add(StaticAsset(url=url, kind=kind), prepend=True)

--- a/next/templatetags/next_static.py
+++ b/next/templatetags/next_static.py
@@ -23,6 +23,8 @@ from django.template.base import Node, NodeList
 from django.utils.safestring import mark_safe
 
 from next.static import (
+    _KIND_CSS,
+    _KIND_JS,
     SCRIPTS_PLACEHOLDER,
     STYLES_PLACEHOLDER,
     StaticAsset,
@@ -35,10 +37,6 @@ if TYPE_CHECKING:
 
 
 register = template.Library()
-
-
-_KIND_CSS = "css"
-_KIND_JS = "js"
 
 _END_BLOCK_USE_STYLE = ("/use_style",)
 _END_BLOCK_USE_SCRIPT = ("/use_script",)
@@ -90,14 +88,14 @@ class _InlineAssetNode(Node):
     """Render an inline asset body and push it onto the active collector.
 
     The block body is rendered with the current template context so inline
-    scripts and styles can still interpolate page variables. The collector
-    dedupes inline entries by the rendered body itself, so two blocks that
-    produce identical HTML (for example the same component rendered twice
-    with no context that leaks into the block) collapse to one entry, while
-    blocks that interpolate different values into the body stay distinct.
-    The node emits nothing in place, since the collector controls final
-    placement inside the matching ``{% collect_styles %}`` /
-    ``{% collect_scripts %}`` slot.
+    scripts and styles can still interpolate page variables. The rendered
+    body is stripped of leading and trailing whitespace before it reaches
+    the collector, so blank-only blocks are silently ignored. The collector
+    dedupes inline entries by the stripped body itself, so two blocks that
+    produce identical HTML collapse to one entry, while blocks that
+    interpolate different values into the body stay distinct. The node emits
+    nothing in place because the collector controls final placement inside
+    the matching collect_styles or collect_scripts slot.
     """
 
     def __init__(self, kind: str, nodelist: NodeList) -> None:

--- a/next/urls.py
+++ b/next/urls.py
@@ -683,22 +683,19 @@ router_manager = RouterManager()
 
 
 class _LazyUrlPatterns(list):
-    """Defer expanding router, form, and static patterns until first use.
+    """Defer expanding router and form patterns until first use.
 
-    Avoids walking the tree at import time. Rebuilds from ``router_manager``,
-    ``form_action_manager``, and ``static_manager`` on each access.
+    Avoids walking the tree at import time. Rebuilds from ``router_manager`` and
+    ``form_action_manager`` on each access.
     Subclasses ``list`` so ``isinstance(urlpatterns, list)`` holds. Overrides
     ``__reversed__`` because the inherited empty internal buffer would break
     ``reversed(urlpatterns)`` in Django's URL resolver.
     """
 
     def _patterns(self) -> list[URLPattern | URLResolver]:
-        from .static import static_manager  # noqa: PLC0415
-
         return [
             *list(router_manager),
             *list(form_action_manager),
-            *list(static_manager),
         ]
 
     def __iter__(self) -> Iterator[URLPattern | URLResolver]:

--- a/next/urls.py
+++ b/next/urls.py
@@ -683,17 +683,23 @@ router_manager = RouterManager()
 
 
 class _LazyUrlPatterns(list):
-    """Defer expanding router and form patterns until first use.
+    """Defer expanding router, form, and static patterns until first use.
 
-    Avoids walking the tree at import time. Rebuilds from ``router_manager`` and
-    ``form_action_manager`` on each access.
+    Avoids walking the tree at import time. Rebuilds from ``router_manager``,
+    ``form_action_manager``, and ``static_manager`` on each access.
     Subclasses ``list`` so ``isinstance(urlpatterns, list)`` holds. Overrides
     ``__reversed__`` because the inherited empty internal buffer would break
     ``reversed(urlpatterns)`` in Django's URL resolver.
     """
 
     def _patterns(self) -> list[URLPattern | URLResolver]:
-        return [*list(router_manager), *list(form_action_manager)]
+        from .static import static_manager  # noqa: PLC0415
+
+        return [
+            *list(router_manager),
+            *list(form_action_manager),
+            *list(static_manager),
+        ]
 
     def __iter__(self) -> Iterator[URLPattern | URLResolver]:
         return iter(self._patterns())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,13 @@ if not settings.configured:
         ROOT_URLCONF="next.urls",
         SECRET_KEY="test-secret-key",  # noqa: S106
         BASE_DIR=project_root,
+        STATIC_URL="/static/",
+        STORAGES={
+            "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+            "staticfiles": {
+                "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
+            },
+        },
         USE_TZ=True,
         TIME_ZONE="UTC",
         NEXT_FRAMEWORK={

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1051,7 +1051,7 @@ class TestSetSlotTag:
             Template("{% load components %}{% /set_slot %}")
 
     def test_short_set_slot_renders_empty_when_slot_missing(self) -> None:
-        """{% set_slot "x" %} void form has no default; empty when slot absent."""
+        """{% set_slot "x" %} void form has no default, renders empty when slot absent."""
         t = Template('{% load components %}{% set_slot "label" %}')
         assert t.render(Context({})) == ""
 

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -106,7 +106,7 @@ class TestStaticAsset:
     """``StaticAsset`` is a slotted, frozen dataclass with an optional source path."""
 
     def test_defaults(self) -> None:
-        """Only ``url`` and ``kind`` are required; ``source_path`` defaults to ``None``."""
+        """Only ``url`` and ``kind`` are required, ``source_path`` defaults to ``None``."""
         asset = StaticAsset(url=CSS_URL, kind="css")
         assert asset.url == CSS_URL
         assert asset.kind == "css"
@@ -205,6 +205,149 @@ class TestStaticCollector:
             "/dep2.css",
             "/own.css",
         ]
+
+    def test_dedup_across_append_then_prepend(self, collector: StaticCollector) -> None:
+        """A URL first appended is ignored on a later ``prepend=True`` call."""
+        collector.add(StaticAsset(url=CSS_URL, kind="css"))
+        collector.add(StaticAsset(url=CSS_URL, kind="css"), prepend=True)
+        assert [a.url for a in collector.styles()] == [CSS_URL]
+
+    def test_dedup_across_prepend_then_append(self, collector: StaticCollector) -> None:
+        """A URL first prepended is ignored on a later plain ``add`` call."""
+        collector.add(StaticAsset(url=CSS_URL, kind="css"), prepend=True)
+        collector.add(StaticAsset(url=CSS_URL, kind="css"))
+        assert [a.url for a in collector.styles()] == [CSS_URL]
+
+    def test_dedup_is_cross_source_path(self, collector: StaticCollector) -> None:
+        """Assets sharing a URL but different ``source_path`` values still dedup."""
+        collector.add(StaticAsset(url=CSS_URL, kind="css"))
+        collector.add(
+            StaticAsset(url=CSS_URL, kind="css", source_path=Path("/tmp/a.css"))
+        )
+        assert [a.url for a in collector.styles()] == [CSS_URL]
+
+    def test_dedup_is_kind_scoped(self, collector: StaticCollector) -> None:
+        """The seen-set is URL-keyed, so the same URL cannot live in both buckets."""
+        collector.add(StaticAsset(url=CSS_URL, kind="css"))
+        collector.add(StaticAsset(url=CSS_URL, kind="js"))
+        assert [a.url for a in collector.styles()] == [CSS_URL]
+        assert collector.scripts() == []
+
+
+class TestStaticCollectorInline:
+    """Inline assets from ``{% #use_style %}`` / ``{% #use_script %}`` blocks."""
+
+    def test_inline_script_appended(self, collector: StaticCollector) -> None:
+        """An inline JS asset lands in ``scripts`` with its body preserved."""
+        collector.add(StaticAsset(url="", kind="js", inline="console.log(1)"))
+        scripts = collector.scripts()
+        assert len(scripts) == 1
+        assert scripts[0].inline == "console.log(1)"
+        assert scripts[0].url == ""
+
+    def test_inline_style_appended(self, collector: StaticCollector) -> None:
+        """An inline CSS asset lands in ``styles`` with its body preserved."""
+        collector.add(StaticAsset(url="", kind="css", inline="body{color:red}"))
+        styles = collector.styles()
+        assert len(styles) == 1
+        assert styles[0].inline == "body{color:red}"
+
+    def test_identical_inline_bodies_dedupe(self, collector: StaticCollector) -> None:
+        """Two inline assets with identical rendered bodies collapse to one entry."""
+        collector.add(StaticAsset(url="", kind="js", inline="same()"))
+        collector.add(StaticAsset(url="", kind="js", inline="same()"))
+        assert len(collector.scripts()) == 1
+        assert collector.scripts()[0].inline == "same()"
+
+    def test_different_inline_bodies_kept_distinct(
+        self, collector: StaticCollector
+    ) -> None:
+        """Inline assets with different rendered bodies are kept independently."""
+        collector.add(StaticAsset(url="", kind="js", inline="one()"))
+        collector.add(StaticAsset(url="", kind="js", inline="two()"))
+        assert [a.inline for a in collector.scripts()] == ["one()", "two()"]
+
+    def test_inline_dedup_is_kind_scoped(self, collector: StaticCollector) -> None:
+        """Identical bodies in different kinds live in both buckets independently."""
+        collector.add(StaticAsset(url="", kind="css", inline="same"))
+        collector.add(StaticAsset(url="", kind="js", inline="same"))
+        assert [a.inline for a in collector.styles()] == ["same"]
+        assert [a.inline for a in collector.scripts()] == ["same"]
+
+    def test_inline_asset_ignores_prepend_flag(
+        self, collector: StaticCollector
+    ) -> None:
+        """``prepend=True`` is ignored for inline assets, they always append."""
+        collector.add(StaticAsset(url=JS_URL, kind="js"), prepend=True)
+        collector.add(StaticAsset(url="", kind="js", inline="inline()"), prepend=True)
+        scripts = collector.scripts()
+        assert scripts[0].url == JS_URL
+        assert scripts[-1].inline == "inline()"
+
+    def test_inline_and_url_assets_coexist(self, collector: StaticCollector) -> None:
+        """URL-form deps prepend, co-located files append, inline blocks append last."""
+        collector.add(StaticAsset(url="/dep.js", kind="js"), prepend=True)
+        collector.add(StaticAsset(url="/file.js", kind="js"))
+        collector.add(StaticAsset(url="", kind="js", inline="one()"))
+        collector.add(StaticAsset(url="", kind="js", inline="two()"))
+        scripts = collector.scripts()
+        assert [(a.url, a.inline) for a in scripts] == [
+            ("/dep.js", None),
+            ("/file.js", None),
+            ("", "one()"),
+            ("", "two()"),
+        ]
+
+    def test_inline_asset_with_unknown_kind_is_ignored(
+        self, collector: StaticCollector
+    ) -> None:
+        """Unknown kinds fall through the warning path even for inline assets."""
+        collector.add(StaticAsset(url="", kind="unknown", inline="data"))
+        assert collector.styles() == []
+        assert collector.scripts() == []
+
+
+class TestDiscoveryDedup:
+    """End-to-end dedup across discovery sources that share URLs."""
+
+    def test_same_module_url_on_two_components_kept_once(
+        self, tmp_path: Path, collector: StaticCollector
+    ) -> None:
+        """Two components listing the same CDN URL produce one collector entry."""
+        shared_cdn = "https://cdn.example.com/lib.js"
+        for name in ("alpha", "beta"):
+            comp_dir = tmp_path / "_components" / name
+            comp_dir.mkdir(parents=True)
+            (comp_dir / "component.djx").write_text(f"<div>{name}</div>")
+            module_path = comp_dir / "component.py"
+            module_path.write_text(f"scripts = [{shared_cdn!r}]\n")
+            info = ComponentInfo(
+                name=name,
+                scope_root=tmp_path,
+                scope_relative="",
+                template_path=comp_dir / "component.djx",
+                module_path=module_path,
+                is_simple=False,
+            )
+            AssetDiscovery(StaticManager()).discover_component_assets(info, collector)
+        assert [a.url for a in collector.scripts()] == [shared_cdn]
+
+    def test_same_component_rendered_twice_registers_once(
+        self,
+        composite_component: ComponentInfo,
+        collector: StaticCollector,
+        fresh_manager: StaticManager,
+    ) -> None:
+        """Invoking ``discover_component_assets`` twice collapses to a single entry."""
+        discovery = AssetDiscovery(fresh_manager)
+        discovery.discover_component_assets(composite_component, collector)
+        discovery.discover_component_assets(composite_component, collector)
+        style_urls = [a.url for a in collector.styles()]
+        script_urls = [a.url for a in collector.scripts()]
+        assert style_urls.count("https://cdn.example.com/extra.css") == 1
+        assert script_urls.count("https://cdn.example.com/extra.js") == 1
+        assert sum(u.endswith("/widget.css") for u in style_urls) == 1
+        assert sum(u.endswith("/widget.js") for u in script_urls) == 1
 
 
 class TestKindToExtension:
@@ -888,6 +1031,44 @@ class TestStaticManagerInject:
         out = fresh_manager.inject(html, collector)
         assert out == "<head></head><body></body>"
 
+    def test_inline_script_body_emitted_verbatim(
+        self, fresh_manager: StaticManager, collector: StaticCollector
+    ) -> None:
+        """Inline script bodies are written into the slot without any wrapping."""
+        body = '<script type="module">const x = 1;</script>'
+        collector.add(StaticAsset(url="", kind="js", inline=body))
+        html = f"<body>{SCRIPTS_PLACEHOLDER}</body>"
+        out = fresh_manager.inject(html, collector)
+        assert out == f"<body>{body}</body>"
+
+    def test_inline_style_body_emitted_verbatim(
+        self, fresh_manager: StaticManager, collector: StaticCollector
+    ) -> None:
+        """Inline style bodies are written into the slot without any wrapping."""
+        body = "<style>.x{color:red}</style>"
+        collector.add(StaticAsset(url="", kind="css", inline=body))
+        html = f"<head>{STYLES_PLACEHOLDER}</head>"
+        out = fresh_manager.inject(html, collector)
+        assert out == f"<head>{body}</head>"
+
+    def test_url_and_inline_interleave_in_order(
+        self, fresh_manager: StaticManager, collector: StaticCollector
+    ) -> None:
+        """Inline bodies append after URL deps and appear in registration order."""
+        collector.add(StaticAsset(url="/dep.js", kind="js"), prepend=True)
+        collector.add(StaticAsset(url="/file.js", kind="js"))
+        collector.add(StaticAsset(url="", kind="js", inline="<script>a()</script>"))
+        collector.add(StaticAsset(url="", kind="js", inline="<script>b()</script>"))
+        html = f"<body>{SCRIPTS_PLACEHOLDER}</body>"
+        out = fresh_manager.inject(html, collector)
+        slot_body = out.removeprefix("<body>").removesuffix("</body>")
+        assert slot_body == (
+            '<script src="/dep.js"></script>\n'
+            '<script src="/file.js"></script>\n'
+            "<script>a()</script>\n"
+            "<script>b()</script>"
+        )
+
 
 class TestStaticManagerPageRoots:
     """``_page_roots`` caches absolute page directories from page backends."""
@@ -1085,6 +1266,128 @@ class TestTemplateTags:
         tpl = Template("{% load next_static %}{% use_style url %}")
         tpl.render(Context({"_static_collector": collector, "url": bad_url}))
         assert collector.styles() == []
+
+    def test_block_use_script_captures_body_and_emits_nothing(
+        self, collector: StaticCollector
+    ) -> None:
+        """``{% #use_script %}`` records the body and emits no markup in place."""
+        tpl = Template(
+            "{% load next_static %}before"
+            "{% #use_script %}<script>inline()</script>{% /use_script %}"
+            "after"
+        )
+        output = tpl.render(Context({"_static_collector": collector}))
+        assert output == "beforeafter"
+        scripts = collector.scripts()
+        assert len(scripts) == 1
+        assert scripts[0].inline == "<script>inline()</script>"
+        assert scripts[0].url == ""
+
+    def test_block_use_style_captures_body_and_emits_nothing(
+        self, collector: StaticCollector
+    ) -> None:
+        """``{% #use_style %}`` records the body and emits no markup in place."""
+        tpl = Template(
+            "{% load next_static %}"
+            "{% #use_style %}<style>.a{color:red}</style>{% /use_style %}"
+        )
+        output = tpl.render(Context({"_static_collector": collector}))
+        assert output == ""
+        styles = collector.styles()
+        assert len(styles) == 1
+        assert styles[0].inline == "<style>.a{color:red}</style>"
+
+    def test_block_use_script_renders_body_with_context(
+        self, collector: StaticCollector
+    ) -> None:
+        """Block body is rendered against the active context, so vars are substituted."""
+        tpl = Template(
+            "{% load next_static %}"
+            "{% #use_script %}<script>id={{ widget_id }};</script>{% /use_script %}"
+        )
+        tpl.render(Context({"_static_collector": collector, "widget_id": "likes"}))
+        assert collector.scripts()[0].inline == "<script>id=likes;</script>"
+
+    def test_block_use_script_appends_after_url_deps(
+        self, collector: StaticCollector
+    ) -> None:
+        """Block form appends, URL form prepends. URL deps land before inline bodies."""
+        tpl = Template(
+            "{% load next_static %}"
+            '{% use_script "/cdn/react.js" %}'
+            "{% #use_script %}<script>boot()</script>{% /use_script %}"
+        )
+        tpl.render(Context({"_static_collector": collector}))
+        assert [(a.url, a.inline) for a in collector.scripts()] == [
+            ("/cdn/react.js", None),
+            ("", "<script>boot()</script>"),
+        ]
+
+    def test_block_use_script_blank_body_is_ignored(
+        self, collector: StaticCollector
+    ) -> None:
+        """A block body that renders to whitespace-only never reaches the collector."""
+        tpl = Template(
+            "{% load next_static %}{% #use_script %}   \n  {% /use_script %}"
+        )
+        tpl.render(Context({"_static_collector": collector}))
+        assert collector.scripts() == []
+
+    @pytest.mark.parametrize(
+        "tpl_src",
+        [
+            "{% load next_static %}"
+            "{% #use_script %}<script>x()</script>{% /use_script %}",
+            "{% load next_static %}"
+            "{% #use_style %}<style>.a{color:red}</style>{% /use_style %}",
+        ],
+        ids=["block_use_script", "block_use_style"],
+    )
+    def test_block_tags_without_collector_noop(self, tpl_src: str) -> None:
+        """Block tags are silent no-ops when no collector is in context."""
+        assert Template(tpl_src).render(Context()) == ""
+
+    def test_block_use_script_duplicate_bodies_dedupe(
+        self, collector: StaticCollector
+    ) -> None:
+        """Two block occurrences with identical rendered bodies collapse to one entry."""
+        tpl = Template(
+            "{% load next_static %}"
+            "{% #use_script %}<script>same()</script>{% /use_script %}"
+            "{% #use_script %}<script>same()</script>{% /use_script %}"
+        )
+        tpl.render(Context({"_static_collector": collector}))
+        assert len(collector.scripts()) == 1
+
+    def test_block_use_script_different_context_stays_distinct(
+        self, collector: StaticCollector
+    ) -> None:
+        """Blocks that interpolate different context into the body stay distinct."""
+        tpl = Template(
+            "{% load next_static %}"
+            "{% #use_script %}<script>mount('{{ id }}')</script>{% /use_script %}"
+        )
+        for instance_id in ("likes", "stars"):
+            tpl.render(Context({"_static_collector": collector, "id": instance_id}))
+        bodies = [a.inline for a in collector.scripts()]
+        assert bodies == [
+            "<script>mount('likes')</script>",
+            "<script>mount('stars')</script>",
+        ]
+
+    def test_block_use_script_same_context_dedups_across_renders(
+        self, collector: StaticCollector
+    ) -> None:
+        """The same block rendered repeatedly with the same context emits once."""
+        tpl = Template(
+            "{% load next_static %}"
+            "{% #use_script %}<script>boot('{{ id }}')</script>{% /use_script %}"
+        )
+        ctx = Context({"_static_collector": collector, "id": "shared"})
+        tpl.render(ctx)
+        tpl.render(ctx)
+        assert len(collector.scripts()) == 1
+        assert collector.scripts()[0].inline == "<script>boot('shared')</script>"
 
 
 class TestComponentTagIntegration:

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,0 +1,1126 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from django.template import Context, Template
+from django.test import RequestFactory, override_settings
+
+from next.components import ComponentInfo
+from next.static import (
+    SCRIPTS_PLACEHOLDER,
+    STYLES_PLACEHOLDER,
+    AssetDiscovery,
+    FileStaticBackend,
+    StaticAsset,
+    StaticBackend,
+    StaticCollector,
+    StaticManager,
+    StaticsFactory,
+    _FileRegistryEntry,
+    _kind_to_extension,
+    _load_python_module,
+    _read_string_list,
+    static_manager,
+    static_serve_view,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+CSS_URL = "https://example.com/a.css"
+JS_URL = "https://example.com/a.js"
+
+
+@pytest.fixture()
+def fresh_manager() -> StaticManager:
+    """Return a freshly instantiated ``StaticManager`` with no loaded backends."""
+    return StaticManager()
+
+
+@pytest.fixture()
+def collector() -> StaticCollector:
+    """Return a fresh ``StaticCollector`` for each test."""
+    return StaticCollector()
+
+
+@pytest.fixture()
+def file_backend() -> FileStaticBackend:
+    """Return a default ``FileStaticBackend`` with an empty registry."""
+    return FileStaticBackend()
+
+
+@pytest.fixture()
+def _reset_global_static_manager() -> Generator[None, None, None]:
+    """Reload the global ``static_manager`` backends after each test that mutates it."""
+    yield
+    static_manager._backends.clear()
+    static_manager._discovery = None
+    static_manager._cached_page_roots = None
+
+
+@pytest.fixture()
+def simple_component(tmp_path: Path) -> ComponentInfo:
+    """Return a ``ComponentInfo`` pointing to a simple ``.djx`` template file."""
+    template_path = tmp_path / "card.djx"
+    template_path.write_text("<div>card</div>")
+    return ComponentInfo(
+        name="card",
+        scope_root=tmp_path,
+        scope_relative="",
+        template_path=template_path,
+        module_path=None,
+        is_simple=True,
+    )
+
+
+@pytest.fixture()
+def composite_component(tmp_path: Path) -> ComponentInfo:
+    """Return a composite ``ComponentInfo`` with co-located css/js/py siblings."""
+    comp_dir = tmp_path / "_components" / "widget"
+    comp_dir.mkdir(parents=True)
+    template_path = comp_dir / "component.djx"
+    template_path.write_text("<div>widget</div>")
+    module_path = comp_dir / "component.py"
+    module_path.write_text(
+        'styles = ["https://cdn.example.com/extra.css"]\n'
+        'scripts = ["https://cdn.example.com/extra.js"]\n'
+    )
+    (comp_dir / "component.css").write_text(".widget {}")
+    (comp_dir / "component.js").write_text("/* widget */")
+    return ComponentInfo(
+        name="widget",
+        scope_root=tmp_path,
+        scope_relative="",
+        template_path=template_path,
+        module_path=module_path,
+        is_simple=False,
+    )
+
+
+class TestStaticAsset:
+    """``StaticAsset`` is a slotted, frozen dataclass with an optional source path."""
+
+    def test_defaults(self) -> None:
+        """Only ``url`` and ``kind`` are required; ``source_path`` defaults to ``None``."""
+        asset = StaticAsset(url=CSS_URL, kind="css")
+        assert asset.url == CSS_URL
+        assert asset.kind == "css"
+        assert asset.source_path is None
+
+    def test_explicit_source_path(self, tmp_path: Path) -> None:
+        """``source_path`` can carry the origin path for file-backed assets."""
+        asset = StaticAsset(url=CSS_URL, kind="css", source_path=tmp_path)
+        assert asset.source_path == tmp_path
+
+
+class TestStaticCollector:
+    """The collector dedupes by URL and splits assets by kind in insertion order."""
+
+    def test_css_and_js_go_to_separate_lists(self, collector: StaticCollector) -> None:
+        """CSS and JS assets are returned by dedicated accessors."""
+        css = StaticAsset(url=CSS_URL, kind="css")
+        js = StaticAsset(url=JS_URL, kind="js")
+        collector.add(css)
+        collector.add(js)
+        assert collector.styles() == [css]
+        assert collector.scripts() == [js]
+
+    def test_duplicate_url_is_ignored(self, collector: StaticCollector) -> None:
+        """A second ``add`` with the same URL does not grow any list."""
+        collector.add(StaticAsset(url=CSS_URL, kind="css"))
+        collector.add(StaticAsset(url=CSS_URL, kind="css"))
+        assert len(collector.styles()) == 1
+
+    def test_unknown_kind_is_logged_and_dropped(
+        self,
+        collector: StaticCollector,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An asset whose ``kind`` is neither css nor js is ignored with a debug log."""
+        with caplog.at_level("DEBUG", logger="next.static"):
+            collector.add(StaticAsset(url="weird://x", kind="weird"))
+        assert collector.styles() == []
+        assert collector.scripts() == []
+        assert any("unknown kind" in rec.message for rec in caplog.records)
+
+    def test_accessors_return_copies(self, collector: StaticCollector) -> None:
+        """``styles`` and ``scripts`` return new lists so callers cannot mutate state."""
+        collector.add(StaticAsset(url=CSS_URL, kind="css"))
+        snapshot = collector.styles()
+        snapshot.clear()
+        assert collector.styles() == [StaticAsset(url=CSS_URL, kind="css")]
+
+    def test_preserves_insertion_order(self, collector: StaticCollector) -> None:
+        """Later unique URLs keep their relative order."""
+        urls = [f"https://cdn/{i}.css" for i in range(3)]
+        for url in urls:
+            collector.add(StaticAsset(url=url, kind="css"))
+        assert [asset.url for asset in collector.styles()] == urls
+
+    def test_prepend_moves_asset_to_front(self, collector: StaticCollector) -> None:
+        """``prepend=True`` inserts before previously appended items."""
+        collector.add(StaticAsset(url="/own.css", kind="css"))
+        collector.add(StaticAsset(url="/dep.css", kind="css"), prepend=True)
+        assert [a.url for a in collector.styles()] == ["/dep.css", "/own.css"]
+
+    def test_prepend_preserves_order_across_multiple_calls(
+        self, collector: StaticCollector
+    ) -> None:
+        """Sequential prepends keep their registration order relative to each other."""
+        collector.add(StaticAsset(url="/own.css", kind="css"))
+        collector.add(StaticAsset(url="/a.css", kind="css"), prepend=True)
+        collector.add(StaticAsset(url="/b.css", kind="css"), prepend=True)
+        collector.add(StaticAsset(url="/c.css", kind="css"), prepend=True)
+        assert [a.url for a in collector.styles()] == [
+            "/a.css",
+            "/b.css",
+            "/c.css",
+            "/own.css",
+        ]
+
+    def test_prepend_works_for_scripts(self, collector: StaticCollector) -> None:
+        """Prepend cursor is tracked independently for the scripts bucket."""
+        collector.add(StaticAsset(url="/own.js", kind="js"))
+        collector.add(StaticAsset(url="/a.js", kind="js"), prepend=True)
+        collector.add(StaticAsset(url="/b.js", kind="js"), prepend=True)
+        assert [a.url for a in collector.scripts()] == [
+            "/a.js",
+            "/b.js",
+            "/own.js",
+        ]
+
+    def test_prepend_respects_dedup(self, collector: StaticCollector) -> None:
+        """A URL already present is not re-prepended and the cursor does not move."""
+        collector.add(StaticAsset(url="/own.css", kind="css"))
+        collector.add(StaticAsset(url="/dep.css", kind="css"), prepend=True)
+        collector.add(StaticAsset(url="/dep.css", kind="css"), prepend=True)
+        collector.add(StaticAsset(url="/dep2.css", kind="css"), prepend=True)
+        assert [a.url for a in collector.styles()] == [
+            "/dep.css",
+            "/dep2.css",
+            "/own.css",
+        ]
+
+
+class TestKindToExtension:
+    """``_kind_to_extension`` maps collector kinds to file extensions."""
+
+    @pytest.mark.parametrize(
+        ("kind", "expected"),
+        [("css", ".css"), ("js", ".js")],
+    )
+    def test_known_kinds(self, kind: str, expected: str) -> None:
+        """Known kinds map to the matching file extension."""
+        assert _kind_to_extension(kind) == expected
+
+    def test_unknown_kind_raises(self) -> None:
+        """Passing an unsupported kind raises ``ValueError``."""
+        with pytest.raises(ValueError, match="Unsupported asset kind"):
+            _kind_to_extension("other")
+
+
+class TestLoadPythonModule:
+    """``_load_python_module`` loads arbitrary ``.py`` files by path."""
+
+    def test_loads_module_exposing_attributes(self, tmp_path: Path) -> None:
+        """A valid ``.py`` file is executed and its attributes are accessible."""
+        source = tmp_path / "mod.py"
+        source.write_text("X = 1\nY = 'ok'\n")
+        module = _load_python_module(source)
+        assert module is not None
+        assert module.X == 1
+        assert module.Y == "ok"
+
+    def test_syntax_error_returns_none(self, tmp_path: Path) -> None:
+        """A broken source file logs a debug message and returns ``None``."""
+        source = tmp_path / "bad.py"
+        source.write_text("def (")
+        assert _load_python_module(source) is None
+
+    def test_missing_spec_returns_none(self, tmp_path: Path) -> None:
+        """When ``spec_from_file_location`` returns ``None`` the loader returns ``None``."""
+        source = tmp_path / "mod.py"
+        source.write_text("X = 1")
+        with patch(
+            "next.static.importlib.util.spec_from_file_location", return_value=None
+        ):
+            assert _load_python_module(source) is None
+
+
+class TestReadStringList:
+    """``_read_string_list`` reads sanitized string lists from module attributes."""
+
+    def test_list_of_strings(self) -> None:
+        """A list of strings is returned intact as a list of strings."""
+        mod = type("M", (), {"urls": ["a", "b"]})()
+        assert _read_string_list(mod, "urls") == ["a", "b"]
+
+    def test_tuple_of_strings(self) -> None:
+        """Tuples are accepted and normalized to a list."""
+        mod = type("M", (), {"urls": ("a", "b")})()
+        assert _read_string_list(mod, "urls") == ["a", "b"]
+
+    def test_non_sequence_attribute_returns_empty(self) -> None:
+        """A non list/tuple attribute returns an empty list."""
+        mod = type("M", (), {"urls": "not-a-list"})()
+        assert _read_string_list(mod, "urls") == []
+
+    def test_missing_attribute_returns_empty(self) -> None:
+        """A missing attribute returns an empty list."""
+        mod = type("M", (), {})()
+        assert _read_string_list(mod, "urls") == []
+
+    def test_drops_empty_and_non_string_items(self) -> None:
+        """Empty strings and non-string members are filtered out."""
+        mod = type("M", (), {"urls": ["a", "", None, 42, "b"]})()
+        assert _read_string_list(mod, "urls") == ["a", "b"]
+
+
+class TestFileStaticBackend:
+    """``FileStaticBackend`` registers files and renders link/script tags."""
+
+    def test_register_returns_prefixed_url(
+        self, file_backend: FileStaticBackend, tmp_path: Path
+    ) -> None:
+        """``register_file`` returns a URL under the ``_next/static`` prefix."""
+        source = tmp_path / "thing.css"
+        source.write_text("")
+        url = file_backend.register_file(source, "about", "css")
+        assert url == "/_next/static/about.css"
+
+    def test_lookup_returns_registry_entry(
+        self, file_backend: FileStaticBackend, tmp_path: Path
+    ) -> None:
+        """``lookup`` resolves the stored absolute path for a registered URL."""
+        source = tmp_path / "thing.js"
+        source.write_text("")
+        file_backend.register_file(source, "widget", "js")
+        entry = file_backend.lookup("widget.js")
+        assert isinstance(entry, _FileRegistryEntry)
+        assert entry.source_path == source.resolve()
+
+    def test_lookup_missing_returns_none(self, file_backend: FileStaticBackend) -> None:
+        """``lookup`` returns ``None`` for an unknown logical name."""
+        assert file_backend.lookup("missing.css") is None
+
+    def test_render_default_tags(self, file_backend: FileStaticBackend) -> None:
+        """The default link/script formatters emit standard HTML markup."""
+        assert file_backend.render_link_tag("/a.css") == (
+            '<link rel="stylesheet" href="/a.css">'
+        )
+        assert file_backend.render_script_tag("/a.js") == (
+            '<script src="/a.js"></script>'
+        )
+
+    def test_custom_tag_templates_from_options(self) -> None:
+        """``OPTIONS`` customize link/script tag templates via ``{url}`` placeholder."""
+        backend = FileStaticBackend(
+            {
+                "OPTIONS": {
+                    "css_tag": '<link data-custom href="{url}">',
+                    "js_tag": '<script data-x src="{url}"></script>',
+                }
+            }
+        )
+        assert backend.render_link_tag("/a.css") == ('<link data-custom href="/a.css">')
+        assert backend.render_script_tag("/a.js") == (
+            '<script data-x src="/a.js"></script>'
+        )
+
+    def test_generate_urls_returns_single_catch_all(
+        self, file_backend: FileStaticBackend
+    ) -> None:
+        """``generate_urls`` returns a single catch-all URL pattern."""
+        patterns = file_backend.generate_urls()
+        assert len(patterns) == 1
+        assert patterns[0].name == "next_static_serve"
+
+    def test_clear_registry_wipes_every_mapping(
+        self, file_backend: FileStaticBackend, tmp_path: Path
+    ) -> None:
+        """``clear_registry`` resets the internal mapping to empty."""
+        (tmp_path / "a.css").write_text("")
+        file_backend.register_file(tmp_path / "a.css", "a", "css")
+        file_backend.clear_registry()
+        assert file_backend.lookup("a.css") is None
+
+
+class TestStaticBackendABC:
+    """``StaticBackend`` is abstract and cannot be instantiated directly."""
+
+    def test_cannot_instantiate_abstract(self) -> None:
+        """Attempting to construct the ABC raises ``TypeError``."""
+        with pytest.raises(TypeError):
+            StaticBackend()  # type: ignore[abstract]
+
+
+class TestStaticsFactory:
+    """``StaticsFactory`` constructs backend instances from config dicts."""
+
+    def test_default_backend_is_file_static_backend(self) -> None:
+        """An empty config resolves to the default ``FileStaticBackend``."""
+        backend = StaticsFactory.create_backend({})
+        assert isinstance(backend, FileStaticBackend)
+
+    def test_explicit_backend_path(self) -> None:
+        """An explicit ``BACKEND`` path instantiates the named class."""
+        backend = StaticsFactory.create_backend(
+            {"BACKEND": "next.static.FileStaticBackend", "OPTIONS": {}}
+        )
+        assert isinstance(backend, FileStaticBackend)
+
+    def test_non_backend_class_raises(self) -> None:
+        """A class that is not a ``StaticBackend`` subclass raises ``TypeError``."""
+        with pytest.raises(TypeError, match="is not a StaticBackend subclass"):
+            StaticsFactory.create_backend({"BACKEND": "builtins.dict"})
+
+
+class TestAssetDiscoveryPageAssets:
+    """``AssetDiscovery.discover_page_assets`` walks layouts, templates, modules."""
+
+    def _make_discovery(
+        self,
+        file_backend: FileStaticBackend,
+        page_roots: tuple[Path, ...] = (),
+    ) -> AssetDiscovery:
+        """Build a discovery helper wired to a ``StaticManager`` stub."""
+        manager = StaticManager()
+        manager._backends = [file_backend]
+        manager._cached_page_roots = page_roots
+        return AssetDiscovery(manager)
+
+    def test_walks_nested_layouts_then_template_then_module(
+        self,
+        tmp_path: Path,
+        file_backend: FileStaticBackend,
+        collector: StaticCollector,
+    ) -> None:
+        """Outer-to-inner layout assets precede template and module-level lists."""
+        page_root = tmp_path / "pages"
+        inner = page_root / "blog"
+        inner.mkdir(parents=True)
+        (page_root / "layout.djx").write_text("root")
+        (page_root / "layout.css").write_text("/* root */")
+        (page_root / "layout.js").write_text("/* root js */")
+        (inner / "layout.djx").write_text("inner")
+        (inner / "layout.css").write_text("/* inner */")
+        (inner / "template.css").write_text("/* tpl */")
+        (inner / "template.js").write_text("/* tpl js */")
+        page_py = inner / "page.py"
+        page_py.write_text(
+            'styles = ["https://ext/inter.css"]\nscripts = ["https://ext/app.js"]\n'
+        )
+
+        discovery = self._make_discovery(file_backend, (page_root.resolve(),))
+        discovery.discover_page_assets(page_py, collector)
+
+        style_urls = [asset.url for asset in collector.styles()]
+        script_urls = [asset.url for asset in collector.scripts()]
+        assert style_urls == [
+            "/_next/static/layout.css",
+            "/_next/static/blog/layout.css",
+            "/_next/static/blog.css",
+            "https://ext/inter.css",
+        ]
+        assert script_urls == [
+            "/_next/static/layout.js",
+            "/_next/static/blog.js",
+            "https://ext/app.js",
+        ]
+
+    def test_no_layout_directories_still_collects_template_and_module(
+        self,
+        tmp_path: Path,
+        file_backend: FileStaticBackend,
+        collector: StaticCollector,
+    ) -> None:
+        """When no layout exists discovery still collects template and module lists."""
+        page_root = tmp_path / "pages"
+        page_root.mkdir()
+        (page_root / "template.css").write_text("/* tpl */")
+        page_py = page_root / "page.py"
+        page_py.write_text('styles = ["https://ext/x.css"]\n')
+
+        discovery = self._make_discovery(file_backend, (page_root.resolve(),))
+        discovery.discover_page_assets(page_py, collector)
+
+        assert [asset.url for asset in collector.styles()] == [
+            "/_next/static/index.css",
+            "https://ext/x.css",
+        ]
+
+    def test_missing_page_py_skips_module_list_collection(
+        self,
+        tmp_path: Path,
+        file_backend: FileStaticBackend,
+        collector: StaticCollector,
+    ) -> None:
+        """A non-existent ``page.py`` is silently skipped."""
+        page_root = tmp_path / "pages"
+        page_root.mkdir()
+        discovery = self._make_discovery(file_backend, (page_root.resolve(),))
+        discovery.discover_page_assets(page_root / "page.py", collector)
+        assert collector.styles() == []
+        assert collector.scripts() == []
+
+    def test_layout_and_template_outside_page_root_use_fallback_names(
+        self,
+        tmp_path: Path,
+        file_backend: FileStaticBackend,
+        collector: StaticCollector,
+    ) -> None:
+        """Files outside any configured page root fall back to directory-based names."""
+        strangedir = tmp_path / "strange"
+        strangedir.mkdir()
+        (strangedir / "layout.djx").write_text("")
+        (strangedir / "layout.css").write_text("")
+        (strangedir / "template.css").write_text("")
+        page_py = strangedir / "page.py"
+        page_py.write_text("")
+
+        discovery = self._make_discovery(file_backend, ())
+        discovery.discover_page_assets(page_py, collector)
+
+        style_urls = [asset.url for asset in collector.styles()]
+        assert "/_next/static/strange/layout.css" in style_urls
+        assert "/_next/static/strange.css" in style_urls
+
+
+class TestAssetDiscoveryComponentAssets:
+    """``AssetDiscovery.discover_component_assets`` handles composite components."""
+
+    def _discovery(
+        self, backend: FileStaticBackend
+    ) -> tuple[AssetDiscovery, StaticManager]:
+        """Build a ``StaticManager``/``AssetDiscovery`` pair wired to ``backend``."""
+        manager = StaticManager()
+        manager._backends = [backend]
+        return AssetDiscovery(manager), manager
+
+    def test_simple_component_is_ignored(
+        self,
+        simple_component: ComponentInfo,
+        file_backend: FileStaticBackend,
+        collector: StaticCollector,
+    ) -> None:
+        """Simple components have no co-located assets and are skipped."""
+        discovery, _ = self._discovery(file_backend)
+        discovery.discover_component_assets(simple_component, collector)
+        assert collector.styles() == []
+        assert collector.scripts() == []
+
+    def test_composite_collects_css_js_and_module_lists(
+        self,
+        composite_component: ComponentInfo,
+        file_backend: FileStaticBackend,
+        collector: StaticCollector,
+    ) -> None:
+        """Composite components contribute co-located files and module lists."""
+        discovery, _ = self._discovery(file_backend)
+        discovery.discover_component_assets(composite_component, collector)
+
+        style_urls = [asset.url for asset in collector.styles()]
+        script_urls = [asset.url for asset in collector.scripts()]
+        assert style_urls == [
+            "/_next/static/components/widget.css",
+            "https://cdn.example.com/extra.css",
+        ]
+        assert script_urls == [
+            "/_next/static/components/widget.js",
+            "https://cdn.example.com/extra.js",
+        ]
+
+    def test_composite_without_files_uses_only_module_lists(
+        self,
+        tmp_path: Path,
+        file_backend: FileStaticBackend,
+        collector: StaticCollector,
+    ) -> None:
+        """A composite that has no css/js files reads only the module lists."""
+        comp_dir = tmp_path / "widget"
+        comp_dir.mkdir()
+        template_path = comp_dir / "component.djx"
+        template_path.write_text("<div/>")
+        module_path = comp_dir / "component.py"
+        module_path.write_text('styles = ["https://a"]\nscripts = ["https://b"]\n')
+        info = ComponentInfo(
+            name="widget",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=template_path,
+            module_path=module_path,
+            is_simple=False,
+        )
+        discovery, _ = self._discovery(file_backend)
+        discovery.discover_component_assets(info, collector)
+        assert [a.url for a in collector.styles()] == ["https://a"]
+        assert [a.url for a in collector.scripts()] == ["https://b"]
+
+    def test_component_directory_falls_back_to_module_path_parent(
+        self,
+        tmp_path: Path,
+        file_backend: FileStaticBackend,
+        collector: StaticCollector,
+    ) -> None:
+        """When ``template_path`` is ``None`` the directory is derived from the module path."""
+        comp_dir = tmp_path / "widget"
+        comp_dir.mkdir()
+        module_path = comp_dir / "component.py"
+        module_path.write_text('styles = ["https://from-module"]\n')
+        (comp_dir / "component.css").write_text(".w {}")
+        info = ComponentInfo(
+            name="widget",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=None,
+            module_path=module_path,
+            is_simple=False,
+        )
+        discovery, _ = self._discovery(file_backend)
+        discovery.discover_component_assets(info, collector)
+        style_urls = [a.url for a in collector.styles()]
+        assert "/_next/static/components/widget.css" in style_urls
+        assert "https://from-module" in style_urls
+
+    def test_component_with_no_paths_is_skipped(
+        self,
+        tmp_path: Path,
+        file_backend: FileStaticBackend,
+        collector: StaticCollector,
+    ) -> None:
+        """A composite with neither template nor module path contributes nothing."""
+        info = ComponentInfo(
+            name="ghost",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=None,
+            module_path=None,
+            is_simple=False,
+        )
+        discovery, _ = self._discovery(file_backend)
+        discovery.discover_component_assets(info, collector)
+        assert collector.styles() == []
+        assert collector.scripts() == []
+
+    def test_missing_module_path_skips_module_list_collection(
+        self,
+        tmp_path: Path,
+        file_backend: FileStaticBackend,
+        collector: StaticCollector,
+    ) -> None:
+        """A composite whose module path does not exist contributes only files."""
+        comp_dir = tmp_path / "widget"
+        comp_dir.mkdir()
+        template_path = comp_dir / "component.djx"
+        template_path.write_text("<div/>")
+        (comp_dir / "component.css").write_text(".w {}")
+        info = ComponentInfo(
+            name="widget",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=template_path,
+            module_path=comp_dir / "does-not-exist.py",
+            is_simple=False,
+        )
+        discovery, _ = self._discovery(file_backend)
+        discovery.discover_component_assets(info, collector)
+        style_urls = [a.url for a in collector.styles()]
+        assert style_urls == ["/_next/static/components/widget.css"]
+
+
+class TestCollectModuleListsInternals:
+    """``_collect_module_lists`` short-circuits when the module cannot load."""
+
+    def test_unloadable_module_is_silently_ignored(
+        self,
+        tmp_path: Path,
+        file_backend: FileStaticBackend,
+        collector: StaticCollector,
+    ) -> None:
+        """A ``_load_python_module`` returning ``None`` leaves the collector empty."""
+        manager = StaticManager()
+        manager._backends = [file_backend]
+        discovery = AssetDiscovery(manager)
+        module_path = tmp_path / "page.py"
+        module_path.write_text("X = 1")
+        with patch("next.static._load_python_module", return_value=None):
+            discovery._collect_module_lists(module_path, collector)
+        assert collector.styles() == []
+        assert collector.scripts() == []
+
+
+class TestAssetDiscoveryInternals:
+    """Internal helpers of ``AssetDiscovery`` cover fallback and error paths."""
+
+    def _discovery(self, backend: FileStaticBackend) -> AssetDiscovery:
+        """Return a discovery helper wired to a blank manager and ``backend``."""
+        manager = StaticManager()
+        manager._backends = [backend]
+        return AssetDiscovery(manager)
+
+    def test_register_file_failure_logs_and_skips_collector(
+        self,
+        tmp_path: Path,
+        collector: StaticCollector,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Backend errors during ``register_file`` are logged and collector is untouched."""
+
+        class _RaisingBackend(FileStaticBackend):
+            def register_file(self, source_path, logical_name, kind):
+                msg = "boom"
+                raise OSError(msg)
+
+        discovery = self._discovery(_RaisingBackend())
+        source = tmp_path / "x.css"
+        source.write_text("")
+        with caplog.at_level("DEBUG", logger="next.static"):
+            discovery._register_file(source, "a", "css", collector)
+        assert collector.styles() == []
+        assert any("Failed to register" in rec.message for rec in caplog.records)
+
+    def test_fallback_logical_name_for_empty_directory_name(
+        self, file_backend: FileStaticBackend
+    ) -> None:
+        """Directories with an empty ``name`` fall back to ``index``."""
+        discovery = self._discovery(file_backend)
+        assert discovery._fallback_logical_name(Path("/")) == "index"
+
+    def test_find_page_root_returns_none_when_outside(
+        self, tmp_path: Path, file_backend: FileStaticBackend
+    ) -> None:
+        """``_find_page_root`` returns ``None`` for a path outside any root."""
+        discovery = self._discovery(file_backend)
+        assert discovery._find_page_root(tmp_path / "page.py") is None
+
+    def test_logical_name_for_template_outside_root_uses_fallback(
+        self, tmp_path: Path, file_backend: FileStaticBackend
+    ) -> None:
+        """A template directory outside ``page_root`` falls back to its name."""
+        discovery = self._discovery(file_backend)
+        other = tmp_path / "somewhere"
+        other.mkdir()
+        (tmp_path / "root").mkdir()
+        name = discovery._logical_name_for_template(other, tmp_path / "root")
+        assert name == "somewhere"
+
+    def test_logical_name_for_layout_outside_root_uses_fallback(
+        self, tmp_path: Path, file_backend: FileStaticBackend
+    ) -> None:
+        """A layout directory outside ``page_root`` falls back to ``<name>/layout``."""
+        discovery = self._discovery(file_backend)
+        other = tmp_path / "somewhere"
+        other.mkdir()
+        (tmp_path / "root").mkdir()
+        name = discovery._logical_name_for_layout(other, tmp_path / "root")
+        assert name == "somewhere/layout"
+
+    def test_logical_name_for_layout_without_root(
+        self, tmp_path: Path, file_backend: FileStaticBackend
+    ) -> None:
+        """Without a ``page_root`` the layout name falls back to ``<name>/layout``."""
+        discovery = self._discovery(file_backend)
+        layout_dir = tmp_path / "pages"
+        layout_dir.mkdir()
+        assert discovery._logical_name_for_layout(layout_dir, None) == "pages/layout"
+
+    def test_logical_name_for_layout_at_page_root_returns_plain_layout(
+        self, tmp_path: Path, file_backend: FileStaticBackend
+    ) -> None:
+        """When ``layout_dir == page_root`` the logical name is just ``layout``."""
+        discovery = self._discovery(file_backend)
+        page_root = tmp_path / "pages"
+        page_root.mkdir()
+        assert discovery._logical_name_for_layout(page_root, page_root) == "layout"
+
+    def test_find_layout_directories_stops_at_filesystem_root(
+        self, tmp_path: Path, file_backend: FileStaticBackend
+    ) -> None:
+        """With no ``page_root`` the walk terminates at the filesystem root."""
+        discovery = self._discovery(file_backend)
+        leaf = tmp_path / "a" / "b"
+        leaf.mkdir(parents=True)
+        page_py = leaf / "page.py"
+        page_py.write_text("")
+        assert discovery._find_layout_directories(page_py, None) == []
+
+
+class TestStaticManagerLifecycle:
+    """``StaticManager`` manages backend loading, iteration, and reload."""
+
+    def test_iter_yields_url_patterns(self, fresh_manager: StaticManager) -> None:
+        """Iterating the manager yields patterns contributed by every backend."""
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "DEFAULT_STATIC_BACKENDS": [
+                    {"BACKEND": "next.static.FileStaticBackend"}
+                ]
+            }
+        ):
+            patterns = list(fresh_manager)
+        assert len(patterns) == 1
+
+    def test_len_reflects_backend_count(self, fresh_manager: StaticManager) -> None:
+        """``len`` returns the number of loaded backends."""
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "DEFAULT_STATIC_BACKENDS": [
+                    {"BACKEND": "next.static.FileStaticBackend"}
+                ]
+            }
+        ):
+            assert len(fresh_manager) == 1
+
+    def test_default_backend_triggers_lazy_load(
+        self, fresh_manager: StaticManager
+    ) -> None:
+        """Accessing ``default_backend`` loads configured backends on first access."""
+        assert isinstance(fresh_manager.default_backend, FileStaticBackend)
+
+    def test_discovery_is_lazy_and_cached(self, fresh_manager: StaticManager) -> None:
+        """``discovery`` is created once and reused on subsequent access."""
+        first = fresh_manager.discovery
+        second = fresh_manager.discovery
+        assert first is second
+
+    def test_falls_back_to_file_backend_when_config_empty(
+        self, fresh_manager: StaticManager
+    ) -> None:
+        """An empty ``DEFAULT_STATIC_BACKENDS`` list keeps a default backend."""
+        with override_settings(NEXT_FRAMEWORK={"DEFAULT_STATIC_BACKENDS": []}):
+            assert isinstance(fresh_manager.default_backend, FileStaticBackend)
+
+    def test_ignores_non_list_configs(self, fresh_manager: StaticManager) -> None:
+        """A non-list ``DEFAULT_STATIC_BACKENDS`` value is coerced to an empty list."""
+        from next.static import next_framework_settings as conf  # noqa: PLC0415
+
+        conf._attr_value_cache["DEFAULT_STATIC_BACKENDS"] = "not-a-list"
+        assert isinstance(fresh_manager.default_backend, FileStaticBackend)
+
+    def test_ignores_non_dict_backend_entries(
+        self, fresh_manager: StaticManager
+    ) -> None:
+        """Non-dict entries inside the backends list are silently skipped."""
+        with override_settings(
+            NEXT_FRAMEWORK={"DEFAULT_STATIC_BACKENDS": ["nope", None, 42]}
+        ):
+            assert isinstance(fresh_manager.default_backend, FileStaticBackend)
+
+    def test_backend_creation_failure_is_logged_and_skipped(
+        self,
+        fresh_manager: StaticManager,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """When a backend import fails the error is logged and the slot is skipped."""
+        with (
+            override_settings(
+                NEXT_FRAMEWORK={
+                    "DEFAULT_STATIC_BACKENDS": [
+                        {"BACKEND": "builtins.dict"},
+                    ]
+                }
+            ),
+            caplog.at_level("ERROR", logger="next.static"),
+        ):
+            assert isinstance(fresh_manager.default_backend, FileStaticBackend)
+        assert any(
+            "Error creating static backend" in rec.message for rec in caplog.records
+        )
+
+    def test_discover_page_assets_delegates_to_discovery(
+        self,
+        fresh_manager: StaticManager,
+        tmp_path: Path,
+        collector: StaticCollector,
+    ) -> None:
+        """``discover_page_assets`` forwards to the shared ``AssetDiscovery`` instance."""
+        page_py = tmp_path / "page.py"
+        page_py.write_text('styles = ["https://ext/a.css"]\n')
+        fresh_manager.discover_page_assets(page_py, collector)
+        assert [a.url for a in collector.styles()] == ["https://ext/a.css"]
+
+    def test_discover_component_assets_delegates_to_discovery(
+        self,
+        fresh_manager: StaticManager,
+        composite_component: ComponentInfo,
+        collector: StaticCollector,
+    ) -> None:
+        """``discover_component_assets`` forwards to the shared ``AssetDiscovery``."""
+        fresh_manager.discover_component_assets(composite_component, collector)
+        assert any(a.url.endswith("components/widget.css") for a in collector.styles())
+
+
+class TestStaticManagerInject:
+    """``StaticManager.inject`` rewrites placeholders into rendered HTML."""
+
+    def test_injects_css_and_js_tags(
+        self, fresh_manager: StaticManager, collector: StaticCollector
+    ) -> None:
+        """Both CSS and JS placeholders are replaced with concatenated tags."""
+        collector.add(StaticAsset(url="/a.css", kind="css"))
+        collector.add(StaticAsset(url="/b.css", kind="css"))
+        collector.add(StaticAsset(url="/a.js", kind="js"))
+        html = f"<head>{STYLES_PLACEHOLDER}</head><body>{SCRIPTS_PLACEHOLDER}</body>"
+        out = fresh_manager.inject(html, collector)
+        assert '<link rel="stylesheet" href="/a.css">' in out
+        assert '<link rel="stylesheet" href="/b.css">' in out
+        assert '<script src="/a.js"></script>' in out
+        assert STYLES_PLACEHOLDER not in out
+        assert SCRIPTS_PLACEHOLDER not in out
+
+    def test_noop_without_placeholders(
+        self, fresh_manager: StaticManager, collector: StaticCollector
+    ) -> None:
+        """HTML without any placeholder is returned unchanged."""
+        collector.add(StaticAsset(url="/a.css", kind="css"))
+        assert fresh_manager.inject("<p>plain</p>", collector) == "<p>plain</p>"
+
+    def test_empty_collector_renders_empty_slots(
+        self, fresh_manager: StaticManager, collector: StaticCollector
+    ) -> None:
+        """An empty collector replaces placeholders with empty strings."""
+        html = f"<head>{STYLES_PLACEHOLDER}</head><body>{SCRIPTS_PLACEHOLDER}</body>"
+        out = fresh_manager.inject(html, collector)
+        assert out == "<head></head><body></body>"
+
+
+class TestStaticManagerPageRoots:
+    """``_page_roots`` caches absolute page directories from page backends."""
+
+    def test_caches_value_after_first_call(
+        self, fresh_manager: StaticManager, tmp_path: Path
+    ) -> None:
+        """Subsequent calls return the cached tuple rather than re-querying."""
+        with patch(
+            "next.pages.get_pages_directories_for_watch",
+            return_value=[tmp_path],
+        ) as mock_roots:
+            first = fresh_manager._page_roots()
+            second = fresh_manager._page_roots()
+        assert first == (tmp_path.resolve(),)
+        assert second is first
+        assert mock_roots.call_count == 1
+
+    def test_returns_empty_when_pages_module_import_fails(
+        self, fresh_manager: StaticManager
+    ) -> None:
+        """When ``next.pages`` cannot be imported the cache falls back to ``()``."""
+        import next.pages as next_pages  # noqa: PLC0415
+
+        original = next_pages.get_pages_directories_for_watch
+        try:
+            del next_pages.get_pages_directories_for_watch
+            assert fresh_manager._page_roots() == ()
+        finally:
+            next_pages.get_pages_directories_for_watch = original
+
+    def test_oserror_on_resolve_is_swallowed(
+        self, fresh_manager: StaticManager
+    ) -> None:
+        """A ``Path.resolve`` OSError is swallowed and the root is dropped."""
+        bad = Path("/does/not/matter")
+        real_resolve = Path.resolve
+
+        def _resolve(self, *, strict=False):
+            if self == bad:
+                msg = "boom"
+                raise OSError(msg)
+            return real_resolve(self, strict=strict)
+
+        with (
+            patch("next.pages.get_pages_directories_for_watch", return_value=[bad]),
+            patch.object(Path, "resolve", _resolve),
+        ):
+            assert fresh_manager._page_roots() == ()
+
+
+class TestStaticServeView:
+    """``static_serve_view`` delegates to ``django.views.static.serve``."""
+
+    @pytest.fixture()
+    def warm_global_backend(self, tmp_path: Path) -> Generator[Path, None, None]:
+        """Prime the module-level ``static_manager`` with a single registered file."""
+        static_manager._backends.clear()
+        static_manager._discovery = None
+        static_manager._cached_page_roots = None
+        static_manager._reload_config()
+        source = tmp_path / "served.css"
+        source.write_text("body{}")
+        static_manager.default_backend.register_file(source, "served", "css")
+        try:
+            yield source
+        finally:
+            static_manager._backends.clear()
+            static_manager._discovery = None
+            static_manager._cached_page_roots = None
+
+    def test_serves_registered_file(self, warm_global_backend: Path) -> None:
+        """A registered file is served with a 200 response and expected content."""
+        request = RequestFactory().get("/_next/static/served.css")
+        response = static_serve_view(request, "served.css")
+        assert response.status_code == 200
+        body = b"".join(response.streaming_content)
+        assert body == b"body{}"
+
+    def test_unregistered_path_returns_404(self, warm_global_backend: Path) -> None:
+        """An unknown logical path returns a 404 response."""
+        request = RequestFactory().get("/_next/static/missing.css")
+        response = static_serve_view(request, "missing.css")
+        assert response.status_code == 404
+
+    @pytest.mark.usefixtures("_reset_global_static_manager")
+    def test_non_file_backend_returns_404(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If the default backend is not a ``FileStaticBackend`` the view 404s."""
+
+        class _Dummy:
+            pass
+
+        monkeypatch.setattr(
+            StaticManager,
+            "default_backend",
+            property(lambda self: _Dummy()),
+        )
+        request = RequestFactory().get("/_next/static/whatever.css")
+        response = static_serve_view(request, "whatever.css")
+        assert response.status_code == 404
+
+
+class TestTemplateTags:
+    """Template tag entry points are exercised through a real Django engine."""
+
+    @pytest.fixture()
+    def engine_template(self) -> type[Template]:
+        """Return the Django ``Template`` class with the static tag library loaded."""
+        return Template
+
+    def test_collect_styles_outputs_placeholder(self) -> None:
+        """``{% collect_styles %}`` emits the raw styles placeholder."""
+        tpl = Template("{% load next_static %}{% collect_styles %}")
+        assert tpl.render(Context()) == STYLES_PLACEHOLDER
+
+    def test_collect_scripts_outputs_placeholder(self) -> None:
+        """``{% collect_scripts %}`` emits the raw scripts placeholder."""
+        tpl = Template("{% load next_static %}{% collect_scripts %}")
+        assert tpl.render(Context()) == SCRIPTS_PLACEHOLDER
+
+    def test_use_style_registers_url_and_renders_nothing(
+        self, collector: StaticCollector
+    ) -> None:
+        """``{% use_style url %}`` registers an asset and emits no markup."""
+        tpl = Template('{% load next_static %}{% use_style "/main.css" %}!')
+        output = tpl.render(Context({"_static_collector": collector}))
+        assert output == "!"
+        assert [a.url for a in collector.styles()] == ["/main.css"]
+
+    def test_use_script_registers_url_and_renders_nothing(
+        self, collector: StaticCollector
+    ) -> None:
+        """``{% use_script url %}`` registers an asset and emits no markup."""
+        tpl = Template('{% load next_static %}{% use_script "/main.js" %}!')
+        output = tpl.render(Context({"_static_collector": collector}))
+        assert output == "!"
+        assert [a.url for a in collector.scripts()] == ["/main.js"]
+
+    def test_use_style_prepends_before_appended_files(
+        self, collector: StaticCollector
+    ) -> None:
+        """``use_style`` lands before items appended by co-located discovery."""
+        collector.add(StaticAsset(url="/_next/static/layout.css", kind="css"))
+        tpl = Template('{% load next_static %}{% use_style "/cdn/dep.css" %}')
+        tpl.render(Context({"_static_collector": collector}))
+        assert [a.url for a in collector.styles()] == [
+            "/cdn/dep.css",
+            "/_next/static/layout.css",
+        ]
+
+    def test_use_script_prepends_before_appended_files(
+        self, collector: StaticCollector
+    ) -> None:
+        """``use_script`` lands before items appended by co-located discovery."""
+        collector.add(StaticAsset(url="/_next/static/layout.js", kind="js"))
+        tpl = Template('{% load next_static %}{% use_script "/cdn/dep.js" %}')
+        tpl.render(Context({"_static_collector": collector}))
+        assert [a.url for a in collector.scripts()] == [
+            "/cdn/dep.js",
+            "/_next/static/layout.js",
+        ]
+
+    @pytest.mark.parametrize(
+        ("context_extra", "tpl_src"),
+        [
+            ({}, '{% load next_static %}{% use_style "/x.css" %}'),
+            (
+                {"_static_collector": "not-a-collector"},
+                '{% load next_static %}{% use_style "/x.css" %}',
+            ),
+        ],
+        ids=["missing_collector", "wrong_type_collector"],
+    )
+    def test_use_tags_without_collector_noop(
+        self, context_extra: dict[str, object], tpl_src: str
+    ) -> None:
+        """Missing or wrong-typed collector makes the use-tags silent no-ops."""
+        tpl = Template(tpl_src)
+        assert tpl.render(Context(context_extra)) == ""
+
+    @pytest.mark.parametrize(
+        "bad_url",
+        ["", None, 42],
+        ids=["empty_string", "none", "non_string"],
+    )
+    def test_use_tags_ignore_invalid_urls(
+        self,
+        collector: StaticCollector,
+        bad_url: object,
+    ) -> None:
+        """Non-string or empty URLs passed to ``use_style`` are ignored."""
+        tpl = Template("{% load next_static %}{% use_style url %}")
+        tpl.render(Context({"_static_collector": collector, "url": bad_url}))
+        assert collector.styles() == []
+
+
+class TestComponentTagIntegration:
+    """The ``{% component %}`` tag forwards to ``static_manager`` for composites."""
+
+    @pytest.mark.usefixtures("_reset_global_static_manager")
+    def test_component_render_discovers_assets_via_static_manager(
+        self,
+        composite_component: ComponentInfo,
+        collector: StaticCollector,
+    ) -> None:
+        """Rendering a composite with a collector in context triggers discovery."""
+        from next.components import components_manager  # noqa: PLC0415
+
+        static_manager._reload_config()
+        with patch.object(
+            components_manager,
+            "get_component",
+            return_value=composite_component,
+        ):
+            tpl = Template('{% load components %}{% component "widget" %}')
+            tpl.render(
+                Context(
+                    {
+                        "current_template_path": str(composite_component.template_path),
+                        "_static_collector": collector,
+                    }
+                )
+            )
+        style_urls = [a.url for a in collector.styles()]
+        assert any(u.endswith("components/widget.css") for u in style_urls)
+
+
+class TestStaticManagerGlobal:
+    """The module-level ``static_manager`` is a live ``StaticManager`` instance."""
+
+    def test_is_static_manager_instance(self) -> None:
+        """The exported singleton is an instance of ``StaticManager``."""
+        assert isinstance(static_manager, StaticManager)

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -6,25 +6,23 @@ from unittest.mock import patch
 
 import pytest
 from django.template import Context, Template
-from django.test import RequestFactory, override_settings
+from django.test import override_settings
 
 from next.components import ComponentInfo
+from next.pages import _load_python_module, _read_string_list
 from next.static import (
     SCRIPTS_PLACEHOLDER,
     STYLES_PLACEHOLDER,
     AssetDiscovery,
-    FileStaticBackend,
     StaticAsset,
     StaticBackend,
     StaticCollector,
+    StaticFilesBackend,
     StaticManager,
     StaticsFactory,
-    _FileRegistryEntry,
     _kind_to_extension,
-    _load_python_module,
-    _read_string_list,
+    discover_colocated_static_assets,
     static_manager,
-    static_serve_view,
 )
 
 
@@ -49,9 +47,26 @@ def collector() -> StaticCollector:
 
 
 @pytest.fixture()
-def file_backend() -> FileStaticBackend:
-    """Return a default ``FileStaticBackend`` with an empty registry."""
-    return FileStaticBackend()
+def static_backend() -> StaticFilesBackend:
+    """Return a default ``StaticFilesBackend``."""
+    return StaticFilesBackend()
+
+
+@pytest.fixture()
+def file_backend() -> StaticBackend:
+    """Test backend with stable deterministic URLs for discovery-order checks."""
+
+    class _DeterministicBackend(StaticFilesBackend):
+        def register_file(
+            self,
+            _source_path: Path,
+            logical_name: str,
+            kind: str,
+        ) -> str:
+            extension = _kind_to_extension(kind)
+            return f"/static/next/{logical_name}{extension}"
+
+    return _DeterministicBackend()
 
 
 @pytest.fixture()
@@ -390,7 +405,7 @@ class TestLoadPythonModule:
         source = tmp_path / "mod.py"
         source.write_text("X = 1")
         with patch(
-            "next.static.importlib.util.spec_from_file_location", return_value=None
+            "next.pages.importlib.util.spec_from_file_location", return_value=None
         ):
             assert _load_python_module(source) is None
 
@@ -424,73 +439,34 @@ class TestReadStringList:
         assert _read_string_list(mod, "urls") == ["a", "b"]
 
 
-class TestFileStaticBackend:
-    """``FileStaticBackend`` registers files and renders link/script tags."""
+class TestStaticFilesBackend:
+    """``StaticFilesBackend`` resolves URLs through staticfiles storage."""
 
-    def test_register_returns_prefixed_url(
-        self, file_backend: FileStaticBackend, tmp_path: Path
-    ) -> None:
-        """``register_file`` returns a URL under the ``_next/static`` prefix."""
+    def test_register_returns_staticfiles_url(self, tmp_path: Path) -> None:
+        """Registered URLs are resolved in the ``/static/next/...`` namespace."""
         source = tmp_path / "thing.css"
         source.write_text("")
-        url = file_backend.register_file(source, "about", "css")
-        assert url == "/_next/static/about.css"
+        backend = StaticFilesBackend()
+        url = backend.register_file(source, "about", "css")
+        assert url == "/static/next/about.css"
 
-    def test_lookup_returns_registry_entry(
-        self, file_backend: FileStaticBackend, tmp_path: Path
+    def test_missing_manifest_entry_raises_runtime_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """``lookup`` resolves the stored absolute path for a registered URL."""
-        source = tmp_path / "thing.js"
+        """Manifest misses surface as actionable runtime errors."""
+        source = tmp_path / "thing.css"
         source.write_text("")
-        file_backend.register_file(source, "widget", "js")
-        entry = file_backend.lookup("widget.js")
-        assert isinstance(entry, _FileRegistryEntry)
-        assert entry.source_path == source.resolve()
+        backend = StaticFilesBackend()
 
-    def test_lookup_missing_returns_none(self, file_backend: FileStaticBackend) -> None:
-        """``lookup`` returns ``None`` for an unknown logical name."""
-        assert file_backend.lookup("missing.css") is None
+        def _raise(_path: str) -> str:
+            msg = "missing manifest entry"
+            raise ValueError(msg)
 
-    def test_render_default_tags(self, file_backend: FileStaticBackend) -> None:
-        """The default link/script formatters emit standard HTML markup."""
-        assert file_backend.render_link_tag("/a.css") == (
-            '<link rel="stylesheet" href="/a.css">'
-        )
-        assert file_backend.render_script_tag("/a.js") == (
-            '<script src="/a.js"></script>'
-        )
-
-    def test_custom_tag_templates_from_options(self) -> None:
-        """``OPTIONS`` customize link/script tag templates via ``{url}`` placeholder."""
-        backend = FileStaticBackend(
-            {
-                "OPTIONS": {
-                    "css_tag": '<link data-custom href="{url}">',
-                    "js_tag": '<script data-x src="{url}"></script>',
-                }
-            }
-        )
-        assert backend.render_link_tag("/a.css") == ('<link data-custom href="/a.css">')
-        assert backend.render_script_tag("/a.js") == (
-            '<script data-x src="/a.js"></script>'
-        )
-
-    def test_generate_urls_returns_single_catch_all(
-        self, file_backend: FileStaticBackend
-    ) -> None:
-        """``generate_urls`` returns a single catch-all URL pattern."""
-        patterns = file_backend.generate_urls()
-        assert len(patterns) == 1
-        assert patterns[0].name == "next_static_serve"
-
-    def test_clear_registry_wipes_every_mapping(
-        self, file_backend: FileStaticBackend, tmp_path: Path
-    ) -> None:
-        """``clear_registry`` resets the internal mapping to empty."""
-        (tmp_path / "a.css").write_text("")
-        file_backend.register_file(tmp_path / "a.css", "a", "css")
-        file_backend.clear_registry()
-        assert file_backend.lookup("a.css") is None
+        monkeypatch.setattr("next.static.staticfiles_storage.url", _raise)
+        with pytest.raises(
+            RuntimeError, match="missing from Django staticfiles manifest"
+        ):
+            backend.register_file(source, "about", "css")
 
 
 class TestStaticBackendABC:
@@ -505,17 +481,17 @@ class TestStaticBackendABC:
 class TestStaticsFactory:
     """``StaticsFactory`` constructs backend instances from config dicts."""
 
-    def test_default_backend_is_file_static_backend(self) -> None:
-        """An empty config resolves to the default ``FileStaticBackend``."""
+    def test_default_backend_is_django_staticfiles_backend(self) -> None:
+        """An empty config resolves to the Django staticfiles-backed backend."""
         backend = StaticsFactory.create_backend({})
-        assert isinstance(backend, FileStaticBackend)
+        assert isinstance(backend, StaticFilesBackend)
 
     def test_explicit_backend_path(self) -> None:
         """An explicit ``BACKEND`` path instantiates the named class."""
         backend = StaticsFactory.create_backend(
-            {"BACKEND": "next.static.FileStaticBackend", "OPTIONS": {}}
+            {"BACKEND": "next.static.StaticFilesBackend", "OPTIONS": {}}
         )
-        assert isinstance(backend, FileStaticBackend)
+        assert isinstance(backend, StaticFilesBackend)
 
     def test_non_backend_class_raises(self) -> None:
         """A class that is not a ``StaticBackend`` subclass raises ``TypeError``."""
@@ -528,7 +504,7 @@ class TestAssetDiscoveryPageAssets:
 
     def _make_discovery(
         self,
-        file_backend: FileStaticBackend,
+        file_backend: StaticFilesBackend,
         page_roots: tuple[Path, ...] = (),
     ) -> AssetDiscovery:
         """Build a discovery helper wired to a ``StaticManager`` stub."""
@@ -540,7 +516,7 @@ class TestAssetDiscoveryPageAssets:
     def test_walks_nested_layouts_then_template_then_module(
         self,
         tmp_path: Path,
-        file_backend: FileStaticBackend,
+        file_backend: StaticFilesBackend,
         collector: StaticCollector,
     ) -> None:
         """Outer-to-inner layout assets precede template and module-level lists."""
@@ -565,21 +541,21 @@ class TestAssetDiscoveryPageAssets:
         style_urls = [asset.url for asset in collector.styles()]
         script_urls = [asset.url for asset in collector.scripts()]
         assert style_urls == [
-            "/_next/static/layout.css",
-            "/_next/static/blog/layout.css",
-            "/_next/static/blog.css",
+            "/static/next/layout.css",
+            "/static/next/blog/layout.css",
+            "/static/next/blog.css",
             "https://ext/inter.css",
         ]
         assert script_urls == [
-            "/_next/static/layout.js",
-            "/_next/static/blog.js",
+            "/static/next/layout.js",
+            "/static/next/blog.js",
             "https://ext/app.js",
         ]
 
     def test_no_layout_directories_still_collects_template_and_module(
         self,
         tmp_path: Path,
-        file_backend: FileStaticBackend,
+        file_backend: StaticFilesBackend,
         collector: StaticCollector,
     ) -> None:
         """When no layout exists discovery still collects template and module lists."""
@@ -593,14 +569,14 @@ class TestAssetDiscoveryPageAssets:
         discovery.discover_page_assets(page_py, collector)
 
         assert [asset.url for asset in collector.styles()] == [
-            "/_next/static/index.css",
+            "/static/next/index.css",
             "https://ext/x.css",
         ]
 
     def test_missing_page_py_skips_module_list_collection(
         self,
         tmp_path: Path,
-        file_backend: FileStaticBackend,
+        file_backend: StaticFilesBackend,
         collector: StaticCollector,
     ) -> None:
         """A non-existent ``page.py`` is silently skipped."""
@@ -614,7 +590,7 @@ class TestAssetDiscoveryPageAssets:
     def test_layout_and_template_outside_page_root_use_fallback_names(
         self,
         tmp_path: Path,
-        file_backend: FileStaticBackend,
+        file_backend: StaticFilesBackend,
         collector: StaticCollector,
     ) -> None:
         """Files outside any configured page root fall back to directory-based names."""
@@ -630,15 +606,15 @@ class TestAssetDiscoveryPageAssets:
         discovery.discover_page_assets(page_py, collector)
 
         style_urls = [asset.url for asset in collector.styles()]
-        assert "/_next/static/strange/layout.css" in style_urls
-        assert "/_next/static/strange.css" in style_urls
+        assert "/static/next/strange/layout.css" in style_urls
+        assert "/static/next/strange.css" in style_urls
 
 
 class TestAssetDiscoveryComponentAssets:
     """``AssetDiscovery.discover_component_assets`` handles composite components."""
 
     def _discovery(
-        self, backend: FileStaticBackend
+        self, backend: StaticFilesBackend
     ) -> tuple[AssetDiscovery, StaticManager]:
         """Build a ``StaticManager``/``AssetDiscovery`` pair wired to ``backend``."""
         manager = StaticManager()
@@ -648,7 +624,7 @@ class TestAssetDiscoveryComponentAssets:
     def test_simple_component_is_ignored(
         self,
         simple_component: ComponentInfo,
-        file_backend: FileStaticBackend,
+        file_backend: StaticFilesBackend,
         collector: StaticCollector,
     ) -> None:
         """Simple components have no co-located assets and are skipped."""
@@ -660,7 +636,7 @@ class TestAssetDiscoveryComponentAssets:
     def test_composite_collects_css_js_and_module_lists(
         self,
         composite_component: ComponentInfo,
-        file_backend: FileStaticBackend,
+        file_backend: StaticFilesBackend,
         collector: StaticCollector,
     ) -> None:
         """Composite components contribute co-located files and module lists."""
@@ -670,18 +646,18 @@ class TestAssetDiscoveryComponentAssets:
         style_urls = [asset.url for asset in collector.styles()]
         script_urls = [asset.url for asset in collector.scripts()]
         assert style_urls == [
-            "/_next/static/components/widget.css",
+            "/static/next/components/widget.css",
             "https://cdn.example.com/extra.css",
         ]
         assert script_urls == [
-            "/_next/static/components/widget.js",
+            "/static/next/components/widget.js",
             "https://cdn.example.com/extra.js",
         ]
 
     def test_composite_without_files_uses_only_module_lists(
         self,
         tmp_path: Path,
-        file_backend: FileStaticBackend,
+        file_backend: StaticFilesBackend,
         collector: StaticCollector,
     ) -> None:
         """A composite that has no css/js files reads only the module lists."""
@@ -707,7 +683,7 @@ class TestAssetDiscoveryComponentAssets:
     def test_component_directory_falls_back_to_module_path_parent(
         self,
         tmp_path: Path,
-        file_backend: FileStaticBackend,
+        file_backend: StaticFilesBackend,
         collector: StaticCollector,
     ) -> None:
         """When ``template_path`` is ``None`` the directory is derived from the module path."""
@@ -727,13 +703,13 @@ class TestAssetDiscoveryComponentAssets:
         discovery, _ = self._discovery(file_backend)
         discovery.discover_component_assets(info, collector)
         style_urls = [a.url for a in collector.styles()]
-        assert "/_next/static/components/widget.css" in style_urls
+        assert "/static/next/components/widget.css" in style_urls
         assert "https://from-module" in style_urls
 
     def test_component_with_no_paths_is_skipped(
         self,
         tmp_path: Path,
-        file_backend: FileStaticBackend,
+        file_backend: StaticFilesBackend,
         collector: StaticCollector,
     ) -> None:
         """A composite with neither template nor module path contributes nothing."""
@@ -753,7 +729,7 @@ class TestAssetDiscoveryComponentAssets:
     def test_missing_module_path_skips_module_list_collection(
         self,
         tmp_path: Path,
-        file_backend: FileStaticBackend,
+        file_backend: StaticFilesBackend,
         collector: StaticCollector,
     ) -> None:
         """A composite whose module path does not exist contributes only files."""
@@ -773,7 +749,7 @@ class TestAssetDiscoveryComponentAssets:
         discovery, _ = self._discovery(file_backend)
         discovery.discover_component_assets(info, collector)
         style_urls = [a.url for a in collector.styles()]
-        assert style_urls == ["/_next/static/components/widget.css"]
+        assert style_urls == ["/static/next/components/widget.css"]
 
 
 class TestCollectModuleListsInternals:
@@ -782,7 +758,7 @@ class TestCollectModuleListsInternals:
     def test_unloadable_module_is_silently_ignored(
         self,
         tmp_path: Path,
-        file_backend: FileStaticBackend,
+        file_backend: StaticFilesBackend,
         collector: StaticCollector,
     ) -> None:
         """A ``_load_python_module`` returning ``None`` leaves the collector empty."""
@@ -791,7 +767,7 @@ class TestCollectModuleListsInternals:
         discovery = AssetDiscovery(manager)
         module_path = tmp_path / "page.py"
         module_path.write_text("X = 1")
-        with patch("next.static._load_python_module", return_value=None):
+        with patch("next.pages._load_python_module", return_value=None):
             discovery._collect_module_lists(module_path, collector)
         assert collector.styles() == []
         assert collector.scripts() == []
@@ -800,7 +776,7 @@ class TestCollectModuleListsInternals:
 class TestAssetDiscoveryInternals:
     """Internal helpers of ``AssetDiscovery`` cover fallback and error paths."""
 
-    def _discovery(self, backend: FileStaticBackend) -> AssetDiscovery:
+    def _discovery(self, backend: StaticFilesBackend) -> AssetDiscovery:
         """Return a discovery helper wired to a blank manager and ``backend``."""
         manager = StaticManager()
         manager._backends = [backend]
@@ -814,7 +790,7 @@ class TestAssetDiscoveryInternals:
     ) -> None:
         """Backend errors during ``register_file`` are logged and collector is untouched."""
 
-        class _RaisingBackend(FileStaticBackend):
+        class _RaisingBackend(StaticFilesBackend):
             def register_file(self, source_path, logical_name, kind):
                 msg = "boom"
                 raise OSError(msg)
@@ -828,21 +804,21 @@ class TestAssetDiscoveryInternals:
         assert any("Failed to register" in rec.message for rec in caplog.records)
 
     def test_fallback_logical_name_for_empty_directory_name(
-        self, file_backend: FileStaticBackend
+        self, file_backend: StaticFilesBackend
     ) -> None:
         """Directories with an empty ``name`` fall back to ``index``."""
         discovery = self._discovery(file_backend)
         assert discovery._fallback_logical_name(Path("/")) == "index"
 
     def test_find_page_root_returns_none_when_outside(
-        self, tmp_path: Path, file_backend: FileStaticBackend
+        self, tmp_path: Path, file_backend: StaticFilesBackend
     ) -> None:
         """``_find_page_root`` returns ``None`` for a path outside any root."""
         discovery = self._discovery(file_backend)
         assert discovery._find_page_root(tmp_path / "page.py") is None
 
     def test_logical_name_for_template_outside_root_uses_fallback(
-        self, tmp_path: Path, file_backend: FileStaticBackend
+        self, tmp_path: Path, file_backend: StaticFilesBackend
     ) -> None:
         """A template directory outside ``page_root`` falls back to its name."""
         discovery = self._discovery(file_backend)
@@ -853,7 +829,7 @@ class TestAssetDiscoveryInternals:
         assert name == "somewhere"
 
     def test_logical_name_for_layout_outside_root_uses_fallback(
-        self, tmp_path: Path, file_backend: FileStaticBackend
+        self, tmp_path: Path, file_backend: StaticFilesBackend
     ) -> None:
         """A layout directory outside ``page_root`` falls back to ``<name>/layout``."""
         discovery = self._discovery(file_backend)
@@ -864,7 +840,7 @@ class TestAssetDiscoveryInternals:
         assert name == "somewhere/layout"
 
     def test_logical_name_for_layout_without_root(
-        self, tmp_path: Path, file_backend: FileStaticBackend
+        self, tmp_path: Path, file_backend: StaticFilesBackend
     ) -> None:
         """Without a ``page_root`` the layout name falls back to ``<name>/layout``."""
         discovery = self._discovery(file_backend)
@@ -873,7 +849,7 @@ class TestAssetDiscoveryInternals:
         assert discovery._logical_name_for_layout(layout_dir, None) == "pages/layout"
 
     def test_logical_name_for_layout_at_page_root_returns_plain_layout(
-        self, tmp_path: Path, file_backend: FileStaticBackend
+        self, tmp_path: Path, file_backend: StaticFilesBackend
     ) -> None:
         """When ``layout_dir == page_root`` the logical name is just ``layout``."""
         discovery = self._discovery(file_backend)
@@ -882,7 +858,7 @@ class TestAssetDiscoveryInternals:
         assert discovery._logical_name_for_layout(page_root, page_root) == "layout"
 
     def test_find_layout_directories_stops_at_filesystem_root(
-        self, tmp_path: Path, file_backend: FileStaticBackend
+        self, tmp_path: Path, file_backend: StaticFilesBackend
     ) -> None:
         """With no ``page_root`` the walk terminates at the filesystem root."""
         discovery = self._discovery(file_backend)
@@ -894,26 +870,14 @@ class TestAssetDiscoveryInternals:
 
 
 class TestStaticManagerLifecycle:
-    """``StaticManager`` manages backend loading, iteration, and reload."""
-
-    def test_iter_yields_url_patterns(self, fresh_manager: StaticManager) -> None:
-        """Iterating the manager yields patterns contributed by every backend."""
-        with override_settings(
-            NEXT_FRAMEWORK={
-                "DEFAULT_STATIC_BACKENDS": [
-                    {"BACKEND": "next.static.FileStaticBackend"}
-                ]
-            }
-        ):
-            patterns = list(fresh_manager)
-        assert len(patterns) == 1
+    """``StaticManager`` manages backend loading and reload."""
 
     def test_len_reflects_backend_count(self, fresh_manager: StaticManager) -> None:
         """``len`` returns the number of loaded backends."""
         with override_settings(
             NEXT_FRAMEWORK={
                 "DEFAULT_STATIC_BACKENDS": [
-                    {"BACKEND": "next.static.FileStaticBackend"}
+                    {"BACKEND": "next.static.StaticFilesBackend"}
                 ]
             }
         ):
@@ -923,7 +887,7 @@ class TestStaticManagerLifecycle:
         self, fresh_manager: StaticManager
     ) -> None:
         """Accessing ``default_backend`` loads configured backends on first access."""
-        assert isinstance(fresh_manager.default_backend, FileStaticBackend)
+        assert isinstance(fresh_manager.default_backend, StaticFilesBackend)
 
     def test_discovery_is_lazy_and_cached(self, fresh_manager: StaticManager) -> None:
         """``discovery`` is created once and reused on subsequent access."""
@@ -936,14 +900,14 @@ class TestStaticManagerLifecycle:
     ) -> None:
         """An empty ``DEFAULT_STATIC_BACKENDS`` list keeps a default backend."""
         with override_settings(NEXT_FRAMEWORK={"DEFAULT_STATIC_BACKENDS": []}):
-            assert isinstance(fresh_manager.default_backend, FileStaticBackend)
+            assert isinstance(fresh_manager.default_backend, StaticFilesBackend)
 
     def test_ignores_non_list_configs(self, fresh_manager: StaticManager) -> None:
         """A non-list ``DEFAULT_STATIC_BACKENDS`` value is coerced to an empty list."""
         from next.static import next_framework_settings as conf  # noqa: PLC0415
 
         conf._attr_value_cache["DEFAULT_STATIC_BACKENDS"] = "not-a-list"
-        assert isinstance(fresh_manager.default_backend, FileStaticBackend)
+        assert isinstance(fresh_manager.default_backend, StaticFilesBackend)
 
     def test_ignores_non_dict_backend_entries(
         self, fresh_manager: StaticManager
@@ -952,7 +916,7 @@ class TestStaticManagerLifecycle:
         with override_settings(
             NEXT_FRAMEWORK={"DEFAULT_STATIC_BACKENDS": ["nope", None, 42]}
         ):
-            assert isinstance(fresh_manager.default_backend, FileStaticBackend)
+            assert isinstance(fresh_manager.default_backend, StaticFilesBackend)
 
     def test_backend_creation_failure_is_logged_and_skipped(
         self,
@@ -970,7 +934,7 @@ class TestStaticManagerLifecycle:
             ),
             caplog.at_level("ERROR", logger="next.static"),
         ):
-            assert isinstance(fresh_manager.default_backend, FileStaticBackend)
+            assert isinstance(fresh_manager.default_backend, StaticFilesBackend)
         assert any(
             "Error creating static backend" in rec.message for rec in caplog.records
         )
@@ -1120,60 +1084,6 @@ class TestStaticManagerPageRoots:
             assert fresh_manager._page_roots() == ()
 
 
-class TestStaticServeView:
-    """``static_serve_view`` delegates to ``django.views.static.serve``."""
-
-    @pytest.fixture()
-    def warm_global_backend(self, tmp_path: Path) -> Generator[Path, None, None]:
-        """Prime the module-level ``static_manager`` with a single registered file."""
-        static_manager._backends.clear()
-        static_manager._discovery = None
-        static_manager._cached_page_roots = None
-        static_manager._reload_config()
-        source = tmp_path / "served.css"
-        source.write_text("body{}")
-        static_manager.default_backend.register_file(source, "served", "css")
-        try:
-            yield source
-        finally:
-            static_manager._backends.clear()
-            static_manager._discovery = None
-            static_manager._cached_page_roots = None
-
-    def test_serves_registered_file(self, warm_global_backend: Path) -> None:
-        """A registered file is served with a 200 response and expected content."""
-        request = RequestFactory().get("/_next/static/served.css")
-        response = static_serve_view(request, "served.css")
-        assert response.status_code == 200
-        body = b"".join(response.streaming_content)
-        assert body == b"body{}"
-
-    def test_unregistered_path_returns_404(self, warm_global_backend: Path) -> None:
-        """An unknown logical path returns a 404 response."""
-        request = RequestFactory().get("/_next/static/missing.css")
-        response = static_serve_view(request, "missing.css")
-        assert response.status_code == 404
-
-    @pytest.mark.usefixtures("_reset_global_static_manager")
-    def test_non_file_backend_returns_404(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """If the default backend is not a ``FileStaticBackend`` the view 404s."""
-
-        class _Dummy:
-            pass
-
-        monkeypatch.setattr(
-            StaticManager,
-            "default_backend",
-            property(lambda self: _Dummy()),
-        )
-        request = RequestFactory().get("/_next/static/whatever.css")
-        response = static_serve_view(request, "whatever.css")
-        assert response.status_code == 404
-
-
 class TestTemplateTags:
     """Template tag entry points are exercised through a real Django engine."""
 
@@ -1214,24 +1124,24 @@ class TestTemplateTags:
         self, collector: StaticCollector
     ) -> None:
         """``use_style`` lands before items appended by co-located discovery."""
-        collector.add(StaticAsset(url="/_next/static/layout.css", kind="css"))
+        collector.add(StaticAsset(url="/static/next/layout.css", kind="css"))
         tpl = Template('{% load next_static %}{% use_style "/cdn/dep.css" %}')
         tpl.render(Context({"_static_collector": collector}))
         assert [a.url for a in collector.styles()] == [
             "/cdn/dep.css",
-            "/_next/static/layout.css",
+            "/static/next/layout.css",
         ]
 
     def test_use_script_prepends_before_appended_files(
         self, collector: StaticCollector
     ) -> None:
         """``use_script`` lands before items appended by co-located discovery."""
-        collector.add(StaticAsset(url="/_next/static/layout.js", kind="js"))
+        collector.add(StaticAsset(url="/static/next/layout.js", kind="js"))
         tpl = Template('{% load next_static %}{% use_script "/cdn/dep.js" %}')
         tpl.render(Context({"_static_collector": collector}))
         assert [a.url for a in collector.scripts()] == [
             "/cdn/dep.js",
-            "/_next/static/layout.js",
+            "/static/next/layout.js",
         ]
 
     @pytest.mark.parametrize(
@@ -1427,3 +1337,164 @@ class TestStaticManagerGlobal:
     def test_is_static_manager_instance(self) -> None:
         """The exported singleton is an instance of ``StaticManager``."""
         assert isinstance(static_manager, StaticManager)
+
+
+class TestStaticfilesDiscovery:
+    """Collected co-located files are exposed to Django staticfiles."""
+
+    def test_discovers_page_and_component_assets(self, tmp_path: Path) -> None:
+        """Discovery maps co-located files into ``next/`` static namespace."""
+        pages_root = tmp_path / "pages"
+        page_dir = pages_root / "blog"
+        page_dir.mkdir(parents=True)
+        (page_dir / "template.djx").write_text("<div/>")
+        (page_dir / "template.css").write_text("/* blog */")
+        (pages_root / "layout.djx").write_text("<html/>")
+        (pages_root / "layout.js").write_text("// root")
+        comp_dir = page_dir / "_components" / "card"
+        comp_dir.mkdir(parents=True)
+        (comp_dir / "component.djx").write_text("<div/>")
+        (comp_dir / "component.css").write_text(".card{}")
+        (comp_dir / "component.py").write_text("")
+
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "DEFAULT_PAGE_BACKENDS": [
+                    {
+                        "BACKEND": "next.urls.FileRouterBackend",
+                        "PAGES_DIR": "pages",
+                        "APP_DIRS": False,
+                        "DIRS": [str(pages_root)],
+                        "OPTIONS": {},
+                    }
+                ]
+            }
+        ):
+            assets = discover_colocated_static_assets()
+
+        assert assets["next/blog.css"] == (page_dir / "template.css").resolve()
+        assert assets["next/layout.js"] == (pages_root / "layout.js").resolve()
+        assert (
+            assets["next/components/card.css"] == (comp_dir / "component.css").resolve()
+        )
+
+
+class TestStaticfilesFinderCoverage:
+    """Cover helper branches in staticfiles discovery and finder code."""
+
+    def test_find_page_root_returns_none_when_not_relative(
+        self, tmp_path: Path
+    ) -> None:
+        """Paths outside configured page roots do not resolve a root."""
+        from next.static import _find_page_root_for  # noqa: PLC0415
+
+        outside = tmp_path / "outside" / "template.djx"
+        outside.parent.mkdir(parents=True)
+        outside.write_text("")
+        root = tmp_path / "pages"
+        root.mkdir()
+        assert _find_page_root_for(outside, (root.resolve(),)) is None
+
+    def test_logical_layout_name_for_root_layout(self, tmp_path: Path) -> None:
+        """Layout at the page tree root maps to the ``layout`` logical name."""
+        from next.static import _logical_layout_name  # noqa: PLC0415
+
+        layout_dir = tmp_path / "pages"
+        layout_dir.mkdir()
+        assert _logical_layout_name(layout_dir, layout_dir) == "layout"
+
+    def test_logical_layout_name_for_nested_layout(self, tmp_path: Path) -> None:
+        """Nested layout directories include their trail plus ``layout``."""
+        from next.static import _logical_layout_name  # noqa: PLC0415
+
+        page_root = tmp_path / "pages"
+        nested = page_root / "blog"
+        nested.mkdir(parents=True)
+        assert _logical_layout_name(nested, page_root) == "blog/layout"
+
+    def test_discovery_skips_unknown_roots_and_dedups_component_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Out-of-scope templates and duplicate component dirs are skipped."""
+        from next.static import discover_colocated_static_assets  # noqa: PLC0415
+
+        page_root = tmp_path / "pages"
+        page_root.mkdir()
+        in_scope = page_root / "blog"
+        in_scope.mkdir()
+        (in_scope / "template.djx").write_text("")
+        (in_scope / "template.css").write_text("")
+
+        out_scope = tmp_path / "other"
+        out_scope.mkdir()
+        (out_scope / "template.djx").write_text("")
+        (out_scope / "template.css").write_text("")
+
+        layout_unknown = tmp_path / "layout-only"
+        layout_unknown.mkdir()
+        (layout_unknown / "layout.djx").write_text("")
+        (layout_unknown / "layout.css").write_text("")
+
+        comp_dir = page_root / "_components" / "card"
+        comp_dir.mkdir(parents=True)
+        comp_file = comp_dir / "component.djx"
+        comp_file.write_text("")
+        (comp_dir / "component.css").write_text("")
+
+        monkeypatch.setattr(
+            "next.pages.get_pages_directories_for_watch",
+            lambda: [page_root],
+        )
+        monkeypatch.setattr(
+            "next.pages.get_template_djx_paths_for_watch",
+            lambda: [in_scope / "template.djx", out_scope / "template.djx"],
+        )
+        monkeypatch.setattr(
+            "next.pages.get_layout_djx_paths_for_watch",
+            lambda: [layout_unknown / "layout.djx"],
+        )
+        monkeypatch.setattr(
+            "next.components.get_component_paths_for_watch",
+            lambda: {comp_file.resolve(), (comp_dir / "component.py").resolve()},
+        )
+
+        assets = discover_colocated_static_assets()
+        assert "next/blog.css" in assets
+        assert "next/other.css" not in assets
+        assert "next/layout-only/layout.css" not in assets
+        assert "next/components/card.css" in assets
+
+    def test_mapped_source_storage_exists_open_and_path(self, tmp_path: Path) -> None:
+        """Mapped storage delegates ``exists``, ``open``, and ``path`` to files."""
+        from next.static import _MappedSourceStorage  # noqa: PLC0415
+
+        src = tmp_path / "x.css"
+        src.write_text("body{}")
+        storage = _MappedSourceStorage({"next/x.css": src})
+        assert storage.exists("next/x.css")
+        assert storage.exists("next/missing.css") is False
+        assert storage.path("next/x.css").endswith("x.css")
+        with storage.open("next/x.css") as f:
+            assert f.read() == b"body{}"
+
+    def test_finder_find_and_list_branches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Finder ``find`` / ``list`` honor hits, misses, and ignore patterns."""
+        from next.static import NextStaticFilesFinder  # noqa: PLC0415
+
+        a = tmp_path / "a.css"
+        b = tmp_path / "b.css"
+        a.write_text("a")
+        b.write_text("b")
+        monkeypatch.setattr(
+            "next.static.discover_colocated_static_assets",
+            lambda: {"next/a.css": a, "next/b.css": b},
+        )
+        finder = NextStaticFilesFinder()
+        assert finder.find("next/a.css") == str(a)
+        assert finder.find("next/miss.css") is None
+        assert finder.find("next/miss.css", find_all=True) == []
+        listed = list(finder.list(["*b.css"]))
+        assert len(listed) == 1
+        assert listed[0][0] == "next/a.css"

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -8,20 +8,26 @@ import pytest
 from django.template import Context, Template
 from django.test import override_settings
 
-from next.components import ComponentInfo
+import next.pages as _next_pages_mod
+from next.components import ComponentInfo, components_manager
 from next.pages import _load_python_module, _read_string_list
 from next.static import (
     SCRIPTS_PLACEHOLDER,
     STYLES_PLACEHOLDER,
     AssetDiscovery,
+    NextStaticFilesFinder,
     StaticAsset,
     StaticBackend,
     StaticCollector,
     StaticFilesBackend,
     StaticManager,
     StaticsFactory,
+    _find_page_root_for,
     _kind_to_extension,
+    _logical_layout_name,
+    _MappedSourceStorage,
     discover_colocated_static_assets,
+    next_framework_settings,
     static_manager,
 )
 
@@ -34,44 +40,40 @@ CSS_URL = "https://example.com/a.css"
 JS_URL = "https://example.com/a.js"
 
 
+class _DeterministicBackend(StaticFilesBackend):
+    """Test backend with stable deterministic URLs for discovery-order checks."""
+
+    def register_file(
+        self,
+        _source_path: Path,
+        logical_name: str,
+        kind: str,
+    ) -> str:
+        extension = _kind_to_extension(kind)
+        return f"/static/next/{logical_name}{extension}"
+
+
 @pytest.fixture()
 def fresh_manager() -> StaticManager:
-    """Return a freshly instantiated ``StaticManager`` with no loaded backends."""
+    """Return a freshly instantiated StaticManager with no loaded backends."""
     return StaticManager()
 
 
 @pytest.fixture()
 def collector() -> StaticCollector:
-    """Return a fresh ``StaticCollector`` for each test."""
+    """Return a fresh StaticCollector for each test."""
     return StaticCollector()
 
 
 @pytest.fixture()
-def static_backend() -> StaticFilesBackend:
-    """Return a default ``StaticFilesBackend``."""
-    return StaticFilesBackend()
-
-
-@pytest.fixture()
 def file_backend() -> StaticBackend:
-    """Test backend with stable deterministic URLs for discovery-order checks."""
-
-    class _DeterministicBackend(StaticFilesBackend):
-        def register_file(
-            self,
-            _source_path: Path,
-            logical_name: str,
-            kind: str,
-        ) -> str:
-            extension = _kind_to_extension(kind)
-            return f"/static/next/{logical_name}{extension}"
-
+    """Return a DeterministicBackend for stable URL assertions in discovery tests."""
     return _DeterministicBackend()
 
 
 @pytest.fixture()
-def _reset_global_static_manager() -> Generator[None, None, None]:
-    """Reload the global ``static_manager`` backends after each test that mutates it."""
+def reset_global_static_manager() -> Generator[None, None, None]:
+    """Reload the global static_manager backends after each test that mutates it."""
     yield
     static_manager._backends.clear()
     static_manager._discovery = None
@@ -80,7 +82,7 @@ def _reset_global_static_manager() -> Generator[None, None, None]:
 
 @pytest.fixture()
 def simple_component(tmp_path: Path) -> ComponentInfo:
-    """Return a ``ComponentInfo`` pointing to a simple ``.djx`` template file."""
+    """Return a ComponentInfo pointing to a simple .djx template file."""
     template_path = tmp_path / "card.djx"
     template_path.write_text("<div>card</div>")
     return ComponentInfo(
@@ -95,7 +97,7 @@ def simple_component(tmp_path: Path) -> ComponentInfo:
 
 @pytest.fixture()
 def composite_component(tmp_path: Path) -> ComponentInfo:
-    """Return a composite ``ComponentInfo`` with co-located css/js/py siblings."""
+    """Return a composite ComponentInfo with co-located css/js/py siblings."""
     comp_dir = tmp_path / "_components" / "widget"
     comp_dir.mkdir(parents=True)
     template_path = comp_dir / "component.djx"
@@ -117,18 +119,34 @@ def composite_component(tmp_path: Path) -> ComponentInfo:
     )
 
 
+@pytest.fixture()
+def make_discovery():
+    """Return a factory that wires an AssetDiscovery to a given backend and page roots."""
+
+    def _factory(
+        backend: StaticBackend,
+        page_roots: tuple[Path, ...] = (),
+    ) -> tuple[AssetDiscovery, StaticManager]:
+        manager = StaticManager()
+        manager._backends = [backend]
+        manager._cached_page_roots = page_roots
+        return AssetDiscovery(manager), manager
+
+    return _factory
+
+
 class TestStaticAsset:
-    """``StaticAsset`` is a slotted, frozen dataclass with an optional source path."""
+    """StaticAsset is a slotted, frozen dataclass with an optional source path."""
 
     def test_defaults(self) -> None:
-        """Only ``url`` and ``kind`` are required, ``source_path`` defaults to ``None``."""
+        """Only url and kind are required. source_path defaults to None."""
         asset = StaticAsset(url=CSS_URL, kind="css")
         assert asset.url == CSS_URL
         assert asset.kind == "css"
         assert asset.source_path is None
 
     def test_explicit_source_path(self, tmp_path: Path) -> None:
-        """``source_path`` can carry the origin path for file-backed assets."""
+        """source_path can carry the origin path for file-backed assets."""
         asset = StaticAsset(url=CSS_URL, kind="css", source_path=tmp_path)
         assert asset.source_path == tmp_path
 
@@ -146,7 +164,7 @@ class TestStaticCollector:
         assert collector.scripts() == [js]
 
     def test_duplicate_url_is_ignored(self, collector: StaticCollector) -> None:
-        """A second ``add`` with the same URL does not grow any list."""
+        """A second add with the same URL does not grow any list."""
         collector.add(StaticAsset(url=CSS_URL, kind="css"))
         collector.add(StaticAsset(url=CSS_URL, kind="css"))
         assert len(collector.styles()) == 1
@@ -156,19 +174,17 @@ class TestStaticCollector:
         collector: StaticCollector,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """An asset whose ``kind`` is neither css nor js is ignored with a debug log."""
+        """An asset whose kind is neither css nor js is ignored with a debug log."""
         with caplog.at_level("DEBUG", logger="next.static"):
             collector.add(StaticAsset(url="weird://x", kind="weird"))
         assert collector.styles() == []
         assert collector.scripts() == []
         assert any("unknown kind" in rec.message for rec in caplog.records)
 
-    def test_accessors_return_copies(self, collector: StaticCollector) -> None:
-        """``styles`` and ``scripts`` return new lists so callers cannot mutate state."""
+    def test_accessors_return_same_list(self, collector: StaticCollector) -> None:
+        """Styles and scripts return the internal list directly for zero-copy reads."""
         collector.add(StaticAsset(url=CSS_URL, kind="css"))
-        snapshot = collector.styles()
-        snapshot.clear()
-        assert collector.styles() == [StaticAsset(url=CSS_URL, kind="css")]
+        assert collector.styles() is collector.styles()
 
     def test_preserves_insertion_order(self, collector: StaticCollector) -> None:
         """Later unique URLs keep their relative order."""
@@ -178,7 +194,7 @@ class TestStaticCollector:
         assert [asset.url for asset in collector.styles()] == urls
 
     def test_prepend_moves_asset_to_front(self, collector: StaticCollector) -> None:
-        """``prepend=True`` inserts before previously appended items."""
+        """prepend=True inserts before previously appended items."""
         collector.add(StaticAsset(url="/own.css", kind="css"))
         collector.add(StaticAsset(url="/dep.css", kind="css"), prepend=True)
         assert [a.url for a in collector.styles()] == ["/dep.css", "/own.css"]
@@ -222,19 +238,19 @@ class TestStaticCollector:
         ]
 
     def test_dedup_across_append_then_prepend(self, collector: StaticCollector) -> None:
-        """A URL first appended is ignored on a later ``prepend=True`` call."""
+        """A URL first appended is ignored on a later prepend=True call."""
         collector.add(StaticAsset(url=CSS_URL, kind="css"))
         collector.add(StaticAsset(url=CSS_URL, kind="css"), prepend=True)
         assert [a.url for a in collector.styles()] == [CSS_URL]
 
     def test_dedup_across_prepend_then_append(self, collector: StaticCollector) -> None:
-        """A URL first prepended is ignored on a later plain ``add`` call."""
+        """A URL first prepended is ignored on a later plain add call."""
         collector.add(StaticAsset(url=CSS_URL, kind="css"), prepend=True)
         collector.add(StaticAsset(url=CSS_URL, kind="css"))
         assert [a.url for a in collector.styles()] == [CSS_URL]
 
     def test_dedup_is_cross_source_path(self, collector: StaticCollector) -> None:
-        """Assets sharing a URL but different ``source_path`` values still dedup."""
+        """Assets sharing a URL but different source_path values still dedup."""
         collector.add(StaticAsset(url=CSS_URL, kind="css"))
         collector.add(
             StaticAsset(url=CSS_URL, kind="css", source_path=Path("/tmp/a.css"))
@@ -250,22 +266,29 @@ class TestStaticCollector:
 
 
 class TestStaticCollectorInline:
-    """Inline assets from ``{% #use_style %}`` / ``{% #use_script %}`` blocks."""
+    """Inline assets from block use_style and use_script tags."""
 
-    def test_inline_script_appended(self, collector: StaticCollector) -> None:
-        """An inline JS asset lands in ``scripts`` with its body preserved."""
-        collector.add(StaticAsset(url="", kind="js", inline="console.log(1)"))
-        scripts = collector.scripts()
-        assert len(scripts) == 1
-        assert scripts[0].inline == "console.log(1)"
-        assert scripts[0].url == ""
-
-    def test_inline_style_appended(self, collector: StaticCollector) -> None:
-        """An inline CSS asset lands in ``styles`` with its body preserved."""
-        collector.add(StaticAsset(url="", kind="css", inline="body{color:red}"))
-        styles = collector.styles()
-        assert len(styles) == 1
-        assert styles[0].inline == "body{color:red}"
+    @pytest.mark.parametrize(
+        ("kind", "body", "accessor"),
+        [
+            ("js", "console.log(1)", "scripts"),
+            ("css", "body{color:red}", "styles"),
+        ],
+        ids=["script", "style"],
+    )
+    def test_inline_asset_appended(
+        self,
+        collector: StaticCollector,
+        kind: str,
+        body: str,
+        accessor: str,
+    ) -> None:
+        """An inline asset lands in the matching bucket with its body preserved."""
+        collector.add(StaticAsset(url="", kind=kind, inline=body))
+        items = getattr(collector, accessor)()
+        assert len(items) == 1
+        assert items[0].inline == body
+        assert items[0].url == ""
 
     def test_identical_inline_bodies_dedupe(self, collector: StaticCollector) -> None:
         """Two inline assets with identical rendered bodies collapse to one entry."""
@@ -292,7 +315,7 @@ class TestStaticCollectorInline:
     def test_inline_asset_ignores_prepend_flag(
         self, collector: StaticCollector
     ) -> None:
-        """``prepend=True`` is ignored for inline assets, they always append."""
+        """prepend=True is ignored for inline assets so they always append."""
         collector.add(StaticAsset(url=JS_URL, kind="js"), prepend=True)
         collector.add(StaticAsset(url="", kind="js", inline="inline()"), prepend=True)
         scripts = collector.scripts()
@@ -353,7 +376,7 @@ class TestDiscoveryDedup:
         collector: StaticCollector,
         fresh_manager: StaticManager,
     ) -> None:
-        """Invoking ``discover_component_assets`` twice collapses to a single entry."""
+        """Invoking discover_component_assets twice collapses to a single entry."""
         discovery = AssetDiscovery(fresh_manager)
         discovery.discover_component_assets(composite_component, collector)
         discovery.discover_component_assets(composite_component, collector)
@@ -366,7 +389,7 @@ class TestDiscoveryDedup:
 
 
 class TestKindToExtension:
-    """``_kind_to_extension`` maps collector kinds to file extensions."""
+    """_kind_to_extension maps collector kinds to file extensions."""
 
     @pytest.mark.parametrize(
         ("kind", "expected"),
@@ -377,16 +400,16 @@ class TestKindToExtension:
         assert _kind_to_extension(kind) == expected
 
     def test_unknown_kind_raises(self) -> None:
-        """Passing an unsupported kind raises ``ValueError``."""
+        """Passing an unsupported kind raises ValueError."""
         with pytest.raises(ValueError, match="Unsupported asset kind"):
             _kind_to_extension("other")
 
 
 class TestLoadPythonModule:
-    """``_load_python_module`` loads arbitrary ``.py`` files by path."""
+    """_load_python_module loads arbitrary .py files by path."""
 
     def test_loads_module_exposing_attributes(self, tmp_path: Path) -> None:
-        """A valid ``.py`` file is executed and its attributes are accessible."""
+        """A valid .py file is executed and its attributes are accessible."""
         source = tmp_path / "mod.py"
         source.write_text("X = 1\nY = 'ok'\n")
         module = _load_python_module(source)
@@ -395,13 +418,13 @@ class TestLoadPythonModule:
         assert module.Y == "ok"
 
     def test_syntax_error_returns_none(self, tmp_path: Path) -> None:
-        """A broken source file logs a debug message and returns ``None``."""
+        """A broken source file logs a debug message and returns None."""
         source = tmp_path / "bad.py"
         source.write_text("def (")
         assert _load_python_module(source) is None
 
-    def test_missing_spec_returns_none(self, tmp_path: Path) -> None:
-        """When ``spec_from_file_location`` returns ``None`` the loader returns ``None``."""
+    def test_missing_spec_returns_none_without_raising(self, tmp_path: Path) -> None:
+        """When spec_from_file_location returns None the loader returns None and does not raise."""
         source = tmp_path / "mod.py"
         source.write_text("X = 1")
         with patch(
@@ -411,7 +434,7 @@ class TestLoadPythonModule:
 
 
 class TestReadStringList:
-    """``_read_string_list`` reads sanitized string lists from module attributes."""
+    """_read_string_list reads sanitized string lists from module attributes."""
 
     def test_list_of_strings(self) -> None:
         """A list of strings is returned intact as a list of strings."""
@@ -440,10 +463,10 @@ class TestReadStringList:
 
 
 class TestStaticFilesBackend:
-    """``StaticFilesBackend`` resolves URLs through staticfiles storage."""
+    """StaticFilesBackend resolves URLs through staticfiles storage."""
 
     def test_register_returns_staticfiles_url(self, tmp_path: Path) -> None:
-        """Registered URLs are resolved in the ``/static/next/...`` namespace."""
+        """Registered URLs are resolved in the /static/next/... namespace."""
         source = tmp_path / "thing.css"
         source.write_text("")
         backend = StaticFilesBackend()
@@ -470,16 +493,16 @@ class TestStaticFilesBackend:
 
 
 class TestStaticBackendABC:
-    """``StaticBackend`` is abstract and cannot be instantiated directly."""
+    """StaticBackend is abstract and cannot be instantiated directly."""
 
     def test_cannot_instantiate_abstract(self) -> None:
-        """Attempting to construct the ABC raises ``TypeError``."""
+        """Attempting to construct the ABC raises TypeError."""
         with pytest.raises(TypeError):
             StaticBackend()  # type: ignore[abstract]
 
 
 class TestStaticsFactory:
-    """``StaticsFactory`` constructs backend instances from config dicts."""
+    """StaticsFactory constructs backend instances from config dicts."""
 
     def test_default_backend_is_django_staticfiles_backend(self) -> None:
         """An empty config resolves to the Django staticfiles-backed backend."""
@@ -487,37 +510,27 @@ class TestStaticsFactory:
         assert isinstance(backend, StaticFilesBackend)
 
     def test_explicit_backend_path(self) -> None:
-        """An explicit ``BACKEND`` path instantiates the named class."""
+        """An explicit BACKEND path instantiates the named class."""
         backend = StaticsFactory.create_backend(
             {"BACKEND": "next.static.StaticFilesBackend", "OPTIONS": {}}
         )
         assert isinstance(backend, StaticFilesBackend)
 
     def test_non_backend_class_raises(self) -> None:
-        """A class that is not a ``StaticBackend`` subclass raises ``TypeError``."""
+        """A class that is not a StaticBackend subclass raises TypeError."""
         with pytest.raises(TypeError, match="is not a StaticBackend subclass"):
             StaticsFactory.create_backend({"BACKEND": "builtins.dict"})
 
 
 class TestAssetDiscoveryPageAssets:
-    """``AssetDiscovery.discover_page_assets`` walks layouts, templates, modules."""
-
-    def _make_discovery(
-        self,
-        file_backend: StaticFilesBackend,
-        page_roots: tuple[Path, ...] = (),
-    ) -> AssetDiscovery:
-        """Build a discovery helper wired to a ``StaticManager`` stub."""
-        manager = StaticManager()
-        manager._backends = [file_backend]
-        manager._cached_page_roots = page_roots
-        return AssetDiscovery(manager)
+    """AssetDiscovery.discover_page_assets walks layouts, templates, and modules."""
 
     def test_walks_nested_layouts_then_template_then_module(
         self,
         tmp_path: Path,
-        file_backend: StaticFilesBackend,
+        file_backend: StaticBackend,
         collector: StaticCollector,
+        make_discovery,
     ) -> None:
         """Outer-to-inner layout assets precede template and module-level lists."""
         page_root = tmp_path / "pages"
@@ -535,7 +548,7 @@ class TestAssetDiscoveryPageAssets:
             'styles = ["https://ext/inter.css"]\nscripts = ["https://ext/app.js"]\n'
         )
 
-        discovery = self._make_discovery(file_backend, (page_root.resolve(),))
+        discovery, _ = make_discovery(file_backend, (page_root.resolve(),))
         discovery.discover_page_assets(page_py, collector)
 
         style_urls = [asset.url for asset in collector.styles()]
@@ -555,8 +568,9 @@ class TestAssetDiscoveryPageAssets:
     def test_no_layout_directories_still_collects_template_and_module(
         self,
         tmp_path: Path,
-        file_backend: StaticFilesBackend,
+        file_backend: StaticBackend,
         collector: StaticCollector,
+        make_discovery,
     ) -> None:
         """When no layout exists discovery still collects template and module lists."""
         page_root = tmp_path / "pages"
@@ -565,7 +579,7 @@ class TestAssetDiscoveryPageAssets:
         page_py = page_root / "page.py"
         page_py.write_text('styles = ["https://ext/x.css"]\n')
 
-        discovery = self._make_discovery(file_backend, (page_root.resolve(),))
+        discovery, _ = make_discovery(file_backend, (page_root.resolve(),))
         discovery.discover_page_assets(page_py, collector)
 
         assert [asset.url for asset in collector.styles()] == [
@@ -576,13 +590,14 @@ class TestAssetDiscoveryPageAssets:
     def test_missing_page_py_skips_module_list_collection(
         self,
         tmp_path: Path,
-        file_backend: StaticFilesBackend,
+        file_backend: StaticBackend,
         collector: StaticCollector,
+        make_discovery,
     ) -> None:
-        """A non-existent ``page.py`` is silently skipped."""
+        """A non-existent page.py is silently skipped."""
         page_root = tmp_path / "pages"
         page_root.mkdir()
-        discovery = self._make_discovery(file_backend, (page_root.resolve(),))
+        discovery, _ = make_discovery(file_backend, (page_root.resolve(),))
         discovery.discover_page_assets(page_root / "page.py", collector)
         assert collector.styles() == []
         assert collector.scripts() == []
@@ -590,8 +605,9 @@ class TestAssetDiscoveryPageAssets:
     def test_layout_and_template_outside_page_root_use_fallback_names(
         self,
         tmp_path: Path,
-        file_backend: StaticFilesBackend,
+        file_backend: StaticBackend,
         collector: StaticCollector,
+        make_discovery,
     ) -> None:
         """Files outside any configured page root fall back to directory-based names."""
         strangedir = tmp_path / "strange"
@@ -602,7 +618,7 @@ class TestAssetDiscoveryPageAssets:
         page_py = strangedir / "page.py"
         page_py.write_text("")
 
-        discovery = self._make_discovery(file_backend, ())
+        discovery, _ = make_discovery(file_backend, ())
         discovery.discover_page_assets(page_py, collector)
 
         style_urls = [asset.url for asset in collector.styles()]
@@ -611,24 +627,17 @@ class TestAssetDiscoveryPageAssets:
 
 
 class TestAssetDiscoveryComponentAssets:
-    """``AssetDiscovery.discover_component_assets`` handles composite components."""
-
-    def _discovery(
-        self, backend: StaticFilesBackend
-    ) -> tuple[AssetDiscovery, StaticManager]:
-        """Build a ``StaticManager``/``AssetDiscovery`` pair wired to ``backend``."""
-        manager = StaticManager()
-        manager._backends = [backend]
-        return AssetDiscovery(manager), manager
+    """AssetDiscovery.discover_component_assets handles composite components."""
 
     def test_simple_component_is_ignored(
         self,
         simple_component: ComponentInfo,
-        file_backend: StaticFilesBackend,
+        file_backend: StaticBackend,
         collector: StaticCollector,
+        make_discovery,
     ) -> None:
         """Simple components have no co-located assets and are skipped."""
-        discovery, _ = self._discovery(file_backend)
+        discovery, _ = make_discovery(file_backend)
         discovery.discover_component_assets(simple_component, collector)
         assert collector.styles() == []
         assert collector.scripts() == []
@@ -636,11 +645,12 @@ class TestAssetDiscoveryComponentAssets:
     def test_composite_collects_css_js_and_module_lists(
         self,
         composite_component: ComponentInfo,
-        file_backend: StaticFilesBackend,
+        file_backend: StaticBackend,
         collector: StaticCollector,
+        make_discovery,
     ) -> None:
         """Composite components contribute co-located files and module lists."""
-        discovery, _ = self._discovery(file_backend)
+        discovery, _ = make_discovery(file_backend)
         discovery.discover_component_assets(composite_component, collector)
 
         style_urls = [asset.url for asset in collector.styles()]
@@ -657,8 +667,9 @@ class TestAssetDiscoveryComponentAssets:
     def test_composite_without_files_uses_only_module_lists(
         self,
         tmp_path: Path,
-        file_backend: StaticFilesBackend,
+        file_backend: StaticBackend,
         collector: StaticCollector,
+        make_discovery,
     ) -> None:
         """A composite that has no css/js files reads only the module lists."""
         comp_dir = tmp_path / "widget"
@@ -675,7 +686,7 @@ class TestAssetDiscoveryComponentAssets:
             module_path=module_path,
             is_simple=False,
         )
-        discovery, _ = self._discovery(file_backend)
+        discovery, _ = make_discovery(file_backend)
         discovery.discover_component_assets(info, collector)
         assert [a.url for a in collector.styles()] == ["https://a"]
         assert [a.url for a in collector.scripts()] == ["https://b"]
@@ -683,10 +694,11 @@ class TestAssetDiscoveryComponentAssets:
     def test_component_directory_falls_back_to_module_path_parent(
         self,
         tmp_path: Path,
-        file_backend: StaticFilesBackend,
+        file_backend: StaticBackend,
         collector: StaticCollector,
+        make_discovery,
     ) -> None:
-        """When ``template_path`` is ``None`` the directory is derived from the module path."""
+        """When template_path is None the directory is derived from the module path."""
         comp_dir = tmp_path / "widget"
         comp_dir.mkdir()
         module_path = comp_dir / "component.py"
@@ -700,7 +712,7 @@ class TestAssetDiscoveryComponentAssets:
             module_path=module_path,
             is_simple=False,
         )
-        discovery, _ = self._discovery(file_backend)
+        discovery, _ = make_discovery(file_backend)
         discovery.discover_component_assets(info, collector)
         style_urls = [a.url for a in collector.styles()]
         assert "/static/next/components/widget.css" in style_urls
@@ -709,8 +721,9 @@ class TestAssetDiscoveryComponentAssets:
     def test_component_with_no_paths_is_skipped(
         self,
         tmp_path: Path,
-        file_backend: StaticFilesBackend,
+        file_backend: StaticBackend,
         collector: StaticCollector,
+        make_discovery,
     ) -> None:
         """A composite with neither template nor module path contributes nothing."""
         info = ComponentInfo(
@@ -721,7 +734,7 @@ class TestAssetDiscoveryComponentAssets:
             module_path=None,
             is_simple=False,
         )
-        discovery, _ = self._discovery(file_backend)
+        discovery, _ = make_discovery(file_backend)
         discovery.discover_component_assets(info, collector)
         assert collector.styles() == []
         assert collector.scripts() == []
@@ -729,8 +742,9 @@ class TestAssetDiscoveryComponentAssets:
     def test_missing_module_path_skips_module_list_collection(
         self,
         tmp_path: Path,
-        file_backend: StaticFilesBackend,
+        file_backend: StaticBackend,
         collector: StaticCollector,
+        make_discovery,
     ) -> None:
         """A composite whose module path does not exist contributes only files."""
         comp_dir = tmp_path / "widget"
@@ -746,25 +760,24 @@ class TestAssetDiscoveryComponentAssets:
             module_path=comp_dir / "does-not-exist.py",
             is_simple=False,
         )
-        discovery, _ = self._discovery(file_backend)
+        discovery, _ = make_discovery(file_backend)
         discovery.discover_component_assets(info, collector)
         style_urls = [a.url for a in collector.styles()]
         assert style_urls == ["/static/next/components/widget.css"]
 
 
-class TestCollectModuleListsInternals:
-    """``_collect_module_lists`` short-circuits when the module cannot load."""
+class TestAssetDiscoveryInternals:
+    """Internal helpers of AssetDiscovery cover fallback and error paths."""
 
     def test_unloadable_module_is_silently_ignored(
         self,
         tmp_path: Path,
-        file_backend: StaticFilesBackend,
+        file_backend: StaticBackend,
         collector: StaticCollector,
+        make_discovery,
     ) -> None:
-        """A ``_load_python_module`` returning ``None`` leaves the collector empty."""
-        manager = StaticManager()
-        manager._backends = [file_backend]
-        discovery = AssetDiscovery(manager)
+        """A _load_python_module returning None leaves the collector empty."""
+        discovery, _ = make_discovery(file_backend)
         module_path = tmp_path / "page.py"
         module_path.write_text("X = 1")
         with patch("next.pages._load_python_module", return_value=None):
@@ -772,30 +785,22 @@ class TestCollectModuleListsInternals:
         assert collector.styles() == []
         assert collector.scripts() == []
 
-
-class TestAssetDiscoveryInternals:
-    """Internal helpers of ``AssetDiscovery`` cover fallback and error paths."""
-
-    def _discovery(self, backend: StaticFilesBackend) -> AssetDiscovery:
-        """Return a discovery helper wired to a blank manager and ``backend``."""
-        manager = StaticManager()
-        manager._backends = [backend]
-        return AssetDiscovery(manager)
-
     def test_register_file_failure_logs_and_skips_collector(
         self,
         tmp_path: Path,
         collector: StaticCollector,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Backend errors during ``register_file`` are logged and collector is untouched."""
+        """Backend errors during register_file are logged and the collector is untouched."""
 
         class _RaisingBackend(StaticFilesBackend):
             def register_file(self, source_path, logical_name, kind):
                 msg = "boom"
                 raise OSError(msg)
 
-        discovery = self._discovery(_RaisingBackend())
+        manager = StaticManager()
+        manager._backends = [_RaisingBackend()]
+        discovery = AssetDiscovery(manager)
         source = tmp_path / "x.css"
         source.write_text("")
         with caplog.at_level("DEBUG", logger="next.static"):
@@ -804,24 +809,24 @@ class TestAssetDiscoveryInternals:
         assert any("Failed to register" in rec.message for rec in caplog.records)
 
     def test_fallback_logical_name_for_empty_directory_name(
-        self, file_backend: StaticFilesBackend
+        self, file_backend: StaticBackend, make_discovery
     ) -> None:
-        """Directories with an empty ``name`` fall back to ``index``."""
-        discovery = self._discovery(file_backend)
+        """Directories with an empty name fall back to index."""
+        discovery, _ = make_discovery(file_backend)
         assert discovery._fallback_logical_name(Path("/")) == "index"
 
     def test_find_page_root_returns_none_when_outside(
-        self, tmp_path: Path, file_backend: StaticFilesBackend
+        self, tmp_path: Path, file_backend: StaticBackend, make_discovery
     ) -> None:
-        """``_find_page_root`` returns ``None`` for a path outside any root."""
-        discovery = self._discovery(file_backend)
+        """_find_page_root returns None for a path outside any configured root."""
+        discovery, _ = make_discovery(file_backend)
         assert discovery._find_page_root(tmp_path / "page.py") is None
 
     def test_logical_name_for_template_outside_root_uses_fallback(
-        self, tmp_path: Path, file_backend: StaticFilesBackend
+        self, tmp_path: Path, file_backend: StaticBackend, make_discovery
     ) -> None:
-        """A template directory outside ``page_root`` falls back to its name."""
-        discovery = self._discovery(file_backend)
+        """A template directory outside page_root falls back to its directory name."""
+        discovery, _ = make_discovery(file_backend)
         other = tmp_path / "somewhere"
         other.mkdir()
         (tmp_path / "root").mkdir()
@@ -829,10 +834,10 @@ class TestAssetDiscoveryInternals:
         assert name == "somewhere"
 
     def test_logical_name_for_layout_outside_root_uses_fallback(
-        self, tmp_path: Path, file_backend: StaticFilesBackend
+        self, tmp_path: Path, file_backend: StaticBackend, make_discovery
     ) -> None:
-        """A layout directory outside ``page_root`` falls back to ``<name>/layout``."""
-        discovery = self._discovery(file_backend)
+        """A layout directory outside page_root falls back to name/layout."""
+        discovery, _ = make_discovery(file_backend)
         other = tmp_path / "somewhere"
         other.mkdir()
         (tmp_path / "root").mkdir()
@@ -840,28 +845,28 @@ class TestAssetDiscoveryInternals:
         assert name == "somewhere/layout"
 
     def test_logical_name_for_layout_without_root(
-        self, tmp_path: Path, file_backend: StaticFilesBackend
+        self, tmp_path: Path, file_backend: StaticBackend, make_discovery
     ) -> None:
-        """Without a ``page_root`` the layout name falls back to ``<name>/layout``."""
-        discovery = self._discovery(file_backend)
+        """Without a page_root the layout name falls back to name/layout."""
+        discovery, _ = make_discovery(file_backend)
         layout_dir = tmp_path / "pages"
         layout_dir.mkdir()
         assert discovery._logical_name_for_layout(layout_dir, None) == "pages/layout"
 
     def test_logical_name_for_layout_at_page_root_returns_plain_layout(
-        self, tmp_path: Path, file_backend: StaticFilesBackend
+        self, tmp_path: Path, file_backend: StaticBackend, make_discovery
     ) -> None:
-        """When ``layout_dir == page_root`` the logical name is just ``layout``."""
-        discovery = self._discovery(file_backend)
+        """When layout_dir equals page_root the logical name is just layout."""
+        discovery, _ = make_discovery(file_backend)
         page_root = tmp_path / "pages"
         page_root.mkdir()
         assert discovery._logical_name_for_layout(page_root, page_root) == "layout"
 
     def test_find_layout_directories_stops_at_filesystem_root(
-        self, tmp_path: Path, file_backend: StaticFilesBackend
+        self, tmp_path: Path, file_backend: StaticBackend, make_discovery
     ) -> None:
-        """With no ``page_root`` the walk terminates at the filesystem root."""
-        discovery = self._discovery(file_backend)
+        """With no page_root the walk terminates at the filesystem root."""
+        discovery, _ = make_discovery(file_backend)
         leaf = tmp_path / "a" / "b"
         leaf.mkdir(parents=True)
         page_py = leaf / "page.py"
@@ -870,10 +875,10 @@ class TestAssetDiscoveryInternals:
 
 
 class TestStaticManagerLifecycle:
-    """``StaticManager`` manages backend loading and reload."""
+    """StaticManager manages backend loading and reload."""
 
     def test_len_reflects_backend_count(self, fresh_manager: StaticManager) -> None:
-        """``len`` returns the number of loaded backends."""
+        """Len returns the number of loaded backends."""
         with override_settings(
             NEXT_FRAMEWORK={
                 "DEFAULT_STATIC_BACKENDS": [
@@ -886,11 +891,11 @@ class TestStaticManagerLifecycle:
     def test_default_backend_triggers_lazy_load(
         self, fresh_manager: StaticManager
     ) -> None:
-        """Accessing ``default_backend`` loads configured backends on first access."""
+        """Accessing default_backend loads configured backends on first access."""
         assert isinstance(fresh_manager.default_backend, StaticFilesBackend)
 
     def test_discovery_is_lazy_and_cached(self, fresh_manager: StaticManager) -> None:
-        """``discovery`` is created once and reused on subsequent access."""
+        """Discovery is created once and reused on subsequent access."""
         first = fresh_manager.discovery
         second = fresh_manager.discovery
         assert first is second
@@ -898,15 +903,15 @@ class TestStaticManagerLifecycle:
     def test_falls_back_to_file_backend_when_config_empty(
         self, fresh_manager: StaticManager
     ) -> None:
-        """An empty ``DEFAULT_STATIC_BACKENDS`` list keeps a default backend."""
+        """An empty DEFAULT_STATIC_BACKENDS list keeps a default backend."""
         with override_settings(NEXT_FRAMEWORK={"DEFAULT_STATIC_BACKENDS": []}):
             assert isinstance(fresh_manager.default_backend, StaticFilesBackend)
 
     def test_ignores_non_list_configs(self, fresh_manager: StaticManager) -> None:
-        """A non-list ``DEFAULT_STATIC_BACKENDS`` value is coerced to an empty list."""
-        from next.static import next_framework_settings as conf  # noqa: PLC0415
-
-        conf._attr_value_cache["DEFAULT_STATIC_BACKENDS"] = "not-a-list"
+        """A non-list DEFAULT_STATIC_BACKENDS value is coerced to an empty list."""
+        next_framework_settings._attr_value_cache["DEFAULT_STATIC_BACKENDS"] = (
+            "not-a-list"
+        )
         assert isinstance(fresh_manager.default_backend, StaticFilesBackend)
 
     def test_ignores_non_dict_backend_entries(
@@ -945,7 +950,7 @@ class TestStaticManagerLifecycle:
         tmp_path: Path,
         collector: StaticCollector,
     ) -> None:
-        """``discover_page_assets`` forwards to the shared ``AssetDiscovery`` instance."""
+        """discover_page_assets forwards to the shared AssetDiscovery instance."""
         page_py = tmp_path / "page.py"
         page_py.write_text('styles = ["https://ext/a.css"]\n')
         fresh_manager.discover_page_assets(page_py, collector)
@@ -957,13 +962,13 @@ class TestStaticManagerLifecycle:
         composite_component: ComponentInfo,
         collector: StaticCollector,
     ) -> None:
-        """``discover_component_assets`` forwards to the shared ``AssetDiscovery``."""
+        """discover_component_assets forwards to the shared AssetDiscovery."""
         fresh_manager.discover_component_assets(composite_component, collector)
         assert any(a.url.endswith("components/widget.css") for a in collector.styles())
 
 
 class TestStaticManagerInject:
-    """``StaticManager.inject`` rewrites placeholders into rendered HTML."""
+    """StaticManager.inject rewrites placeholders into rendered HTML."""
 
     def test_injects_css_and_js_tags(
         self, fresh_manager: StaticManager, collector: StaticCollector
@@ -1035,7 +1040,7 @@ class TestStaticManagerInject:
 
 
 class TestStaticManagerPageRoots:
-    """``_page_roots`` caches absolute page directories from page backends."""
+    """page_roots caches absolute page directories from page backends."""
 
     def test_caches_value_after_first_call(
         self, fresh_manager: StaticManager, tmp_path: Path
@@ -1045,8 +1050,8 @@ class TestStaticManagerPageRoots:
             "next.pages.get_pages_directories_for_watch",
             return_value=[tmp_path],
         ) as mock_roots:
-            first = fresh_manager._page_roots()
-            second = fresh_manager._page_roots()
+            first = fresh_manager.page_roots()
+            second = fresh_manager.page_roots()
         assert first == (tmp_path.resolve(),)
         assert second is first
         assert mock_roots.call_count == 1
@@ -1054,20 +1059,18 @@ class TestStaticManagerPageRoots:
     def test_returns_empty_when_pages_module_import_fails(
         self, fresh_manager: StaticManager
     ) -> None:
-        """When ``next.pages`` cannot be imported the cache falls back to ``()``."""
-        import next.pages as next_pages  # noqa: PLC0415
-
-        original = next_pages.get_pages_directories_for_watch
+        """When next.pages cannot be imported the cache falls back to an empty tuple."""
+        original = _next_pages_mod.get_pages_directories_for_watch
         try:
-            del next_pages.get_pages_directories_for_watch
-            assert fresh_manager._page_roots() == ()
+            del _next_pages_mod.get_pages_directories_for_watch
+            assert fresh_manager.page_roots() == ()
         finally:
-            next_pages.get_pages_directories_for_watch = original
+            _next_pages_mod.get_pages_directories_for_watch = original
 
     def test_oserror_on_resolve_is_swallowed(
         self, fresh_manager: StaticManager
     ) -> None:
-        """A ``Path.resolve`` OSError is swallowed and the root is dropped."""
+        """A Path.resolve OSError is swallowed and the root is dropped."""
         bad = Path("/does/not/matter")
         real_resolve = Path.resolve
 
@@ -1081,67 +1084,70 @@ class TestStaticManagerPageRoots:
             patch("next.pages.get_pages_directories_for_watch", return_value=[bad]),
             patch.object(Path, "resolve", _resolve),
         ):
-            assert fresh_manager._page_roots() == ()
+            assert fresh_manager.page_roots() == ()
 
 
 class TestTemplateTags:
     """Template tag entry points are exercised through a real Django engine."""
 
-    @pytest.fixture()
-    def engine_template(self) -> type[Template]:
-        """Return the Django ``Template`` class with the static tag library loaded."""
-        return Template
+    @pytest.mark.parametrize(
+        ("tag", "placeholder"),
+        [
+            ("collect_styles", STYLES_PLACEHOLDER),
+            ("collect_scripts", SCRIPTS_PLACEHOLDER),
+        ],
+        ids=["styles", "scripts"],
+    )
+    def test_collect_tag_outputs_placeholder(self, tag: str, placeholder: str) -> None:
+        """The collect tag emits the matching raw placeholder string."""
+        tpl = Template(f"{{% load next_static %}}{{% {tag} %}}")
+        assert tpl.render(Context()) == placeholder
 
-    def test_collect_styles_outputs_placeholder(self) -> None:
-        """``{% collect_styles %}`` emits the raw styles placeholder."""
-        tpl = Template("{% load next_static %}{% collect_styles %}")
-        assert tpl.render(Context()) == STYLES_PLACEHOLDER
-
-    def test_collect_scripts_outputs_placeholder(self) -> None:
-        """``{% collect_scripts %}`` emits the raw scripts placeholder."""
-        tpl = Template("{% load next_static %}{% collect_scripts %}")
-        assert tpl.render(Context()) == SCRIPTS_PLACEHOLDER
-
-    def test_use_style_registers_url_and_renders_nothing(
-        self, collector: StaticCollector
+    @pytest.mark.parametrize(
+        ("tag", "url", "accessor"),
+        [
+            ("use_style", "/main.css", "styles"),
+            ("use_script", "/main.js", "scripts"),
+        ],
+        ids=["style", "script"],
+    )
+    def test_use_tag_registers_url_and_renders_nothing(
+        self,
+        collector: StaticCollector,
+        tag: str,
+        url: str,
+        accessor: str,
     ) -> None:
-        """``{% use_style url %}`` registers an asset and emits no markup."""
-        tpl = Template('{% load next_static %}{% use_style "/main.css" %}!')
+        """The use tag registers an asset on the collector and emits no markup."""
+        tpl = Template(f'{{% load next_static %}}{{% {tag} "{url}" %}}!')
         output = tpl.render(Context({"_static_collector": collector}))
         assert output == "!"
-        assert [a.url for a in collector.styles()] == ["/main.css"]
+        assert [a.url for a in getattr(collector, accessor)()] == [url]
 
-    def test_use_script_registers_url_and_renders_nothing(
-        self, collector: StaticCollector
+    @pytest.mark.parametrize(
+        ("tag", "existing_url", "dep_url", "kind", "accessor"),
+        [
+            ("use_style", "/static/next/layout.css", "/cdn/dep.css", "css", "styles"),
+            ("use_script", "/static/next/layout.js", "/cdn/dep.js", "js", "scripts"),
+        ],
+        ids=["style", "script"],
+    )
+    def test_use_tag_prepends_before_appended_files(
+        self,
+        collector: StaticCollector,
+        tag: str,
+        existing_url: str,
+        dep_url: str,
+        kind: str,
+        accessor: str,
     ) -> None:
-        """``{% use_script url %}`` registers an asset and emits no markup."""
-        tpl = Template('{% load next_static %}{% use_script "/main.js" %}!')
-        output = tpl.render(Context({"_static_collector": collector}))
-        assert output == "!"
-        assert [a.url for a in collector.scripts()] == ["/main.js"]
-
-    def test_use_style_prepends_before_appended_files(
-        self, collector: StaticCollector
-    ) -> None:
-        """``use_style`` lands before items appended by co-located discovery."""
-        collector.add(StaticAsset(url="/static/next/layout.css", kind="css"))
-        tpl = Template('{% load next_static %}{% use_style "/cdn/dep.css" %}')
+        """The use tag lands before items appended by co-located discovery."""
+        collector.add(StaticAsset(url=existing_url, kind=kind))
+        tpl = Template(f'{{% load next_static %}}{{% {tag} "{dep_url}" %}}')
         tpl.render(Context({"_static_collector": collector}))
-        assert [a.url for a in collector.styles()] == [
-            "/cdn/dep.css",
-            "/static/next/layout.css",
-        ]
-
-    def test_use_script_prepends_before_appended_files(
-        self, collector: StaticCollector
-    ) -> None:
-        """``use_script`` lands before items appended by co-located discovery."""
-        collector.add(StaticAsset(url="/static/next/layout.js", kind="js"))
-        tpl = Template('{% load next_static %}{% use_script "/cdn/dep.js" %}')
-        tpl.render(Context({"_static_collector": collector}))
-        assert [a.url for a in collector.scripts()] == [
-            "/cdn/dep.js",
-            "/static/next/layout.js",
+        assert [a.url for a in getattr(collector, accessor)()] == [
+            dep_url,
+            existing_url,
         ]
 
     @pytest.mark.parametrize(
@@ -1172,45 +1178,44 @@ class TestTemplateTags:
         collector: StaticCollector,
         bad_url: object,
     ) -> None:
-        """Non-string or empty URLs passed to ``use_style`` are ignored."""
+        """Non-string or empty URLs passed to use_style are ignored."""
         tpl = Template("{% load next_static %}{% use_style url %}")
         tpl.render(Context({"_static_collector": collector, "url": bad_url}))
         assert collector.styles() == []
 
-    def test_block_use_script_captures_body_and_emits_nothing(
-        self, collector: StaticCollector
+    @pytest.mark.parametrize(
+        ("open_tag", "close_tag", "body", "accessor"),
+        [
+            ("#use_script", "/use_script", "<script>inline()</script>", "scripts"),
+            ("#use_style", "/use_style", "<style>.a{color:red}</style>", "styles"),
+        ],
+        ids=["script", "style"],
+    )
+    def test_block_use_tag_captures_body_and_emits_nothing(
+        self,
+        collector: StaticCollector,
+        open_tag: str,
+        close_tag: str,
+        body: str,
+        accessor: str,
     ) -> None:
-        """``{% #use_script %}`` records the body and emits no markup in place."""
+        """The block form records the body and emits no markup in place."""
         tpl = Template(
-            "{% load next_static %}before"
-            "{% #use_script %}<script>inline()</script>{% /use_script %}"
+            f"{{% load next_static %}}before"
+            f"{{% {open_tag} %}}{body}{{% {close_tag} %}}"
             "after"
         )
         output = tpl.render(Context({"_static_collector": collector}))
         assert output == "beforeafter"
-        scripts = collector.scripts()
-        assert len(scripts) == 1
-        assert scripts[0].inline == "<script>inline()</script>"
-        assert scripts[0].url == ""
-
-    def test_block_use_style_captures_body_and_emits_nothing(
-        self, collector: StaticCollector
-    ) -> None:
-        """``{% #use_style %}`` records the body and emits no markup in place."""
-        tpl = Template(
-            "{% load next_static %}"
-            "{% #use_style %}<style>.a{color:red}</style>{% /use_style %}"
-        )
-        output = tpl.render(Context({"_static_collector": collector}))
-        assert output == ""
-        styles = collector.styles()
-        assert len(styles) == 1
-        assert styles[0].inline == "<style>.a{color:red}</style>"
+        items = getattr(collector, accessor)()
+        assert len(items) == 1
+        assert items[0].inline == body
+        assert items[0].url == ""
 
     def test_block_use_script_renders_body_with_context(
         self, collector: StaticCollector
     ) -> None:
-        """Block body is rendered against the active context, so vars are substituted."""
+        """Block body is rendered against the active context so vars are substituted."""
         tpl = Template(
             "{% load next_static %}"
             "{% #use_script %}<script>id={{ widget_id }};</script>{% /use_script %}"
@@ -1221,7 +1226,7 @@ class TestTemplateTags:
     def test_block_use_script_appends_after_url_deps(
         self, collector: StaticCollector
     ) -> None:
-        """Block form appends, URL form prepends. URL deps land before inline bodies."""
+        """Block form appends and URL form prepends so URL deps land before inline bodies."""
         tpl = Template(
             "{% load next_static %}"
             '{% use_script "/cdn/react.js" %}'
@@ -1301,17 +1306,15 @@ class TestTemplateTags:
 
 
 class TestComponentTagIntegration:
-    """The ``{% component %}`` tag forwards to ``static_manager`` for composites."""
+    """The component tag forwards to static_manager for composites."""
 
-    @pytest.mark.usefixtures("_reset_global_static_manager")
+    @pytest.mark.usefixtures("reset_global_static_manager")
     def test_component_render_discovers_assets_via_static_manager(
         self,
         composite_component: ComponentInfo,
         collector: StaticCollector,
     ) -> None:
         """Rendering a composite with a collector in context triggers discovery."""
-        from next.components import components_manager  # noqa: PLC0415
-
         static_manager._reload_config()
         with patch.object(
             components_manager,
@@ -1332,18 +1335,19 @@ class TestComponentTagIntegration:
 
 
 class TestStaticManagerGlobal:
-    """The module-level ``static_manager`` is a live ``StaticManager`` instance."""
+    """The module-level static_manager is a live StaticManager instance."""
 
     def test_is_static_manager_instance(self) -> None:
-        """The exported singleton is an instance of ``StaticManager``."""
+        """The exported singleton is an instance of StaticManager."""
         assert isinstance(static_manager, StaticManager)
 
 
+@pytest.mark.integration()
 class TestStaticfilesDiscovery:
     """Collected co-located files are exposed to Django staticfiles."""
 
     def test_discovers_page_and_component_assets(self, tmp_path: Path) -> None:
-        """Discovery maps co-located files into ``next/`` static namespace."""
+        """Discovery maps co-located files into the next/ static namespace."""
         pages_root = tmp_path / "pages"
         page_dir = pages_root / "blog"
         page_dir.mkdir(parents=True)
@@ -1386,8 +1390,6 @@ class TestStaticfilesFinderCoverage:
         self, tmp_path: Path
     ) -> None:
         """Paths outside configured page roots do not resolve a root."""
-        from next.static import _find_page_root_for  # noqa: PLC0415
-
         outside = tmp_path / "outside" / "template.djx"
         outside.parent.mkdir(parents=True)
         outside.write_text("")
@@ -1396,34 +1398,24 @@ class TestStaticfilesFinderCoverage:
         assert _find_page_root_for(outside, (root.resolve(),)) is None
 
     def test_logical_layout_name_for_root_layout(self, tmp_path: Path) -> None:
-        """Layout at the page tree root maps to the ``layout`` logical name."""
-        from next.static import _logical_layout_name  # noqa: PLC0415
-
+        """Layout at the page tree root maps to the layout logical name."""
         layout_dir = tmp_path / "pages"
         layout_dir.mkdir()
         assert _logical_layout_name(layout_dir, layout_dir) == "layout"
 
     def test_logical_layout_name_for_nested_layout(self, tmp_path: Path) -> None:
-        """Nested layout directories include their trail plus ``layout``."""
-        from next.static import _logical_layout_name  # noqa: PLC0415
-
+        """Nested layout directories include their trail plus layout."""
         page_root = tmp_path / "pages"
         nested = page_root / "blog"
         nested.mkdir(parents=True)
         assert _logical_layout_name(nested, page_root) == "blog/layout"
 
-    def test_discovery_skips_unknown_roots_and_dedups_component_dirs(
+    def test_discovery_skips_out_of_scope_templates_and_layouts(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Out-of-scope templates and duplicate component dirs are skipped."""
-        from next.static import discover_colocated_static_assets  # noqa: PLC0415
-
+        """Templates outside the page root and layouts with no root are not mapped."""
         page_root = tmp_path / "pages"
         page_root.mkdir()
-        in_scope = page_root / "blog"
-        in_scope.mkdir()
-        (in_scope / "template.djx").write_text("")
-        (in_scope / "template.css").write_text("")
 
         out_scope = tmp_path / "other"
         out_scope.mkdir()
@@ -1435,6 +1427,38 @@ class TestStaticfilesFinderCoverage:
         (layout_unknown / "layout.djx").write_text("")
         (layout_unknown / "layout.css").write_text("")
 
+        monkeypatch.setattr(
+            "next.static.get_pages_directories_for_watch",
+            lambda: [page_root],
+        )
+        monkeypatch.setattr(
+            "next.static.get_template_djx_paths_for_watch",
+            lambda: [out_scope / "template.djx"],
+        )
+        monkeypatch.setattr(
+            "next.static.get_layout_djx_paths_for_watch",
+            lambda: [layout_unknown / "layout.djx"],
+        )
+        monkeypatch.setattr(
+            "next.components.get_component_paths_for_watch",
+            set,
+        )
+
+        assets = discover_colocated_static_assets()
+        assert "next/other.css" not in assets
+        assert "next/layout-only/layout.css" not in assets
+
+    def test_discovery_includes_in_scope_templates_and_deduplicates_components(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In-scope templates are mapped and duplicate component dirs are deduplicated."""
+        page_root = tmp_path / "pages"
+        page_root.mkdir()
+        in_scope = page_root / "blog"
+        in_scope.mkdir()
+        (in_scope / "template.djx").write_text("")
+        (in_scope / "template.css").write_text("")
+
         comp_dir = page_root / "_components" / "card"
         comp_dir.mkdir(parents=True)
         comp_file = comp_dir / "component.djx"
@@ -1442,16 +1466,16 @@ class TestStaticfilesFinderCoverage:
         (comp_dir / "component.css").write_text("")
 
         monkeypatch.setattr(
-            "next.pages.get_pages_directories_for_watch",
+            "next.static.get_pages_directories_for_watch",
             lambda: [page_root],
         )
         monkeypatch.setattr(
-            "next.pages.get_template_djx_paths_for_watch",
-            lambda: [in_scope / "template.djx", out_scope / "template.djx"],
+            "next.static.get_template_djx_paths_for_watch",
+            lambda: [in_scope / "template.djx"],
         )
         monkeypatch.setattr(
-            "next.pages.get_layout_djx_paths_for_watch",
-            lambda: [layout_unknown / "layout.djx"],
+            "next.static.get_layout_djx_paths_for_watch",
+            list,
         )
         monkeypatch.setattr(
             "next.components.get_component_paths_for_watch",
@@ -1460,14 +1484,10 @@ class TestStaticfilesFinderCoverage:
 
         assets = discover_colocated_static_assets()
         assert "next/blog.css" in assets
-        assert "next/other.css" not in assets
-        assert "next/layout-only/layout.css" not in assets
         assert "next/components/card.css" in assets
 
     def test_mapped_source_storage_exists_open_and_path(self, tmp_path: Path) -> None:
-        """Mapped storage delegates ``exists``, ``open``, and ``path`` to files."""
-        from next.static import _MappedSourceStorage  # noqa: PLC0415
-
+        """Mapped storage delegates exists, open, and path to files."""
         src = tmp_path / "x.css"
         src.write_text("body{}")
         storage = _MappedSourceStorage({"next/x.css": src})
@@ -1480,9 +1500,7 @@ class TestStaticfilesFinderCoverage:
     def test_finder_find_and_list_branches(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Finder ``find`` / ``list`` honor hits, misses, and ignore patterns."""
-        from next.static import NextStaticFilesFinder  # noqa: PLC0415
-
+        """Finder find and list honor hits, misses, and ignore patterns."""
         a = tmp_path / "a.css"
         b = tmp_path / "b.css"
         a.write_text("a")


### PR DESCRIPTION
## Static assets pipeline

Adds a full static-asset pipeline to next-dj: co-located CSS/JS files are auto-discovered next to `layout.djx` / `template.djx` / `component.djx`, module-level `styles` / `scripts` lists on `page.py` / `component.py` are merged in, and two template-tag families (URL form and block form) let layouts and components declare shared dependencies or hoist inline `<script>` / `<style>` bodies. The collector deduplicates, orders and injects everything into `{% collect_styles %}` / `{% collect_scripts %}` placeholders in cascade-friendly order. A dedicated `/_next/static/` route serves the on-disk files through Django's built-in static handling with a pluggable backend.

### Highlights

- **Co-located discovery.** Drop `template.css` / `template.js` next to `template.djx`, `component.css` / `component.js` next to `component.djx`, and they are picked up automatically. URL naming follows the page/component path, e.g. `pages/about/template.css` → `/_next/static/about.css`, `_components/card/component.js` → `/_next/static/components/card.js`.
- **Module-level lists.** `page.py` and `component.py` can declare `styles = [...]` / `scripts = [...]` for extra CSS/JS (local paths or external CDN URLs).
- **Template tags.**
    - `{% collect_styles %}` / `{% collect_scripts %}` mark the injection slots (typically inside `<head>` and before `</body>`).
    - `{% use_style "..." %}` / `{% use_script "..." %}` — URL form, **prepend** into the cascade, dedup by URL. Ideal for shared third-party deps (Bootstrap, React, …) anywhere in layouts, pages or components.
    - `{% #use_style %}...{% /use_style %}` / `{% #use_script %}...{% /use_script %}` — block form, capture rendered HTML body and **append** to the slot, dedup by rendered body content.
- **Two dedup strategies.**
    - URL-form entries dedupe by URL string (same URL from multiple layers → one `<link>` / `<script>`).
    - Inline block entries dedupe by the rendered body (scoped per kind). Identical bodies collapse to one; blocks that interpolate `{{ id }}` / `{{ label }}` stay distinct per render.
- **Cascade-friendly ordering.**
    1. `use_style` / `use_script` URLs (prepended, in registration order).
    2. Co-located layout → template → page → component files (depth-first render order).
    3. Module-level `styles` / `scripts` after each scope's own file.
    4. Inline `{% #use_* %}` bodies appended last (so inline boot code runs after every dependency is loaded).
- **Pluggable backend.** `StaticBackend` / `StaticsFactory` / `StaticManager` expose swap-in points for URL rendering, placeholder strategy and file serving. Defaults use Django's built-in static file serving, no extra I/O from the framework.
- **`/_next/static/` serve route.** Mirrors the `/_next/forms` convention; mounted from `next.urls` with a safe path-traversal guard.

### Example (layout + component)

Layout declares globals once:
```jinja
    <!-- layout.djx -->
    <head>
        {% use_style "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" %}
        {% collect_styles %}
    </head>
    <body>
        {% block content %}{% endblock %}
        {% use_script "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" %}
        {% collect_scripts %}
    </body>
```
A component declares its own deps and inline boot code (split into shared + per-instance chunks so content-dedup works):
```jinja
    {# _components/counter/component.djx #}
    {% use_script "https://unpkg.com/react@18.3.1/umd/react.production.min.js" %}
    {% use_script "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js" %}
    {% use_script "https://unpkg.com/@babel/standalone@7.24.7/babel.min.js" %}

    <div class="counter-root" id="counter-{{ id }}" data-counter-label="{{ label }}"></div>

    {% #use_script %}
    <script type="text/babel" data-presets="react">
        const { useState } = React;
        window.Counter = function Counter({ label }) {
            const [count, setCount] = useState(0);
            return (
                <button type="button" className="btn btn-outline-success"
                        onClick={() => setCount(count + 1)}>
                    {label}: {count}
                </button>
            );
        };
    </script>
    {% /use_script %}

    {% #use_script %}
    <script type="text/babel" data-presets="react">
        {
            const mount = document.getElementById("counter-{{ id }}");
            ReactDOM.createRoot(mount).render(
                <Counter label={mount.dataset.counterLabel} />,
            );
        }
    </script>
    {% /use_script %}
```
Rendering the counter twice with `id="likes"` and `id="stars"` produces exactly:

- one `<link>` for Bootstrap CSS
- one `<script>` each for React / ReactDOM / Babel (URL-dedupped to one)
- one `<script type="text/babel">` with the shared `Counter` definition (content-dedup collapses two renders to one)
- two `<script type="text/babel">` mount blocks (`counter-likes`, `counter-stars`) — kept distinct because `{{ id }}` differs per render

### Files touched

- `next/static.py` — `StaticAsset`, `StaticCollector`, `StaticBackend`, `StaticsFactory`, `StaticManager`, `AssetDiscovery`.
- `next/templatetags/next_static.py` — `collect_styles`, `collect_scripts`, `use_style`, `use_script`, block-form `#use_style` / `#use_script`.
- `next/urls.py` — `/_next/static/<path>` route via Django's built-in static serving.
- `next/conf.py` — new settings for backend selection / placeholders.
- `next/components.py`, `next/pages.py` — hooks into `AssetDiscovery` during render.
- `examples/static/` — full example app: layout Bootstrap deps, page-level fonts, Bootstrap widget, Chart.js dashboard, and a React/Babel counter demonstrating both dedup strategies.
- `docs/content/guide/static-assets.rst` — end-to-end guide covering co-located files, module lists, both tag forms, dedup semantics, cascade order, backend customization and the Babel/React split-block caveats.

### Tests

- `tests/test_static.py` — 111 tests, core unit coverage for `StaticAsset`, `StaticCollector` (URL + inline dedup, prepend/append ordering, kind scoping), `StaticManager` (inject, interleave, placeholder handling, page-root caching) and all template tags (URL form + block form, including dedup across multiple renders and different contexts).
- `examples/static/tests/tests.py` — 82 end-to-end tests using Django's `Client`: cascade order, counter mount points, URL dedup of React CDNs, content-dedup of the shared `Counter` definition, per-instance mount blocks, `/_next/static/` serve view.
- **100% coverage** on both the core and the example app. All lint / format / type-check / sphinx-build `-W` pass.

## Related issues

#92 

## Checklist

- [x] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [x] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [x] Link issues with `Fixes #123` / `Closes #123` when applicable

---

Full guidelines: [CONTRIBUTING.md](https://github.com/next-dj/next-dj/blob/main/CONTRIBUTING.md)
