### PR TITLE
fix(urls): expand URL/query coercion & fixes documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ GitHub.sublime-settings
 # js
 node_modules
 next/static/next/next.min.js
+
+# sphinx docs build outputs
+docs/_build*/

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ dev-setup: # setup development environment
 
 docs: # build documentation
 	uv sync --locked --group docs
-	uv run sphinx-build -a -E docs docs/_build
+	uv run sphinx-build -aETW --keep-going -b html docs docs/_build
 
 docs-serve: docs # build and serve documentation
 	@echo "Opening documentation in browser..."

--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@ A next-gen framework based on Django without the tears.
 
 `next.dj` adds file-based routing, nested `layout.djx` wrappers, reusable components with co-located assets, dependency-injected context and actions, and form dispatch via `{% form %}`. Directories map to URLs. A `page.py` file turns a segment into a page. Configuration lives in the `NEXT_FRAMEWORK` mapping alongside standard Django settings.
 
-Read the **Overview** and **Installation** guides on Read the Docs for the mental model and a minimal working `INSTALLED_APPS` / `NEXT_FRAMEWORK` setup:
-
-- [Overview](https://next-dj.readthedocs.io/en/latest/content/intro/overview.html)
-- [Installation](https://next-dj.readthedocs.io/en/latest/content/intro/install.html)
-
 ## Documentation
 
 Full documentation is available at https://next-dj.readthedocs.io/.

--- a/docs/content/contributing/writing-documentation.rst
+++ b/docs/content/contributing/writing-documentation.rst
@@ -223,6 +223,15 @@ The table below lists the public package, its primary narrative page, and its re
    * - ``next.signals``
      - :doc:`/content/topics/signals`
      - :doc:`/content/ref/signals`
+   * - ``next.utils``
+     - :doc:`/content/topics/file-router`
+     - :doc:`/content/ref/utils`
+   * - ``next.checks``
+     - :doc:`/content/faq/troubleshooting`
+     - :doc:`/content/ref/system-checks`
+   * - ``next.templatetags``
+     - :doc:`/content/topics/static-assets/template-tags`, :doc:`/content/topics/forms/templates`
+     - :doc:`/content/ref/template-tags`
 
 When you edit the signal aggregator in ``next/signals.py``, update :doc:`/content/topics/signals` and :doc:`/content/ref/signals` so every re-exported name and payload matches the module.
 

--- a/docs/content/deployment/static-files.rst
+++ b/docs/content/deployment/static-files.rst
@@ -39,7 +39,9 @@ Run ``collectstatic`` during the deployment build.
 
    uv run python manage.py collectstatic --noinput
 
-Django copies every co-located ``component.css``, ``component.js``, ``component.mjs``, ``layout.css``, ``layout.js``, ``layout.mjs``, ``template.css``, ``template.js``, ``template.mjs``, and any custom stem file into ``STATIC_ROOT``.
+Django copies every co-located file into ``STATIC_ROOT``.
+The default stems are ``component``, ``layout``, and ``template``, the default kinds are ``css``, ``js``, and ``module`` (extensions ``.css``, ``.js``, ``.mjs``).
+Files registered under custom stems and custom kinds are copied through the same finder, so an extension added through ``default_kinds.register`` ships with the rest.
 Project ``static/`` directories and any directory listed in ``STATICFILES_DIRS`` are copied as well.
 
 Hashed URLs

--- a/docs/content/deployment/wsgi-asgi.rst
+++ b/docs/content/deployment/wsgi-asgi.rst
@@ -28,7 +28,8 @@ The difference lies in how Django dispatches the request.
 WSGI Configuration
 ------------------
 
-A standard ``config/wsgi.py`` works without modification. See Django's :doc:`WSGI deployment guide <django:howto/deployment/wsgi/index>`.
+A standard ``config/wsgi.py`` works without modification.
+See Django's :doc:`WSGI deployment guide <django:howto/deployment/wsgi/index>`.
 
 .. code-block:: python
    :caption: config/wsgi.py
@@ -49,15 +50,17 @@ Run with a production WSGI server such as ``gunicorn`` or ``uwsgi``.
 
    uv run gunicorn config.wsgi:application --workers 4 --bind 0.0.0.0:8000
 
-The example uses four workers.
-Gunicorn's own default ``--workers`` is ``1``.
-A common starting point is ``(2 * num_cores) + 1``.
+The example passes ``--workers 4``.
+Effective worker counts depend on Gunicorn CLI flags and environment variables (for example ``WEB_CONCURRENCY``).
+Verify the upstream Gunicorn docs for your installed version instead of trusting second-hand shortcuts.
+Teams often iterate from rough heuristics such as ``(2 * num_cores) + 1`` once they profile real traffic and saturation.
 Tune based on the expected concurrency and the average request duration.
 
 ASGI Configuration
 ------------------
 
-A standard ``config/asgi.py`` works without modification. See Django's :doc:`ASGI deployment guide <django:howto/deployment/asgi/index>`.
+A standard ``config/asgi.py`` works without modification.
+See Django's :doc:`ASGI deployment guide <django:howto/deployment/asgi/index>`.
 
 .. code-block:: python
    :caption: config/asgi.py

--- a/docs/content/deployment/wsgi-asgi.rst
+++ b/docs/content/deployment/wsgi-asgi.rst
@@ -50,7 +50,8 @@ Run with a production WSGI server such as ``gunicorn`` or ``uwsgi``.
    uv run gunicorn config.wsgi:application --workers 4 --bind 0.0.0.0:8000
 
 The example uses four workers.
-Gunicorn's own default ``--workers`` count is the number of CPU cores plus one.
+Gunicorn's own default ``--workers`` is ``1``.
+A common starting point is ``(2 * num_cores) + 1``.
 Tune based on the expected concurrency and the average request duration.
 
 ASGI Configuration

--- a/docs/content/faq/general.rst
+++ b/docs/content/faq/general.rst
@@ -9,47 +9,49 @@ This page answers high-level questions about the project, its scope, and its lif
    :local:
    :depth: 2
 
-What is next.dj and is it a Django replacement
------------------------------------------------
+What Is next.dj and Is It a Django Replacement
+----------------------------------------------
 
 next.dj is a framework built on Django, not a replacement for it.
 It adds file-based routing, a layout system, reusable components, and form dispatch on top of a regular Django project.
 See :doc:`/content/intro/overview`, especially :ref:`intro-overview-django-unchanged`, for what stays stock Django versus what the framework adds.
 
-Which Django and Python versions are supported
+Which Django and Python Versions Are Supported
 ----------------------------------------------
 
 The :doc:`/content/intro/install` *Requirements* list names the tested Python and Django combinations.
 
-Is next.dj production ready
+Is next.dj Production Ready
 ---------------------------
 
 next.dj is used in production.
 Run ``manage.py check`` to confirm a deployment matches framework expectations, and pin a supported Python and Django release (see :doc:`/content/intro/install`).
-See `Which symbols are safe to depend on`_ below for guidance on the public API surface.
+See :ref:`faq-safe-symbols` below for guidance on the public API surface.
 
-How do I follow the project
+How Do I Follow the Project
 ---------------------------
 
 Watch the repository on GitHub.
 Releases ship through PyPI under the distribution name ``next.dj``, imported as ``next`` (see :doc:`/content/intro/install`).
 Discussions and feature requests live on GitHub Discussions.
 
-What about plugins
+What About Plugins
 ------------------
 
 The project does not ship a plugin registry.
 The five extension mechanisms in :doc:`/content/topics/extending` cover the common cases.
 Distribute your customisations as ordinary Python packages.
 
-What about a CLI
+What About a CLI
 ----------------
 
 The framework does not add a new CLI.
 Django's ``manage.py`` plus the framework system checks cover the operational surface.
 
-Which symbols are safe to depend on
-------------------------------------
+.. _faq-safe-symbols:
+
+Which Symbols Are Safe to Depend On
+-----------------------------------
 
 Two rules define the public surface.
 First, anything exported from a top-level ``next.*`` package is safe to import.

--- a/docs/content/faq/general.rst
+++ b/docs/content/faq/general.rst
@@ -51,8 +51,10 @@ Django's ``manage.py`` plus the framework system checks cover the operational su
 Which symbols are safe to depend on
 ------------------------------------
 
-Anything exported from a top-level ``next.*`` package is safe to import.
-Symbols whose names start with a single underscore are internal and may change without notice.
+Two rules define the public surface.
+First, anything exported from a top-level ``next.*`` package is safe to import.
+Second, symbols whose names start with a single underscore are internal and may change without notice, even when they appear in a module ``__all__``.
+The underscore rule is binding and overrides any incidental re-export.
 See :doc:`/content/ref/forms` for a concrete example of how the API tiers apply to ``next.forms``.
 
 See Also

--- a/docs/content/faq/troubleshooting.rst
+++ b/docs/content/faq/troubleshooting.rst
@@ -145,17 +145,19 @@ Three common causes explain this.
   Compare your scenario with the lifecycle discussion in :doc:`/content/topics/dependency-injection`.
 
 To inspect what the resolver would actually inject, use ``resolve_call`` from ``next.testing`` in a shell or test.
-The snippet below assumes a non-bracketed ``notes/pages/notes/`` page module and a custom ``DTenant`` provider declared in the project.
+The snippet below uses ``fetch_note``, the ``@context("note")`` callable from the :doc:`tutorial </content/intro/tutorial02>` detail page.
 
 .. code-block:: python
 
    from next.testing import resolve_call, make_resolution_context
-   from notes.providers import DTenant
-   from notes.pages.notes.page import notes
 
-   resolved = resolve_call(notes, url_kwargs={"tenant_slug": "acme"})
+   def fetch_note(note_id):  # the callable under test
+       ...
+
+   resolved = resolve_call(fetch_note, url_kwargs={"id": "1"})
    print(resolved)
 
+Import the real ``fetch_note`` directly when the page module sits at an importable path.
 ``resolve_call`` returns the kwargs dict the resolver would pass to the callable.
 Use ``make_resolution_context`` when you need finer control over the request, form, URL kwargs, or context data supplied to the resolver.
 
@@ -168,19 +170,21 @@ Confirm that the provider class is imported during ``AppConfig.ready``.
 Testing with custom providers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``reset_registries()`` clears the provider list as well as the dependency registry.
-A custom provider registered in ``AppConfig.ready`` disappears after a ``reset_registries()`` call, which isolation tests often run in ``setUp`` or a fixture.
-Re-register the provider inside the test or in a ``setUp`` method that runs after ``reset_registries()``.
+``reset_registries()`` resets the form-action and component backends.
+It does not touch the provider list, so a custom provider registered in ``AppConfig.ready`` survives the call.
+To swap a provider for the duration of a test, use ``override_provider`` from ``next.testing``.
+The context manager prepends the provider to the resolver list on entry and removes it on exit.
 
 .. code-block:: python
 
-   from next.testing import reset_registries
+   from next.testing import override_provider
    from myapp.providers import TenantProvider
 
    class TenantProviderTests(TestCase):
-       def setUp(self):
-           reset_registries()
-           TenantProvider()  # re-registers at class creation
+       def test_resolves_tenant(self):
+           with override_provider(TenantProvider()):
+               response = self.client.get("/dashboard/")
+           self.assertEqual(response.status_code, 200)
 
 See :doc:`/content/howto/test-a-component-in-isolation` for the full isolation-test setup.
 

--- a/docs/content/faq/troubleshooting.rst
+++ b/docs/content/faq/troubleshooting.rst
@@ -12,15 +12,16 @@ This page lists the most common errors and warnings plus the actions that resolv
 Pages
 -----
 
-Page does not appear at the expected URL
+Page Does Not Appear at the Expected URL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Confirm that the directory contains a ``page.py`` plus at least one body source: a ``render`` function, a ``template`` attribute, a ``template.djx``, or a sibling ``layout.djx``.
+Confirm that the directory contains a ``page.py`` plus at least one body source, a ``render`` function, a ``template`` attribute, a ``template.djx``, or a sibling ``layout.djx``.
 Confirm that the application is listed in ``INSTALLED_APPS`` and ``APP_DIRS=True`` in the page backend.
 
-Run ``uv run python manage.py check`` and resolve every warning. The command runs Django's :doc:`system check framework <django:ref/checks>` together with the next.dj checks.
+Run ``uv run python manage.py check`` and resolve every warning.
+The command runs Django's :doc:`system check framework <django:ref/checks>` together with the next.dj checks.
 
-Page renders without layout
+Page Renders Without Layout
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A layout must contain the placeholder block ``{% block template %}{% endblock template %}`` or its short form ``{% block template %}{% endblock %}``.
@@ -28,14 +29,14 @@ Without the placeholder the framework drops the body at render time without an e
 
 Confirm that ``layout.djx`` sits in the same directory as ``page.py`` or in an ancestor directory.
 
-next.W043 warning
+next.W043 Warning
 ~~~~~~~~~~~~~~~~~
 
 A page module declares more than one body source.
 Keep exactly one body source.
 The choices are a ``render`` function, a ``template`` module attribute, or a sibling ``template.djx`` file.
 
-``render`` raised ``TypeError``
+``render`` Raised ``TypeError``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``render`` must return ``str`` or a Django :class:`~django.http.HttpResponseBase` subclass.
@@ -45,7 +46,7 @@ See :doc:`/content/topics/pages`.
 Forms
 -----
 
-HTTP 400 from form submission
+HTTP 400 From Form Submission
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The dispatcher rejected the request because ``_next_form_page`` is missing or invalid.
@@ -58,7 +59,7 @@ CSRF token is missing or stale.
 The ``{% form %}`` tag injects the token automatically.
 Manual forms need ``{% csrf_token %}`` plus a fresh cookie.
 
-next.E041 collision
+next.E041 Collision
 ~~~~~~~~~~~~~~~~~~~
 
 Two actions are registered under the same name by different handlers.
@@ -67,19 +68,19 @@ Rename one of them or change its namespace to avoid the collision.
 Components
 ----------
 
-next.E020 or next.E034 collision
+next.E020 or next.E034 Collision
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Two components share the same name in the same scope.
 Rename one or move one to a different page tree.
 
-Component does not render
+Component Does Not Render
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Confirm that ``COMPONENTS_DIR`` is set on ``DEFAULT_COMPONENT_BACKENDS``.
 Confirm that the component folder name matches the string argument to ``{% component %}``.
 
-Component prop does not resolve
+Component Prop Does Not Resolve
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``{% component "card" title=some_var %}`` resolves ``some_var`` from the parent template context.
@@ -89,31 +90,31 @@ Pick the form that matches the value you want to pass.
 Static
 ------
 
-CSS or JS not loaded
+CSS or JS Not Loaded
 ~~~~~~~~~~~~~~~~~~~~
 
 Confirm that ``{% collect_styles %}`` sits in the layout ``<head>`` and ``{% collect_scripts %}`` sits at the bottom of ``<body>``.
 Confirm that the asset filename matches a registered stem and a registered kind.
 
-Hashed URL does not change
+Hashed URL Does Not Change
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Restart the development server.
 The watcher picks up file content changes but a hash computed at startup can stale during long sessions.
 
-next.W030 empty static backends
+next.W030 Empty Static Backends
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``manage.py check`` warns when ``DEFAULT_STATIC_BACKENDS`` is empty.
 The framework falls back to the bundled ``StaticFilesBackend``, but you should either restore an explicit backend entry or accept that no custom chain is configured.
 
-next.E038 duplicate BACKEND entries
+next.E038 Duplicate BACKEND Entries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Two identical ``BACKEND`` dotted paths appear in ``DEFAULT_STATIC_BACKENDS``.
 Remove or rename one entry so each backend class appears once.
 
-next.W042 unusable JS_CONTEXT_SERIALIZER
+next.W042 Unusable JS_CONTEXT_SERIALIZER
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``JS_CONTEXT_SERIALIZER`` is set but does not resolve to a class that implements the ``JsContextSerializer`` protocol (a ``dumps`` method).
@@ -123,13 +124,13 @@ Dependency Injection
 --------------------
 
 DependencyCycleError
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 The resolver raises ``DependencyCycleError`` when two providers depend on each other.
 Read the chain printed on the exception, remove one ``Depends`` edge, or merge providers.
 See :doc:`/content/topics/dependency-injection` for request-cache interactions during form re-renders.
 
-DI parameter resolves to None
+DI Parameter Resolves to None
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Three common causes explain this.
@@ -151,8 +152,8 @@ The snippet below uses ``fetch_note``, the ``@context("note")`` callable from th
 
    from next.testing import resolve_call, make_resolution_context
 
-   def fetch_note(note_id):  # the callable under test
-       ...
+   def fetch_note(note_id):
+       return None
 
    resolved = resolve_call(fetch_note, url_kwargs={"id": "1"})
    print(resolved)
@@ -161,13 +162,13 @@ Import the real ``fetch_note`` directly when the page module sits at an importab
 ``resolve_call`` returns the kwargs dict the resolver would pass to the callable.
 Use ``make_resolution_context`` when you need finer control over the request, form, URL kwargs, or context data supplied to the resolver.
 
-Custom marker not handled
+Custom Marker Not Handled
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Confirm that the provider class is imported during ``AppConfig.ready``.
 ``RegisteredParameterProvider`` registers at class creation, so the import must happen before the resolver caches the provider list.
 
-Testing with custom providers
+Testing With Custom Providers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``reset_registries()`` resets the form-action and component backends.
@@ -191,7 +192,7 @@ See :doc:`/content/howto/test-a-component-in-isolation` for the full isolation-t
 URL Resolution
 --------------
 
-Virtual routes and bracket directories
+Virtual Routes and Bracket Directories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A plain directory that contains only a ``template.djx`` and no ``page.py`` is a virtual route.
@@ -200,42 +201,42 @@ The router still maps it to a URL.
 Captured-parameter directories (names in brackets) must contain ``page.py``, ``layout.djx``, ``template.djx``, or a child directory whose subtree includes ``page.py``.
 Otherwise ``manage.py check`` reports :ref:`next.E010 <ref-system-checks>`.
 
-URL name not found
+URL Name Not Found
 ~~~~~~~~~~~~~~~~~~
 
 Run ``uv run python manage.py shell`` and print ``reverse("next:page_<name>")``.
 If it raises ``NoReverseMatch``, verify that the directory contains at least one of ``page.py``, ``template.djx``, or a child page, and that it sits under an active ``PAGES_DIR`` root configured in ``DEFAULT_PAGE_BACKENDS``.
 
-Captured parameter name differs from directory name
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Captured Parameter Name Differs From Directory Name
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The router normalises hyphens in directory names to underscores.
 A directory named ``[my-id]`` produces the parameter ``my_id``, not ``my-id``.
 Access it as ``DUrl[str]`` annotated ``my_id`` in your context function.
 Rename the directory to ``[my_id]`` to avoid confusion.
 
-Two pages collide under the same URL pattern
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Two Pages Collide Under the Same URL Pattern
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The system check :ref:`next.E015 <ref-system-checks>` reports when the same Django URL pattern is produced from multiple sources.
 This happens when two backends each walk a directory that maps to the same logical path.
 Verify that ``DIRS`` and ``APP_DIRS`` in your page backends do not overlap.
 
-Routes do not refresh
+Routes Do Not Refresh
 ~~~~~~~~~~~~~~~~~~~~~
 
 The bundled ``FileRouterBackend`` refreshes automatically when the dev server detects a filesystem change.
 The manual ``router_manager.reload()`` call is only for a custom backend that reads routes from a non-filesystem source such as a database.
 See :doc:`/content/howto/reload-routes-from-code`.
 
-Template tags look undefined
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Template Tags Look Undefined
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The framework registers ``{% form %}``, ``{% component %}``, ``{% collect_styles %}``, and related tags as Django builtins during ``AppConfig.ready``.
 You normally **do not** ``{% load %}`` the ``next.templatetags.*`` libraries.
 If the template engine reports ``Invalid block tag`` on one of these names, confirm ``next.apps.NextFrameworkConfig`` is listed in ``INSTALLED_APPS`` and run ``manage.py check`` before chasing import paths.
 
-``template.djx`` edits and hot reload
+``template.djx`` Edits and Hot Reload
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The dev watcher restarts the process when Python entrypoints such as ``page.py`` change.
@@ -244,7 +245,7 @@ Editing only ``template.djx`` or other DJX files refreshes rendered output witho
 Settings Behaviour
 ------------------
 
-STRICT_CONTEXT causes unexpected exceptions
+STRICT_CONTEXT Causes Unexpected Exceptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When ``STRICT_CONTEXT = True`` in ``NEXT_FRAMEWORK``, any context processor that raises ``TypeError``, ``ValueError``, ``AttributeError``, or ``KeyError`` re-raises the exception instead of logging a warning and continuing.
@@ -252,8 +253,8 @@ This is recommended in production to surface misconfigured processors immediatel
 To debug, disable ``STRICT_CONTEXT`` temporarily and read the logged warning to identify the offending processor.
 See :ref:`ref-settings` for the full description of this key.
 
-Components are not available at startup
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Components Are Not Available at Startup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default ``LAZY_COMPONENT_MODULES = False``, which means ``component.py`` modules under configured component roots are imported during ``AppConfig.ready``.
 If a module raises an import error at startup, the server does not start.

--- a/docs/content/faq/usage.rst
+++ b/docs/content/faq/usage.rst
@@ -9,69 +9,69 @@ This page answers questions that come up while building a project with next.dj.
    :local:
    :depth: 2
 
-How do I add a page
+How Do I Add a Page
 -------------------
 
 Create a directory under the page root and add a ``page.py`` plus a ``template.djx`` inside it.
 See :doc:`/content/howto/add-a-page` for a recipe.
 
-How do I pass data to the template
+How Do I Pass Data to the Template
 ----------------------------------
 
 Use ``@context("key")`` inside ``page.py`` to publish a value.
 The template renders the value as ``{{ key }}``.
 See :doc:`/content/topics/context`.
 
-How do I share data across pages
+How Do I Share Data Across Pages
 --------------------------------
 
 Declare the context in a ``page.py`` that sits in a directory above the consuming page, and pass ``inherit_context=True`` to the decorator.
 See :doc:`/content/howto/share-context-across-pages`.
 
-How do I capture URL parameters
+How Do I Capture URL Parameters
 -------------------------------
 
 Name the directory ``[param]`` for a string or ``[type:param]`` for a typed value.
 Inside the page module annotate the parameter with ``DUrl[T]``.
 See :doc:`/content/topics/file-router`.
 
-How do I render a form
+How Do I Render a Form
 ----------------------
 
 Register a handler with ``@action`` and render the form with ``{% form @action="name" %}``.
 See :doc:`/content/intro/tutorial04`.
 
-How do I customise the static output
+How Do I Customise the Static Output
 ------------------------------------
 
 Subclass a static backend, register its dotted path in ``DEFAULT_STATIC_BACKENDS``, and override how tags or asset URLs are produced.
 See :doc:`/content/howto/write-a-static-backend`.
 
-How do I test a page
+How Do I Test a Page
 --------------------
 
 Use ``NextClient`` from ``next.testing.client``.
 See :doc:`/content/topics/testing`.
 
-How do I run the development server
+How Do I Run the Development Server
 -----------------------------------
 
 Run ``uv run python manage.py runserver``.
 The autoreloader picks up new and changed page directories without a restart.
 
-How do I deploy in production
+How Do I Deploy in Production
 -----------------------------
 
 Serve the project through a WSGI or ASGI server and collect static files the same way as any Django project.
 See :doc:`/content/deployment/index` for the framework-specific checklist.
 
-How do I integrate Django admin
+How Do I Integrate Django Admin
 -------------------------------
 
 Mount ``admin.site.urls`` above ``include("next.urls")`` in ``config/urls.py``.
 See :doc:`/content/howto/integrate-django-admin`.
 
-How do I split routes across applications
+How Do I Split Routes Across Applications
 -----------------------------------------
 
 Two strategies.
@@ -79,22 +79,22 @@ Use ``APP_DIRS=True`` so every application contributes its own page tree.
 Use ``DIRS`` to add project level page roots.
 See :doc:`/content/topics/file-router`.
 
-How do I share components across projects
+How Do I Share Components Across Projects
 -----------------------------------------
 
 Place the shared components in one folder and reference it through ``DEFAULT_COMPONENT_BACKENDS["DIRS"]``.
 See :doc:`/content/howto/share-components-across-projects`.
 
-How do I add context processors to pages
------------------------------------------
+How Do I Add Context Processors to Pages
+----------------------------------------
 
 Add a ``context_processors`` list to the ``OPTIONS`` dict of the relevant page backend entry.
 The list merges with the processors from the first ``TEMPLATES`` entry in Django settings.
 Duplicates are dropped.
 See :doc:`/content/topics/context` for the merge order and a full settings example.
 
-How do I keep query parameters after a form action redirect
-------------------------------------------------------------
+How Do I Keep Query Parameters After a Form Action Redirect
+-----------------------------------------------------------
 
 Build the redirect URL from the form's ``cleaned_data`` inside the action handler.
 The ``{% form %}`` tag posts to the framework's action endpoint, so ``request.GET`` is empty on the POST side.
@@ -117,7 +117,7 @@ Reconstruct the query string from the validated fields instead.
 For filter forms with no side effects, use ``<form method="get">`` directly and skip ``@action`` altogether.
 The ``DQuery`` marker then reads every filter from the query string on the GET request without a round-trip through the action endpoint.
 
-Can a form action return a custom HTTP status code
+Can a Form Action Return a Custom HTTP Status Code
 --------------------------------------------------
 
 Return any ``HttpResponseBase`` subclass.
@@ -136,8 +136,8 @@ Return any ``HttpResponseBase`` subclass.
 
 Common choices are ``HttpResponse(status=204)`` for no-content responses, ``HttpResponse(status=201)`` for created resources, and ``HttpResponseRedirect(url, status=303)`` for POST-redirect-GET flows.
 
-How do I translate URLs or templates
--------------------------------------
+How Do I Translate URLs or Templates
+------------------------------------
 
 Internationalisation stays on Django's stack.
 Configure ``LocaleMiddleware``, translation files, and ``i18n_patterns`` (or your preferred URL prefix strategy) the same way as in a stock Django project.

--- a/docs/content/howto/add-a-custom-stem.rst
+++ b/docs/content/howto/add-a-custom-stem.rst
@@ -57,6 +57,13 @@ Verification
 Editing ``apps.py`` restarts the dev server, so the new stem registration is live on the next boot.
 Reload a page that uses the file and confirm the asset appears in the rendered HTML.
 
+Confirm the staticfiles finder picks the new file up.
+
+.. code-block:: bash
+   :caption: shell
+
+   uv run python manage.py findstatic next/notes/pages/page.css
+
 See Also
 --------
 

--- a/docs/content/howto/add-a-custom-template-loader.rst
+++ b/docs/content/howto/add-a-custom-template-loader.rst
@@ -45,6 +45,10 @@ That string appears in diagnostics such as the ``next.W043`` body-source warning
            candidate = file_path.parent / "template.md"
            return candidate if candidate.is_file() else None
 
+The loaded body is rendered as a Django template after composition with the layout chain.
+A ``{{ ... }}`` or ``{% ... %}`` token inside ``template.md`` is evaluated by the template engine before the user sees the page.
+Wrap untrusted Markdown in ``{% verbatim %}{% endverbatim %}`` inside ``load_template``, or escape the braces, when the source comes from an author who should not run template tags.
+
 Append the loader after the built-in DJX loader unless you intend to replace it entirely.
 
 .. code-block:: python

--- a/docs/content/howto/build-a-custom-asset-backend.rst
+++ b/docs/content/howto/build-a-custom-asset-backend.rst
@@ -200,6 +200,24 @@ With a Vite build present, the ``src`` is the hashed file from ``dist/.vite/mani
 Delete the manifest and reload.
 The page still renders and the log carries a single fallback warning.
 
+The fallback warning reaches the console only when ``LOGGING`` routes the ``kanban.backends`` logger to a handler at ``WARNING`` or below.
+Django's default configuration sends warnings to ``stderr`` in development.
+In production, add an explicit entry.
+
+.. code-block:: python
+   :caption: config/settings.py
+
+   LOGGING = {
+       "version": 1,
+       "disable_existing_loggers": False,
+       "handlers": {
+           "console": {"class": "logging.StreamHandler"},
+       },
+       "loggers": {
+           "kanban.backends": {"handlers": ["console"], "level": "WARNING"},
+       },
+   }
+
 See Also
 --------
 

--- a/docs/content/howto/read-query-parameters.rst
+++ b/docs/content/howto/read-query-parameters.rst
@@ -83,7 +83,8 @@ The annotation drives coercion of the raw query string.
    Three wire formats are accepted, but only one is consulted per request.
    ``request.GET.getlist(name)`` runs first.
    When it returns more than one value, the plain repeated form ``?brand=Acme&brand=Globex`` is used as-is.
-   When it returns one value or none, the resolver falls back to the bracket form ``?brand[]=Acme&brand[]=Globex`` only when the plain value is empty, and to the comma-delimited form ``?brand=Acme,Globex`` only when the plain value is a single non-empty string that contains a comma.
+   When the plain value is empty, the resolver falls back to the bracket form ``?brand[]=Acme&brand[]=Globex``.
+   When the plain value is a single non-empty string that contains a comma, the resolver falls back to the comma-delimited form ``?brand=Acme,Globex``.
    Each element is then coerced using the same rules as the scalar form for ``T``.
 
 A scalar parameter that is absent from the query string receives the declared default, or ``None`` when no default is given.

--- a/docs/content/howto/read-query-parameters.rst
+++ b/docs/content/howto/read-query-parameters.rst
@@ -14,7 +14,7 @@ Solution
 
 Annotate a ``@context`` parameter with the ``DQuery[T]`` marker.
 The framework reads :attr:`request.GET <django:django.http.HttpRequest.GET>`, coerces the value to the annotated type, and injects it.
-``DQuery`` supports ``str``, ``int``, ``bool``, ``float``, and ``list[T]`` for multi-value parameters.
+``DQuery`` supports ``str``, ``int``, ``bool``, ``float``, ``UUID``, ``Decimal``, ``date``, ``datetime``, and ``list[T]`` for multi-value parameters.
 
 Walkthrough
 -----------
@@ -67,17 +67,27 @@ The annotation drives coercion of the raw query string.
 ``DQuery[bool]``.
    ``True`` when the value is ``1``, ``true``, or ``yes``, case-insensitive. Every other value, including ``0`` and ``false``, is ``False``.
 
+``DQuery[UUID]``.
+   Parsed with :class:`UUID(...) <uuid.UUID>`. A value that does not parse falls back to the raw string.
+
+``DQuery[Decimal]``.
+   Parsed with :class:`Decimal(...) <decimal.Decimal>`. A value that does not parse falls back to the raw string.
+
+``DQuery[date]`` and ``DQuery[datetime]``.
+   Parsed via :meth:`date.fromisoformat <datetime.date.fromisoformat>` and :meth:`datetime.fromisoformat <datetime.datetime.fromisoformat>`. A value that does not parse falls back to the raw string.
+
 ``DQuery[str]``.
    The raw value, unchanged.
 
 ``DQuery[list[T]]``.
-   The value is split across three wire formats in priority order.
-   The plain repeated form ``?brand=Acme&brand=Globex`` wins first.
-   The bracket-suffix form ``?brand[]=Acme&brand[]=Globex`` (emitted by axios and similar clients) is the second fallback.
-   The comma-delimited form ``?brand=Acme,Globex`` is the third fallback.
+   Three wire formats are accepted, but only one is consulted per request.
+   ``request.GET.getlist(name)`` runs first.
+   When it returns more than one value, the plain repeated form ``?brand=Acme&brand=Globex`` is used as-is.
+   When it returns one value or none, the resolver falls back to the bracket form ``?brand[]=Acme&brand[]=Globex`` only when the plain value is empty, and to the comma-delimited form ``?brand=Acme,Globex`` only when the plain value is a single non-empty string that contains a comma.
    Each element is then coerced using the same rules as the scalar form for ``T``.
 
-A parameter that is absent from the query string receives the declared default, or ``None`` when no default is given.
+A scalar parameter that is absent from the query string receives the declared default, or ``None`` when no default is given.
+A ``DQuery[list[T]]`` parameter that is absent in all three wire formats returns the declared default, or an empty list when no default is given.
 
 Read Several Typed Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/content/howto/reload-routes-from-code.rst
+++ b/docs/content/howto/reload-routes-from-code.rst
@@ -18,19 +18,21 @@ Walkthrough
 -----------
 
 Wire the receiver.
+The module exposes a ``connect`` helper that ``AppConfig.ready`` calls, so the receiver wiring lives at module top level instead of inside a function body.
 
 .. code-block:: python
    :caption: notes/receivers.py
 
    from django.db.models.signals import post_delete, post_save
-   from django.dispatch import receiver
    from next.urls import router_manager
    from notes.models import Note
 
-   @receiver(post_save, sender=Note)
-   @receiver(post_delete, sender=Note)
    def reload_router(**_kwargs) -> None:
        router_manager.reload()
+
+   def connect() -> None:
+       post_save.connect(reload_router, sender=Note)
+       post_delete.connect(reload_router, sender=Note)
 
 Connect the receiver from ``AppConfig.ready`` so it runs at startup.
 
@@ -38,12 +40,13 @@ Connect the receiver from ``AppConfig.ready`` so it runs at startup.
    :caption: notes/apps.py
 
    from django.apps import AppConfig
+   from notes import receivers
 
    class NotesConfig(AppConfig):
        name = "notes"
 
        def ready(self) -> None:
-           from notes import receivers  # noqa: F401, PLC0415
+           receivers.connect()
 
 Each call rebuilds the backend list from the current ``NEXT_FRAMEWORK`` configuration, clears Django's URL caches, and emits ``router_reloaded``.
 Receivers should tolerate being invoked more than once when several writes batch into one task.

--- a/docs/content/howto/reload-routes-from-code.rst
+++ b/docs/content/howto/reload-routes-from-code.rst
@@ -17,36 +17,37 @@ The framework rebuilds every backend from the current configuration, clears the 
 Walkthrough
 -----------
 
-Wire the receiver.
-The module exposes a ``connect`` helper that ``AppConfig.ready`` calls, so the receiver wiring lives at module top level instead of inside a function body.
+Wire the receivers.
+Each receiver is decorated with ``@receiver`` at module top level, and ``AppConfig.ready`` imports the module so the decorators run once on startup.
 
 .. code-block:: python
    :caption: notes/receivers.py
 
    from django.db.models.signals import post_delete, post_save
+   from django.dispatch import receiver
    from next.urls import router_manager
    from notes.models import Note
 
-   def reload_router(**_kwargs) -> None:
+   @receiver(post_save, sender=Note)
+   def reload_router_on_save(**_kwargs) -> None:
        router_manager.reload()
 
-   def connect() -> None:
-       post_save.connect(reload_router, sender=Note)
-       post_delete.connect(reload_router, sender=Note)
+   @receiver(post_delete, sender=Note)
+   def reload_router_on_delete(**_kwargs) -> None:
+       router_manager.reload()
 
-Connect the receiver from ``AppConfig.ready`` so it runs at startup.
+Import the receivers module from ``AppConfig.ready`` so the decorators run at startup.
 
 .. code-block:: python
    :caption: notes/apps.py
 
    from django.apps import AppConfig
-   from notes import receivers
 
    class NotesConfig(AppConfig):
        name = "notes"
 
        def ready(self) -> None:
-           receivers.connect()
+           from notes import receivers  # noqa: F401, PLC0415
 
 Each call rebuilds the backend list from the current ``NEXT_FRAMEWORK`` configuration, clears Django's URL caches, and emits ``router_reloaded``.
 Receivers should tolerate being invoked more than once when several writes batch into one task.

--- a/docs/content/howto/require-login-on-pages.rst
+++ b/docs/content/howto/require-login-on-pages.rst
@@ -45,6 +45,9 @@ The middleware lets the login page and static assets through, and redirects ever
 
 Place the middleware after :class:`~django.contrib.auth.middleware.AuthenticationMiddleware` so ``request.user`` is populated when the guard runs.
 
+Use :func:`next.urls.page_reverse` instead of a hard-coded path when redirecting to a file-routed login page.
+See :doc:`/content/topics/url-reversing` for the full reversing surface.
+
 .. code-block:: python
    :caption: config/settings.py
 

--- a/docs/content/howto/resolve-feature-flags-with-di.rst
+++ b/docs/content/howto/resolve-feature-flags-with-di.rst
@@ -29,14 +29,11 @@ The provider claims any parameter whose annotation origin is ``DFlag`` and reads
 .. code-block:: python
    :caption: flags/providers.py
 
-   from typing import TYPE_CHECKING, get_args, get_origin
+   import inspect
+   from typing import get_args, get_origin
    from next.deps import DDependencyBase, RegisteredParameterProvider
+   from next.deps.context import ResolutionContext
    from .cache import get_cached_flag
-
-   if TYPE_CHECKING:
-       import inspect
-
-       from next.deps.context import ResolutionContext
 
    class DFlag[T](DDependencyBase[T]):
        """Annotate a parameter with `DFlag[Flag]` to inject the matching `Flag`."""

--- a/docs/content/howto/resolve-feature-flags-with-di.rst
+++ b/docs/content/howto/resolve-feature-flags-with-di.rst
@@ -113,42 +113,45 @@ The next ``get_cached_flag`` call refetches from the database.
    :caption: flags/receivers.py
 
    from django.db.models.signals import post_delete, post_save
-   from django.dispatch import receiver
    from .cache import invalidate_flag
    from .models import Flag
 
-   @receiver(post_save, sender=Flag)
    def _invalidate_on_save(sender: type[Flag], instance: Flag, **_: object) -> None:  # noqa: ARG001
        """Drop the cached entry so the next read reflects the updated row."""
        invalidate_flag(instance.name)
 
-   @receiver(post_delete, sender=Flag)
    def _invalidate_on_delete(sender: type[Flag], instance: Flag, **_: object) -> None:  # noqa: ARG001
        """Drop the cached entry when the flag is removed from the database."""
        invalidate_flag(instance.name)
 
+   def connect() -> None:
+       post_save.connect(_invalidate_on_save, sender=Flag)
+       post_delete.connect(_invalidate_on_delete, sender=Flag)
+
 Wire the provider and receivers at app ready
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Import the provider and receiver modules from ``AppConfig.ready``.
-The provider registers itself with the resolver on import.
-The receivers connect to the model signals.
+``flags.providers`` registers ``FlagProvider`` with the resolver as a side effect of import, so a top-level import of the module is enough.
+``flags.receivers`` exposes a ``connect`` helper that ``AppConfig.ready`` calls, which keeps the actual signal wiring out of import time.
 
 .. code-block:: python
    :caption: flags/apps.py
 
    from django.apps import AppConfig
+   from flags import providers, receivers
+
+   _ = providers
 
    class FlagsConfig(AppConfig):
        default_auto_field = "django.db.models.BigAutoField"
        name = "flags"
 
        def ready(self) -> None:
-           """Import provider and receiver modules so DI and signals wire up."""
-           from flags import providers, receivers  # noqa: F401, PLC0415
+           """Connect receivers once the app registry is populated."""
+           receivers.connect()
 
-The imports run at ready time, not at module top level.
-Importing ``receivers`` earlier would reach ``@receiver(post_save, sender=Flag)`` before the app registry knows ``Flag``.
+The ``_ = providers`` line documents the intentional side-effect import.
+``receivers.connect`` runs at ready time, so the signal connections happen after the app registry knows ``Flag``.
 
 Consume the marker in a component
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -224,8 +227,8 @@ The banner appears.
 Set ``enabled`` to ``False`` and save.
 The ``post_save`` receiver drops the cached entry, the next ``get_cached_flag`` call refetches, and the banner collapses to an empty string.
 
-A second context function that also asks for ``DFlag[Flag]`` receives the same instance.
-The request-scoped cache calls the provider once per resolution pass.
+A second context function that also asks for ``DFlag[Flag]`` triggers the provider again on the same request, but ``get_cached_flag`` shares Django's :class:`~django.core.cache.backends.locmem.LocMemCache` entry, so the lookup is served from process memory rather than the database.
+The framework's per-resolution cache only memoises ``Depends("name")`` callables, so identity across calls comes from the LocMem cache the helper builds.
 
 See Also
 --------

--- a/docs/content/howto/scope-requests-per-tenant.rst
+++ b/docs/content/howto/scope-requests-per-tenant.rst
@@ -108,19 +108,22 @@ The provider matches the bare ``DTenant`` annotation when a request carries a te
 
 Unlike ``DFlag[Flag]``, ``DTenant`` is matched by class identity rather than ``get_origin``, so it carries no type parameter and the provider compares ``param.annotation`` to the class directly.
 
-Import the module from ``AppConfig.ready`` so the auto-registry wires the provider at startup.
+Import the module at the top of ``apps.py`` so the auto-registry wires the provider at startup.
+The ``ready`` hook does not need to re-run anything because ``RegisteredParameterProvider`` registers the provider as a side effect of class definition.
 
 .. code-block:: python
    :caption: notes/apps.py
 
    from django.apps import AppConfig
+   from notes import providers
+
+   _ = providers
 
    class NotesConfig(AppConfig):
        default_auto_field = "django.db.models.BigAutoField"
        name = "notes"
 
-       def ready(self):
-           from notes import providers  # noqa: F401, PLC0415
+The ``_ = providers`` line documents the intentional side-effect import so a linter does not flag it as unused.
 
 A page context function now requests the tenant by name and type, and the resolver hands back the model instance.
 Keep real annotations in these modules, because the resolver compares parameter annotations by identity.

--- a/docs/content/howto/scope-requests-per-tenant.rst
+++ b/docs/content/howto/scope-requests-per-tenant.rst
@@ -200,7 +200,8 @@ List it in the page backend ``OPTIONS`` so the file router runs it.
 Prefix Asset URLs Per Tenant
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Scope the static backend the same way: subclass ``StaticFilesBackend`` and override the renderer methods.
+Scope the static backend the same way.
+Subclass ``StaticFilesBackend`` and override the renderer methods.
 Read the tenant from the ``request`` keyword argument that the static manager passes to every renderer, then prepend the tenant slug to each collected URL.
 Register the subclass in ``DEFAULT_STATIC_BACKENDS``.
 

--- a/docs/content/howto/share-components-across-projects.rst
+++ b/docs/content/howto/share-components-across-projects.rst
@@ -11,8 +11,8 @@ Several Django projects in the same repository should reuse a single UI kit inst
 Scope
 -----
 
-:doc:`/content/topics/multi-project` is the full guide: page ``DIRS``, shared static, autoreload, and naming conventions.
-This page is the shortest path: point ``DEFAULT_COMPONENT_BACKENDS`` at one shared folder.
+:doc:`/content/topics/multi-project` is the full guide and covers page ``DIRS``, shared static, autoreload, and naming conventions.
+This page is the shortest path and points ``DEFAULT_COMPONENT_BACKENDS`` at one shared folder.
 
 Solution
 --------
@@ -86,8 +86,8 @@ A project can override a shared component by placing a component with the same n
 
    projects/admin/admin_app/_components/button/component.djx
 
-The project local version wins because the visibility resolver scores it by scope specificity.
-A component inside the project's own page tree is more specific than a global ``DIRS`` root, so it shadows the shared component of the same name.
+The project local version wins because the visibility resolver scores the project's page-tree root and a global ``DIRS`` root equally and breaks the tie by registration order.
+The page-tree backend registers first during the URL router walk, so its components shadow same-name entries contributed through ``DIRS``.
 
 Static Files
 ~~~~~~~~~~~~

--- a/docs/content/howto/test-a-component-in-isolation.rst
+++ b/docs/content/howto/test-a-component-in-isolation.rst
@@ -68,7 +68,7 @@ The ``assert_has_class`` and ``find_anchor`` helpers from ``next.testing`` keep 
 .. code-block:: python
    :caption: tests/test_info_card.py
 
-   from next.testing import assert_has_class, render_component_by_name
+   from next.testing import assert_has_class, find_anchor, render_component_by_name
 
    def test_info_card_marks_the_root() -> None:
        html = render_component_by_name(
@@ -77,6 +77,15 @@ The ``assert_has_class`` and ``find_anchor`` helpers from ``next.testing`` keep 
            context={"title": "Quick start"},
        )
        assert_has_class(html, "info-card")
+
+   def test_info_card_links_to_detail() -> None:
+       html = render_component_by_name(
+           "info_card",
+           at="notes/pages/template.djx",
+           context={"title": "Quick start", "href": "/notes/1/"},
+       )
+       anchor = find_anchor(html, href="/notes/1/", text="Quick start")
+       assert 'href="/notes/1/"' in anchor
 
 Pass a Request When the Component Needs One
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/content/howto/use-formsets.rst
+++ b/docs/content/howto/use-formsets.rst
@@ -37,12 +37,13 @@ Register the action.
 .. code-block:: python
    :caption: notes/pages/notes/bulk/page.py
 
+   from django.forms.formsets import BaseFormSet
    from django.http import HttpResponseRedirect
    from django.urls import reverse
    from next.forms import action
    from notes.forms import NoteFormSet
 
-   def build_bulk_formset() -> tuple[type[NoteFormSet], dict]:
+   def build_bulk_formset() -> tuple[type[BaseFormSet], dict]:
        return NoteFormSet, {}
 
    @action("bulk_create", form_class=build_bulk_formset)

--- a/docs/content/howto/use-modelform-for-crud.rst
+++ b/docs/content/howto/use-modelform-for-crud.rst
@@ -152,6 +152,8 @@ Tests assert the same flow.
        assert not Note.objects.filter(pk=note.id).exists()
 
 The ``_url_param_id`` key in the POST data mirrors the hidden field that the ``{% form %}`` tag emits for a captured URL parameter.
+The dispatcher casts each recovered value to ``int`` when the cast succeeds and falls back to the original string when it does not, so a handler can declare ``DUrl["id", int]`` and receive the integer on both the initial render and the re-render.
+Annotate the parameter as ``DUrl["id", str]`` to opt out of the int-first coercion.
 
 See Also
 --------

--- a/docs/content/howto/write-a-router-backend.rst
+++ b/docs/content/howto/write-a-router-backend.rst
@@ -29,18 +29,12 @@ Its only contract is ``generate_urls``, which returns the patterns the backend c
 .. code-block:: python
    :caption: wiki/backends.py
 
-   from __future__ import annotations
-   from typing import TYPE_CHECKING
+   from collections.abc import Callable
    from django.apps import apps as django_apps
    from django.db.utils import DatabaseError
-   from django.urls import URLPattern, path
+   from django.urls import URLPattern, URLResolver, path
    from next.conf import next_framework_settings
    from next.urls import FileRouterBackend
-
-   if TYPE_CHECKING:
-       from collections.abc import Callable
-
-       from django.urls import URLResolver
 
    PUBLIC_PREFIX = "wiki"
 

--- a/docs/content/howto/write-a-static-backend.rst
+++ b/docs/content/howto/write-a-static-backend.rst
@@ -154,3 +154,4 @@ See Also
 
    :doc:`/content/topics/static-assets/backends` for the backend contract.
    :doc:`/content/topics/static-assets/asset-kinds` for the renderer methods.
+   :doc:`/content/howto/build-a-custom-asset-backend` for resolving URLs through an external manifest.

--- a/docs/content/internals/action-dispatch.rst
+++ b/docs/content/internals/action-dispatch.rst
@@ -13,7 +13,7 @@ It traces a submission from the template ``{% form %}`` tag through the validati
 Overview
 --------
 
-The dispatcher runs at ``/_next/form/<uid>/`` where the UID is a 16 character hash of the action name.
+The dispatcher runs at ``/_next/form/<uid>/`` where the UID is the first 16 hex characters of the SHA-256 digest of the action name.
 The dispatcher loads the action handler, builds the form, runs the validation chain, and either calls the handler or re-renders the origin page.
 Any non-POST method short-circuits before that work and returns HTTP 405.
 
@@ -23,9 +23,9 @@ Pipeline
 .. mermaid::
 
    flowchart TB
-       Template["form tag in template"] -- POST --> Endpoint["form dispatch endpoint"]
-       Template -- "non-POST" --> NotAllowed["HTTP 405"]
-       Endpoint --> Lookup["Resolve action by UID"]
+       Template["form tag in template"] --> Endpoint["form dispatch endpoint"]
+       Endpoint -- "non-POST" --> NotAllowed["HTTP 405"]
+       Endpoint -- POST --> Lookup["Resolve action by UID"]
        Lookup -- unknown UID --> NotFound["HTTP 404"]
        Lookup -- "found, no form_class" --> HandlerOnly["Run handler only"]
        Lookup -- "found, form_class" --> Build["Build form"]
@@ -97,11 +97,12 @@ The override calls ``super().dispatch`` to keep the standard pipeline.
 Shared Dependency Cache
 -----------------------
 
-The dispatcher reuses the dependency cache from the initial render path on the re-render path.
+The dispatcher creates a fresh dependency cache on every POST and shares it across each stage of the dispatch.
+``get_initial``, the factory resolution, the handler call, and any re-render after validation failure all read and write the same cache.
 Two consequences flow from this.
 
-- Custom providers are idempotent across initial render and re-render.
-- Re-render is cheap because layouts and context functions reuse cached values.
+- Custom providers are idempotent across the dispatch stages.
+- Re-render after a validation failure is cheap because layouts and context functions reuse the values cached during the initial bind.
 
 The cache hangs on ``request`` under the attribute named ``REQUEST_DEP_CACHE_ATTR``.
 Read it through ``next.deps.get_request_dep_cache(request)`` rather than the raw attribute.

--- a/docs/content/internals/autoreload.rst
+++ b/docs/content/internals/autoreload.rst
@@ -49,11 +49,17 @@ The pipeline is wired by ``next.apps.autoreload.install()``, which ``NextFramewo
 Modules
 -------
 
+Installer
+~~~~~~~~~
+
 ``next.apps.autoreload``.
    ``install()`` swaps ``StatReloader`` and connects the watch signal.
    ``uninstall()`` restores the previous reloader. Test suites that call ``AppConfig.ready`` multiple times use it to avoid double-patching.
 
-``next.server.autoreload`` (distinct from ``next.apps.autoreload``, the installer above).
+Runtime
+~~~~~~~
+
+``next.server.autoreload``.
    ``NextStatReloader`` extends the Django stat reloader and also restarts the process when the discovered route set changes.
 
 ``next.server.watcher``.

--- a/docs/content/internals/autoreload.rst
+++ b/docs/content/internals/autoreload.rst
@@ -63,8 +63,8 @@ Runtime
    ``NextStatReloader`` extends the Django stat reloader and also restarts the process when the discovered route set changes.
 
 ``next.server.watcher``.
-   ``iter_all_autoreload_watch_specs`` collects watch specs from every registered subsystem.
-   ``FilesystemWatchContributor`` is the Protocol a subsystem implements to contribute ``(root, glob)`` watch specs through an ``iter_watch_specs`` method.
+   ``iter_all_autoreload_watch_specs`` returns the deduplicated list of built-in specs plus pairs registered through ``register_autoreload_watch_spec``.
+   ``FilesystemWatchContributor`` is a runtime-checkable protocol exported for type annotations only and is not iterated at runtime.
 
 ``next.server.roots``.
    ``get_framework_filesystem_roots_for_linking`` returns the canonical page and component directory roots for build tooling.
@@ -80,7 +80,7 @@ A watch spec is a tuple of a root path and one glob pattern.
 User code calls ``iter_all_autoreload_watch_specs`` instead, which wraps the built-in set with the registered extra specs.
 
 - Each page root contributes a ``**/page.py`` spec.
-- Each page root paired with its components folder name contributes a ``**/<components>/**/component.py`` spec.
+- Each page root paired with its components folder name contributes a ``**/_components/**/component.py`` spec.
 - Each extra component root from ``DEFAULT_COMPONENT_BACKENDS`` contributes a ``**/component.py`` spec.
 
 Only Python entrypoints are watched.
@@ -120,7 +120,7 @@ Custom routers subscribe to ``watch_specs_ready`` to register additional pattern
 Extension Points
 ----------------
 
-- Implement a custom backend that contributes its own watch specs through the subsystem watch module.
+- Register extra ``(path, glob)`` pairs from ``AppConfig.ready`` through ``register_autoreload_watch_spec``.
 - Subscribe to ``router_reloaded`` for in process cache refresh.
 - Subscribe to ``watch_specs_ready`` for diagnostic logging during development.
 

--- a/docs/content/internals/component-pipeline.rst
+++ b/docs/content/internals/component-pipeline.rst
@@ -76,12 +76,13 @@ Resolution Order
 A component reference resolves through the visibility resolver.
 The resolver collects every component visible from the template path, then scores each by scope specificity.
 The highest score wins.
-A component in the template's own page tree outscores a same-named component contributed through ``DIRS``.
-Equal scores fall back first to component name, then to registration order.
+A component nested in a sub-folder of the template's own page tree outscores a same-named component contributed at a tree root or through a ``DIRS`` root.
+A page-tree root and a ``DIRS`` root both score zero, so the tie breaks on registration order.
 
 The full sort key is ``(-score, component.name, registration_position)``.
 Equal scores break first by component name, then by registration order, so the component discovered first shadows a later same-named one.
 Registration order operates inside a single ``FileComponentsBackend``.
+The page-tree backend records its roots during the URL router walk before ``DIRS`` roots are scanned, so its components shadow same-name entries from ``DIRS``.
 Across backends, the order of entries in ``DEFAULT_COMPONENT_BACKENDS`` decides which backend is consulted first.
 
 Two components in the same scope with the same name are reported by ``next.E020``.
@@ -101,7 +102,8 @@ Component Context Resolution
 
 Each ``@component.context("key")`` function runs once per component render.
 When a component's ``component.py`` fails to import, the renderer falls back to plain template rendering and the ``@component.context`` callables in that module do not run.
-On the template render path the resolver shares the request-scoped dependency cache through ``get_request_dep_cache``, so values produced by page level context are visible inside the component.
+On the template render path the resolver shares the request-scoped dependency cache through ``get_request_dep_cache``, so DI parameters resolved earlier in the request are reused inside the component callables.
+Page context values reach the component through the template scope, not through the DI cache.
 A component whose ``component.py`` defines a ``render`` function uses a fresh ``DependencyCache`` for that call instead of the shared request cache.
 The surrounding template scope (props and page context variables) is still forwarded to the resolver as DI parameters.
 The lazy ``csrf_token`` and any ``@component.context`` callables are not run on this path.

--- a/docs/content/internals/contributing-notes.rst
+++ b/docs/content/internals/contributing-notes.rst
@@ -53,7 +53,7 @@ System Checks
 ~~~~~~~~~~~~~
 
 Every check lives next to the subsystem it validates.
-The codes follow ``next.E<NN>`` for errors and ``next.W<NN>`` for warnings.
+The codes follow ``next.E<NNN>`` for errors and ``next.W<NNN>`` for warnings.
 A new check registers through ``next.checks.register_all``.
 
 Signals
@@ -62,6 +62,37 @@ Signals
 Every signal lives in a ``signals`` submodule of its subsystem.
 The aggregator ``next.signals`` re-exports each name.
 A new signal adds an entry to the aggregator and to the topic catalog in ``docs/content/topics/signals.rst``.
+
+Module Docstrings
+~~~~~~~~~~~~~~~~~
+
+Python files start with the first ``import`` statement.
+Test modules in particular carry no module-level docstring.
+
+Imports
+~~~~~~~
+
+Every ``import`` lives at the top of the module.
+Imports inside functions or methods are not used, including inside tests.
+
+Docstrings
+~~~~~~~~~~
+
+A docstring is one summary line, or at most a short paragraph.
+Examples, enumerations, and historical notes belong in the guide documentation, not in docstrings.
+
+Prose Punctuation
+~~~~~~~~~~~~~~~~~
+
+The same punctuation rules that bind the documentation also bind every docstring, comment, and log message in ``next/``.
+No semicolon joins two clauses. No em or en dash separates one statement from the next.
+The full rule set lives in :doc:`/content/contributing/style-guide`.
+
+Decorative Separators
+~~~~~~~~~~~~~~~~~~~~~
+
+CSS, JavaScript, and Jinja files in ``docs/_static`` and ``docs/_templates`` carry no decorative ``/* ---- section ---- */`` banners.
+A comment explains a non-obvious choice and nothing else.
 
 Testing the Framework
 ---------------------

--- a/docs/content/internals/contributing-notes.rst
+++ b/docs/content/internals/contributing-notes.rst
@@ -47,6 +47,7 @@ Public Callables
 ~~~~~~~~~~~~~~~~
 
 Names exposed through ``@page.context``, ``@component.context``, ``@action``, and through provider classes never start with an underscore.
+``@context`` imported from ``next.pages`` is the documented alias for ``@page.context`` used in page modules.
 Names prefixed with ``_`` stay module internal.
 
 System Checks
@@ -66,8 +67,8 @@ A new signal adds an entry to the aggregator and to the topic catalog in ``docs/
 Module Docstrings
 ~~~~~~~~~~~~~~~~~
 
-Python files start with the first ``import`` statement.
-Test modules in particular carry no module-level docstring.
+Test modules carry no module-level docstring.
+Production modules may include a one-line summary at the top.
 
 Imports
 ~~~~~~~
@@ -85,7 +86,8 @@ Prose Punctuation
 ~~~~~~~~~~~~~~~~~
 
 The same punctuation rules that bind the documentation also bind every docstring, comment, and log message in ``next/``.
-No semicolon joins two clauses. No em or en dash separates one statement from the next.
+No semicolon joins two clauses.
+No em or en dash separates one statement from the next.
 The full rule set lives in :doc:`/content/contributing/style-guide`.
 
 Decorative Separators

--- a/docs/content/internals/di-resolver.rst
+++ b/docs/content/internals/di-resolver.rst
@@ -47,10 +47,10 @@ Modules
    Like ``resolve_dependencies``, it strips ``EXPLICIT_RESOLVE_KEYS`` from the injectable context so a context key cannot shadow a dedicated provider such as ``request`` or ``form``.
 
 ``next.deps.providers``.
-   The ``ParameterProvider`` protocol and the ``RegisteredParameterProvider`` base class.
+   The ``ParameterProvider`` protocol, the ``RegisteredParameterProvider`` base class, and the ``ProviderRegistry`` list-style helper.
 
 ``next.deps.cache``.
-   ``REQUEST_DEP_CACHE_ATTR`` constant, ``DependencyCycleError`` exception, ``get_request_dep_cache`` accessor.
+   ``DependencyCache`` accumulator, the ``REQUEST_DEP_CACHE_ATTR`` constant, the ``DependencyCycleError`` exception, and the ``get_request_dep_cache`` accessor.
 
 ``next.deps.context``.
    ``ResolutionContext`` value object passed to every provider, plus the ``RESERVED_KEYS`` frozenset of names excluded from name-based resolution.
@@ -74,7 +74,7 @@ See :doc:`/content/topics/dependency-injection` for the single source of truth o
 
 Custom providers register through ``RegisteredParameterProvider``.
 A subclass that does not set ``priority`` inherits the default ``100``, so it is consulted after every built-in provider.
-A subclass joins the chain when its module is imported, in subclass definition order.
+The resolver sorts the registry by ``priority`` as the primary key and by subclass definition order as the stable tie-break.
 
 Depends Forms
 -------------
@@ -105,10 +105,10 @@ Each resolution pass owns a ``DependencyCache``.
 It lives on the ``ResolutionContext`` for that pass and holds named dependency values.
 The cache key is the dependency name string alone, with no type component.
 
-Form validation failures re-render the origin page.
-``FormActionDispatch.dispatch`` attaches the dispatch cache dict to the request under the attribute named ``REQUEST_DEP_CACHE_ATTR``.
-The page context and component context renderers read it back through ``get_request_dep_cache`` and rejoin the same cache.
-That attribute carries the cache only for the form-failure re-render path, not for an ordinary page request.
+``FormActionDispatch.dispatch`` creates a fresh dispatch cache dict on every POST and attaches it to the request under the attribute named ``REQUEST_DEP_CACHE_ATTR``.
+The cache is shared across each stage of the dispatch: ``get_initial``, the factory resolution, the handler call, and any re-render after validation failure.
+On a re-render the page context and component context renderers read it back through ``get_request_dep_cache`` and rejoin the same cache.
+An ordinary page request that does not pass through the form dispatcher never sees this attribute.
 
 Two consequences flow from the cache.
 
@@ -116,8 +116,8 @@ Idempotent providers.
    Custom providers must not depend on producing a fresh value between two invocations within the same request.
    The cache holds the first result.
 
-Shared across re-render.
-   Form validation failures reuse the cache from the initial render to keep re-render cheap.
+Shared across the dispatch.
+   The dispatch cache attaches on every form-dispatch POST and is consumed on the validation-failure re-render to keep the second pass cheap.
 
 Cycle Detection
 ---------------

--- a/docs/content/internals/di-resolver.rst
+++ b/docs/content/internals/di-resolver.rst
@@ -34,7 +34,7 @@ Pipeline
        Markers -- Context --> CtxByKey[Context by key]
        Markers -- DUrl --> UrlProv[URL provider]
        Markers -- DQuery --> QueryProv[Query provider]
-       Markers -- DForm --> FormProv[Form provider]
+       Markers -- form or DForm or class --> FormProv[Form provider]
        Markers -- name match --> NameProv[Context or URL kwargs by name]
 
 Modules

--- a/docs/content/internals/overview.rst
+++ b/docs/content/internals/overview.rst
@@ -117,8 +117,9 @@ The dependency graph between subsystems is shallow.
 
 - ``next.conf`` has no internal dependencies and sits at the bottom.
 - ``next.deps`` depends only on ``next.conf``.
-- ``next.pages``, ``next.components``, ``next.urls``, ``next.static`` depend on ``next.conf`` and ``next.deps``.
-- ``next.forms`` depends on ``next.pages``, ``next.deps``, and ``next.urls``.
+- ``next.pages``, ``next.components``, ``next.static`` depend on ``next.conf`` and ``next.deps``.
+- ``next.forms`` depends on ``next.pages`` and ``next.deps``.
+- ``next.urls`` depends on ``next.conf``, ``next.deps``, ``next.pages``, ``next.components``, and ``next.forms``.
 - ``next.server`` depends on ``next.conf``, ``next.pages``, ``next.urls``, and ``next.components``, the subsystems whose trees it watches.
 - ``next.testing`` depends on the page, component, form, dependency, and static subsystems to drive isolation and rendering helpers.
 - ``next.apps`` depends on every subsystem.
@@ -146,7 +147,7 @@ Each subsystem keeps a flat module layout.
    * - ``next.static``
      - ``manager``, ``collector``, ``discovery``, ``backends``, ``assets``, ``scripts``, ``serializers``, ``defaults``, ``finders``, ``checks``, ``signals``.
    * - ``next.deps``
-     - ``resolver``, ``providers``, ``cache``, ``context``, ``markers``, ``checks``, ``signals``.
+     - ``resolver``, ``providers``, ``cache``, ``context``, ``markers``, ``signals``. The ``checks`` module is a reserved stub with no checks registered yet.
    * - ``next.server``
      - ``autoreload``, ``watcher``, ``roots``, ``checks``, ``signals``.
    * - ``next.conf``
@@ -156,7 +157,7 @@ Each subsystem keeps a flat module layout.
    * - ``next.apps``
      - ``config``, ``autoreload``, ``templates``, ``staticfiles``, ``components``.
    * - ``next.checks``
-     - ``common``. Aggregates system-check registration.
+     - ``__init__`` aggregates system-check registration across every subpackage. ``common`` provides shared helpers used by individual ``checks`` modules.
    * - ``next.templatetags``
      - ``components``, ``forms``, ``next_static``.
 

--- a/docs/content/internals/overview.rst
+++ b/docs/content/internals/overview.rst
@@ -61,10 +61,8 @@ Bootstrap
 ---------
 
 Django calls ``NextFrameworkConfig.ready()`` once per process after all applications load.
-``ready()`` first registers every framework :doc:`system check </content/ref/system-checks>` through ``next.checks.register_all``.
-It then runs installers in order: ``next.apps.autoreload.install``, ``next.apps.templates.install``, ``next.apps.staticfiles.install``, and ``next.apps.components.install``.
-These hooks wire the subsystems above into the Django runtime before the first request arrives.
-See :doc:`/content/ref/apps` for the full API.
+The hook registers the framework system checks and runs four installers that wire the subsystems above into the Django runtime before the first request arrives.
+See :doc:`/content/ref/apps` for the canonical ordering and the full API.
 
 How They Compose
 ----------------

--- a/docs/content/internals/page-discovery.rst
+++ b/docs/content/internals/page-discovery.rst
@@ -21,13 +21,14 @@ Pipeline
 .. mermaid::
 
    flowchart LR
-       Walk[Filesystem walk] --> Loaders[Template loaders]
-       Loaders --> Manager[Page]
-       Manager --> TemplateCache[Template cache]
+       Walk[Filesystem walk] --> Dispatcher[FilesystemTreeDispatcher]
+       Dispatcher --> Pairs["(url_path, page.py) pairs"]
+       Pairs --> Manager[Page]
        Manager --> ContextReg[Context registry]
-       TemplateCache --> Render[Render request]
-       ContextReg --> Render
-       Render --> InheritedCtx[Inherited page.py context]
+       Manager --> RenderReq[Render request]
+       ContextReg --> RenderReq
+       RenderReq --> Loaders[Template loaders]
+       Loaders --> InheritedCtx[Inherited page.py context]
        InheritedCtx --> PageCtx[Page @context functions]
        PageCtx --> Processors[Context processors]
        Processors --> LayoutCompose[Layout composition]

--- a/docs/content/internals/page-discovery.rst
+++ b/docs/content/internals/page-discovery.rst
@@ -28,11 +28,11 @@ Pipeline
        Manager --> RenderReq[Render request]
        ContextReg --> RenderReq
        RenderReq --> Loaders[Template loaders]
-       Loaders --> InheritedCtx[Inherited page.py context]
+       Loaders --> LayoutCompose[Layout composition]
+       LayoutCompose --> InheritedCtx[Inherited page.py context]
        InheritedCtx --> PageCtx[Page @context functions]
        PageCtx --> Processors[Context processors]
-       Processors --> LayoutCompose[Layout composition]
-       LayoutCompose --> Output[Final HTML body]
+       Processors --> Output[Final HTML body]
 
 Modules
 -------
@@ -64,12 +64,28 @@ Render Path
 
 1. The view loads the page module through the mtime-keyed module memo, reading from disk only when the file changed.
 2. The body source produces the page body string.
-3. ``Page.build_render_context`` assembles the template scope, see `Context Resolution`_ below.
-4. The framework composes the ancestor layout chain, the innermost layout wrapping the page body first and each outer layout wrapping the result.
-5. Each layout substitutes the wrapped content into ``{% block template %}{% endblock template %}``.
+3. The framework composes the ancestor layout chain, the innermost layout wrapping the page body first and each outer layout wrapping the result.
+   Each layout substitutes the wrapped content into ``{% block template %}{% endblock template %}``.
+4. ``Page.build_render_context`` assembles the template scope, see `Context Resolution`_ below.
+5. The composed template string renders against the assembled scope.
 6. The static manager replaces the ``{% collect_styles %}`` and ``{% collect_scripts %}`` placeholder tokens with the rendered tags accumulated by the request-scoped ``StaticCollector``.
 
 When the body source is a ``render`` function that returns an ``HttpResponseBase``, the response is returned verbatim and steps 3 through 6 do not run.
+
+Composed-Template Cache
+-----------------------
+
+``Page`` keeps two parallel dicts that short-circuit the layout composition step when nothing on disk has changed.
+
+``_template_registry``.
+   Maps a ``page.py`` path to its already-composed template string.
+
+``_template_source_mtimes``.
+   Snapshots the modification time of every file that contributed to the composition, including the page body source and each ancestor ``layout.djx``.
+
+On every request ``_is_template_stale`` compares the current mtimes against the snapshot.
+A change to any contributing file evicts the entry, the composition step rebuilds the template string, and the new snapshot is stored.
+The dynamic ``render`` path bypasses this cache entirely, so a ``render`` function that returns a fresh body never poisons the registry.
 
 Layout Composition
 ------------------

--- a/docs/content/internals/request-lifecycle.rst
+++ b/docs/content/internals/request-lifecycle.rst
@@ -85,7 +85,8 @@ The collector finalises before the template tags emit their slot.
 Tag Injection
 ~~~~~~~~~~~~~
 
-``{% collect_styles %}`` and ``{% collect_scripts %}`` ask the collector for the appropriate slot and emit the HTML.
+``{% collect_styles %}`` and ``{% collect_scripts %}`` emit placeholder tokens during template rendering.
+After the layout chain finishes, the static manager replaces every placeholder token with the rendered tags accumulated by the request-scoped ``StaticCollector``.
 The framework injects the ``Next`` JS context script before any other script in the page.
 
 Form Submission Path
@@ -104,7 +105,7 @@ Extension Points
 - Add an entry to ``MIDDLEWARE`` to intercept the request before next.dj sees it.
 - Subscribe to ``page_rendered`` to inspect the final HTML.
 - Subclass ``StaticBackend`` to change how the collector renders.
-- Subclass ``FileRouterBackend`` to feed the resolver from a different source.
+- Subclass ``RouterBackend`` to feed the resolver from a different source.
 
 See Also
 --------

--- a/docs/content/internals/static-pipeline.rst
+++ b/docs/content/internals/static-pipeline.rst
@@ -70,6 +70,7 @@ Modules
 ``next.static.discovery``.
    ``AssetDiscovery`` walks the filesystem and produces ``StaticAsset`` records.
    Hosts ``StemRegistry`` plus the ``default_stems`` instance and reads the ``default_kinds`` registry from ``next.static.assets``.
+   ``default_stems`` is not re-exported from the ``next.static`` package surface, so code that registers a stem imports it from ``next.static.discovery`` directly.
 
 ``next.static.assets``.
    The ``StaticAsset`` frozen dataclass and ``KindRegistry`` plus the ``default_kinds`` instance.

--- a/docs/content/internals/static-pipeline.rst
+++ b/docs/content/internals/static-pipeline.rst
@@ -69,10 +69,10 @@ Modules
 
 ``next.static.discovery``.
    ``AssetDiscovery`` walks the filesystem and produces ``StaticAsset`` records.
-   Honours the ``default_stems`` and ``default_kinds`` registries.
+   Hosts ``StemRegistry`` plus the ``default_stems`` instance and reads the ``default_kinds`` registry from ``next.static.assets``.
 
 ``next.static.assets``.
-   The ``StaticAsset`` frozen dataclass and the ``KindRegistry`` plus the ``default_kinds`` instance.
+   The ``StaticAsset`` frozen dataclass and ``KindRegistry`` plus the ``default_kinds`` instance.
 
 ``next.static.collector``.
    ``StaticCollector`` plus the dedup strategies ``UrlDedup``, ``HashContentDedup``, ``IdentityDedup`` and the JS context policies.

--- a/docs/content/internals/url-router.rst
+++ b/docs/content/internals/url-router.rst
@@ -48,10 +48,8 @@ Modules
    ``FilesystemTreeDispatcher`` walks the pages directory tree and yields ``(url_path, page_file)`` pairs that the router turns into URL patterns.
 
 ``next.urls.markers``.
-   ``DUrl`` and ``DQuery`` markers used in annotations.
-   ``DUrl.__class_getitem__`` builds the marker for the bare-type, named-key, and named-key-with-type forms, wrapping string and tuple arguments in a ``GenericAlias`` the providers introspect.
-   The four parameter providers ``HttpRequestProvider``, ``UrlByAnnotationProvider``, ``UrlKwargsProvider``, and ``QueryParamProvider`` that register with the resolver.
-   The ``get_multi_values`` helper that reads a multi-value query parameter outside the resolver.
+   Hosts the ``DUrl`` and ``DQuery`` annotation markers, the four request/URL/query parameter providers, and the ``get_multi_values`` helper.
+   See :doc:`/content/topics/dependency-injection` for the marker semantics and the provider order.
 
 ``next.urls.reverse``.
    ``page_reverse`` and ``with_query`` helpers.
@@ -92,7 +90,7 @@ If two routes resolve to the same Django path the ``next.E015`` system check rep
 Extension Points
 ----------------
 
-- Subclass ``FileRouterBackend`` to add patterns or augment naming.
+- Subclass ``RouterBackend`` to feed the resolver from a different source, or subclass ``FileRouterBackend`` to add patterns or augment naming on the file-based backend.
 - Register a custom backend in ``RouterFactory`` and reference it through the settings dotted path.
 - Subscribe to ``route_registered`` to observe each new pattern.
   It fires once per discovered pattern with ``sender=FileRouterBackend`` and the ``url_path`` and ``file_path`` keyword arguments.

--- a/docs/content/internals/url-router.rst
+++ b/docs/content/internals/url-router.rst
@@ -46,6 +46,7 @@ Modules
 
 ``next.urls.dispatcher``.
    ``FilesystemTreeDispatcher`` walks the pages directory tree and yields ``(url_path, page_file)`` pairs that the router turns into URL patterns.
+   The module-level helper ``scan_pages_tree`` instantiates the dispatcher with the configured skip set and returns the same pairs as an iterator.
 
 ``next.urls.markers``.
    Hosts the ``DUrl`` and ``DQuery`` annotation markers, the four request/URL/query parameter providers, and the ``get_multi_values`` helper.

--- a/docs/content/intro/install.rst
+++ b/docs/content/intro/install.rst
@@ -13,7 +13,8 @@ Requirements
 - Django 4.2 or newer (4.2, 5.0, 5.1, 5.2, 6.0 supported).
 - An ASGI or WSGI server compatible with the Django version in use.
 
-next.dj extends Django. It does not replace the ORM, migrations, admin, or auth (:ref:`intro-overview-django-unchanged`).
+next.dj extends Django.
+It does not replace the ORM, migrations, admin, or auth (:ref:`intro-overview-django-unchanged`).
 
 Install the Package
 -------------------

--- a/docs/content/intro/install.rst
+++ b/docs/content/intro/install.rst
@@ -67,7 +67,7 @@ This list replaces the one ``django-admin startproject`` generates.
 It intentionally drops ``django.contrib.admin`` because next.dj does not require the admin site.
 Add ``django.contrib.admin`` back if the project needs it.
 
-The ``next`` app registers system checks, template tags, autoreload hooks, and signal connections at startup.
+The ``next`` app registers system checks, template tag builtins, autoreload hooks, and static file collectors at startup.
 
 Configure NEXT_FRAMEWORK
 ------------------------
@@ -108,11 +108,6 @@ A fresh ``django-admin startproject`` already includes it, and ``manage.py check
 Mount the Router
 ----------------
 
-.. note::
-
-   Without this ``include("next.urls")`` edit Django never reaches the file router.
-   Every page returns a 404 until the line is in place.
-
 Forward all unmatched URLs to next.dj by replacing ``config/urls.py`` with the file below.
 This replacement also removes the ``admin`` import that ``startproject`` generated, which pairs with dropping ``django.contrib.admin`` from ``INSTALLED_APPS`` above.
 
@@ -124,6 +119,11 @@ This replacement also removes the ``admin`` import that ``startproject`` generat
    urlpatterns = [
        path("", include("next.urls")),
    ]
+
+.. note::
+
+   Without this ``include("next.urls")`` edit Django never reaches the file router.
+   Every page returns a 404 until the line is in place.
 
 URLs declared above the ``include`` keep working.
 Anything not matched by Django falls through to the file router, which resolves it against your ``pages/`` tree.
@@ -191,4 +191,3 @@ The environment is ready for the tutorial.
 
    :doc:`tutorial01` builds the first real page of the Notes application.
    :doc:`/content/topics/project-layout` explains where files belong as the project grows.
-   :doc:`/content/deployment/index` covers production setup once the application is feature complete.

--- a/docs/content/intro/overview.rst
+++ b/docs/content/intro/overview.rst
@@ -27,11 +27,11 @@ Layouts and context.
 
 Components.
    A folder under the configured components root becomes a reusable template fragment.
-   Components carry their own Python file, template, and co-located CSS and JS, meaning those assets live in the same folder as the component.
+   Components carry a template plus optional Python, CSS, and JS files in one folder.
    The framework discovers them by name and renders them through the ``{% component %}`` tag.
 
 Form actions.
-   A ``@action`` decorator registers a callable as a form handler under a required action name, for example ``@action("create_note", form_class=NoteForm)``.
+   A ``@action`` decorator registers a callable as a form handler under the name passed to the decorator, for example ``@action("create_note", form_class=NoteForm)``.
    The ``{% form %}`` template tag points at that handler by the same name.
    The framework injects only the parameters that the handler signature asks for.
 
@@ -46,10 +46,7 @@ Standard ``.html`` templates in other apps are unchanged.
 
 For the design principles behind that split, read :doc:`/content/misc/design-philosophy`.
 
-Key Terms
----------
-
-You will see the nouns *page*, *layout*, *component*, *action*, and *context function* on every page.
+The nouns *page*, *layout*, *component*, *action*, and *context function* appear on every documentation page.
 :doc:`/content/misc/glossary` defines each one.
 
 A Minimal Project

--- a/docs/content/intro/tutorial01.rst
+++ b/docs/content/intro/tutorial01.rst
@@ -16,7 +16,6 @@ You have followed :doc:`install` and you can serve a placeholder page at ``http:
 You have a Django application named ``notes`` registered in ``INSTALLED_APPS``.
 From :doc:`install` your ``config/urls.py`` already forwards URLs to next.dj through ``include("next.urls")``.
 If ``/`` does not respond, revisit :doc:`install`.
-Directory layout maps to URLs through the file router. See :doc:`/content/topics/file-router` and :doc:`/content/topics/pages` when you need the rules behind ``pages/``.
 
 Walkthrough
 -----------
@@ -44,7 +43,6 @@ Keep the fields minimal so the tutorial stays focused on the framework.
            return self.title
 
 Apply the :doc:`migration <django:topics/migrations>` and seed two rows so the index page has something to render.
-The ``startproject`` scaffold uses SQLite by default, so ``migrate`` creates the ``db.sqlite3`` file in the project root.
 
 .. code-block:: bash
    :caption: shell
@@ -189,4 +187,5 @@ The next part wraps every page in a layout and shares site-wide context.
 
    :doc:`tutorial02` adds a layout and shared context.
    :doc:`/content/topics/file-router` covers route shapes, captured parameters, and virtual routes.
+   :doc:`/content/topics/pages` documents the rules behind ``pages/``.
    :doc:`/content/ref/pages` lists every public API on ``next.pages``.

--- a/docs/content/intro/tutorial02.rst
+++ b/docs/content/intro/tutorial02.rst
@@ -87,7 +87,7 @@ Pass ``inherit_context=True`` so every descendant page can read the value too.
    def tagline() -> str:
        return "A small tutorial application."
 
-``inherit_context`` defaults to ``False``, so a layout context value is visible only to the page that declares it.
+``inherit_context`` defaults to ``False``, so a context value published in ``page.py`` is visible only to the page that declares it.
 Passing ``inherit_context=True`` publishes the value to every descendant page as well.
 Without that flag the layout would still render but pages further down the tree would not see them.
 
@@ -153,6 +153,7 @@ Drop a second layout inside ``notes/pages/notes/`` to wrap only the detail pages
 
 Reload ``/notes/1/`` and you should see both layouts at once.
 The root layout wraps the inner layout which wraps the detail template.
+Composition works by folding each descendant body into the parent ``{% block template %}`` placeholder, so adding ancestor layouts never requires changes to the inner templates.
 
 Use Counts Across Pages
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/content/intro/tutorial02.rst
+++ b/docs/content/intro/tutorial02.rst
@@ -70,7 +70,9 @@ Share Site Context
 ~~~~~~~~~~~~~~~~~~
 
 The layout references ``site_name`` and ``tagline``, but no page module produces them yet.
-Add a ``page.py`` next to ``layout.djx`` to publish those values with ``inherit_context=True`` so every descendant page can read them.
+Add a ``page.py`` next to ``layout.djx`` and define a :term:`context function` for each value.
+A context function is a callable decorated with ``@context("key")`` that publishes a value to the template scope.
+Pass ``inherit_context=True`` so every descendant page can read the value too.
 
 .. code-block:: python
    :caption: notes/pages/page.py
@@ -203,12 +205,14 @@ Common Pitfalls
 ---------------
 
 Layout shows but page body does not.
-   Add ``{% block template %}{% endblock template %}`` where the page body should land.
-   When the layout omits the block the framework still renders the layout, but the body has no explicit slot.
+   Add ``{% block template %}{% endblock template %}`` to the innermost ``layout.djx`` that wraps the page.
+   An ancestor layout that omits the block still wraps its descendants because the framework folds the inner layout into a ``{% block template %}`` block on the way out.
+   The placeholder is mandatory only in the innermost layout that should host the page body.
 
 ``DUrl`` resolves to ``None`` when the captured segment is missing.
-   ``DUrl[T]`` reads the segment whose name matches the parameter and coerces to ``T`` for ``int``, ``bool``, and ``float`` as described in :doc:`/content/topics/dependency-injection`.
-   ``DUrl["name"]`` returns the raw string for that segment.
+   ``DUrl[T]`` reads the segment whose name matches the parameter and coerces the value to ``T``.
+   The supported types are documented in :doc:`/content/topics/dependency-injection`.
+   ``DUrl["name"]`` returns the captured segment in string form.
    When the Python parameter name differs from the segment, use ``DUrl["id", int]`` for an ``[id]`` directory.
 
 Inherited context not available in a descendant.

--- a/docs/content/intro/tutorial03.rst
+++ b/docs/content/intro/tutorial03.rst
@@ -14,7 +14,6 @@ Prerequisites
 You have finished :doc:`tutorial02`.
 The root layout publishes ``site_name``, ``tagline``, and ``note_count``.
 The detail page at ``/notes/<id>/`` renders one note from the URL.
-:doc:`tutorial04` adds form actions on top of this component-driven UI.
 
 Walkthrough
 -----------

--- a/docs/content/intro/tutorial04.rst
+++ b/docs/content/intro/tutorial04.rst
@@ -7,7 +7,7 @@ Goal
 ----
 
 This part wires create, edit, and delete flows for notes through the form and action subsystem.
-By the end the index has a create form, each detail page has edit and delete buttons, and every submission lands in a typed handler that the framework dispatches automatically.
+By the end the index has a create form, each detail page has edit and delete buttons, and every submission lands in a typed action handler that the framework dispatches automatically.
 
 Prerequisites
 -------------
@@ -43,12 +43,13 @@ Create ``notes/forms.py``.
 ``next.forms.ModelForm`` and ``next.forms.Form`` are the framework form base classes.
 They participate in :doc:`form dispatch </content/topics/forms/index>`.
 A plain Django ``Form`` or ``ModelForm`` cannot be passed to ``@action`` because the dispatch pipeline expects the framework base class.
-``next.forms`` also re-exports every Django form field and widget, so ``BooleanField`` and the rest are importable from one place.
+``next.forms`` re-exports the common Django form fields and widgets used in this tutorial, so ``BooleanField`` and the rest are importable from one place.
+Import other fields directly from :mod:`django.forms` when you need them.
 
 Register the Create Action
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-An ``@action`` handler registers when its module is imported.
+An ``@action`` action handler registers when its module is imported.
 Placing it in the page's ``page.py`` means the file router imports it on the first request, so the natural home is next to the page that exposes the form.
 Update ``notes/pages/page.py``.
 
@@ -215,11 +216,12 @@ Extend the detail template.
      </p>
    </article>
 
-The two hidden inputs in this form come from different places.
+The rendered form carries several hidden inputs from different sources.
 ``confirm`` is a real field on ``DeleteNoteForm``, so the template posts it explicitly.
-``_url_param_id`` carries the captured URL ``id``, and the ``{% form %}`` tag emits it automatically for every captured URL parameter.
-That hidden field lets the handler resolve ``DUrl["id", int]`` without any extra argument on the tag.
-Add the handler to the detail page.
+The ``{% form %}`` tag emits four framework fields automatically.
+``csrfmiddlewaretoken`` carries the CSRF token, ``_next_form_page`` identifies the origin page, ``_next_form_origin`` records the request path, and ``_url_param_id`` echoes the captured URL ``id``.
+The ``_url_param_id`` field lets the action handler resolve ``DUrl["id", int]`` without any extra argument on the tag.
+Add the action handler to the detail page.
 
 .. code-block:: python
    :caption: notes/pages/notes/[id]/page.py
@@ -248,7 +250,8 @@ How Re-render Works
 ~~~~~~~~~~~~~~~~~~~
 
 A failing validation re-renders the origin page rather than producing an error page.
-The re-render keeps the request scoped DI cache, so it reuses the values the page already computed for this request.
+The framework keeps a per-request cache that memoises ``Depends("name")`` callables across the initial render and any subsequent re-render in the same request, and the re-render reads from it instead of recomputing.
+See :doc:`/content/topics/dependency-injection` for the full cache model.
 It runs the same context functions, so the surrounding page content stays consistent.
 See :doc:`/content/topics/forms/validation-rerender` for the full re-render contract.
 
@@ -287,7 +290,7 @@ The Notes application is functionally complete.
              template.djx
 
 Users can create, view, edit, and delete notes.
-Every action goes through a typed handler that receives the validated form and any DI markers it asks for.
+Every action goes through a typed action handler that receives the validated form and any DI markers it asks for.
 
 Common Pitfalls
 ---------------

--- a/docs/content/intro/tutorial04.rst
+++ b/docs/content/intro/tutorial04.rst
@@ -52,6 +52,7 @@ Register the Create Action
 An ``@action`` action handler registers when its module is imported.
 Placing it in the page's ``page.py`` means the file router imports it on the first request, so the natural home is next to the page that exposes the form.
 Update ``notes/pages/page.py``.
+The ``inherit_context=True`` flag on the three layout-scope callables stays from :doc:`tutorial02` so each value still reaches every descendant page.
 
 .. code-block:: python
    :caption: notes/pages/page.py
@@ -218,7 +219,7 @@ Extend the detail template.
 
 The rendered form carries several hidden inputs from different sources.
 ``confirm`` is a real field on ``DeleteNoteForm``, so the template posts it explicitly.
-The ``{% form %}`` tag emits four framework fields automatically.
+The ``{% form %}`` tag emits the framework fields shown below.
 ``csrfmiddlewaretoken`` carries the CSRF token, ``_next_form_page`` identifies the origin page, ``_next_form_origin`` records the request path, and ``_url_param_id`` echoes the captured URL ``id``.
 The ``_url_param_id`` field lets the action handler resolve ``DUrl["id", int]`` without any extra argument on the tag.
 Add the action handler to the detail page.

--- a/docs/content/intro/tutorial05.rst
+++ b/docs/content/intro/tutorial05.rst
@@ -214,8 +214,9 @@ Open ``http://127.0.0.1:8000/about/`` and confirm that the new page is served wi
 
 .. note::
 
-   The autoreloader emits a ``router_reloaded`` signal each time the route set changes.
-   See :doc:`/content/howto/observe-framework-signals` for how to listen for it.
+   The framework emits ``action_dispatched`` after a successful handler run, recorded above through ``SignalRecorder``.
+   The autoreloader emits a companion ``router_reloaded`` signal each time the route set changes, so a test that wants to react to filesystem-driven route changes can subscribe to it the same way.
+   See :doc:`/content/howto/observe-framework-signals` for the full subscriber pattern.
 
 Checkpoint
 ----------
@@ -260,3 +261,4 @@ The tutorial is complete.
    :doc:`whatsnext` lists where to go next, by topic.
    :doc:`/content/topics/testing` covers the full testing surface.
    :doc:`/content/internals/autoreload` explains how the reloader watches the filesystem.
+   :doc:`/content/deployment/index` covers production setup once the application is feature complete.

--- a/docs/content/intro/whatsnext.rst
+++ b/docs/content/intro/whatsnext.rst
@@ -53,6 +53,6 @@ Multi-Tenant or Multi-Project Setup
 Community
 ---------
 
-Source code lives in the :repo:`next.dj repository <>`.
+Source code lives in the :repo:`next.dj repository`.
 File an issue or open a discussion when something is unclear.
 Contributions to the documentation are welcome, see :doc:`/content/contributing/index`.

--- a/docs/content/intro/whatsnext.rst
+++ b/docs/content/intro/whatsnext.rst
@@ -53,6 +53,9 @@ Multi-Tenant or Multi-Project Setup
 Community
 ---------
 
-Source code lives in the :repo:`next.dj repository`.
+Source code lives in the `next.dj repository`_.
+
+.. _`next.dj repository`: https://github.com/next-dj/next-dj
+
 File an issue or open a discussion when something is unclear.
 Contributions to the documentation are welcome, see :doc:`/content/contributing/index`.

--- a/docs/content/misc/design-philosophy.rst
+++ b/docs/content/misc/design-philosophy.rst
@@ -13,7 +13,8 @@ For a practical description of what next.dj adds to Django, see :doc:`/content/i
 Stay Inside Django
 ------------------
 
-Ordinary Django concerns stay in place. See :ref:`intro-overview-django-unchanged` in :doc:`/content/intro/overview` for the split.
+Ordinary Django concerns stay in place.
+See :ref:`intro-overview-django-unchanged` in :doc:`/content/intro/overview` for the split.
 This page explains why routing, layouts, components, assets, and form dispatch sit on that base and what trade-offs follow.
 
 Filesystem as a Single Source of Truth

--- a/docs/content/misc/glossary.rst
+++ b/docs/content/misc/glossary.rst
@@ -76,6 +76,7 @@ Terms used throughout the next.dj documentation.
    manager
       The singleton orchestrator for one subsystem.
       Examples include ``page``, ``components_manager``, ``router_manager``, ``form_action_manager``.
+      ``page`` is the outlier without a ``_manager`` suffix because the rendering manager is exposed as a decorator-style facade rather than a named singleton.
 
    origin page
       The page that rendered a form.

--- a/docs/content/misc/glossary.rst
+++ b/docs/content/misc/glossary.rst
@@ -63,8 +63,7 @@ Terms used throughout the next.dj documentation.
 
    JS context policy
       Algorithm class that resolves duplicate serialised keys for ``window.Next.context``.
-      The built-in classes are ``FirstWinsPolicy``, ``LastWinsPolicy``, ``RaiseOnConflictPolicy``, and ``DeepMergePolicy``.
-      Selected through ``JS_CONTEXT_POLICY`` inside static backend ``OPTIONS``. See :doc:`/content/topics/static-assets/js-context`.
+      Selected through ``JS_CONTEXT_POLICY`` inside static backend ``OPTIONS``, see :doc:`/content/topics/static-assets/js-context`.
 
    NextScriptBuilder
       Constructs the ``next.min.js`` tag, preload link, and ``Next._init`` shell.

--- a/docs/content/ref/components.rst
+++ b/docs/content/ref/components.rst
@@ -146,17 +146,41 @@ Use it to test factory wiring.
 .. autoclass:: next.components.BoomBackend
    :members:
 
-The underscore-prefixed render helpers exported from this module (``_inject_component_context``, ``_merge_csrf_context``, ``_render_template_string``) are internal hooks.
+The underscore-prefixed render helpers exported from this module are internal hooks.
 Do not use them in application code.
+
+.. autofunction:: next.components._inject_component_context
+
+.. autofunction:: next.components._merge_csrf_context
+
+.. autofunction:: next.components._render_template_string
 
 Signals
 -------
 
-See :doc:`signals` and :doc:`/content/topics/signals` for the components signals (``component_registered``, ``components_registered``, ``component_backend_loaded``, ``component_rendered``).
+See :doc:`signals` and :doc:`/content/topics/signals` for the components signals.
 
-.. automodule:: next.components.signals
-   :members:
-   :no-index:
+The module ``next.components.signals`` exposes four ``django.dispatch.Signal`` instances.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 25 45
+
+   * - Signal
+     - Sender
+     - Payload
+   * - ``component_registered``
+     - ``ComponentRegistry``
+     - ``info`` (``ComponentInfo``)
+   * - ``components_registered``
+     - ``ComponentRegistry``
+     - ``infos`` (tuple of ``ComponentInfo``)
+   * - ``component_backend_loaded``
+     - ``ComponentsManager``
+     - ``backend`` (``ComponentsBackend``), ``config`` (mapping)
+   * - ``component_rendered``
+     - ``ComponentsManager``
+     - ``info`` (``ComponentInfo``), ``template_path`` (``Path`` or ``None``)
 
 The package ``__init__`` re-exports ``next_framework_settings`` from :doc:`/content/ref/conf` as a convenience for backend code that reads ``LAZY_COMPONENT_MODULES``.
 

--- a/docs/content/ref/conf.rst
+++ b/docs/content/ref/conf.rst
@@ -33,8 +33,13 @@ Helpers
 Import Utilities
 ~~~~~~~~~~~~~~~~
 
-.. automodule:: next.conf.imports
-   :members:
+.. autofunction:: next.conf.imports.import_class_cached
+
+.. autofunction:: next.conf.imports.perform_import
+
+.. autofunction:: next.conf.imports.clear_import_cache
+
+.. autodata:: next.conf.imports.IMPORT_STRINGS
 
 Signals
 -------

--- a/docs/content/ref/decorators.rst
+++ b/docs/content/ref/decorators.rst
@@ -23,7 +23,10 @@ The first positional argument is ``func_or_key``.
 Called bare as ``@context`` it receives the decorated function and merges its returned dict into the template context.
 Called as ``@context("greeting")`` it receives a key string and binds the function's return value to that key.
 Pass ``inherit_context=True`` to publish the value to every descendant page.
-Pass ``serialize=True`` to expose the return value to the browser under ``window.Next.context``, and ``serializer=`` to route that key through a custom ``JsContextSerializer``.
+Pass ``serialize=True`` to expose the return value to the browser under ``window.Next.context``.
+The value must be JSON-encodable by the active serializer.
+See :ref:`Serialization for the Browser <topics-context-serialization>` for the contract.
+Pass ``serializer=`` to route that key through a custom ``JsContextSerializer``.
 
 @component.context
 ~~~~~~~~~~~~~~~~~~
@@ -35,7 +38,9 @@ Registers a component context function inside ``component.py``.
 The first positional argument is ``func_or_key``.
 Called bare as ``@component.context`` it merges the function's returned dict into the component template scope.
 Called as ``@component.context("greeting")`` it binds the function's return value to that key.
-Pass ``serialize=True`` to include the return value in ``window.Next.context``, and ``serializer=`` to route that key through a custom ``JsContextSerializer``.
+Pass ``serialize=True`` to include the return value in ``window.Next.context``.
+The value must be JSON-encodable by the active serializer, the same contract documented under :ref:`Serialization for the Browser <topics-context-serialization>`.
+Pass ``serializer=`` to route that key through a custom ``JsContextSerializer``.
 
 @action
 ~~~~~~~
@@ -75,8 +80,9 @@ DUrl
 
 Type annotation that injects the captured URL parameter with the matching name.
 Pass a generic argument to coerce the value to a type.
-The named form ``DUrl["key"]`` targets a segment by name and applies no coercion.
+The named form ``DUrl["key"]`` targets a segment by name and delivers it in string form, without extra type coercion.
 The named-and-typed form ``DUrl["key", Type]`` targets a segment by name and coerces the value to ``Type``.
+See :doc:`/content/topics/dependency-injection` for the supported coercion types.
 
 DQuery
 ~~~~~~
@@ -85,7 +91,7 @@ DQuery
    :no-index:
 
 Type annotation that injects a query string value.
-Supports ``DQuery[str]``, ``DQuery[int]``, ``DQuery[bool]``, ``DQuery[float]``, and ``DQuery[list[T]]``.
+Supports ``DQuery[str]``, ``DQuery[int]``, ``DQuery[bool]``, ``DQuery[float]``, ``DQuery[UUID]``, ``DQuery[Decimal]``, ``DQuery[date]``, ``DQuery[datetime]``, and ``DQuery[list[T]]`` for any of those scalars.
 
 DForm
 ~~~~~

--- a/docs/content/ref/decorators.rst
+++ b/docs/content/ref/decorators.rst
@@ -15,8 +15,7 @@ Decorators
 @context
 ~~~~~~~~
 
-.. autofunction:: next.pages.context
-   :no-index:
+.. py:decorator:: @context(func_or_key=None, *, inherit_context=False, serialize=False, serializer=None)
 
 Registers a context function on a page module (``page.py``).
 The first positional argument is ``func_or_key``.
@@ -31,8 +30,7 @@ Pass ``serializer=`` to route that key through a custom ``JsContextSerializer``.
 @component.context
 ~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: next.components.context
-   :no-index:
+.. py:decorator:: @component.context(func_or_key=None, *, serialize=False, serializer=None)
 
 Registers a component context function inside ``component.py``.
 The first positional argument is ``func_or_key``.
@@ -45,11 +43,12 @@ Pass ``serializer=`` to route that key through a custom ``JsContextSerializer``.
 @action
 ~~~~~~~
 
-.. autofunction:: next.forms.action
-   :no-index:
+.. py:decorator:: @action(name, *, form_class=None, namespace=None)
 
-Registers a form action handler.
-Pass ``form_class=`` for forms that need validation, ``namespace=`` to scope short names.
+Registers a form action handler under ``name``.
+``name`` is the first positional argument and must be unique across the project.
+Pass ``form_class=`` for forms that need validation.
+Pass ``namespace=`` to scope short names, which prefixes the stored key with ``"<namespace>:"``.
 
 Dependency Markers
 ------------------
@@ -91,7 +90,8 @@ DQuery
    :no-index:
 
 Type annotation that injects a query string value.
-Supports ``DQuery[str]``, ``DQuery[int]``, ``DQuery[bool]``, ``DQuery[float]``, ``DQuery[UUID]``, ``DQuery[Decimal]``, ``DQuery[date]``, ``DQuery[datetime]``, and ``DQuery[list[T]]`` for any of those scalars.
+Supports ``DQuery[str]``, ``DQuery[int]``, ``DQuery[bool]``, ``DQuery[float]``, ``DQuery[UUID]``, ``DQuery[Decimal]``, ``DQuery[date]``, and ``DQuery[datetime]``.
+``DQuery[list[T]]`` accepts any of those scalars as the element type.
 
 DForm
 ~~~~~

--- a/docs/content/ref/deps.rst
+++ b/docs/content/ref/deps.rst
@@ -36,8 +36,8 @@ Subclasses join the resolver's registry through ``__init_subclass__``, so the re
 
 .. note::
 
-   ``ProviderRegistry`` is an internal list-style helper kept for test scaffolding and possible external consumers.
-   It is absent from ``next.deps.__all__``, and the framework itself does not use it.
+   ``ProviderRegistry`` is internal.
+   It is absent from ``next.deps.__all__`` and carries no compatibility promise.
 
 Markers
 ~~~~~~~

--- a/docs/content/ref/deps.rst
+++ b/docs/content/ref/deps.rst
@@ -59,6 +59,8 @@ Context
 
 ``RESERVED_KEYS`` lists the names (``request``, ``form``, ``_cache``, ``_stack``, ``_context_data``) stripped from name-based resolution.
 A context key cannot shadow a reserved resolver input.
+``DependencyResolver.EXPLICIT_RESOLVE_KEYS`` is the class-level alias of the same frozenset.
+Subclasses override it to broaden or narrow the stripped names, and the resolver reads ``self.EXPLICIT_RESOLVE_KEYS`` rather than the module constant during dispatch.
 See :doc:`/content/internals/di-resolver` for the resolution detail.
 
 Signals

--- a/docs/content/ref/forms.rst
+++ b/docs/content/ref/forms.rst
@@ -6,7 +6,7 @@ Forms Reference
 Module Summary
 --------------
 
-``next.forms`` exposes form action registration, dispatch, formset helpers, frozen field and form specs, and a complete re-export of every Django form field and widget.
+``next.forms`` exposes form action registration, dispatch, formset helpers, frozen field and form specs, and a curated set of commonly used Django form fields and widgets.
 It also re-exports ``page`` from ``next.pages`` so that a single ``from next.forms import action, page`` covers the two most common decorators in a ``page.py``.
 
 API Tiers
@@ -23,12 +23,12 @@ Stable.
 Advanced.
    ``FormProvider``, ``FormActionBackend``, ``FormActionFactory``, ``RegistryFormActionBackend``, ``FormActionDispatch``, ``FormActionOptions``, ``ActionMeta``, ``build_form_namespace_for_action``, the frozen specs (``FieldSpec``, ``FormsetSpec``, ``FormSpec``, ``FormSectionSpec``, ``FormsetRowSpec``, ``FieldKind``), the spec helpers (``field_spec``, ``form_spec``, ``formset_spec``), the formset helper ``cleanup_extra_initial``, and the ``signals`` and ``checks`` submodules.
    Use these when writing a custom backend or a form renderer.
-   ``FormProvider`` is the DI provider the framework auto-registers to resolve the bound ``form`` parameter, so application code never instantiates it.
+   ``FormProvider`` auto-registers through the ``__init_subclass__`` hook on ``RegisteredParameterProvider`` and resolves the bound ``form`` parameter, so application code never instantiates it.
 
 Internal hooks.
    Symbols with a leading underscore are implementation details re-exported for testing and advanced backend authoring.
-   The complete list lives in ``next.forms.__all__``: ``_bind_form_for_post``, ``_filter_reserved_url_kwargs``, ``_form_action_context_callable``, ``_form_from_initial_data``, ``_get_caller_path``, ``_make_uid``, ``_normalize_handler_response``, ``_url_kwargs_from_post``, and ``_url_kwargs_from_resolver_or_post``.
-   Do not import them in application code.
+   The full set lives in ``next.forms.__all__``, which is the source of truth for the internal hook surface.
+   Do not import these names in application code.
 
 .. note::
 
@@ -62,7 +62,8 @@ Form Base Classes
 Fields and Widgets
 ~~~~~~~~~~~~~~~~~~
 
-The framework re-exports the full Django field and widget catalog through ``next.forms`` so a single import covers a form definition.
+The framework re-exports a curated set of commonly used Django form fields and widgets through ``next.forms`` so a single import covers most form definitions.
+Import any other Django field or widget directly from ``django.forms``.
 
 .. automodule:: next.forms.base
    :members:

--- a/docs/content/ref/forms.rst
+++ b/docs/content/ref/forms.rst
@@ -17,11 +17,11 @@ The lists below are representative.
 The autodoc blocks under `Public API`_ are the exhaustive surface.
 
 Stable.
-   ``@action``, ``page``, ``Form``, ``ModelForm``, ``BaseForm``, ``BaseModelForm``, ``DForm``, ``FormActionManager``, ``form_action_manager``, and the UID helpers (``FORM_ACTION_REVERSE_NAME``, ``URL_NAME_FORM_ACTION``, ``redirect_to_origin``, ``validated_next_form_page_path``).
+   ``@action``, ``page``, ``Form``, ``ModelForm``, ``BaseForm``, ``BaseModelForm``, ``DForm``, ``FormActionManager``, ``form_action_manager``, and the UID helpers (``FORM_ACTION_REVERSE_NAME``, ``URL_NAME_FORM_ACTION``, ``redirect_to_origin``).
    Use these in application code.
 
 Advanced.
-   ``FormProvider``, ``FormActionBackend``, ``FormActionFactory``, ``RegistryFormActionBackend``, ``FormActionDispatch``, ``FormActionOptions``, ``ActionMeta``, ``build_form_namespace_for_action``, the frozen specs (``FieldSpec``, ``FormsetSpec``, ``FormSpec``, ``FormSectionSpec``, ``FormsetRowSpec``, ``FieldKind``), the spec helpers (``field_spec``, ``form_spec``, ``formset_spec``), the formset helper ``cleanup_extra_initial``, and the ``signals`` and ``checks`` submodules.
+   ``FormProvider``, ``FormActionBackend``, ``FormActionFactory``, ``RegistryFormActionBackend``, ``FormActionDispatch``, ``FormActionOptions``, ``ActionMeta``, ``build_form_namespace_for_action``, ``validated_next_form_page_path``, the frozen specs (``FieldSpec``, ``FormsetSpec``, ``FormSpec``, ``FormSectionSpec``, ``FormsetRowSpec``, ``FieldKind``), the spec helpers (``field_spec``, ``form_spec``, ``formset_spec``), the formset helper ``cleanup_extra_initial``, and the ``signals`` and ``checks`` submodules.
    Use these when writing a custom backend or a form renderer.
    ``FormProvider`` auto-registers through the ``__init_subclass__`` hook on ``RegisteredParameterProvider`` and resolves the bound ``form`` parameter, so application code never instantiates it.
 
@@ -29,12 +29,6 @@ Internal hooks.
    Symbols with a leading underscore are implementation details re-exported for testing and advanced backend authoring.
    The full set lives in ``next.forms.__all__``, which is the source of truth for the internal hook surface.
    Do not import these names in application code.
-
-.. note::
-
-   ``next.forms.__all__`` includes the underscore-prefixed internal hooks so that test helpers and custom backends can reach them through a documented path.
-   Application code should import only from the Stable tier.
-   The same tier vocabulary is summarised for every package in :doc:`/content/faq/general`.
 
 Public API
 ----------

--- a/docs/content/ref/server.rst
+++ b/docs/content/ref/server.rst
@@ -24,11 +24,17 @@ They are re-read on render with mtime-based invalidation.
 Watcher
 ~~~~~~~
 
-``FilesystemWatchContributor`` is a runtime-checkable protocol for objects that yield ``(root, glob)`` pairs through ``iter_watch_specs``. Each pair is a filesystem root and a glob pattern relative to that root, both consumed by ``StatReloader.watch_dir``. The watcher collects contributor specs through ``iter_all_autoreload_watch_specs`` and feeds the deduplicated list to the reloader.
+``register_autoreload_watch_spec(path, glob)`` registers one extra directory and glob pair with the watcher.
+Call it from your own ``AppConfig.ready`` to have additional trees watched without changing the ``next`` package.
+The built-in specs for pages and filesystem components are derived from ``NEXT_FRAMEWORK`` and need no registration.
 
-``register_autoreload_watch_spec(path, glob)`` registers one extra directory and glob pair with the watcher. Call it from your own ``AppConfig.ready`` to have additional trees watched without changing the ``next`` package. The built-in specs for pages and filesystem components are derived from ``NEXT_FRAMEWORK`` and need no registration.
+``iter_all_autoreload_watch_specs`` returns the deduplicated list of built-in watch specs together with every pair registered through ``register_autoreload_watch_spec``.
+Each entry is a ``(path, glob)`` tuple consumed by ``StatReloader.watch_dir``.
+The function emits the ``watch_specs_ready`` signal on every call so subscribers can inspect the resolved set.
 
-``iter_all_autoreload_watch_specs`` resolves the complete spec set, the built-in roots plus every registered extra spec, and emits the ``watch_specs_ready`` signal so subscribers can inspect or augment the result.
+``FilesystemWatchContributor`` is a runtime-checkable protocol declaring a single ``iter_watch_specs()`` method.
+It is exported for type annotations only.
+The watcher does not iterate contributors at runtime, so registration goes through ``register_autoreload_watch_spec``.
 
 .. automodule:: next.server.watcher
    :members:

--- a/docs/content/ref/settings.rst
+++ b/docs/content/ref/settings.rst
@@ -15,7 +15,7 @@ Backends
 --------
 
 DEFAULT_PAGE_BACKENDS
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 List of page backend configurations.
 

--- a/docs/content/ref/settings.rst
+++ b/docs/content/ref/settings.rst
@@ -38,7 +38,8 @@ Keys are ``BACKEND``, ``DIRS``, ``APP_DIRS``, ``PAGES_DIR``, and ``OPTIONS``.
 
 ``DIRS`` accepts two kinds of entry.
 An absolute or project-relative path that resolves to an existing directory is added as an extra page root.
-A plain string that does not resolve to a directory is treated as a skip name: the router will not enter any directory with that name during the file walk.
+A plain string that does not resolve to a directory is treated as a skip name.
+The router will not enter any directory with that name during the file walk.
 
 See :doc:`/content/topics/file-router` for the full semantics including examples.
 
@@ -75,7 +76,8 @@ Default value.
        }
    ]
 
-The first static backend's ``OPTIONS`` dict accepts ``JS_CONTEXT_POLICY``, a dotted path to a conflict-resolution class the static manager applies when two context functions publish the same key for serialisation.
+The first static backend's ``OPTIONS`` dict accepts ``JS_CONTEXT_POLICY``, a dotted path to a conflict-resolution class.
+The static manager applies the policy when two context functions publish the same key for serialisation.
 See :doc:`/content/topics/static-assets/js-context` under *Key Conflict Policy* for the available policies and an example.
 
 The same ``OPTIONS`` dict accepts ``DEDUP_STRATEGY``, a dotted path to a dedup strategy class the collector instantiates once per request to drop assets several components register more than once.
@@ -108,6 +110,8 @@ Template used to compute URL names from directory paths.
 Default value ``"page_{name}"``.
 
 The framework normalises the path through the parser and substitutes ``{name}`` with the result.
+Slashes, square brackets, colons, hyphens, and underscores are collapsed to a single underscore, and the leading and trailing underscores are stripped.
+The directory path ``notes/[id]`` becomes ``notes_id`` and produces the URL name ``page_notes_id``.
 
 Templates
 ---------
@@ -131,7 +135,8 @@ JavaScript Context
 NEXT_JS_OPTIONS
 ~~~~~~~~~~~~~~~~~
 
-Dict passed to ``NextScriptBuilder.from_options`` for the bundled ``next.min.js`` runtime: injection ``policy`` (``auto``, ``disabled``, or ``manual``), and optional string templates ``preload_template``, ``script_tag_template``, and ``init_template``.
+Dict passed to ``NextScriptBuilder.from_options`` for the bundled ``next.min.js`` runtime.
+Keys are the injection ``policy`` (``auto``, ``disabled``, or ``manual``) and the optional string templates ``preload_template``, ``script_tag_template``, and ``init_template``.
 
 Default value ``{}`` (automatic injection with default templates).
 
@@ -158,7 +163,8 @@ Strictness
 STRICT_CONTEXT
 ~~~~~~~~~~~~~~
 
-When ``True``, any exception raised by a Django context processor (``TypeError``, ``ValueError``, ``AttributeError``, or ``KeyError``) is re-raised immediately instead of being logged as a warning and swallowed.
+When ``True``, any ``TypeError``, ``ValueError``, ``AttributeError``, or ``KeyError`` raised by a Django context processor is re-raised immediately.
+The default behaviour is to log a warning and swallow the exception.
 The check applies only to processors listed under a page backend ``OPTIONS["context_processors"]``.
 Context callables registered with ``@context`` always propagate their exceptions regardless of this setting.
 When ``False``, the default, a failing processor is skipped so local development keeps rendering.
@@ -169,17 +175,12 @@ Default value ``False``.
 LAZY_COMPONENT_MODULES
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-When ``False``, the default, ``next.apps.components.install`` imports every ``component.py`` found in configured component roots so ``@component.context`` and ``@action`` decorators run before the first HTTP request.
-
-When ``True``, that bulk import is skipped.
-Each ``component.py`` discovered through a configured root is imported the first time ``get_component`` resolves that component.
-
-Components discovered through ``_components`` directories beside page files are unaffected.
-The file router imports those modules as it walks the page tree, regardless of this flag.
+Controls bulk import of ``component.py`` modules in configured component roots during ``next.apps.components.install``.
+When ``True``, each ``component.py`` is imported on demand the first time ``get_component`` resolves it.
+Components discovered through ``_components`` directories beside page files are imported by the file router as it walks the page tree, regardless of this flag.
 
 Default value ``False``.
-See :doc:`/content/deployment/settings` for production defaults.
-For tests, ``eager_load_components`` imports every registered ``component.py`` even when this flag is ``True``. See :doc:`/content/topics/testing`.
+See :doc:`/content/deployment/settings` for production defaults and :doc:`/content/topics/testing` for the ``eager_load_components`` helper.
 
 Patching Defaults
 -----------------
@@ -201,6 +202,9 @@ Use ``next.conf.extend_default_backend`` to patch one key of a default backend e
 The helper returns a deep copy of the default list with the entry at ``index`` (default ``0``) patched by the keyword overrides.
 Nested dicts such as ``OPTIONS`` are merged.
 
+The helper raises ``ImproperlyConfigured`` when ``key`` is not a known backend-list setting.
+It raises ``IndexError`` when ``index`` is out of range for the default list.
+
 See :doc:`conf` for the helper API and :doc:`/content/howto/extend-a-default-backend` for the recipe.
 
 See Also
@@ -210,4 +214,5 @@ See Also
 
    :doc:`/content/topics/extending` for the broader picture.
    :doc:`/content/deployment/settings` for production tuned values.
-   :doc:`/content/topics/static-assets/js-context` for ``NEXT_JS_OPTIONS`` and ``ScriptInjectionPolicy``.
+   :doc:`/content/topics/static-assets/js-context` for ``NEXT_JS_OPTIONS``.
+   :class:`next.static.scripts.ScriptInjectionPolicy` for the policy enum.

--- a/docs/content/ref/signals.rst
+++ b/docs/content/ref/signals.rst
@@ -27,7 +27,10 @@ fire for that sender.
    * - ``action_dispatched``
      - ``FormActionDispatch``
      - ``action_name``, ``form``, ``url_kwargs``, ``duration_ms``, ``response_status``, ``dep_cache``
-     - After an action handler runs and the response is coerced. ``form`` is the bound form, or ``None`` for handler-only actions. ``duration_ms`` times the handler call. ``dep_cache`` is a copy of the dispatch dependency-injection cache.
+     - After an action handler runs and the response is coerced.
+       ``form`` is the bound form, or ``None`` for handler-only actions.
+       ``duration_ms`` times the handler call.
+       ``dep_cache`` is a copy of the dispatch dependency-injection cache.
    * - ``action_registered``
      - Form action backend class
      - ``action_name``, ``uid``, ``form_class``, ``namespace``, ``handler``
@@ -101,17 +104,10 @@ fire for that sender.
      - ``specs``
      - After the reloader resolves the full list of watch specs.
 
-Aggregated Signals
-------------------
-
-.. automodule:: next.signals
-   :members:
-   :imported-members:
-
 Subpackage Signals
 ------------------
 
-The aggregator forwards from these modules.
+The aggregator ``next.signals`` forwards from the modules below.
 
 Pages
 ~~~~~

--- a/docs/content/ref/static.rst
+++ b/docs/content/ref/static.rst
@@ -58,8 +58,6 @@ See :doc:`/content/topics/static-assets/js-context` for the runtime script optio
 JS Context Serializer
 ~~~~~~~~~~~~~~~~~~~~~
 
-See :doc:`/content/topics/static-assets/js-context` for how the serializer is chosen and configured.
-
 .. automodule:: next.static.serializers
    :members:
 

--- a/docs/content/ref/static.rst
+++ b/docs/content/ref/static.rst
@@ -77,7 +77,7 @@ Staticfiles Finder
 
 ``NextStaticFilesFinder`` is the Django staticfiles finder for co-located assets.
 It maps assets such as ``template.css``, ``layout.js``, ``component.css``, and any registered stems to their source files under the ``next/`` staticfiles namespace.
-It surfaces every such asset to ``collectstatic`` and to ``{% static "next/..." %}`` lookups during development.
+It surfaces every such asset to ``collectstatic`` for production output and to ``{% static "next/..." %}`` lookups when ``DEBUG`` is true and the staticfiles app serves files itself.
 The mapping is rebuilt on each lookup so assets added at runtime are picked up.
 
 The finder is appended to ``STATICFILES_FINDERS`` automatically by ``NextFrameworkConfig.ready`` through ``next.apps.staticfiles.install``.

--- a/docs/content/ref/urls.rst
+++ b/docs/content/ref/urls.rst
@@ -40,6 +40,11 @@ Parser
 Dispatcher
 ~~~~~~~~~~
 
+.. admonition:: Deep import path
+
+   The names in ``next.urls.dispatcher`` are not re-exported from ``next.urls``.
+   Import them through the submodule path when a custom backend or test needs to call them directly.
+
 .. automodule:: next.urls.dispatcher
    :members:
 
@@ -79,6 +84,10 @@ They are exported from ``next.urls`` for introspection and for authors writing c
 
 See :doc:`/content/internals/di-resolver` for the full provider registration sequence and the resolution order.
 
+``DUrl`` and ``DQuery`` both accept ``str``, ``int``, ``bool``, ``float``, ``UUID``, ``Decimal``, ``date``, and ``datetime``.
+``DQuery`` additionally accepts ``list[T]`` for any of those scalars.
+See :doc:`/content/topics/dependency-injection` and :doc:`/content/topics/file-router` for the full coercion reference.
+
 Signals
 -------
 
@@ -92,6 +101,24 @@ The URL subsystem fires two signals.
    The sender is the ``RouterManager`` class.
 
 See :doc:`signals` and :doc:`/content/topics/signals` for the wider signal catalog.
+
+Checks
+------
+
+``next.urls.checks`` registers Django system checks that validate the URL configuration at startup.
+
+``check_next_pages_configuration``.
+   Validates the ``NEXT_FRAMEWORK['DEFAULT_PAGE_BACKENDS']`` structure, the ``BACKEND`` path, and per-backend ``DIRS``/``APP_DIRS``/``PAGES_DIR``/``OPTIONS`` keys.
+
+``check_duplicate_url_parameters``.
+   Fails with :ref:`next.E028 <ref-system-checks>` when one route repeats a captured parameter name.
+
+``check_url_patterns``.
+   Fails with :ref:`next.E015 <ref-system-checks>` when two file routes resolve to the same Django path string.
+
+.. automodule:: next.urls.checks
+   :members:
+   :no-index:
 
 See Also
 --------

--- a/docs/content/ref/urls.rst
+++ b/docs/content/ref/urls.rst
@@ -24,8 +24,9 @@ Backends
 Manager
 ~~~~~~~
 
-``urlpatterns`` is a ``list`` subclass that rebuilds the router and form-action patterns on each access.
-A route added after import is therefore visible without a process restart.
+``urlpatterns`` is a ``list`` subclass that recollects router and form-action patterns from the active backends on each access.
+The backends themselves are cached by ``router_manager`` and are only rebuilt when ``router_manager.reload()`` runs or when ``DEFAULT_PAGE_BACKENDS`` changes.
+A route added after import is therefore visible without a process restart, but each access still iterates the cached backend list rather than walking the page tree again.
 ``RouterManager`` owns the active backend list, and the ``router_manager`` singleton exposes ``reload()`` to rebuild it.
 
 .. automodule:: next.urls.manager
@@ -86,7 +87,43 @@ See :doc:`/content/internals/di-resolver` for the full provider registration seq
 
 ``DUrl`` and ``DQuery`` both accept ``str``, ``int``, ``bool``, ``float``, ``UUID``, ``Decimal``, ``date``, and ``datetime``.
 ``DQuery`` additionally accepts ``list[T]`` for any of those scalars.
-See :doc:`/content/topics/dependency-injection` and :doc:`/content/topics/file-router` for the full coercion reference.
+
+The following table is the canonical coercion reference.
+A value that fails to parse falls back to the raw captured string rather than raising.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Annotation type
+     - Accepted wire values
+     - Result
+   * - ``str``
+     - Any captured string.
+     - Returned unchanged.
+   * - ``int``
+     - Decimal digit string.
+     - ``int(value)``.
+   * - ``float``
+     - Decimal float string.
+     - ``float(value)``.
+   * - ``bool``
+     - ``"1"``, ``"true"``, ``"yes"`` map to ``True``, anything else to ``False``.
+     - Boolean.
+   * - ``UUID``
+     - Canonical UUID string, or an already parsed :class:`~uuid.UUID`.
+     - :class:`~uuid.UUID` instance.
+   * - ``Decimal``
+     - Numeric string parseable by :class:`~decimal.Decimal`.
+     - :class:`~decimal.Decimal` instance.
+   * - ``date``
+     - ISO 8601 date accepted by :meth:`date.fromisoformat <datetime.date.fromisoformat>`.
+     - :class:`~datetime.date` instance.
+   * - ``datetime``
+     - ISO 8601 datetime accepted by :meth:`datetime.fromisoformat <datetime.datetime.fromisoformat>`.
+     - :class:`~datetime.datetime` instance.
+
+See :doc:`/content/topics/dependency-injection` and :doc:`/content/topics/file-router` for the narrative coverage of each marker.
 
 Signals
 -------

--- a/docs/content/ref/utils.rst
+++ b/docs/content/ref/utils.rst
@@ -7,7 +7,8 @@ Module Summary
 --------------
 
 ``next.utils`` exposes two helpers that project code can import: ``resolve_base_dir`` and ``classify_dirs_entries``.
-``caller_source_path`` is a registration-internal frame helper the framework uses to attribute a decorated callable to its defining file, documented here for contributors rather than for project use.
+The module also defines a registration-internal frame helper that the framework uses to attribute decorated callables to their defining file.
+That helper is not part of the public surface and is excluded from the autodoc table below.
 
 ``resolve_base_dir`` returns ``settings.BASE_DIR`` coerced to ``pathlib.Path``, or ``None`` when it is unset, for backends that resolve project-relative paths.
 ``classify_dirs_entries`` splits a backend ``DIRS`` list into existing directory roots and plain skip-name segments, the same split the file router applies.
@@ -17,7 +18,7 @@ Public API
 
 .. automodule:: next.utils
    :members:
-   :exclude-members: _classify_one_dir_entry
+   :exclude-members: _classify_one_dir_entry, caller_source_path
 
 See Also
 --------

--- a/docs/content/security/csrf-and-forms.rst
+++ b/docs/content/security/csrf-and-forms.rst
@@ -28,17 +28,17 @@ Origin Validation
 The framework adds a second hidden field named ``_next_form_page`` with the absolute path to the rendering page.
 The dispatcher validates the path before invoking the handler.
 
-Several checks apply.
+Two checks apply, and they fail in different ways.
 
-The posted path must resolve under ``settings.BASE_DIR``.
+The posted ``_next_form_page`` must resolve under ``settings.BASE_DIR``.
 It must name ``page.py`` (the framework stores the absolute path to that module).
 Either the file must exist, or the directory must contain a sibling ``template.djx`` so virtual routes can re-render after validation failures.
+A submission that fails this check returns HTTP 400 and the handler does not run.
 
 The hidden field ``_next_form_origin`` carries a same-site path that starts with ``/`` and not with ``//``.
-The ``{% form %}`` tag emits it on every render, and ``redirect_to_origin`` falls back to ``/`` when it is missing.
+The ``{% form %}`` tag emits it on every render.
+A missing or off-site value never blocks dispatch, ``redirect_to_origin`` simply falls back to ``/``.
 Handlers can call ``redirect_to_origin`` from ``next.forms`` to redirect back to the page that rendered the form.
-
-A submission that fails these checks returns HTTP 400 and the handler does not run.
 
 Manual Forms
 ------------
@@ -49,7 +49,7 @@ A hand crafted ``<form>`` element bypasses these guarantees, so prefer the tag.
 
 When a hand crafted form is unavoidable, render the tag once and copy the generated markup, or keep the form inside a ``{% form %}`` block and add only the extra fields you need.
 
-The ``current_page_module_path`` variable is published by the framework on every rendered page.
+The framework publishes the ``current_page_module_path`` variable on every rendered page, so a hand crafted form can read the origin path from the template context when no ``{% form %}`` block emits the hidden field.
 
 GET Forms
 ---------
@@ -97,7 +97,8 @@ The simplest way to obtain the origin path is to read the hidden ``_next_form_pa
 
 This works because every ``{% form %}`` block emits the ``_next_form_page`` hidden field.
 
-To post without a rendered form, re-publish the existing ``current_page_module_path`` value with ``@context("current_page_module_path", serialize=True)`` so it reaches ``window.Next.context``.
+To post without a rendered form, re-publish the existing value through a callable that resolves it from the page context.
+Declare a ``page.py`` callable annotated ``path: str = Context("current_page_module_path")`` and decorate it with ``@context("current_page_module_path", serialize=True)`` so the value reaches ``window.Next.context``.
 
 Cross Origin Requests
 ---------------------

--- a/docs/content/security/di-and-untrusted-input.rst
+++ b/docs/content/security/di-and-untrusted-input.rst
@@ -30,9 +30,9 @@ Never interpolate into queries.
 URL Parameters
 --------------
 
-``DUrl[int]`` coerces the captured value to ``int``.
-A value that fails coercion falls through as the raw string, so the page module still runs.
-Use a directory named with the typed segment form such as ``[int:id]`` to reject a non integer capture with ``404`` before the page module runs.
+``DUrl[T]`` coerces the captured value to ``T`` for ``int``, ``float``, ``bool``, ``UUID``, ``Decimal``, ``date``, and ``datetime``.
+A value that fails to parse falls through as the raw string, so the page module still runs.
+Use a directory named with the typed segment form such as ``[int:id]`` or ``[uuid:id]`` to reject a malformed capture with ``404`` before the page module runs.
 
 ``DUrl[str]`` accepts any non slash value.
 Always validate the string before passing it into ORM lookups or external services.
@@ -54,7 +54,8 @@ The ``is_public`` filter prevents an attacker from reading a private note by gue
 Query Strings
 -------------
 
-``DQuery[int]`` coerces or rejects.
+``DQuery[T]`` coerces the value to ``T`` for the same scalar set as ``DUrl``.
+A value that fails to parse falls back to the raw query string rather than raising, so a crafted input cannot crash the page module.
 ``DQuery[str]`` returns the raw string.
 ``DQuery[list[T]]`` returns a list of coerced values.
 

--- a/docs/content/security/di-and-untrusted-input.rst
+++ b/docs/content/security/di-and-untrusted-input.rst
@@ -113,6 +113,7 @@ The ``url_kwargs`` dict and ``request.GET`` are both untrusted.
 .. code-block:: python
    :caption: notes/providers.py
 
+   import re
    from typing import get_origin
    from django.http import Http404
    from next.deps import DDependencyBase, RegisteredParameterProvider
@@ -127,14 +128,15 @@ The ``url_kwargs`` dict and ``request.GET`` are both untrusted.
 
        def resolve(self, param, context):
            slug = str(context.url_kwargs["slug"])
-           if not slug.isalnum() or len(slug) > 50:
+           if not re.fullmatch(r"[a-zA-Z0-9-]{1,50}", slug):
                raise Http404
            try:
                return Link.objects.get(slug=slug)
            except Link.DoesNotExist:
                raise Http404 from None
 
-The explicit ``isalnum`` and length check make the validation visible to readers and to security audits.
+The explicit length and character check make the validation visible to readers and to security audits.
+The resolver does not wrap or swallow provider exceptions, so ``Http404`` raised here propagates unchanged through to Django's view layer.
 
 Redirects
 ---------

--- a/docs/content/topics/components.rst
+++ b/docs/content/topics/components.rst
@@ -14,11 +14,9 @@ This page covers the two component shapes, the rules for props and slots, how co
 Overview
 --------
 
-The default ``FileComponentsBackend`` registers components from page trees and from configured ``DIRS`` roots.
-The :ref:`components-folder-discovery` section below covers the discovery mechanism in full.
-
 Components compose freely.
 A page template can call a component, a component template can call another component, and a layout can call any component that is in scope.
+The :ref:`components-folder-discovery` section below covers how the default ``FileComponentsBackend`` finds them.
 
 Component Shapes
 ----------------
@@ -42,7 +40,7 @@ Composite components add Python logic when the template needs computed values th
 
    A composite component may supply its template body from Python instead of a ``component.djx`` file.
    When ``component.py`` exposes a module-level string named ``component`` and no ``component.djx`` file exists, the framework uses that string as the template body.
-   ``ComponentScanner`` registers the component and ``ComponentTemplateLoader.load`` reads the string.
+   ``ComponentScanner`` registers the component with ``template_path`` pointing at the ``component.py`` file itself, and ``ComponentTemplateLoader.load`` reads the ``component`` attribute from that module.
    A ``component.py`` with neither a ``render`` function nor a ``component`` string and no ``component.djx`` alongside it produces a component that renders nothing.
 
 .. code-block:: text
@@ -71,7 +69,8 @@ When the URL router walks the page trees it skips directories that match a confi
 The backend recognises three sources for components.
 
 App page trees.
-   As the URL router walks each page tree it calls ``register_components_folder_from_router_walk``, which pushes every ``COMPONENTS_DIR`` folder it finds into the ``FileComponentsBackend``.
+   As the URL router walks each page tree it calls ``register_components_folder_from_router_walk`` once per ``COMPONENTS_DIR`` folder it encounters.
+   The helper registers that folder into the first ``FileComponentsBackend`` and deduplicates by resolved path, so a folder seen twice is registered only once.
    A folder named ``COMPONENTS_DIR`` under that tree is a components root for the application.
 
    .. note::
@@ -82,6 +81,7 @@ App page trees.
 Project directories.
    The ``DIRS`` list adds absolute or project-relative roots that contribute global components.
    Components in these roots are visible from every template.
+   The scanner only inspects the immediate children of each root, so place every component folder or ``.djx`` file directly under the ``DIRS`` entry rather than in nested sub-folders.
 
 Custom backends.
    Additional entries in ``DEFAULT_COMPONENT_BACKENDS`` can serve components from any other source.
@@ -104,8 +104,8 @@ Custom backends.
        ]
    }
 
-Components Scope
-----------------
+Component Scope
+---------------
 
 Components are resolved through a scope tree.
 A template only sees components from its own branch of the tree plus any project-level roots in ``DIRS``.
@@ -138,7 +138,8 @@ Void Form
 ~~~~~~~~~
 
 The tag has no closing form when the component does not take slots.
-Single line, no children.
+The void form fits on one line and accepts no child markup.
+Use the block form covered under :ref:`components-multiline-tags` when the component renders slot content.
 
 .. code-block:: jinja
    :caption: void form
@@ -189,6 +190,7 @@ The framework enables ``re.DOTALL`` for Django's tag lexer at startup, so tag bo
 
    This changes template parsing for **every** template the process loads, not only DJX files.
    If you rely on Django's stock behaviour where a newline inside ``{% ... %}`` ends the tag, adjust those templates before adopting next.dj.
+   The patch is applied once at import time and is one-way, so the original Django pattern is not restored when the components template tag library is unloaded.
 
 .. code-block:: jinja
    :caption: multiline void tag
@@ -327,7 +329,7 @@ The framework resolves parameters from the surrounding template scope, from URL 
 
    Registration raises ``ValueError`` for a key reserved for dependency injection, such as ``request``.
    It also raises ``ValueError`` for a duplicate registration of two different functions under the same key, or of two different unkeyed callables, in one ``component.py``.
-   Re-registering the identical function is a no-op.
+   Re-registering the same function under the same key replaces the stored entry rather than raising.
 
 Pass ``serialize=True`` and optionally ``serializer=`` to include the return value in ``window.Next.context``.
 The behaviour is identical to ``@context`` on a page module, so the value must be JSON-encodable by the active serializer.
@@ -335,6 +337,7 @@ See :doc:`static-assets/js-context` for the serialization options and :ref:`Seri
 
 An unkeyed ``@component.context`` returning a dict serializes each key of that dict separately.
 A keyed ``@component.context`` serializes its return value under the given key.
+An unkeyed callable that returns anything other than a mapping is silently dropped from the template scope.
 
 Co-located Static Assets
 ------------------------
@@ -362,15 +365,18 @@ See :doc:`static-assets/deduplication` for the dedup rules.
 Module Loading
 --------------
 
-By default the framework imports every registered ``component.py`` during component backend setup.
-``import_all_component_modules`` walks the whole registry, not only the ``DIRS`` roots.
+By default the framework imports every ``component.py`` from each ``DIRS`` root during component backend setup.
+``import_all_component_modules`` walks the registry built from those roots.
 The bulk import runs the side effects of ``@component.context`` so they are visible from the first request.
 A ``component.py`` may also register a form action with ``@action``, which the same import makes visible.
 See :doc:`/content/topics/forms/actions` for the action decorator.
 
-The ``LAZY_COMPONENT_MODULES`` flag gates this eager bulk import.
-When the flag is set the framework skips it and imports a ``component.py`` on first resolve instead.
-Page-tree ``component.py`` modules are imported by the URL router as it walks the page trees, so they are available regardless of the flag.
+Page-tree ``component.py`` modules follow a different path.
+The URL router walks each page tree and ``register_components_folder_from_router_walk`` imports every ``component.py`` it registers inline.
+They are available regardless of ``LAZY_COMPONENT_MODULES``.
+
+The ``LAZY_COMPONENT_MODULES`` flag gates the ``DIRS`` bulk import only.
+When the flag is set the framework skips that step and imports a ``component.py`` on first resolve instead.
 See :ref:`ref-settings` for the exact behaviour.
 
 .. code-block:: python
@@ -380,7 +386,7 @@ See :ref:`ref-settings` for the exact behaviour.
        "LAZY_COMPONENT_MODULES": True,
    }
 
-The render Function
+The Render Function
 -------------------
 
 A composite component can define a ``render`` function in ``component.py`` that returns the component body as a string in place of the template.
@@ -391,8 +397,9 @@ Return an empty string to render nothing, which turns the component into a serve
 A ``render`` function takes over completely.
 The component template and ``@component.context`` callables do not run for that component.
 The function may return a string or an :class:`~django.http.HttpResponse`.
-When it returns an :class:`~django.http.HttpResponse`, only the decoded body is spliced into the page.
+When it returns an :class:`~django.http.HttpResponse`, the body is decoded as UTF-8 regardless of the response's ``Content-Type`` charset and spliced into the page.
 The response status code and headers are not propagated.
+Any other return value is coerced through ``str()`` before splicing.
 
 When ``component.py`` defines no ``render`` function, the component renders its template and runs every ``@component.context`` callable as usual.
 
@@ -425,10 +432,25 @@ Lifecycle Signals
 
 The framework emits four signals during the component lifecycle.
 
-- ``component_registered`` fires when an individual component enters the registry.
-- ``components_registered`` fires once after a bulk discovery, with a list of every component that registered during the cycle.
-- ``component_backend_loaded`` fires after a component backend is created from its config entry.
-- ``component_rendered`` fires after a component renders to HTML.
+.. list-table::
+   :header-rows: 1
+   :widths: 28 28 44
+
+   * - Name
+     - Sender
+     - Keyword arguments
+   * - ``component_registered``
+     - ``ComponentRegistry``
+     - ``info``
+   * - ``components_registered``
+     - ``ComponentRegistry``
+     - ``infos``
+   * - ``component_backend_loaded``
+     - ``ComponentsManager``
+     - ``backend``, ``config``
+   * - ``component_rendered``
+     - ``ComponentsManager``
+     - ``info``, ``template_path``
 
 See :doc:`/content/ref/signals` for the full signal catalog.
 

--- a/docs/content/topics/components.rst
+++ b/docs/content/topics/components.rst
@@ -73,7 +73,11 @@ The backend recognises three sources for components.
 App page trees.
    As the URL router walks each page tree it calls ``register_components_folder_from_router_walk``, which pushes every ``COMPONENTS_DIR`` folder it finds into the ``FileComponentsBackend``.
    A folder named ``COMPONENTS_DIR`` under that tree is a components root for the application.
-   When several ``FileComponentsBackend`` entries are configured, ``register_components_folder_from_router_walk`` registers app page-tree folders into the first one only.
+
+   .. note::
+
+      When several ``FileComponentsBackend`` entries are configured, ``register_components_folder_from_router_walk`` registers app page-tree folders into the first one only.
+      Configure additional ``FileComponentsBackend`` instances through ``DIRS`` so they pick up their own roots independently.
 
 Project directories.
    The ``DIRS`` list adds absolute or project-relative roots that contribute global components.
@@ -179,8 +183,12 @@ Multiline Tags
 ~~~~~~~~~~~~~~
 
 Both the void form and the block form accept line breaks inside the tag body, which is useful when a component takes many props.
-The framework enables ``re.DOTALL`` for Django's tag lexer at startup, so tag bodies wrap across lines in every template type, not only in component tags.
-See :ref:`ref-template-tags` under *Multiline tag bodies* for the global parsing caveat.
+The framework enables ``re.DOTALL`` for Django's tag lexer at startup, so tag bodies wrap across lines in every template type.
+
+.. caution::
+
+   This changes template parsing for **every** template the process loads, not only DJX files.
+   If you rely on Django's stock behaviour where a newline inside ``{% ... %}`` ends the tag, adjust those templates before adopting next.dj.
 
 .. code-block:: jinja
    :caption: multiline void tag
@@ -322,8 +330,8 @@ The framework resolves parameters from the surrounding template scope, from URL 
    Re-registering the identical function is a no-op.
 
 Pass ``serialize=True`` and optionally ``serializer=`` to include the return value in ``window.Next.context``.
-The behaviour is identical to ``@context`` on a page module.
-See :doc:`static-assets/js-context` for the serialization options.
+The behaviour is identical to ``@context`` on a page module, so the value must be JSON-encodable by the active serializer.
+See :doc:`static-assets/js-context` for the serialization options and :ref:`Serialization for the Browser <topics-context-serialization>` for the encodability contract.
 
 An unkeyed ``@component.context`` returning a dict serializes each key of that dict separately.
 A keyed ``@component.context`` serializes its return value under the given key.
@@ -372,6 +380,39 @@ See :ref:`ref-settings` for the exact behaviour.
        "LAZY_COMPONENT_MODULES": True,
    }
 
+The render Function
+-------------------
+
+A composite component can define a ``render`` function in ``component.py`` that returns the component body as a string in place of the template.
+The function receives DI-resolved parameters drawn from the surrounding template scope, including props and page context variables.
+The lazy ``csrf_token`` and any ``@component.context`` callables are not run on this path.
+Return an empty string to render nothing, which turns the component into a server side gate.
+
+A ``render`` function takes over completely.
+The component template and ``@component.context`` callables do not run for that component.
+The function may return a string or an :class:`~django.http.HttpResponse`.
+When it returns an :class:`~django.http.HttpResponse`, only the decoded body is spliced into the page.
+The response status code and headers are not propagated.
+
+When ``component.py`` defines no ``render`` function, the component renders its template and runs every ``@component.context`` callable as usual.
+
+.. code-block:: python
+   :caption: _components/feature_guard/component.py
+
+   def render(flag_enabled: bool = False) -> str:
+       if not flag_enabled:
+           return ""
+       return "<div class='feature'>New feature</div>"
+
+Invoke the guard from a page template and forward the flag from the surrounding context.
+
+.. code-block:: jinja
+   :caption: notes/pages/template.djx
+
+   {% component "feature_guard" flag_enabled=flags.new_ui %}
+
+See ``examples/feature-flags`` for a feature guard built this way.
+
 Hot Reload
 ----------
 
@@ -411,33 +452,6 @@ Three patterns build on the sections above.
 - Wrap arbitrary child markup with a block component that has a single ``content`` slot, as in cards, alerts, and dialogs.
 - Add a ``component.py`` when the template needs values computed from the surrounding context, see :doc:`/content/howto/build-a-composite-component`.
 - Ship a folder of reusable components under a ``DIRS`` root for a shared UI kit, see :doc:`multi-project` and :doc:`/content/misc/examples`.
-
-Conditional Rendering
-~~~~~~~~~~~~~~~~~~~~~
-
-A composite component can define a ``render`` function in ``component.py``.
-The function receives DI-resolved parameters and returns the component body as a string.
-A ``render`` function is resolved with the surrounding template scope (props and page context variables) available as DI parameters.
-The lazy ``csrf_token`` and any ``@component.context`` callables are not run on this path.
-Return an empty string to render nothing, which turns the component into a server side gate.
-
-A ``render`` function takes over completely.
-The component template and ``@component.context`` callables do not run for that component.
-The function may return a string or an :class:`~django.http.HttpResponse`.
-When it returns an :class:`~django.http.HttpResponse`, only the decoded body is spliced into the page.
-The response status code and headers are not propagated.
-
-When ``component.py`` defines no ``render`` function, the component renders its template and runs every ``@component.context`` callable as usual.
-
-.. code-block:: python
-   :caption: _components/feature_guard/component.py
-
-   def render(flag_enabled: bool = False) -> str:
-       if not flag_enabled:
-           return ""
-       return "<div class='feature'>New feature</div>"
-
-See ``examples/feature-flags`` for a feature guard built this way.
 
 See Also
 --------

--- a/docs/content/topics/context.rst
+++ b/docs/content/topics/context.rst
@@ -4,10 +4,13 @@ Context
 =======
 
 Context is the data that pages and components publish into their template scope.
-This page covers the two shapes of the ``@context`` decorator and the ways to vary them, how inheritance flows down the route tree, how component context differs from page context, how to expose values to the JavaScript bundle, and how to swap out the serializer that ships values to the browser.
+This page covers the two shapes of the ``@context`` decorator and the ways to vary them.
+It also walks inheritance down the route tree, how component context differs from page context, and how to expose values to the JavaScript bundle.
+A final section covers how to swap out the serializer that ships values to the browser.
 
 This page is the concept reference for context.
-Once you understand the decorator and the ``serialize`` flag here, :doc:`/content/topics/static-assets/js-context` covers the full ``window.Next.context`` mechanics and :doc:`/content/howto/override-the-js-context-serializer` walks through replacing the serializer.
+Once you understand the decorator and the ``serialize`` flag here, :doc:`/content/topics/static-assets/js-context` covers the full ``window.Next.context`` mechanics.
+The :doc:`/content/howto/override-the-js-context-serializer` how-to walks through replacing the serializer.
 
 .. contents::
    :local:
@@ -29,6 +32,23 @@ Page context.
 Component context.
    ``@component.context("key")`` in a ``component.py``.
    Resolves once per component instance during render.
+
+Framework-Provided Keys
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Every page render starts with three keys already populated, before any user-defined ``@context`` callable runs.
+
+``request``.
+   The active :class:`~django.http.HttpRequest`, when the route was reached through the HTTP stack.
+
+``current_template_path``.
+   The absolute path of the body source on disk.
+   It points at the sibling ``template.djx`` when one exists, or at the ``page.py`` itself when the body comes from ``render`` or ``template``.
+
+``current_page_module_path``.
+   The absolute path of the ``page.py`` module being rendered.
+
+User ``@context`` callables can read these keys by parameter name, and template-side machinery such as the ``{% component %}`` and ``{% form %}`` tags relies on them.
 
 The Decorator
 -------------
@@ -214,7 +234,9 @@ Pass ``serialize=True`` on ``@context`` or ``@component.context`` to publish the
 Pass ``serializer=`` on that decorator for a per-key encoder, or set ``NEXT_FRAMEWORK["JS_CONTEXT_SERIALIZER"]`` for a project-wide default.
 
 A value marked ``serialize=True`` must be encodable by the active serializer.
-The default ``JsonJsContextSerializer`` runs values through Django ``DjangoJSONEncoder``, which handles primitives, ``list``, ``dict``, ``datetime``, ``Decimal``, ``UUID``, and lazy translation strings.
+The default ``JsonJsContextSerializer`` runs values through Django ``DjangoJSONEncoder``.
+That encoder handles primitives, ``list``, ``dict``, ``datetime``, ``date``, ``time``, ``timedelta``, ``Decimal``, ``UUID``, and Django ``Promise`` instances such as lazy translation strings.
+Switching ``JS_CONTEXT_SERIALIZER`` to ``PydanticJsContextSerializer`` also unwraps :class:`pydantic.BaseModel` subclasses via ``model_dump``.
 A ``QuerySet``, a ``Manager``, a bare model instance, a Django ``Form``, and any other unsupported type raises ``TypeError`` at render time with the offending key in the message.
 Materialise such values before returning.
 Use ``list(queryset)`` for collections and a plain ``dict`` projection for model instances.

--- a/docs/content/topics/context.rst
+++ b/docs/content/topics/context.rst
@@ -157,10 +157,12 @@ The framework computes the template scope in this order.
 1. URL kwargs from the matched route are seeded into the context dict.
 2. Inherited context functions from every ancestor ``page.py``, walked from the route root inward.
 3. Page level context functions declared in the current ``page.py``.
-4. Context processors come from ``OPTIONS.context_processors`` on each page backend entry inside ``DEFAULT_PAGE_BACKENDS`` plus the ``context_processors`` list of the first ``TEMPLATES`` entry in Django settings.
+4. Context processors run after every ``@context`` callable.
+   The first source is ``OPTIONS.context_processors`` on each page backend entry inside ``DEFAULT_PAGE_BACKENDS``.
+   The second source is the ``context_processors`` list of the first ``TEMPLATES`` entry in Django settings.
    See :ref:`ref-settings` and :doc:`project-layout` for the backend layout.
    The two lists merge in that order with duplicate dotted paths dropped, so a processor listed twice runs once.
-   Each processor return dict is applied with ``update`` after every ``@context`` callable, so a processor key overwrites a page or inherited value.
+   Each processor return dict is applied with ``update``, so a processor key overwrites a page or inherited value.
 5. Component context functions when a ``{% component %}`` tag is encountered during render.
 
 A later step that uses the same key overrides earlier values.
@@ -202,12 +204,24 @@ Leave the parameter untyped and return early if it is already an instance of the
 
 Declaring the parameter as ``str`` would break the descendant re-run.
 
+.. _topics-context-serialization:
+
 Serialization for the Browser
 -----------------------------
 
 next.dj ships a ``window.Next`` object to the browser through the :doc:`static pipeline <static-assets/index>`.
 Pass ``serialize=True`` on ``@context`` or ``@component.context`` to publish the return value under ``window.Next.context``.
 Pass ``serializer=`` on that decorator for a per-key encoder, or set ``NEXT_FRAMEWORK["JS_CONTEXT_SERIALIZER"]`` for a project-wide default.
+
+A value marked ``serialize=True`` must be encodable by the active serializer.
+The default ``JsonJsContextSerializer`` runs values through Django ``DjangoJSONEncoder``, which handles primitives, ``list``, ``dict``, ``datetime``, ``Decimal``, ``UUID``, and lazy translation strings.
+A ``QuerySet``, a ``Manager``, a bare model instance, a Django ``Form``, and any other unsupported type raises ``TypeError`` at render time with the offending key in the message.
+Materialise such values before returning.
+Use ``list(queryset)`` for collections and a plain ``dict`` projection for model instances.
+
+Values not marked ``serialize=True`` stay server-side only.
+Template rendering iterates a queryset or resolves a lazy string directly.
+The materialisation rule applies only to keys that travel to the client.
 
 See :doc:`static-assets/js-context` for serializers, duplicate-key policies, ``NEXT_JS_OPTIONS``, and reading values from co-located JS.
 See :doc:`/content/howto/override-the-js-context-serializer` for a guided recipe when the default JSON encoder is not enough.

--- a/docs/content/topics/dependency-injection.rst
+++ b/docs/content/topics/dependency-injection.rst
@@ -21,7 +21,7 @@ Custom providers and tests can import ``resolver`` from ``next.deps`` and call `
 Built In Providers
 ------------------
 
-The framework registers eight providers.
+The framework registers a fixed list of providers at startup.
 Each one carries an explicit ``priority`` value, the resolver consults them from lowest to highest, and the first match wins.
 
 1. Named dependency provider.
@@ -42,8 +42,10 @@ Each one carries an explicit ``priority`` value, the resolver consults them from
    A parameter annotated ``DQuery[T]`` reads ``request.GET`` by parameter name and coerces to ``T``.
 
 The order makes the marker-driven providers narrow and decisive.
-``Depends`` and ``Context`` look only at the parameter default, ``DForm``, ``DUrl``, and ``DQuery`` look only at the annotation, so they never compete with one another.
-The context-by-name and URL-kwargs providers are the broad fallbacks that match on the bare parameter name.
+``Depends`` and ``Context`` look only at the parameter default.
+``DUrl`` and ``DQuery`` look only at the annotation.
+The form provider is broader, it matches the parameter name ``form``, the marker ``DForm[FormClass]``, and any plain class annotation whose type the bound form is an instance of.
+The context-by-name and URL-kwargs providers are the fallbacks that match on the bare parameter name.
 They run after the marker providers so an explicit marker always wins over an accidental name collision.
 
 DUrl
@@ -63,10 +65,12 @@ The URL path provider coerces the captured segment to the requested type.
        return Note.objects.get(pk=note_id)
 
 In the simplest form ``DUrl[T]`` matches the captured segment whose name
-equals the parameter name, then coerces the string value to ``T``. Coercion applies when ``T``
-is ``int``, ``bool``, or ``float``. For any other type, including ``str``,
-the value is returned as-is.
+equals the parameter name, then coerces the captured value to ``T``.
+``T`` may be ``str``, ``int``, ``bool``, ``float``, ``UUID``, ``Decimal``, ``date``, or ``datetime``.
+A value that already satisfies ``T`` passes through untouched, so a Django converter that pre-coerced the segment, such as ``[uuid:id]`` producing a :class:`~uuid.UUID`, reaches the handler in that shape.
+A failed parse falls back to the raw captured value rather than raising.
 ``bool`` treats ``"1"``, ``"true"``, and ``"yes"`` as ``True`` and everything else as ``False``.
+``date`` and ``datetime`` parse the ISO 8601 forms accepted by :meth:`date.fromisoformat <datetime.date.fromisoformat>` and :meth:`datetime.fromisoformat <datetime.datetime.fromisoformat>`.
 For wildcard ``[[name]]`` segments the captured value is the matched path string. Annotate as ``DUrl[str]`` or leave it unannotated.
 
 The marker has three forms.
@@ -77,14 +81,17 @@ The marker has three forms.
    directory segment.
 
 ``DUrl["segment"]``.
-   Reads the named captured segment and returns it unchanged as a string.
+   Reads the named captured segment and returns it in string form.
    Use it when the parameter name differs from the segment name and no
-   coercion is needed.
+   type coercion is needed.
 
 ``DUrl["segment", T]``.
    Reads the named captured segment and coerces it to ``T``. Use it when
    the parameter name differs from the segment name, for example
    ``note_id: DUrl["id", int]`` for an ``[id]`` directory.
+
+The string in ``DUrl["segment"]`` and ``DUrl["segment", T]`` is the URL kwarg key the resolver looks up, not the Django converter label.
+Hyphens in directory names are normalised to underscores in the kwarg, so a ``[my-id]`` directory is read as ``DUrl["my_id"]``.
 
 .. note::
 
@@ -113,7 +120,7 @@ Django converts the captured value before the URL kwargs provider sees it.
      - ``DUrl[str]``
    * - ``[uuid:name]``
      - ``uuid.UUID``
-     - Plain ``uuid.UUID`` parameter, or ``DUrl[str]`` for the string form
+     - ``DUrl[UUID]`` for the parsed form, ``DUrl[str]`` for the canonical string
 
 DQuery
 ~~~~~~
@@ -123,12 +130,15 @@ The query provider reads from ``request.GET``.
 .. code-block:: python
    :caption: notes/pages/search/page.py
 
+   from notes.models import Note
    from next.pages import context
    from next.urls import DQuery
 
    @context("results")
-   def results(query: DQuery[str] = "") -> list:
-       return search(query) if query else []
+   def results(query: DQuery[str] = "") -> list[Note]:
+       if not query:
+           return []
+       return list(Note.objects.filter(title__icontains=query))
 
 The provider supports scalar types and lists.
 
@@ -159,6 +169,9 @@ The provider supports scalar types and lists.
      - ``?tag=a,b,c``
 
 The provider returns the parameter default when the key is absent.
+
+``DQuery`` accepts the same scalar set as ``DUrl``, namely ``str``, ``int``, ``bool``, ``float``, ``UUID``, ``Decimal``, ``date``, and ``datetime``, plus ``list[T]`` for any of those scalars.
+A value that fails to parse falls back to the raw query string rather than raising.
 
 Context Markers
 ---------------
@@ -314,22 +327,27 @@ Import before resolution.
    Register the provider before the resolver caches its provider list.
    The natural place is ``AppConfig.ready`` of the application that owns the provider.
 
+A custom provider that does not declare ``priority`` inherits the ``RegisteredParameterProvider`` default of ``100``.
+The built-in providers occupy the range ``10`` (named dependency) through ``80`` (query string), so the default keeps a custom provider after every built-in.
+Set ``priority`` on the subclass when the new provider has to claim a parameter the built-ins would otherwise match, for example a value below ``50`` for an annotation that should outrank ``DUrl``.
+
 Resolution Cache
 ----------------
 
 The resolver creates a fresh ``DependencyCache`` for each resolution pass.
-During form-dispatch re-renders, the dispatcher attaches the cache to the request so the page and component context functions reuse the same memoised values.
+The cache memoises ``Depends("name")`` callables only, keyed by the registered name.
+Parameter providers run once per parameter per resolution pass and their results are not stored, so a second context function that asks for the same ``DQuery`` or ``DUrl`` parameter triggers another provider call.
 
-A second context function in the same page render that asks for the same dependency receives the cached value, not a fresh call.
+A second context function in the same page render that asks for the same ``Depends("name")`` dependency receives the memoised value, not a fresh call.
 
-The cache is also shared between the initial render of a form page and the re-render on validation failure.
+The same cache is shared between the initial render of a form page and the re-render on validation failure.
 ``FormActionDispatch`` attaches its dependency cache to the request, and ``get_request_dep_cache`` reads it back.
 The function returns ``None`` outside a form dispatch, so callers handle the missing case.
 
 .. code-block:: python
    :caption: reading the cache
 
-   from next.deps.cache import get_request_dep_cache
+   from next.deps import get_request_dep_cache
 
    def render(request) -> str:
        cache = get_request_dep_cache(request)
@@ -362,8 +380,8 @@ Resolver Lifecycle
 
 The resolver builds its provider registry on first use and reuses it, so register custom providers from ``AppConfig.ready`` and see :doc:`/content/internals/di-resolver` for the full lifecycle.
 
-A custom provider can publish a value once and let several context functions ask for it.
-The request cache calls the provider a single time, so every context function reads the same instance without duplicating queries.
+A custom provider that wants to share one value across several context functions in the same render should publish it through ``Depends("name")``, because the per-resolution cache memoises named dependencies but not raw provider calls.
+Register a named callable through ``resolver.dependency("active_tenant")`` and have each ``@context`` function ask for ``Depends("active_tenant")``.
 See :doc:`/content/howto/share-context-across-pages` for a worked example.
 
 See Also

--- a/docs/content/topics/dependency-injection.rst
+++ b/docs/content/topics/dependency-injection.rst
@@ -24,29 +24,29 @@ Built In Providers
 The framework registers a fixed list of providers at startup.
 Each one carries an explicit ``priority`` value, the resolver consults them from lowest to highest, and the first match wins.
 
-1. Named dependency provider.
+1. Named dependency provider (priority 10).
    A parameter with default ``Depends(...)`` receives the resolved dependency.
-2. Context by default provider.
+2. Context by default provider (priority 20).
    A parameter with a ``Context(...)`` default receives the named context value.
-3. Context by name provider.
+3. Context by name provider (priority 30).
    A parameter whose name matches a context key receives that context value.
-4. Form provider.
+4. Form provider (priority 40).
    A parameter named ``form`` or annotated ``DForm[FormClass]`` receives the bound form during action dispatch.
-5. HttpRequest provider.
+5. HttpRequest provider (priority 50).
    A parameter annotated ``HttpRequest`` or ``HttpRequest | None`` receives the current request.
-6. URL annotation provider.
+6. URL annotation provider (priority 60).
    A parameter annotated ``DUrl[T]`` reads the captured URL segment and coerces it to ``T``.
-7. URL kwargs provider.
+7. URL kwargs provider (priority 70).
    A parameter whose name matches a captured URL segment resolves to that value.
-8. Query string provider.
+8. Query string provider (priority 80).
    A parameter annotated ``DQuery[T]`` reads ``request.GET`` by parameter name and coerces to ``T``.
 
-The order makes the marker-driven providers narrow and decisive.
+The order makes the default-driven and marker-driven providers decisive.
 ``Depends`` and ``Context`` look only at the parameter default.
 ``DUrl`` and ``DQuery`` look only at the annotation.
-The form provider is broader, it matches the parameter name ``form``, the marker ``DForm[FormClass]``, and any plain class annotation whose type the bound form is an instance of.
-The context-by-name and URL-kwargs providers are the fallbacks that match on the bare parameter name.
-They run after the marker providers so an explicit marker always wins over an accidental name collision.
+The context-by-name provider sits ahead of the form, URL, and query providers because a context key under the same name is considered a deliberate publication.
+The form provider matches the parameter name ``form``, the marker ``DForm[FormClass]``, and any plain class annotation whose type the bound form is an instance of.
+The URL-kwargs provider is the last fallback that matches on the bare parameter name, after every marker provider has had a chance to claim the parameter.
 
 DUrl
 ~~~~
@@ -247,7 +247,9 @@ Re-entering a name that is already on the stack raises ``DependencyCycleError``.
    next.deps.cache.DependencyCycleError: Circular dependency: profile -> settings -> profile
 
 The chain in the message is the resolution path that closed the loop, read left to right.
-Catch it with ``from next.deps import DependencyCycleError``. The path ``next.deps.cache`` is an implementation detail.
+The traceback lists the fully qualified path ``next.deps.cache.DependencyCycleError`` because that is where the exception class is defined.
+Import the exception from the public ``next.deps`` namespace with ``from next.deps import DependencyCycleError``.
+The deeper ``next.deps.cache`` path is an implementation detail and is not part of the supported import surface.
 Break the cycle by removing one ``Depends`` edge.
 Here ``settings`` does not need ``profile`` at all, so the fix is to drop that parameter.
 
@@ -314,7 +316,7 @@ Use the new marker.
    from next.pages import context
 
    @context("note")
-   def note(note: DNote[Note]) -> Note:
+   def current_note(note: DNote[Note]) -> Note:
        return note
 
 Two rules apply to the marker class.
@@ -372,8 +374,9 @@ Do not use future annotations in modules with DI parameters.
    Plain Python files that only import the framework can use future annotations freely.
 
 Keep DI types runtime importable.
-   The resolver evaluates string annotations through ``typing.get_type_hints``.
-   Types hidden behind ``if TYPE_CHECKING`` are not available at evaluation time.
+   Most providers compare annotations through ``typing.get_origin``, which returns ``None`` for string annotations and never imports the target type.
+   The ``HttpRequest`` provider does call ``typing.get_type_hints`` on the wrapped callable as a fallback, and that call evaluates string annotations.
+   Types hidden behind ``if TYPE_CHECKING`` are not visible to either path, so keep DI-touching annotations on classes that import at module top level.
 
 Resolver Lifecycle
 ------------------

--- a/docs/content/topics/extending.rst
+++ b/docs/content/topics/extending.rst
@@ -181,6 +181,9 @@ Implement the methods listed in the protocol and pass the class to the framework
    * - JS context serializer
      - ``next.static.JsContextSerializer``
 
+Select a serializer implementation with the ``JS_CONTEXT_SERIALIZER`` setting.
+The default is ``JsonJsContextSerializer``.
+
 ``next.pages.loaders.TemplateLoader`` is an abstract base class rather than a protocol.
 Subclass it explicitly and register the subclass through ``TEMPLATE_LOADERS``.
 
@@ -207,10 +210,6 @@ The framework calls the strategy at a well known point in the pipeline.
    * - JS context conflict policy
      - ``JS_CONTEXT_POLICY`` in the first static backend ``OPTIONS``
      - ``FirstWinsPolicy``
-
-The JS context serializer is the ``JsContextSerializer`` protocol listed under
-*Protocols* above. Select an implementation with the ``JS_CONTEXT_SERIALIZER``
-setting. The default is ``JsonJsContextSerializer``.
 
 Use a strategy when the customisation is a single algorithm rather than a complete subsystem.
 

--- a/docs/content/topics/extending.rst
+++ b/docs/content/topics/extending.rst
@@ -15,7 +15,7 @@ The Five Mechanisms
 
 Backend.
    Replace or augment a complete subsystem.
-   Used for URL routing, components, forms dispatch, the :doc:`static pipeline <static-assets/index>`, and JS context serialization.
+   Used for URL routing, components, forms dispatch, and the :doc:`static pipeline <static-assets/index>`.
 
 Registry.
    Add new entries to a global list at startup.
@@ -159,9 +159,8 @@ Register the spec from ``AppConfig.ready`` so it is in place before the watcher 
 Edits to any ``*.yaml`` file under ``notes/rules`` now restart the development server.
 Duplicate ``(path, glob)`` pairs are dropped, so registering the same spec twice is safe.
 
-A subsystem that produces watch specs of its own implements the ``FilesystemWatchContributor`` Protocol from ``next.server.watcher``.
-The Protocol declares a single ``iter_watch_specs()`` method that yields ``(root, glob)`` pairs for the file watcher.
-When the watcher collects the final spec list it sends the ``watch_specs_ready`` signal with ``sender`` set to the ``iter_all_autoreload_watch_specs`` function itself.
+``register_autoreload_watch_spec`` is the only way to add extra trees to the watcher.
+``iter_all_autoreload_watch_specs`` from ``next.server`` resolves the final spec set and sends the ``watch_specs_ready`` signal with ``sender`` set to the function itself.
 Subscribe to that signal to observe or audit the resolved spec set.
 See :doc:`/content/internals/autoreload` for the full watcher pipeline.
 
@@ -203,10 +202,10 @@ The framework calls the strategy at a well known point in the pipeline.
      - Configured through
      - Default
    * - Static dedup
-     - ``DEDUP_STRATEGY`` in static backend ``OPTIONS``
+     - ``DEDUP_STRATEGY`` in the first static backend ``OPTIONS``
      - ``UrlDedup``
    * - JS context conflict policy
-     - ``JS_CONTEXT_POLICY`` in static backend ``OPTIONS``
+     - ``JS_CONTEXT_POLICY`` in the first static backend ``OPTIONS``
      - ``FirstWinsPolicy``
 
 The JS context serializer is the ``JsContextSerializer`` protocol listed under

--- a/docs/content/topics/file-router.rst
+++ b/docs/content/topics/file-router.rst
@@ -115,12 +115,8 @@ Name your directories without hyphens when you want the parameter name and the d
    def fetch_note(post_id: DUrl[int]) -> Note:
        return Note.objects.get(pk=post_id)
 
-``DUrl[int]`` reads the captured segment whose name matches the parameter,
-so the parameter ``post_id`` resolves the ``[int:post_id]`` segment and the
-marker coerces it to ``int``.
-When the parameter name has to differ from the segment name, name the
-segment explicitly with ``DUrl["post_id", int]``.
-See :doc:`dependency-injection` for the full set of ``DUrl`` forms.
+``DUrl[int]`` reads the captured segment whose name matches the parameter, so ``post_id`` resolves the ``[int:post_id]`` segment and the marker coerces it to ``int``.
+See :doc:`dependency-injection` for the full set of ``DUrl`` forms and the coercion table.
 
 Virtual Routes
 --------------

--- a/docs/content/topics/file-router.rst
+++ b/docs/content/topics/file-router.rst
@@ -79,7 +79,7 @@ The bracket syntax accepts every Django path converter.
      - Any non empty value with no slash.
    * - ``[int:name]``
      - ``<int:name>``
-     - Positive integers, including zero.
+     - Non-negative integers, including zero.
    * - ``[slug:name]``
      - ``<slug:name>``
      - URL slugs of ASCII letters, digits, hyphens, and underscores.
@@ -191,7 +191,8 @@ The router resolves routes from two sources, in the same way ``staticfiles`` res
 
 App directories.
    When ``APP_DIRS`` is ``True`` the router scans each installed application for a directory named ``PAGES_DIR``.
-   In the tutorial this is ``notes/pages/`` because ``PAGES_DIR`` defaults to ``pages``.
+   ``PAGES_DIR`` is required on every backend entry, and the ``next.E024`` system check fails when the key is missing.
+   In the tutorial it is set to ``pages``, so the router scans ``notes/pages/``.
 
 Project directories.
    The ``DIRS`` list adds absolute or project-relative paths to the scan.
@@ -296,7 +297,8 @@ Each backend can read from a different directory, register a different ``PAGES_D
    }
 
 Two backends produce two independent sets of URLs.
-The Django URL resolver checks them in order, the first match wins.
+The Django URL resolver checks them in order.
+The first match wins.
 Both backends emit the same signals and follow the same naming rules.
 
 Common Patterns
@@ -327,6 +329,8 @@ Hot Reload
 A backend that reads from a database or other dynamic source needs to rebuild its pattern list when the data changes.
 ``router_manager.reload()`` clears the resolver cache and rebuilds every backend, and the call is idempotent.
 Each invocation emits a ``router_reloaded`` signal with the manager class as sender, so long lived processes can listen for it to refresh cached URL references.
+The call walks every page tree configured in ``DEFAULT_PAGE_BACKENDS``, so a burst of model writes can dominate the request latency.
+Receivers should debounce or batch invocations when one logical change triggers many model signals at once.
 See :doc:`/content/howto/reload-routes-from-code` for the model-signal receiver that triggers the reload.
 
 System Checks

--- a/docs/content/topics/forms/actions.rst
+++ b/docs/content/topics/forms/actions.rst
@@ -335,7 +335,7 @@ System Checks
 
 The forms subsystem contributes Django system checks.
 
-- ``next.E041`` reports two ``@action`` registrations that share a name but come from different handlers.
+- ``next.E041`` reports two or more ``@action`` registrations that share a name but come from different handlers.
 - ``next.E044`` reports a malformed or non-importable ``DEFAULT_FORM_ACTION_BACKENDS`` entry, including a non-string ``BACKEND`` path.
 - ``next.E045`` reports a backend that does not subclass ``FormActionBackend``.
 

--- a/docs/content/topics/forms/actions.rst
+++ b/docs/content/topics/forms/actions.rst
@@ -82,6 +82,8 @@ The handler can take any parameters the dependency injector knows how to resolve
    from django.http import HttpRequest, HttpResponseRedirect
    from next.forms import action
    from next.urls import DUrl
+   from notes.forms import NoteForm
+   from notes.models import Note
 
    @action("simple", form_class=NoteForm)
    def simple(form: NoteForm) -> HttpResponseRedirect:
@@ -210,6 +212,9 @@ A ``(FormClass, init_kwargs)`` tuple.
    The dispatcher passes ``**init_kwargs`` straight to the form constructor and skips ``get_initial`` entirely.
    Use this when the form needs constructor arguments that only exist at request time.
 
+Do not include ``data`` or ``files`` in ``init_kwargs``.
+The dispatcher passes both keyword arguments itself, populated from ``request.POST`` and ``request.FILES``, so a kwarg with either name would conflict at construction time.
+
 The factory is dependency-resolved, so it can declare ``request: HttpRequest``, a ``DUrl[...]`` parameter, or any ``Depends`` provider in its signature.
 
 .. code-block:: python
@@ -269,7 +274,11 @@ Each lives at its own URL so the dispatcher can tell them apart.
 .. code-block:: python
    :caption: notes/pages/notes/[id]/page.py
 
+   from django.http import HttpResponseRedirect
    from next.forms import action
+   from next.urls import DUrl
+   from notes.forms import NoteForm
+   from notes.models import Note
 
    @action("update_note", form_class=NoteForm)
    def update_note(form: NoteForm, note_id: DUrl["id", int]) -> HttpResponseRedirect:

--- a/docs/content/topics/forms/backends.rst
+++ b/docs/content/topics/forms/backends.rst
@@ -131,28 +131,14 @@ FormActionManager
 
 The module-level ``form_action_manager`` instance holds the active backends behind a thin facade.
 Application code reaches it through ``from next.forms import form_action_manager``.
-
-``default_backend``.
-   Property that returns the first configured backend.
-   Used internally by the template tag and the dispatcher.
-
-``get_action_url(action_name)``.
-   Returns the reverse URL of the first backend that knows ``action_name``.
-   Raises ``KeyError`` for an unknown name.
-
-``render_form_fragment(request, action_name, form, template_fragment=None, *, page_file_path=None)``.
-   Delegates the validation-failure render to ``default_backend.render_form_fragment``.
-
-``clear_registries()``.
-   Calls ``clear_registry`` on every backend that exposes it.
-   Use it for test isolation, see Testing below.
+See :doc:`/content/ref/forms` for the full member list of ``next.forms.manager``.
 
 Testing
 -------
 
 Tests that register actions through ``@action`` must drop the global registry between cases so action names from one test do not leak into the next.
 Call :func:`next.testing.reset_form_actions` from a pytest fixture or a ``setUp`` method.
-The helper clears every backend through ``form_action_manager.clear_registries`` and resets the import cache, so subsequent imports of a ``page.py`` re-register their actions.
+The helper invokes ``form_action_manager._reload_config()``, which rebuilds the backend list from the current ``NEXT_FRAMEWORK["DEFAULT_FORM_ACTION_BACKENDS"]`` setting and discards any actions registered against the previous backend instances.
 
 See :doc:`/content/topics/testing` for the surrounding helpers and fixtures.
 

--- a/docs/content/topics/forms/backends.rst
+++ b/docs/content/topics/forms/backends.rst
@@ -91,7 +91,8 @@ An unknown UID returns 404 from the parent dispatch, and the audit row still rec
 See :doc:`/content/howto/write-a-form-action-backend` for the guarded pattern that recovers the action name from the UID index.
 
 The ``validated_next_form_page_path(request)`` helper validates the hidden ``_next_form_page`` POST field and returns a trusted ``Path | None``.
-Call it inside a ``dispatch`` override when the custom backend needs to know which page initiated the form submission — for example, to build a custom redirect target.
+Call it inside a ``dispatch`` override when the custom backend needs to know which page initiated the form submission.
+A custom redirect target keyed off that page is one such case.
 
 Registering a Custom Backend
 ----------------------------
@@ -125,6 +126,36 @@ An override runs inside the dispatch and can change or block the response.
 A signal receiver runs decoupled and only observes.
 Use the override when the side effect must be transactional with the dispatch.
 
+FormActionManager
+-----------------
+
+The module-level ``form_action_manager`` instance holds the active backends behind a thin facade.
+Application code reaches it through ``from next.forms import form_action_manager``.
+
+``default_backend``.
+   Property that returns the first configured backend.
+   Used internally by the template tag and the dispatcher.
+
+``get_action_url(action_name)``.
+   Returns the reverse URL of the first backend that knows ``action_name``.
+   Raises ``KeyError`` for an unknown name.
+
+``render_form_fragment(request, action_name, form, template_fragment=None, *, page_file_path=None)``.
+   Delegates the validation-failure render to ``default_backend.render_form_fragment``.
+
+``clear_registries()``.
+   Calls ``clear_registry`` on every backend that exposes it.
+   Use it for test isolation, see Testing below.
+
+Testing
+-------
+
+Tests that register actions through ``@action`` must drop the global registry between cases so action names from one test do not leak into the next.
+Call :func:`next.testing.reset_form_actions` from a pytest fixture or a ``setUp`` method.
+The helper clears every backend through ``form_action_manager.clear_registries`` and resets the import cache, so subsequent imports of a ``page.py`` re-register their actions.
+
+See :doc:`/content/topics/testing` for the surrounding helpers and fixtures.
+
 System Checks
 -------------
 
@@ -154,6 +185,8 @@ Custom Error Fragment
 
 Override ``render_form_fragment`` to return custom HTML for the validation error path.
 The override signature is ``render_form_fragment(request, action_name, form, template_fragment=None, *, page_file_path=None)``.
+The bundled ``RegistryFormActionBackend`` ignores ``template_fragment`` and always re-renders the origin page through the page-template loader.
+The argument stays in the signature so an override can use it, but the default implementation does not consult it.
 When no action meta or template body is found, the default implementation falls back to ``form.as_p()``.
 Override ``render_form_fragment`` to replace this fallback entirely.
 

--- a/docs/content/topics/forms/formsets.rst
+++ b/docs/content/topics/forms/formsets.rst
@@ -184,26 +184,51 @@ Validating an Inline Formset
 A parent form that owns an inline formset attaches the formset on construction and validates it inside ``clean``.
 Raising ``ValidationError`` from ``clean`` routes the failure through the standard re-render pipeline.
 
-Use a factory callable as ``form_class`` so the dispatcher attaches the formset to the parent form before calling ``form.is_valid()``.
+Use a factory callable as ``form_class`` so the dispatcher binds the inline formset to the parent form before calling ``form.is_valid()``.
 The factory returns ``(FormClass, init_kwargs)`` and the dispatcher passes those kwargs to the constructor.
+``NoteForm.__init__`` rebinds ``row_formset`` to ``self.data`` with ``instance=self.instance`` so the formset validates against the same POST as the parent form.
+
+.. code-block:: python
+   :caption: notes/forms.py
+
+   from django.forms import inlineformset_factory
+   from next.forms import ModelForm
+   from notes.models import Note, Row
+
+   RowFormSet = inlineformset_factory(Note, Row, fields=("label",), extra=1)
+
+   class NoteForm(ModelForm):
+       class Meta:
+           model = Note
+           fields = ("title", "body")
+
+       def __init__(self, *args, **kwargs):
+           super().__init__(*args, **kwargs)
+           self.row_formset = RowFormSet(
+               data=self.data or None,
+               instance=self.instance,
+               prefix="rows",
+           )
+
+       def clean(self):
+           cleaned = super().clean()
+           if not self.row_formset.is_valid():
+               self.add_error(None, "Fix the row errors below.")
+           return cleaned
 
 .. code-block:: python
    :caption: notes/pages/notes/[id]/edit/page.py
 
-   from django.forms import inlineformset_factory
    from django.http import HttpResponseRedirect
    from django.shortcuts import get_object_or_404
    from next.forms import action
    from next.urls import DUrl
    from notes.forms import NoteForm
-   from notes.models import Note, Row
-
-   RowFormSet = inlineformset_factory(Note, Row, fields=("label",), extra=1)
+   from notes.models import Note
 
    def note_form_factory(note_id: DUrl["id", int]) -> tuple:
        note = get_object_or_404(Note, pk=note_id)
-       row_formset = RowFormSet(prefix="rows")
-       return NoteForm, {"instance": note, "row_formset": row_formset}
+       return NoteForm, {"instance": note}
 
    @action("update_note", form_class=note_form_factory)
    def update_note(form: NoteForm) -> HttpResponseRedirect:
@@ -211,9 +236,7 @@ The factory returns ``(FormClass, init_kwargs)`` and the dispatcher passes those
        form.row_formset.save()
        return HttpResponseRedirect("/")
 
-``NoteForm`` accepts ``row_formset`` in its constructor and inspects it from ``clean``.
-The parent page re-renders with both the parent and the row errors in scope.
-See ``examples/admin`` for a worked example of the same pattern.
+The parent page re-renders with both the parent and the row errors in scope on validation failure.
 
 Common Patterns
 ---------------

--- a/docs/content/topics/forms/formsets.rst
+++ b/docs/content/topics/forms/formsets.rst
@@ -43,12 +43,13 @@ Pass the formset class as ``form_class``.
 .. code-block:: python
    :caption: notes/pages/notes/bulk/page.py
 
+   from django.forms.formsets import BaseFormSet
    from django.http import HttpResponseRedirect
    from django.urls import reverse
    from next.forms import action
    from notes.forms import NoteFormSet
 
-   def build_bulk_formset() -> tuple[type[NoteFormSet], dict]:
+   def build_bulk_formset() -> tuple[type[BaseFormSet], dict]:
        return NoteFormSet, {"initial": [{"title": "Draft"}]}
 
    @action("bulk_create_notes", form_class=build_bulk_formset)
@@ -147,6 +148,7 @@ Use ``modelformset_factory`` for editing several existing instances.
 
    from types import SimpleNamespace
 
+   from django.forms.formsets import BaseFormSet
    from django.http import HttpResponseRedirect
    from django.urls import reverse
    from next.forms import action
@@ -159,7 +161,7 @@ Use ``modelformset_factory`` for editing several existing instances.
        formset = NoteEditFormSet(queryset=Note.objects.all())
        return SimpleNamespace(form=formset)
 
-   def build_edit_formset() -> tuple[type[NoteEditFormSet], dict]:
+   def build_edit_formset() -> tuple[type[BaseFormSet], dict]:
        return NoteEditFormSet, {"queryset": Note.objects.all()}
 
    @action("edit_all_notes", form_class=build_edit_formset)
@@ -179,34 +181,11 @@ Field errors render on each row through ``row.errors`` and non field errors rend
 Validating an Inline Formset
 ----------------------------
 
-When a parent form owns an inline formset, validate the formset inside the parent form ``clean`` method.
-Raising ``ValidationError`` from ``clean`` routes the failure through the standard re-render pipeline instead of producing a bare error response.
+A parent form that owns an inline formset attaches the formset on construction and validates it inside ``clean``.
+Raising ``ValidationError`` from ``clean`` routes the failure through the standard re-render pipeline.
 
-The framework does not attach the inline formset to the parent form.
-The handler builds the formset and assigns it to the form before calling ``form.is_valid()``.
-
-.. code-block:: python
-   :caption: notes/forms.py
-
-   from django.core.exceptions import ValidationError
-   from next.forms import ModelForm
-
-   class NoteForm(ModelForm):
-       class Meta:
-           model = Note
-           fields = ("title",)
-
-       def clean(self):
-           cleaned = super().clean()
-           row_formset = getattr(self, "row_formset", None)
-           if row_formset is not None and not row_formset.is_valid():
-               raise ValidationError("Fix the rows before saving.")
-           return cleaned
-
-Use a factory callable as ``form_class`` to attach the inline formset before the dispatcher calls ``form.is_valid()``.
-The factory is dependency-resolved, so it fetches the parent instance and constructs the formset at request time.
-It returns ``(FormClass, init_kwargs)`` and the dispatcher creates the form with those kwargs, so ``row_formset`` is already attached when ``is_valid()`` runs.
-The handler receives the already-validated form and calls ``save()`` directly.
+Use a factory callable as ``form_class`` so the dispatcher attaches the formset to the parent form before calling ``form.is_valid()``.
+The factory returns ``(FormClass, init_kwargs)`` and the dispatcher passes those kwargs to the constructor.
 
 .. code-block:: python
    :caption: notes/pages/notes/[id]/edit/page.py
@@ -232,27 +211,9 @@ The handler receives the already-validated form and calls ``save()`` directly.
        form.row_formset.save()
        return HttpResponseRedirect("/")
 
-``NoteForm`` must accept ``row_formset`` in its constructor so ``clean`` can see it.
-
-.. code-block:: python
-   :caption: notes/forms.py (NoteForm additions)
-
-   class NoteForm(ModelForm):
-       def __init__(self, *args, row_formset=None, **kwargs):
-           super().__init__(*args, **kwargs)
-           self.row_formset = row_formset
-
-       def clean(self):
-           row_formset = getattr(self, "row_formset", None)
-           if row_formset is not None and not row_formset.is_valid():
-               raise ValidationError("Row formset has errors.")
-
-       class Meta:
-           model = Note
-           fields = ["title", "body"]
-
-The parent page re-renders with both the parent form errors and the row errors in scope.
-See ``examples/admin`` for a worked inline formset.
+``NoteForm`` accepts ``row_formset`` in its constructor and inspects it from ``clean``.
+The parent page re-renders with both the parent and the row errors in scope.
+See ``examples/admin`` for a worked example of the same pattern.
 
 Common Patterns
 ---------------

--- a/docs/content/topics/forms/modelforms.rst
+++ b/docs/content/topics/forms/modelforms.rst
@@ -152,6 +152,8 @@ A custom DI provider can centralise the instance lookup.
            except model_cls.DoesNotExist as exc:
                raise Http404 from exc
 
+Subclassing ``RegisteredParameterProvider`` auto-registers the provider with the dependency resolver at import time, so importing ``notes/providers.py`` is enough to wire it.
+
 The handler can now take the instance directly.
 
 .. code-block:: python

--- a/docs/content/topics/forms/modelforms.rst
+++ b/docs/content/topics/forms/modelforms.rst
@@ -1,7 +1,7 @@
 .. _topics-forms-modelforms:
 
-ModelForm Support
-=================
+ModelForms
+==========
 
 A :doc:`ModelForm <django:topics/forms/modelforms>` adapts a Django model to a form.
 next.dj supports ModelForms anywhere a plain ``Form`` works.

--- a/docs/content/topics/forms/overview.rst
+++ b/docs/content/topics/forms/overview.rst
@@ -43,14 +43,22 @@ The :doc:`dependency resolver </content/topics/dependency-injection>` fills each
        note_id: DUrl["id", int],
        request: HttpRequest,
    ) -> HttpResponseRedirect:
+       form.instance.pk = note_id
        form.save()
-       return HttpResponseRedirect("/")
+       return HttpResponseRedirect(request.path)
 
 Validation Outcomes
 ~~~~~~~~~~~~~~~~~~~
 
-A submission is valid, invalid, handler-only, or malformed.
-See :doc:`validation-rerender` for each outcome and its status code.
+Each POST resolves to one outcome and the dispatcher decides what to send back.
+
+- Valid. The handler runs and its return value reaches the client.
+- Invalid. The origin page re-renders with the bound failing form in scope.
+- Malformed. The dispatcher returns ``HTTP 400`` when the origin reference is missing or unsafe.
+
+The orthogonal axis is whether the action declares a ``form_class``.
+Actions without one skip form construction and call the handler directly.
+See :doc:`actions` for the form-less variant and :doc:`validation-rerender` for the re-render flow.
 
 Where to Declare Actions
 ------------------------

--- a/docs/content/topics/forms/overview.rst
+++ b/docs/content/topics/forms/overview.rst
@@ -11,27 +11,6 @@ This page covers the mental model behind that pipeline.
    :local:
    :depth: 2
 
-Overview
---------
-
-Five things make a form work.
-
-Form class.
-   A subclass of ``next.forms.Form`` or ``next.forms.ModelForm``.
-
-Action.
-   A Python callable decorated with ``@action("name", form_class=...)``.
-
-Template tag.
-   ``{% form @action="name" %}`` opens a block, closed by ``{% endform %}``, that resolves the action UID, posts to its dispatch URL, and injects a CSRF token.
-
-Dispatch endpoint.
-   One URL per action that binds POST data and calls the handler when valid.
-   A non-POST request to a dispatch URL returns HTTP 405.
-
-Re-render pipeline.
-   On validation failure the framework renders the origin page again with the bound form in scope.
-
 Concepts
 --------
 

--- a/docs/content/topics/forms/serializers.rst
+++ b/docs/content/topics/forms/serializers.rst
@@ -158,6 +158,7 @@ Render a Form in a Different Engine
 
 Use the spec to ship form structure to a Jinja2 macro or a JSON consumer.
 Each spec is a frozen dataclass, so a custom renderer can read its fields directly or build its own plain-dict projection.
+A bare Django ``Form`` is not JSON-encodable, so a form destined for ``@context(..., serialize=True)`` must travel as a ``FormSpec`` (or a custom projection) rather than as the form instance itself.
 
 Snapshot Diffing
 ~~~~~~~~~~~~~~~~

--- a/docs/content/topics/forms/serializers.rst
+++ b/docs/content/topics/forms/serializers.rst
@@ -125,18 +125,8 @@ Custom renderers can branch on ``kind`` without re instantiating the widget.
 Shared Dependency Cache Across Re-render
 ----------------------------------------
 
-The dispatcher saves the dependency cache from the initial render of a form page.
-On a failed POST the cache is reattached to the re-rendered page so context functions and providers do not run twice.
-Two consequences flow from this.
-
-Idempotent providers.
-   Custom providers must not depend on a fresh evaluation between initial render and re-render.
-   The cache holds the value from the first call.
-
-Cheap re-render.
-   Form pages re-render quickly because layouts, context functions, and components reuse cached values.
-
-The framework exposes the cache through ``next.deps.get_request_dep_cache`` when an action needs to read it.
+The dispatcher reuses one dependency cache across the initial bind and the re-render, so providers run once and templates rebuild cheaply.
+See :ref:`topics-forms-validation-rerender` for the mechanics and the ``get_request_dep_cache`` access path.
 
 Spec vs Bound Form
 ------------------
@@ -163,14 +153,22 @@ A bare Django ``Form`` is not JSON-encodable, so a form destined for ``@context(
 Snapshot Diffing
 ~~~~~~~~~~~~~~~~
 
-Cache a ``FormSpec`` from one render and compare against the spec of the next render to detect added or removed fields.
-The frozen dataclass implements ``__eq__`` automatically.
+The dataclass ``__eq__`` does not detect structural drift on its own because ``FieldSpec.bound`` carries a Django ``BoundField`` without value equality.
+Compare on stable attributes instead.
+
+.. code-block:: python
+   :caption: detect added or removed fields
+
+   def field_names(spec: FormSpec) -> tuple[str, ...]:
+       return tuple(field.bound.name for section in spec.sections for field in section.fields)
+
+   added = set(field_names(new_spec)) - set(field_names(old_spec))
+   removed = set(field_names(old_spec)) - set(field_names(new_spec))
 
 System Integration
 ~~~~~~~~~~~~~~~~~~
 
-The Django admin example uses ``form_spec`` to render forms inside the admin chrome while keeping all dispatch behaviour inside next.dj.
-See ``examples/admin`` for the complete walkthrough.
+Use ``form_spec`` to render a form inside another rendering layer such as the Django admin while keeping dispatch on next.dj.
 
 See Also
 --------

--- a/docs/content/topics/forms/signals.rst
+++ b/docs/content/topics/forms/signals.rst
@@ -78,7 +78,8 @@ The sender is ``FormActionDispatch``.
 The payload carries ``action_name``, ``form``, ``url_kwargs``, ``duration_ms``, ``response_status``, and ``dep_cache``.
 
 ``form``.
-   The bound form after successful validation, or ``None`` for a handler-only action registered without a ``form_class``.
+   The bound form after the handler returns normally and the response has been coerced, or ``None`` for a handler-only action registered without a ``form_class``.
+   A handler that raises an exception aborts the dispatch and the signal does not fire.
 
 ``url_kwargs``.
    A copy of the URL kwargs the dispatcher resolved before invoking the handler.

--- a/docs/content/topics/forms/templates.rst
+++ b/docs/content/topics/forms/templates.rst
@@ -121,6 +121,7 @@ Re-rendered page after a failing POST.
 
 The tag does not read a ``form`` context key.
 On the initial render it reads a context key named after the action that holds a ``SimpleNamespace`` with a ``form`` attribute, and falls back to building that namespace itself when the key is absent.
+A namespaced action name contains ``:`` and is not addressable from the template scope, so its context lookup runs in Python only.
 Customise the initial form by overriding ``get_initial`` on the form class rather than publishing a ``form`` context.
 
 .. code-block:: python

--- a/docs/content/topics/forms/templates.rst
+++ b/docs/content/topics/forms/templates.rst
@@ -29,7 +29,7 @@ The tag does six things.
 2. Emits a ``<form method="post">`` element with ``action`` set to ``/_next/form/<uid>/``.
 3. Emits a hidden ``csrfmiddlewaretoken`` input with the current CSRF token.
 4. Emits a hidden ``_next_form_page`` field with the absolute path to the current ``page.py``.
-5. Emits a hidden ``_next_form_origin`` field with the request path of the rendering page, consumed by ``redirect_to_origin``.
+5. Emits a hidden ``_next_form_origin`` field set to ``request.path`` verbatim, consumed by ``redirect_to_origin``.
 6. Publishes a ``form`` variable inside the block, either the unbound form on a GET or the bound form on a re-rendered failure.
 
 The Action Reference
@@ -85,7 +85,9 @@ Captured URL Parameters
 -----------------------
 
 The tag does not need any argument to forward captured URL parameters.
-When the page URL captures a parameter the tag emits a hidden ``_url_param_<name>`` field for every captured kwarg in ``request.resolver_match.kwargs``, skipping the dispatch ``uid`` and any name reserved by the dependency resolver.
+
+At render time the tag reads ``request.resolver_match.kwargs`` and emits a hidden ``_url_param_<name>`` field for every captured kwarg, skipping the dispatch ``uid`` and any name reserved by the dependency resolver.
+The captured values come from the URL converters of the rendering page.
 
 .. code-block:: jinja
    :caption: notes/pages/notes/[id]/template.djx
@@ -97,7 +99,11 @@ When the page URL captures a parameter the tag emits a hidden ``_url_param_<name
 
 A page whose URL captures ``id`` therefore posts a hidden ``_url_param_id`` field automatically.
 The handler receives the same value through ``DUrl["id", int]`` or any other URL marker.
-On the POST the dispatcher reads these hidden ``_url_param_*`` fields back into the handler's URL kwargs, since the dispatch URL itself captures only the action UID.
+
+On the POST the dispatch URL captures only the action UID.
+The dispatcher recovers the page URL kwargs by reading every ``_url_param_*`` field from ``request.POST``, stripping the prefix from each name.
+Each recovered value is a string from the form body, so the dispatcher tries ``int(value)`` first and falls back to the original string when the cast fails.
+Declare the handler parameter as ``DUrl["id", int]`` to keep the int shape on both the initial render and the re-render, or as ``DUrl["id", str]`` to opt out of the int-first coercion.
 
 The form Variable
 -----------------

--- a/docs/content/topics/forms/validation-rerender.rst
+++ b/docs/content/topics/forms/validation-rerender.rst
@@ -50,8 +50,8 @@ What Survives Re-render
 One important thing carries over from the initial render.
 
 Dependency cache.
-   Every value produced by the resolver during dispatch is stored on the request under ``REQUEST_DEP_CACHE_ATTR``.
-   Read it through ``next.deps.get_request_dep_cache(request)`` rather than the raw attribute.
+   Read the per-request cache through ``next.deps.get_request_dep_cache(request)``.
+   The dispatcher stores it on the request under the attribute named by ``REQUEST_DEP_CACHE_ATTR`` so the helper can find it.
    The re-render reuses each cached value without rerunning the provider.
    A custom DI provider must therefore be idempotent across a render cycle.
 
@@ -125,7 +125,7 @@ The ``redirect_to_origin`` helper sends the user back to whichever page rendered
        Note.objects.filter(pk=note_id).update(favourite=True)
        return redirect_to_origin(request, fallback="/notes/")
 
-``redirect_to_origin(request, fallback="/")`` reads the hidden ``_next_form_origin`` field that the ``{% form %}`` tag emits with the request path of the rendering page.
+``redirect_to_origin(request, fallback="/")`` reads the hidden ``_next_form_origin`` field that the ``{% form %}`` tag sets to ``request.path`` verbatim at render time.
 It accepts the value only when it is a string that starts with a single ``/``.
 A protocol-relative input beginning with ``//`` is rejected, which blocks open-redirect input.
 When the field is absent or fails validation the helper redirects to ``fallback`` instead.
@@ -177,49 +177,14 @@ See :doc:`signals` for the full list and payload shapes.
 Edge Cases
 ----------
 
-Missing ``_next_form_page`` field.
-   The dispatcher returns HTTP 400.
-   Plain HTML forms must include the field explicitly.
-
-Origin page renamed or deleted.
-   The dispatcher returns HTTP 400 when the path no longer exists.
-   In development the autoreloader picks up the restructured directories, in production a redeploy rebuilds the URL patterns.
-
-Form class renamed.
-   Renaming the form class has no effect on the UID.
-   The UID is hashed from the action name.
-   A submission only fails when the origin ``page.py`` path becomes invalid.
-
-Pre dispatch redirect from handler.
-   A handler that returns ``HttpResponseRedirect`` skips the re-render path entirely.
-   Use this on success, never on validation failure.
-
-Virtual page origin.
-   Covered in detail under :ref:`The Origin Page <topics-forms-validation-rerender-origin>` above.
-   Routes backed only by a sibling ``template.djx`` (no ``page.py``) still resolve an origin path for re-render.
-
-CSRF token on re-render.
-   The re-render runs the ``{% form %}`` tag again, which calls Django's ``get_token`` and emits a fresh ``csrfmiddlewaretoken`` hidden input.
-   The token the browser already holds in its cookie stays valid, so the resubmission after a correction passes CSRF without a page reload.
-   A re-render never reuses the token string from the failed POST. It always emits the current one.
-
-File uploads.
-   An invalid submission does not preserve uploaded files.
-   The HTTP spec does not let a server re-populate an ``<input type="file">``, so the bound form on the re-render has no file data and the user must pick the file again.
-   The bound form still reports a missing-file error on the field when the upload was required.
-   Always set ``enctype="multipart/form-data"`` on the ``{% form %}`` tag so the dispatcher receives ``request.FILES`` in the first place.
-
-Partial form state.
-   Every text, select, checkbox, and textarea value survives the re-render because the dispatcher binds the failing form to ``request.POST`` and the template renders the bound widgets.
-   ``cleaned_data`` holds only the fields that passed validation. Fields that failed keep their raw submitted value on the widget so the user can correct them in place.
-   Password inputs are the exception. Django widgets clear them on render unless ``render_value=True`` is set on the widget.
-
-Wrong-origin re-render.
-   When a re-render shows the wrong page, the cause is almost always a stale or hand-built ``_next_form_page`` field.
-   The dispatcher trusts that field for the origin, so a form copied between pages or a hand-crafted ``<form>`` with a hardcoded path re-renders against the wrong module.
-   Let the ``{% form %}`` tag emit the field. It writes the path of the page that actually rendered the form.
-   A hand-built form must set ``_next_form_page`` to ``{{ current_page_module_path }}``, which the framework publishes on every rendered page.
-   When the field points outside ``BASE_DIR`` or at a path that no longer exists, the dispatcher returns HTTP 400 rather than rendering the wrong page.
+- Missing or stale ``_next_form_page`` field returns HTTP 400. Plain HTML forms must set the field to ``{{ current_page_module_path }}``.
+- Origin ``page.py`` renamed or deleted returns HTTP 400 when the path no longer exists on disk.
+- Renaming the form class has no effect on the UID, which is hashed from the action name.
+- A handler that returns ``HttpResponseRedirect`` skips the re-render path entirely. Use this on success only.
+- Virtual page origins backed by ``template.djx`` resolve through the template loader, as :ref:`topics-forms-validation-rerender-origin` explains above.
+- The re-render emits a fresh ``csrfmiddlewaretoken`` through ``get_token``, so the browser cookie stays valid and the resubmission passes CSRF without a reload.
+- File inputs reset on re-render because the HTTP spec does not let a server re-populate them. Set ``enctype="multipart/form-data"`` and re-prompt the user for the upload.
+- Text, select, checkbox, and textarea widgets keep their raw submitted values because the dispatcher binds the failing form to ``request.POST``. Password widgets clear unless ``render_value=True``.
 
 Common Patterns
 ---------------

--- a/docs/content/topics/forms/validation-rerender.rst
+++ b/docs/content/topics/forms/validation-rerender.rst
@@ -17,12 +17,15 @@ The Origin Page
 ---------------
 
 Every rendered ``{% form %}`` tag emits a hidden ``_next_form_page`` field that contains the absolute path to the current ``page.py``.
-The dispatcher reads that field to know which page rendered the form.
+The dispatcher reads that field on the re-render branch to locate the origin page.
 
-The dispatcher rejects a submission when the field is missing or blank, when its basename is not ``page.py``, or when resolving the path raises ``OSError``.
-It also rejects the submission when ``BASE_DIR`` is unset or when the resolved path falls outside ``BASE_DIR``.
-A path whose ``page.py`` does not exist is rejected too, unless a sibling ``template.djx`` stands in for it.
-Each rejection returns HTTP 400 with a short diagnostic message so it is easy to spot in logs.
+On a validation failure the dispatcher rejects the submission and returns ``HTTP 400 Missing or invalid _next_form_page`` when any of the following holds.
+
+- The field is missing or blank.
+- The basename is not ``page.py``.
+- Resolving the path raises ``OSError``.
+- ``BASE_DIR`` is unset, or the resolved path falls outside ``BASE_DIR``.
+- The ``page.py`` does not exist on disk and no sibling ``template.djx`` stands in for it.
 
 Virtual routes are fully supported as origin pages.
 A directory that has only a ``template.djx`` and no ``page.py`` is a virtual route (see :doc:`/content/topics/file-router` for the routing rules).

--- a/docs/content/topics/layouts.rst
+++ b/docs/content/topics/layouts.rst
@@ -177,36 +177,8 @@ The two trees do not share layouts.
 Project Level Root Layout
 -------------------------
 
-Place a root layout outside of any application by adding a project directory to ``DIRS``.
-
-.. code-block:: text
-   :caption: project layout
-
-   chrome/
-     layout.djx
-   notes/
-     routes/
-       page.py
-       template.djx
-
-.. code-block:: python
-   :caption: config/settings.py
-
-   NEXT_FRAMEWORK = {
-       "DEFAULT_PAGE_BACKENDS": [
-           {
-               "BACKEND": "next.urls.FileRouterBackend",
-               "DIRS": [str(BASE_DIR / "chrome")],
-               "APP_DIRS": True,
-               "PAGES_DIR": "routes",
-               "OPTIONS": {"context_processors": []},
-           }
-       ]
-   }
-
-The router walks application directories first then continues into ``chrome``.
-The ``chrome/layout.djx`` wraps every page found in every application.
-See :doc:`multi-project` for the full pattern.
+Place a root layout outside of any application by adding a project directory to ``DIRS`` so a single ``layout.djx`` wraps every page across every installed app.
+See :doc:`multi-project` for the full settings example and the layered-projects pattern.
 
 Cross Cutting Behaviour
 -----------------------

--- a/docs/content/topics/layouts.rst
+++ b/docs/content/topics/layouts.rst
@@ -47,6 +47,14 @@ The innermost wraps the page body.
 The middle layout wraps the result.
 The outermost layout wraps the result again.
 
+Layout-Only Directories
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A page directory that contains a sibling ``layout.djx`` but no body source still renders.
+The body slot is the empty string and the layout chain composes around it.
+Use this shape for landing routes whose whole markup belongs in the layout shell.
+:ref:`next.E012 <ref-system-checks>` does not fire in this case.
+
 Layout Template Contract
 ------------------------
 
@@ -191,7 +199,10 @@ They contribute variables that every layout and every page template can use.
 Because they run last, a processor that returns the same key as a ``@context`` function overwrites that value.
 Processor-to-processor duplicates are resolved by dotted path, keeping the first occurrence.
 See :doc:`context` under *Resolution Order* for the full merge order and the **first** ``TEMPLATES`` entry rule.
-Processor failures are logged and swallowed by default unless ``STRICT_CONTEXT`` is enabled. Semantics live in :ref:`ref-settings`.
+A processor that raises ``TypeError``, ``ValueError``, ``AttributeError``, or ``KeyError`` is logged and swallowed by default.
+Set ``STRICT_CONTEXT = True`` to re-raise those exceptions instead.
+Any other exception type propagates regardless of the setting.
+Semantics live in :ref:`ref-settings`.
 
 Static Collector
 ~~~~~~~~~~~~~~~~
@@ -204,7 +215,8 @@ Page Rendered Signal
 ~~~~~~~~~~~~~~~~~~~~
 
 The ``page_rendered`` signal fires once per request after the layout chain produces the final HTML.
-Subscribe to observe the rendered body without disturbing the rendering pipeline.
+Subscribe to observe rendering duration, the number of collected styles and scripts, and the keys present in the template scope.
+See :doc:`signals` for the full payload.
 
 Common Pitfalls
 ---------------

--- a/docs/content/topics/multi-project.rst
+++ b/docs/content/topics/multi-project.rst
@@ -163,7 +163,8 @@ Prefer distinct names for project-specific components over relying on this order
 Hot Reload
 ----------
 
-Every directory listed in a component backend ``DIRS``, including the shared ``_shared/_components/`` root, contributes its own ``**/component.py`` watch spec to the :doc:`autoreloader </content/internals/autoreload>`.
+Every directory listed in a component backend ``DIRS`` contributes its own ``**/component.py`` watch spec to the :doc:`autoreloader </content/internals/autoreload>`.
+The shared ``_shared/_components/`` root participates the same way.
 Each project runs its own development server with its own reloader process.
 A change to a ``component.py`` inside ``_shared/_components/`` restarts only the project processes whose configuration includes that root.
 

--- a/docs/content/topics/multi-project.rst
+++ b/docs/content/topics/multi-project.rst
@@ -119,7 +119,7 @@ The shared directory ships static files alongside components.
    ]
 
 The Django static files finder picks up files from both directories.
-Co-located CSS and JS from shared components are emitted by the static collector.
+The static collector emits co-located CSS and JS sitting next to any component, page, or layout in either tree.
 
 Shared Components Convention
 ----------------------------
@@ -164,7 +164,8 @@ Hot Reload
 ----------
 
 Every directory listed in a component backend ``DIRS``, including the shared ``_shared/_components/`` root, contributes its own ``**/component.py`` watch spec to the :doc:`autoreloader </content/internals/autoreload>`.
-A change to a ``component.py`` inside ``_shared/_components/`` restarts the development server for every project that watches that root.
+Each project runs its own development server with its own reloader process.
+A change to a ``component.py`` inside ``_shared/_components/`` restarts only the project processes whose configuration includes that root.
 
 The ``components_registered`` signal includes the full set after each reload so long-lived processes can refresh their caches.
 

--- a/docs/content/topics/pages.rst
+++ b/docs/content/topics/pages.rst
@@ -172,12 +172,12 @@ The ``inherit_context=True`` flag on a keyed function publishes the value to
 every descendant page rather than to the declaring page alone.
 See :doc:`context` for that flag and the other ways to vary the decorator.
 
-.. _topics-pages-js-context:
-
 Including Values in the JS Context
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Pass ``serialize=True`` to include the return value in ``window.Next.context`` on the client side.
+The value must be JSON-encodable by the active serializer.
+See :ref:`Serialization for the Browser <topics-context-serialization>` for the accepted shapes and common pitfalls.
 Pass ``serializer=`` with a ``JsContextSerializer`` instance to use a per-key serializer for that value instead of the global ``JS_CONTEXT_SERIALIZER`` setting.
 
 .. code-block:: python
@@ -204,7 +204,7 @@ Pass ``serializer=`` with a ``JsContextSerializer`` instance to use a per-key se
 Custom Template Loaders
 -----------------------
 
-The sibling ``template.djx`` discovery is one implementation of the ``next.pages.loaders.TemplateLoader`` contract.
+The sibling ``template.djx`` loader is one implementation of the ``next.pages.loaders.TemplateLoader`` contract.
 Register additional loaders in ``NEXT_FRAMEWORK["TEMPLATE_LOADERS"]`` to support other file formats.
 
 .. code-block:: python
@@ -252,10 +252,12 @@ A loader sets one class attribute, implements two required methods, and may over
    Class attribute string used by the system check to name the loader in conflict warnings.
 
 ``can_load(file_path)``.
-   Boolean check that decides whether the loader recognises a directory.
+   Boolean check that decides whether the loader recognises this page.
+   ``file_path`` is the absolute path to the ``page.py`` file.
+   The loader inspects the sibling directory through ``file_path.parent`` to look for its source.
 
 ``load_template(file_path)``.
-   Returns the body string or ``None``.
+   Returns the body string or ``None`` for the same ``page.py`` path.
    The framework treats ``None`` as "did not match" and tries the next loader.
 
 ``source_path(file_path)``.

--- a/docs/content/topics/pages.rst
+++ b/docs/content/topics/pages.rst
@@ -14,20 +14,7 @@ Overview
 --------
 
 The smallest page is a folder that contains a ``page.py`` and a sibling ``template.djx``.
-
-Pages share four pluggable parts.
-
-Page module.
-   A ``page.py`` file that declares context functions, action handlers, and optional ``render`` or ``template`` attributes.
-
-Body source.
-   A function, a string, or a template file that produces the page body.
-
-Context functions.
-   Callables decorated with ``@context("key")`` that publish values into the template scope.
-
-Layout chain.
-   Zero or more ``layout.djx`` files in ancestor directories that wrap the body.
+A page module declares context functions, action handlers, and optional ``render`` or ``template`` attributes, and any number of ancestor ``layout.djx`` files wrap the resulting body.
 
 Body Sources
 ------------
@@ -43,18 +30,14 @@ A page module can supply its body through these sources.
    A plain string assigned at module level.
    Used as the page body when no ``render`` function exists, and checked before any template loader.
 
-Sibling ``template.djx`` file.
-   The default source for most pages.
-   Loaded through the ``DjxTemplateLoader`` and composed with the layout chain.
+Registered template loaders.
+   The ordered list under ``NEXT_FRAMEWORK["TEMPLATE_LOADERS"]``.
+   ``DjxTemplateLoader`` is the default first entry and resolves the sibling ``template.djx``.
+   Loaders run in declared order and the first one whose ``can_load`` returns ``True`` supplies the body.
 
-Custom template loaders.
-   Any loader registered in ``NEXT_FRAMEWORK["TEMPLATE_LOADERS"]`` other than ``DjxTemplateLoader``.
-   Loaders run in declared order and the first one that matches supplies the body.
-
-Sibling ``layout.djx``.
-   A ``layout.djx`` file in the same directory as ``page.py`` wraps the body of the current page and is itself wrapped by ancestor layouts.
-   When no other body source exists the body slot is empty, so the page renders the layout shell alone.
-   :ref:`next.E012 <ref-system-checks>` does not fire for a page that has a sibling ``layout.djx``.
+A page directory may instead host only a sibling ``layout.djx``.
+That directory has no body source, and the layout chain renders with an empty body slot.
+See *Layout-only directories* under :doc:`layouts` for the wrapping rules, and note that :ref:`next.E012 <ref-system-checks>` does not fire when a sibling ``layout.djx`` is present.
 
 See *Render Order* below for the per-request sequence and the ``render`` short-circuit.
 Processor ordering and ``STRICT_CONTEXT`` behaviour are documented in :doc:`context` and :ref:`ref-settings`.
@@ -75,8 +58,8 @@ This is the authoritative ordering for the page render path.
 
 A ``render`` function therefore cannot read a value that a ``@context`` callable would publish, because the callables have not run yet.
 
-The render Function
--------------------
+The ``render`` Function
+-----------------------
 
 The ``render`` function takes any DI-resolved parameters the resolver can fill.
 The most common shape is ``request`` plus captured URL parameters and marker-driven values.
@@ -106,8 +89,8 @@ Anything else.
 
 Exceptions raised inside ``render`` propagate to the Django request stack unchanged.
 
-The template Attribute
-----------------------
+The ``template`` Attribute
+--------------------------
 
 Assign a string to the module-level ``template`` attribute when the body is small enough to live next to the Python code.
 
@@ -186,7 +169,7 @@ Pass ``serializer=`` with a ``JsContextSerializer`` instance to use a per-key se
    from next.pages import context
 
    @context("featured", serialize=True)
-   def featured() -> dict:
+   def featured_payload() -> dict:
        return {"id": 1, "title": "Hello"}
 
 .. code-block:: python
@@ -242,6 +225,10 @@ Register additional loaders in ``NEXT_FRAMEWORK["TEMPLATE_LOADERS"]`` to support
 
 A user-provided ``NEXT_FRAMEWORK["TEMPLATE_LOADERS"]`` replaces the default list entirely.
 Include ``DjxTemplateLoader`` explicitly when you still want sibling ``template.djx`` files to load.
+
+Call ``next.pages.page.register_template(file_path, template_str)`` from an app's ``ready()`` to attach an in-process template string to a page path without authoring a loader class.
+The method seeds the same composed-template registry that the regular pipeline writes to, so the next render of that page serves the supplied string.
+See :doc:`/content/ref/pages` for the full ``Page`` surface.
 
 Loader Contract
 ~~~~~~~~~~~~~~~~~
@@ -350,6 +337,10 @@ Register a ``MarkdownTemplateLoader`` in ``NEXT_FRAMEWORK["TEMPLATE_LOADERS"]`` 
 The loader renders the Markdown to a body string, and that body flows through the ancestor layout chain like any other source.
 The page module still supplies context functions and action handlers as usual.
 
+The loader output passes through Django's template engine before the layout chain renders it.
+Any ``{{ ... }}`` or ``{% ... %}`` token inside the Markdown source is evaluated.
+Wrap untrusted prose in ``{% verbatim %}`` blocks inside the loader, or escape the braces before returning the body, when authors should not be able to invoke template tags.
+
 .. seealso::
 
    The *Custom Template Loaders* section above for the ``template.md`` loader, and ``examples/markdown-blog`` for a working setup.
@@ -360,7 +351,7 @@ System Checks
 The pages subsystem contributes Django system checks. The ``check_page_functions`` check inspects every ``page.py`` and reports the following.
 
 ``next.E012``.
-   The page module has no body source: no ``render`` function, no ``template`` attribute, no registered template loader match, and no sibling ``layout.djx``.
+   The page module has neither a ``render`` function nor a ``template`` attribute, no registered loader can produce a body, and no sibling ``layout.djx`` wraps it.
 
 ``next.E013``.
    The page module defines a ``render`` attribute that is not callable.

--- a/docs/content/topics/project-layout.rst
+++ b/docs/content/topics/project-layout.rst
@@ -118,7 +118,9 @@ When you need to override a single key inside ``DEFAULT_PAGE_BACKENDS`` without 
        )
    }
 
-The helper merges the new dict into the existing first backend entry.
+The helper deep copies the default list and patches the first backend entry.
+Scalar and list overrides replace the existing value.
+Dict overrides such as ``OPTIONS`` are merged one level deep into the default dict.
 Use it for narrow overrides such as changing the page directory name.
 
 Per Project Page DIRS

--- a/docs/content/topics/signals.rst
+++ b/docs/content/topics/signals.rst
@@ -112,7 +112,8 @@ Receiver Patterns
 
 Connect once at startup.
 
-The import sits inside ``ready`` because Django's app registry is not fully initialised at module import time, making this the one approved exception to the module-level import rule.
+Django's app registry is not fully initialised at module import time, so the receiver import lives inside ``ready``.
+This is the one approved exception to the module-level import rule.
 
 .. code-block:: python
    :caption: notes/apps.py
@@ -149,7 +150,20 @@ They run in registration order.
 Disconnecting
 ~~~~~~~~~~~~~
 
-Call ``signal.disconnect`` when a receiver should stop firing.
+Call ``signal.disconnect(receiver)`` when a receiver should stop firing.
+The same ``dispatch_uid`` passed to ``connect`` can be supplied to ``disconnect`` so a receiver wired by string identifier can also be removed by that identifier.
+
+.. code-block:: python
+   :caption: notes/receivers.py
+
+   from next.signals import action_dispatched
+
+   def log_dispatch(sender, **kwargs) -> None:
+       ...
+
+   action_dispatched.connect(log_dispatch, dispatch_uid="notes.log_dispatch")
+   action_dispatched.disconnect(dispatch_uid="notes.log_dispatch")
+
 The ``SignalRecorder`` from ``next.testing.signals`` disconnects its receivers on context-manager exit, or when ``stop()`` is called explicitly.
 
 Test Helpers

--- a/docs/content/topics/signals.rst
+++ b/docs/content/topics/signals.rst
@@ -124,7 +124,7 @@ This is the one approved exception to the module-level import rule.
        name = "notes"
 
        def ready(self) -> None:
-           from notes import receivers  # noqa: F401
+           from notes import receivers  # noqa: F401, PLC0415
 
 Use ``django.dispatch.receiver`` to connect a callable to a signal.
 

--- a/docs/content/topics/static-assets/asset-kinds.rst
+++ b/docs/content/topics/static-assets/asset-kinds.rst
@@ -166,7 +166,8 @@ System Checks
 
 The static system checks validate the backend configuration only.
 They do not validate kind registration.
-A bad call to ``default_kinds.register`` raises ``ValueError`` during ``AppConfig.ready``, which aborts ``manage.py check`` before any check runs.
+A bad call to ``default_kinds.register`` raises ``ValueError`` during ``AppConfig.ready``.
+Because Django runs ``ready`` for every management command and during ASGI or WSGI worker boot, the exception aborts whatever process is starting up, not only ``manage.py check``.
 
 Common Patterns
 ---------------

--- a/docs/content/topics/static-assets/asset-kinds.rst
+++ b/docs/content/topics/static-assets/asset-kinds.rst
@@ -164,7 +164,7 @@ Customise the rendered output through the ``module_tag`` key in the backend ``OP
 System Checks
 -------------
 
-The static system checks validate the backend configuration only.
+The static system checks validate the backend configuration and the ``JS_CONTEXT_SERIALIZER`` setting (``next.W042``).
 They do not validate kind registration.
 A bad call to ``default_kinds.register`` raises ``ValueError`` during ``AppConfig.ready``.
 Because Django runs ``ready`` for every management command and during ASGI or WSGI worker boot, the exception aborts whatever process is starting up, not only ``manage.py check``.

--- a/docs/content/topics/static-assets/backends.rst
+++ b/docs/content/topics/static-assets/backends.rst
@@ -99,7 +99,9 @@ This covers most customisation without a subclass.
 Dedup and JS Context Options
 ----------------------------
 
-The first backend ``OPTIONS`` also carries two pipeline level keys.
+The first entry of ``DEFAULT_STATIC_BACKENDS`` owns the pipeline-level options.
+``DEDUP_STRATEGY`` and ``JS_CONTEXT_POLICY`` are read from the first backend ``OPTIONS`` only.
+The same keys on a second or third backend are ignored, so place the configured values on the leading entry.
 
 .. note::
 
@@ -131,28 +133,10 @@ Writing a Custom Backend
 ------------------------
 
 Subclass ``StaticFilesBackend`` to keep the staticfiles resolution and change only the rendered markup.
+Override ``render_link_tag``, ``render_script_tag``, and ``render_module_tag`` so ``.css``, ``.js``, and ``.mjs`` assets all carry the new attribute or host.
+A renderer that is not overridden falls back to the parent output, which is why dropping ``render_module_tag`` makes ``.mjs`` assets skip the customisation.
 
-.. code-block:: python
-   :caption: notes/backends.py
-
-   import base64
-   import hashlib
-   from pathlib import Path
-   from next.static import StaticFilesBackend
-
-   class SriBackend(StaticFilesBackend):
-       def render_link_tag(self, url, *, request=None) -> str:
-           return f'<link rel="stylesheet" href="{url}" crossorigin>'
-
-       def render_script_tag(self, url, *, request=None) -> str:
-           return f'<script src="{url}" crossorigin></script>'
-
-       def render_module_tag(self, url, *, request=None) -> str:
-           return f'<script type="module" src="{url}" crossorigin></script>'
-
-Override ``render_module_tag`` as well, otherwise ``.mjs`` assets miss the attribute the override adds.
-
-This example adds ``crossorigin`` only.
+:doc:`/content/howto/write-a-static-backend` walks through the attribute and CDN recipes.
 For a complete Subresource Integrity implementation that also computes the ``integrity`` hash, see :doc:`/content/security/static-assets`.
 
 Subclass the abstract ``StaticBackend`` directly only when the project resolves assets from a source other than Django staticfiles, such as a build manifest.
@@ -205,10 +189,8 @@ System Checks
 -------------
 
 The static checks validate the backend configuration at startup.
-They use the codes ``next.E036``, ``next.E037``, ``next.E038``, ``next.W030``, and ``next.W031``.
 Run ``uv run python manage.py check`` after editing the backend list.
-
-A separate check, ``next.W042``, validates the ``JS_CONTEXT_SERIALIZER`` setting, see :doc:`js-context`.
+The full list of static check codes lives in :doc:`/content/ref/system-checks`.
 
 The ``next.W031`` check validates the ``css_tag`` and ``js_tag`` templates.
 The ``module_tag`` template is not checked, so verify it contains ``{url}`` yourself.

--- a/docs/content/topics/static-assets/backends.rst
+++ b/docs/content/topics/static-assets/backends.rst
@@ -193,7 +193,7 @@ A custom backend can vary its output per request, for example to pick a CDN host
            return f'<link rel="stylesheet" href="{prefix}{url}">'
 
 The manager passes the current request to every renderer call.
-See ``examples/multi-tenant`` for a worked tenant prefix backend.
+See the `multi-tenant example <https://github.com/next-dj/next-dj/tree/main/examples/multi-tenant>`__ for a worked tenant prefix backend.
 
 Signals
 -------

--- a/docs/content/topics/static-assets/co-located-files.rst
+++ b/docs/content/topics/static-assets/co-located-files.rst
@@ -110,11 +110,6 @@ Layout assets enter first as the layout chain unfolds from the root.
 Page assets follow.
 Component assets enter in the order the components appear in the template.
 
-Hot Reload
-----------
-
-See :doc:`overview` for how the per-request collector picks up new co-located files without a process restart.
-
 Recipes
 -------
 

--- a/docs/content/topics/static-assets/co-located-files.rst
+++ b/docs/content/topics/static-assets/co-located-files.rst
@@ -27,6 +27,7 @@ Discovery groups stems into three roles.
 ``component`` role.
    Default stem ``component``.
    Matches files alongside the component's ``component.djx`` or ``component.py``.
+   Simple components without a folder have no co-located directory, so discovery skips them.
 
 .. code-block:: text
    :caption: directory layout
@@ -110,26 +111,28 @@ Layout assets enter first as the layout chain unfolds from the root.
 Page assets follow.
 Component assets enter in the order the components appear in the template.
 
-Recipes
--------
+Common Patterns
+---------------
 
-Site-Wide Reset
-~~~~~~~~~~~~~~~
+A ``layout.css`` at the root applies to every page under that layout because layout assets enter the collector first.
+A ``layout.css`` at an inner layout scopes the styles to pages below that layout only.
+Use ``component.js`` for plain behaviour and ``component.mjs`` when the script depends on ECMAScript module imports.
 
-Place ``layout.css`` next to the root ``layout.djx``.
-Every page below the layout inherits the reset because layout assets enter the collector first.
+External URLs via Module Lists
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Per-Section Styles
-~~~~~~~~~~~~~~~~~~
+Declare ``styles`` and ``scripts`` at module level in ``page.py`` or ``component.py`` to register external URLs alongside co-located files.
 
-Add a ``layout.css`` next to an inner layout.
-The styles apply only to pages below that layout.
+.. code-block:: python
+   :caption: notes/_components/note_card/component.py
 
-Component Behaviour
-~~~~~~~~~~~~~~~~~~~
+   styles = ["https://cdn.example.com/reset.css"]
+   scripts = ["https://cdn.example.com/vendor.js", "/static/local/widget.mjs"]
 
-Use ``component.js`` for behaviour that runs on every page that includes the component.
-Use ``component.mjs`` when the script depends on ECMAScript module imports.
+Each variable is a list of strings.
+The slot is picked from the registered placeholder name, ``styles`` or ``scripts``.
+The kind is inferred from the URL extension through the kind registry.
+URLs with an unknown extension are dropped with a debug log.
 
 See Also
 --------

--- a/docs/content/topics/static-assets/custom-stems.rst
+++ b/docs/content/topics/static-assets/custom-stems.rst
@@ -77,10 +77,8 @@ A repeated registration of the same stem is a no op.
 Stem and Kind Interaction
 -------------------------
 
-A new stem participates in every registered kind.
-After registering a ``vendor`` stem, discovery looks for ``vendor.css``, ``vendor.js``, and ``vendor.mjs`` inside component folders, because the three built in kinds cover those extensions.
-
-Pair a stem with a custom kind to reach a unique file convention, see :doc:`asset-kinds`.
+A new stem participates in every registered kind, so a registration combines with every kind extension automatically.
+See :doc:`/content/howto/add-a-custom-stem` for a worked example, and :doc:`asset-kinds` for pairing a stem with a custom kind.
 
 Owner Resolution
 ----------------
@@ -90,11 +88,6 @@ A ``vendor.css`` inside a component folder is still owned by the component.
 A ``page.css`` next to ``template.djx`` is still owned by the page.
 
 The owner determines when the collector adds the asset.
-
-Hot Reload
-----------
-
-See :doc:`overview` for how a new co-located file under a registered stem is picked up without a process restart.
 
 Common Patterns
 ---------------

--- a/docs/content/topics/static-assets/deduplication.rst
+++ b/docs/content/topics/static-assets/deduplication.rst
@@ -17,7 +17,7 @@ The collector holds a dedup strategy.
 A strategy reduces a ``StaticAsset`` to a hashable key.
 The collector ignores any asset whose key was already recorded.
 
-The framework ships three strategies.
+The framework ships three strategies in ``next.static.collector``.
 
 ``UrlDedup``.
    The default.

--- a/docs/content/topics/static-assets/index.rst
+++ b/docs/content/topics/static-assets/index.rst
@@ -15,8 +15,13 @@ The pipeline is fully pluggable through asset kinds, custom stems, and backends.
 :doc:`co-located-files`
    How asset files are paired with pages and components.
 
+.. rubric:: Authoring
+
 :doc:`template-tags`
    Template tags that emit the collected output.
+
+:doc:`js-context`
+   Exposing context to the browser through the ``Next`` object.
 
 .. rubric:: Mechanics
 
@@ -28,11 +33,6 @@ The pipeline is fully pluggable through asset kinds, custom stems, and backends.
 
 :doc:`custom-stems`
    Recognise additional filenames as component assets.
-
-.. rubric:: Browser side
-
-:doc:`js-context`
-   Exposing context to the browser through the ``Next`` object.
 
 .. rubric:: Extending
 

--- a/docs/content/topics/static-assets/index.rst
+++ b/docs/content/topics/static-assets/index.rst
@@ -4,7 +4,8 @@ Static Assets
 =============
 
 The static pipeline discovers co-located CSS, JS, and module files, deduplicates them across requests, and injects them into HTML.
-The injection point is the location of the ``{% collect_styles %}`` and ``{% collect_scripts %}`` template tags.
+The default injection points are the ``collect_*`` template tags, which mark placeholder slots in the layout.
+Extra slots register through ``default_placeholders.register``, so projects can add their own injection points beyond ``styles`` and ``scripts``.
 The pipeline is fully pluggable through asset kinds, custom stems, and backends.
 
 .. rubric:: Concepts

--- a/docs/content/topics/static-assets/js-context.rst
+++ b/docs/content/topics/static-assets/js-context.rst
@@ -26,6 +26,7 @@ Keys without the flag stay server-side only.
 
 A value the active serializer cannot encode raises ``TypeError`` during rendering, when the collector registers it.
 The error names the offending key.
+See :ref:`Serialization for the Browser <topics-context-serialization>` for the accepted shapes and the common materialisation patterns.
 
 Serializers
 -----------
@@ -58,7 +59,14 @@ Set ``NEXT_FRAMEWORK["JS_CONTEXT_SERIALIZER"]`` to the dotted path of a serializ
    }
 
 ``resolve_serializer`` reads the setting on every call.
-When the key is absent the framework uses ``JsonJsContextSerializer``.
+When the key is absent or set to an empty string the framework uses ``JsonJsContextSerializer``.
+
+System Check
+~~~~~~~~~~~~
+
+The ``next.W042`` system check validates ``JS_CONTEXT_SERIALIZER`` at startup.
+It warns when the value is not a string, when the dotted path cannot be imported, when the resolved attribute is not a class, when the class cannot be instantiated, or when the instance does not implement the ``JsContextSerializer`` protocol (a ``dumps(value) -> str`` method).
+The check is skipped when the key is absent or set to an empty string.
 
 Per-Key Serializer
 ------------------
@@ -149,6 +157,10 @@ Configure the policy through the first static backend ``OPTIONS``.
        ]
    }
 
+The configured policy only fires across modules, when a page and a component share a key or when two components do.
+Two ``@context`` decorators on the same page that register the same key always resolve first-wins, regardless of ``JS_CONTEXT_POLICY``.
+Pick distinct keys when both registrations live in the same module.
+
 Writing a Policy
 ----------------
 
@@ -178,7 +190,19 @@ Point ``JS_CONTEXT_POLICY`` in the first static backend ``OPTIONS`` at the dotte
 Reading on the Client
 ---------------------
 
-Co-located JS and inline scripts read ``window.Next.context``.
+Register the key server-side with ``serialize=True``.
+
+.. code-block:: python
+   :caption: notes/pages/page.py
+
+   from next.pages import context
+   from notes.models import Note
+
+   @context("note_count", serialize=True)
+   def note_count() -> int:
+       return Note.objects.count()
+
+Co-located JS and inline scripts then read the value under ``window.Next.context``.
 
 .. code-block:: javascript
    :caption: notes/_components/note_card/component.js
@@ -212,13 +236,14 @@ An absent or empty ``NEXT_JS_OPTIONS`` uses the ``AUTO`` policy and the default 
      - Skips injection entirely. ``window.Next`` is not defined.
      - Pages that serve raw data or HTML fragments and have no client-side JS that reads ``window.Next``.
    * - ``MANUAL``
-     - Skips automatic injection but builds the tag strings on request via ``NextScriptBuilder`` methods.
+     - Skips automatic injection.
+       Build the tags yourself with ``NextScriptBuilder.from_options``.
      - Pages where you control placement of the script tags in a layout template.
 
 .. note::
 
-   Under ``MANUAL``, the framework builds the ``NextScriptBuilder`` but skips injection.
-   Retrieve it via ``next.static.default_manager._next_script_builder()`` to emit the ``<script>`` tag yourself, for example in a custom template tag or middleware.
+   Under ``MANUAL`` the static manager does not emit ``window.Next`` for you.
+   Construct your own builder through ``NextScriptBuilder.from_options(next_js_url, NEXT_JS_OPTIONS)`` and emit ``preload_link()``, ``script_tag()``, and ``init_script(js_context)`` from a custom template tag or middleware.
 
 Set the policy through the ``NEXT_JS_OPTIONS`` dict.
 

--- a/docs/content/topics/static-assets/js-context.rst
+++ b/docs/content/topics/static-assets/js-context.rst
@@ -157,7 +157,7 @@ Configure the policy through the first static backend ``OPTIONS``.
        ]
    }
 
-The configured policy only fires across modules, when a page and a component share a key or when two components do.
+The configured policy fires anywhere the same key reaches the collector twice, including page-to-component, component-to-component, page-to-layout, and any contributor that calls ``StaticCollector.add_js_context`` directly.
 Two ``@context`` decorators on the same page that register the same key always resolve first-wins, regardless of ``JS_CONTEXT_POLICY``.
 Pick distinct keys when both registrations live in the same module.
 
@@ -236,14 +236,14 @@ An absent or empty ``NEXT_JS_OPTIONS`` uses the ``AUTO`` policy and the default 
      - Skips injection entirely. ``window.Next`` is not defined.
      - Pages that serve raw data or HTML fragments and have no client-side JS that reads ``window.Next``.
    * - ``MANUAL``
-     - Skips automatic injection.
-       Build the tags yourself with ``NextScriptBuilder.from_options``.
+     - Skips automatic injection in the static manager, the same as ``DISABLED``.
+       The script builder stays available for custom emission.
      - Pages where you control placement of the script tags in a layout template.
 
 .. note::
 
-   Under ``MANUAL`` the static manager does not emit ``window.Next`` for you.
-   Construct your own builder through ``NextScriptBuilder.from_options(next_js_url, NEXT_JS_OPTIONS)`` and emit ``preload_link()``, ``script_tag()``, and ``init_script(js_context)`` from a custom template tag or middleware.
+   Under ``MANUAL`` the static manager skips both the preload hint and the ``Next._init`` wrap, exactly like ``DISABLED``.
+   To inject ``window.Next`` yourself, resolve the runtime URL with ``staticfiles_storage.url(NEXT_JS_STATIC_PATH)`` from ``next.static.scripts``, then build a ``NextScriptBuilder.from_options(url, NEXT_JS_OPTIONS)`` and emit ``preload_link()``, ``script_tag()``, and ``init_script(js_context)`` from a custom template tag or middleware.
 
 Set the policy through the ``NEXT_JS_OPTIONS`` dict.
 
@@ -282,6 +282,7 @@ Use them to add attributes such as ``nonce``, ``async``, or ``crossorigin`` with
 
 A template carries only its own placeholder, ``{url}`` or ``{payload}``, and no other substitution is supported.
 The templates are formatted with Python ``str.format``, not Django templates.
+A literal ``{`` or ``}`` inside the template body collides with the formatter and must be doubled to ``{{`` or ``}}`` to survive ``str.format``.
 For per-request values such as CSP nonces, use a custom static backend instead.
 
 See Also

--- a/docs/content/topics/static-assets/overview.rst
+++ b/docs/content/topics/static-assets/overview.rst
@@ -47,6 +47,10 @@ StaticAsset
 ``inline``.
    The pre-rendered inline body, or ``None`` for URL assets.
 
+``url`` and ``inline`` are mutually exclusive.
+A URL asset carries a non-empty ``url`` and a ``None`` ``inline``.
+An inline asset carries a ``None`` or empty ``url`` and a non-empty ``inline`` body.
+
 Asset Kinds
 -----------
 

--- a/docs/content/topics/static-assets/overview.rst
+++ b/docs/content/topics/static-assets/overview.rst
@@ -91,7 +91,8 @@ A render that uses the component adds the asset to the collector, which deduplic
 After the page renders, the static manager replaces the ``styles`` slot token emitted by ``{% collect_styles %}`` with the link tags produced by ``render_link_tag`` on the active backend.
 ``render_link_tag`` resolves the on-disk path to a public URL through Django staticfiles, so manifest hashing and CDN settings apply to the emitted tag.
 
-The same flow applies to ``component.js`` (kind ``js``) and ``component.mjs`` (kind ``module``), which land in the ``scripts`` slot emitted by ``{% collect_scripts %}``.
+The same flow applies to ``component.js`` (kind ``js``, classic script) and ``component.mjs`` (kind ``module``, ECMAScript module), which both land in the ``scripts`` slot emitted by ``{% collect_scripts %}``.
+The extension picks the kind, so a file named ``component.js`` never renders through ``render_module_tag``.
 :doc:`/content/internals/static-pipeline` traces the pipeline step by step.
 
 Stems and Owners

--- a/docs/content/topics/static-assets/signals.rst
+++ b/docs/content/topics/static-assets/signals.rst
@@ -71,11 +71,12 @@ The sender is the static manager.
 
 ``placeholders_replaced``
    A tuple of slot names whose token appeared in ``html_before``.
-   The tuple is computed lazily and is only populated when at least one receiver is connected to ``html_injected``.
+   The whole ``html_injected`` dispatch is skipped when no receiver is connected, so the tuple is built only on the request paths where a listener is present.
 
 ``injected_bytes``
    A signed ``int`` equal to ``len(html_after) - len(html_before)``.
    Negative when injection shortens the document, for example when a slot token is longer than the rendered tags it replaces.
+   The preload hint is added before the diff is measured, so under ``AUTO`` an empty collector can still produce a positive value because the preload link grows the document.
 
 ``request``
    The active ``HttpRequest`` or ``None``.

--- a/docs/content/topics/static-assets/signals.rst
+++ b/docs/content/topics/static-assets/signals.rst
@@ -59,8 +59,26 @@ html_injected
 
 Fires after placeholder replacement completes.
 The sender is the static manager.
-The payload carries ``html_before``, ``html_after``, ``collector``, ``placeholders_replaced``, ``injected_bytes``, and ``request``.
-The ``request`` argument carries the active ``HttpRequest`` or ``None``.
+
+``html_before``
+   The raw HTML string the manager received before injection.
+
+``html_after``
+   The HTML string after every slot token was replaced.
+
+``collector``
+   The sealed ``StaticCollector`` used for this render.
+
+``placeholders_replaced``
+   A tuple of slot names whose token appeared in ``html_before``.
+   The tuple is computed lazily and is only populated when at least one receiver is connected to ``html_injected``.
+
+``injected_bytes``
+   A signed ``int`` equal to ``len(html_after) - len(html_before)``.
+   Negative when injection shortens the document, for example when a slot token is longer than the rendered tags it replaces.
+
+``request``
+   The active ``HttpRequest`` or ``None``.
 
 backend_loaded
 ~~~~~~~~~~~~~~
@@ -70,6 +88,12 @@ The sender is the backend class.
 The payload carries ``config`` and ``instance``.
 
 Register imports from ``AppConfig.ready`` so receivers exist before the first request.
+
+.. note::
+
+   ``backend_loaded`` re-fires whenever the static manager rebuilds its backend chain.
+   Tests that toggle ``DEFAULT_STATIC_BACKENDS`` through ``override_settings`` or call ``reset_default_manager`` trigger the signal again on the next access.
+   Make receivers idempotent.
 
 Pipeline placement
 ------------------

--- a/docs/content/topics/static-assets/template-tags.rst
+++ b/docs/content/topics/static-assets/template-tags.rst
@@ -3,7 +3,7 @@
 Static Template Tags
 ====================
 
-The static pipeline registers six Django template tags.
+The static pipeline registers four Django template tags plus two inline block forms.
 ``{% collect_styles %}`` and ``{% collect_scripts %}`` mark placeholder slots in the layout.
 ``{% use_style %}`` and ``{% use_script %}`` register an external URL on the active collector.
 ``{% #use_style %}`` and ``{% #use_script %}`` are block forms that capture an inline body.
@@ -78,6 +78,8 @@ use_script
    {% use_script "https://cdn.example.com/vendor.js" %}
 
 The asset is prepended to the collector the same way as ``use_style``.
+The tag always registers the URL under kind ``js``, so it cannot publish an ECMAScript module.
+For a ``.mjs`` dependency, list the URL in the page or component ``scripts`` module-level variable instead, see :doc:`co-located-files`.
 
 Inline Blocks
 -------------

--- a/docs/content/topics/static-assets/template-tags.rst
+++ b/docs/content/topics/static-assets/template-tags.rst
@@ -3,9 +3,10 @@
 Static Template Tags
 ====================
 
-The static pipeline exposes four template tags, two of which also have a block form.
+The static pipeline registers six Django template tags.
 ``{% collect_styles %}`` and ``{% collect_scripts %}`` mark placeholder slots in the layout.
-``{% use_style %}`` and ``{% use_script %}`` register external or inline assets from a template.
+``{% use_style %}`` and ``{% use_script %}`` register an external URL on the active collector.
+``{% #use_style %}`` and ``{% #use_script %}`` are block forms that capture an inline body.
 
 .. contents::
    :local:
@@ -105,8 +106,8 @@ The collector deduplicates inline entries by the rendered body, so two identical
 Placement Rules
 ---------------
 
-Place each ``{% collect_styles %}`` and ``{% collect_scripts %}`` tag once in the layout chain.
-A token that appears twice is replaced in both spots.
+Place each ``{% collect_styles %}`` and ``{% collect_scripts %}`` tag exactly once in the layout chain.
+The manager replaces every occurrence of the slot token with the same rendered output, so a tag that appears twice emits every collected asset twice in the final HTML.
 The recommended placement is the outermost layout.
 
 - ``{% collect_styles %}`` inside ``<head>``.

--- a/docs/content/topics/testing.rst
+++ b/docs/content/topics/testing.rst
@@ -13,7 +13,8 @@ This page covers the public surface of the module and the patterns for testing p
 Choose the Right Helper
 -----------------------
 
-``next.testing`` groups its helpers into focused submodules covering the client, isolation, signal capture, rendering, loaders, HTML assertions, patching, action helpers, and dependency context builders.
+``next.testing`` groups its helpers into focused submodules.
+The submodules cover the client, isolation, signal capture, rendering, loaders, HTML assertions, patching, action helpers, and dependency context builders.
 The table below maps each testing goal to the helper and its import path.
 
 .. list-table::
@@ -78,6 +79,13 @@ Pytest.
    Set ``DJANGO_SETTINGS_MODULE`` in ``pytest.ini`` so ``pytest-django`` can configure Django before collecting tests.
    Run the suite with ``uv run pytest``.
 
+   .. code-block:: ini
+      :caption: pytest.ini
+
+      [pytest]
+      DJANGO_SETTINGS_MODULE = config.settings
+      python_files = test_*.py
+
 Stdlib ``unittest``.
    Call ``django.setup()`` once before importing any ``next.testing`` helper, then run the suite with the standard runner.
 
@@ -125,7 +133,8 @@ Tests that write ``template.djx`` or ``page.py`` files to ``tmp_path`` need both
 .. note::
 
    When ``LAZY_COMPONENT_MODULES = True`` in ``NEXT_FRAMEWORK``, bulk import of ``component.py`` modules from configured component roots is skipped during ``AppConfig.ready``.
-   After ``reset_registries()``, decorator side effects from those modules are absent until resolve time unless you call ``eager_load_components()`` from ``next.testing.loaders``, which imports every registered ``component.py`` regardless of the flag.
+   After ``reset_registries()``, decorator side effects from those modules are absent until resolve time.
+   Call ``eager_load_components()`` from ``next.testing.loaders`` to import every registered ``component.py`` regardless of the flag.
 
    .. code-block:: python
       :caption: conftest.py, eager loading with lazy modules
@@ -142,12 +151,15 @@ Tests that write ``template.djx`` or ``page.py`` files to ``tmp_path`` need both
           reset_registries()
 
    With the default ``LAZY_COMPONENT_MODULES = False``, all registrations are in place after ``AppConfig.ready``, so the extra call is unnecessary.
-
-   ``eager_load_pages(base_dir)`` is a separate helper that imports every ``page.py`` under a given directory.
-   Use it when a test suite does not go through the full request cycle and must trigger ``@context`` and ``@action`` side-effects manually.
-   ``clear_loaded_dirs()`` drops the per-directory memoisation so a later ``eager_load_pages`` call re-imports.
-   It is needed only when a test rewrites ``page.py`` files on disk within a single session.
    See :ref:`ref-settings` for the full description of ``LAZY_COMPONENT_MODULES``.
+
+Eager Page Loading
+~~~~~~~~~~~~~~~~~~
+
+``eager_load_pages(base_dir)`` imports every ``page.py`` under a given directory.
+Use it when a test suite does not go through the full request cycle and must trigger ``@context`` and ``@action`` side-effects manually.
+``clear_loaded_dirs()`` drops the per-directory memoisation so a later ``eager_load_pages`` call re-imports.
+It is needed only when a test rewrites ``page.py`` files on disk within a single session.
 
 NextClient
 ----------
@@ -204,9 +216,20 @@ It does not invoke a ``render()`` function declared in ``page.py``.
 Use ``NextClient`` for pages whose body is built by ``render()``.
 Use it for snapshot tests and template assertion tests that do not need URL routing.
 
-Pass ``request=`` to supply a custom ``HttpRequest``.
+Pass an ``HttpRequest`` as the second positional argument to supply a custom request.
 When omitted the helper synthesises one through ``RequestFactory().get("/")`` so context functions and the static collector see a real request object.
 Extra keyword arguments are forwarded to the underlying ``page.render`` call as URL kwargs, which feeds them into ``DUrl`` markers and other URL-scoped providers.
+
+.. code-block:: python
+   :caption: render with a custom request
+
+   from django.test import RequestFactory
+   from next.testing.rendering import render_page
+
+   def test_index_with_request() -> None:
+       request = RequestFactory().get("/?debug=1")
+       html = render_page("notes/pages/page.py", request)
+       assert "Notes" in html
 
 Capture Signals
 ---------------

--- a/docs/content/topics/testing.rst
+++ b/docs/content/topics/testing.rst
@@ -72,10 +72,14 @@ See :doc:`/content/ref/testing` for generated signatures.
 Boot the Suite
 --------------
 
-Set ``DJANGO_SETTINGS_MODULE`` in ``pytest.ini`` so pytest-django can configure Django before collecting tests.
-Run the suite with ``uv run pytest``.
-The ``next.testing`` helpers assume the app registry is populated; ``pytest-django`` does this automatically.
-A stdlib ``unittest`` suite calls ``django.setup()`` once before importing any ``next.testing`` helper.
+The ``next.testing`` helpers assume the app registry is populated before any helper is imported.
+
+Pytest.
+   Set ``DJANGO_SETTINGS_MODULE`` in ``pytest.ini`` so ``pytest-django`` can configure Django before collecting tests.
+   Run the suite with ``uv run pytest``.
+
+Stdlib ``unittest``.
+   Call ``django.setup()`` once before importing any ``next.testing`` helper, then run the suite with the standard runner.
 
 Isolate Registries
 ------------------
@@ -148,10 +152,8 @@ Tests that write ``template.djx`` or ``page.py`` files to ``tmp_path`` need both
 NextClient
 ----------
 
-``NextClient`` is a thin subclass of Django's ``Client`` that adds ``post_action`` and ``get_action_url``, both of which resolve an action name through ``resolve_action_url``.
-It does nothing special on creation.
-The file router builds lazily through Django's URL resolver on the first request.
-Use it for end to end HTTP tests.
+``NextClient`` is a thin subclass of Django's ``Client`` that adds ``post_action`` and ``get_action_url``.
+Both resolve an action name through ``resolve_action_url`` before delegating to the underlying client.
 
 .. code-block:: python
    :caption: tests/test_index.py
@@ -201,6 +203,10 @@ Use ``next.testing.rendering`` to render a page without an HTTP round trip.
 It does not invoke a ``render()`` function declared in ``page.py``.
 Use ``NextClient`` for pages whose body is built by ``render()``.
 Use it for snapshot tests and template assertion tests that do not need URL routing.
+
+Pass ``request=`` to supply a custom ``HttpRequest``.
+When omitted the helper synthesises one through ``RequestFactory().get("/")`` so context functions and the static collector see a real request object.
+Extra keyword arguments are forwarded to the underlying ``page.render`` call as URL kwargs, which feeds them into ``DUrl`` markers and other URL-scoped providers.
 
 Capture Signals
 ---------------
@@ -309,9 +315,7 @@ HTML Utilities
        )
        assert_has_class(html, "note-card")
 
-``find_anchor`` returns the matching anchor tag.
-It accepts an ``href`` keyword that matches the anchor ``href`` exactly and a ``text`` keyword that matches a substring against the anchor's stripped inner text.
-It raises ``LookupError`` when no anchor matches the filters.
+``find_anchor`` returns the matching anchor tag and raises ``LookupError`` when no anchor matches the filters, see :func:`next.testing.html.find_anchor` for the accepted keywords.
 ``assert_has_class`` and ``assert_missing_class`` check the class list of the first start tag in the fragment.
 
 Patching
@@ -342,6 +346,8 @@ Patching
 
 A ``StaticCollectorProxy`` is yielded by ``patch_static_collector(capture=True)``.
 Its ``.collector`` attribute holds the collector built inside the block, so a test can assert on the emitted styles and scripts without parsing HTML.
+Pass ``factory=`` to swap the collector implementation entirely.
+The callable runs in place of the default ``create_collector`` and returns a custom ``StaticCollector`` for the duration of the block.
 
 Use ``patch_static_collector(capture=True)`` to inspect which assets a page emits:
 

--- a/docs/content/topics/url-reversing.rst
+++ b/docs/content/topics/url-reversing.rst
@@ -114,7 +114,9 @@ The helper takes a URL string and adds, replaces, or removes query parameters.
    with_query("/filter/", tag=["python", "django"])
    # "/filter/?tag=python&tag=django"
 
-An existing parameter with an empty value, such as ``?flag=``, is kept unless you pass that key explicitly.
+   # An empty-valued parameter is preserved unless you pass that key.
+   with_query("/search/?flag=", query="next.dj")
+   # "/search/?flag=&query=next.dj"
 
 Multi Value Keys
 ~~~~~~~~~~~~~~~~

--- a/docs/content/topics/url-reversing.rst
+++ b/docs/content/topics/url-reversing.rst
@@ -209,18 +209,27 @@ Pagination
 Testing
 -------
 
-Both helpers are pure functions and are safe to call from tests without any Django request context.
+``with_query`` is a pure stdlib helper.
+It accepts a URL string and keyword arguments and returns a string, so a unit test can call it without configuring Django.
 
 .. code-block:: python
-   :caption: tests
+   :caption: with_query test
 
-   from next.urls import page_reverse, with_query
-
-   def test_page_reverse_empty() -> None:
-       assert page_reverse() == "/"
+   from next.urls import with_query
 
    def test_with_query_drops_none() -> None:
        assert with_query("/?a=1", a=None) == "/"
+
+``page_reverse`` calls into the Django URL resolver, so the test process needs configured Django settings and a loaded URL configuration before the helper resolves anything.
+Use ``pytest-django`` or call ``django.setup()`` once, then assert against the produced path.
+
+.. code-block:: python
+   :caption: page_reverse test
+
+   from next.urls import page_reverse
+
+   def test_page_reverse_empty() -> None:
+       assert page_reverse() == "/"
 
 Reading the Query String Back
 -----------------------------
@@ -231,7 +240,8 @@ To read them in a page or component, annotate a parameter with the ``DQuery[T]``
 
 ``DQuery[list[T]]`` accepts several wire formats for a repeated parameter, and ``with_query`` emits the repeated-key form when you pass a list.
 To read a repeated parameter outside the resolver, call ``get_multi_values(request, name)`` from ``next.urls``, which returns every value for that key as a list.
-Captured **path** segments are separate. They flow through ``DUrl`` or plain URL kwargs as described in :doc:`dependency-injection`.
+Captured path segments are separate.
+They flow through ``DUrl`` or plain URL kwargs as described in :doc:`dependency-injection`.
 
 See :doc:`/content/howto/read-query-parameters` for the full typed-query walkthrough.
 

--- a/next/urls/markers.py
+++ b/next/urls/markers.py
@@ -142,7 +142,7 @@ class UrlByAnnotationProvider(RegisteredParameterProvider):
         raw = url_kwargs.get(key)
         if raw is None:
             return None
-        return _coerce_url_value(str(raw), _url_type_hint(args))
+        return _coerce_url_value(raw, _url_type_hint(args))
 
 
 def _url_type_hint(args: tuple[object, ...]) -> type:
@@ -177,9 +177,7 @@ class UrlKwargsProvider(RegisteredParameterProvider):
         hint = (
             param.annotation if param.annotation is not inspect.Parameter.empty else str
         )
-        if hint is str or hint is inspect.Parameter.empty:
-            return str(raw)
-        return _coerce_url_value(str(raw), hint)
+        return _coerce_url_value(raw, hint)
 
 
 class QueryParamProvider(RegisteredParameterProvider):

--- a/next/urls/parser.py
+++ b/next/urls/parser.py
@@ -8,29 +8,46 @@ a Django path pattern. Bracket syntax `[name]` maps to `<str:name>`,
 from __future__ import annotations
 
 import re
-from typing import ClassVar
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from typing import TYPE_CHECKING, ClassVar
+from uuid import UUID
 
 
-def _coerce_url_value(value: str, hint: type) -> object:
-    """Coerce a URL string toward `int`, `bool`, `float`, or `str`.
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
-    Returns the original string when conversion fails so the caller
-    can decide how to react. The helper is shared by `DUrl` and
-    `DQuery` parameter resolution.
-    """
-    if hint is int:
-        try:
-            return int(value)
-        except ValueError:
-            return value
-    if hint is bool:
-        return value.lower() in ("1", "true", "yes")
-    if hint is float:
-        try:
-            return float(value)
-        except ValueError:
-            return value
-    return value
+
+def _coerce_bool(text: str) -> bool:
+    return text.lower() in ("1", "true", "yes")
+
+
+_COERCERS: dict[type, Callable[[str], object]] = {
+    str: str,
+    int: int,
+    bool: _coerce_bool,
+    float: float,
+    UUID: UUID,
+    Decimal: Decimal,
+    datetime: datetime.fromisoformat,
+    date: date.fromisoformat,
+}
+
+
+def _coerce_url_value(value: object, hint: object) -> object:
+    """Coerce `value` to `hint`, passing it through on failure or unsupported hint."""
+    if not isinstance(hint, type):
+        return value
+    if isinstance(value, hint):
+        return value
+    coercer = _COERCERS.get(hint)
+    if coercer is None:
+        return value
+    text = value if isinstance(value, str) else str(value)
+    try:
+        return coercer(text)
+    except (ValueError, InvalidOperation):
+        return value
 
 
 class URLPatternParser:

--- a/tests/deps/test_providers.py
+++ b/tests/deps/test_providers.py
@@ -199,13 +199,13 @@ class TestUrlKwargsProvider:
 
 
 class TestCoerceUrlValue:
-    """Tests for ``_coerce_url_value``."""
+    """Table-driven checks for ``_coerce_url_value``."""
 
     @pytest.mark.parametrize(
         "case", COERCE_URL_VALUE_CASES, ids=[c.id for c in COERCE_URL_VALUE_CASES]
     )
     def test_coerce(self, case: CoerceUrlValueCase) -> None:
-        """Coercion follows int, bool, float, and str rules."""
+        """Apply registered coercions and retain the input when conversion cannot run."""
         assert _coerce_url_value(case.raw, case.hint) == case.expected
 
 

--- a/tests/deps/test_query.py
+++ b/tests/deps/test_query.py
@@ -5,8 +5,10 @@ from django.http import HttpRequest, QueryDict
 
 from next.deps import DependencyResolver
 from next.urls import DQuery, QueryParamProvider, get_multi_values
-from next.urls.parser import _coerce_url_value
-from tests.support import _ctx, inspect_parameter
+from tests.support import (
+    _ctx,
+    inspect_parameter,
+)
 
 
 @pytest.fixture()
@@ -269,28 +271,6 @@ class TestQueryParamProviderEndToEnd:
 
         resolved = resolver.resolve_dependencies(view, request=request)
         assert resolved["brand"] == ["Acme", "Globex"]
-
-
-class TestCoerceUrlValue:
-    """Cover the shared string coercion helper used by URL and query parsers."""
-
-    @pytest.mark.parametrize(
-        ("value", "hint", "expected"),
-        [
-            ("42", int, 42),
-            ("oops", int, "oops"),
-            ("1.5", float, 1.5),
-            ("oops", float, "oops"),
-            ("true", bool, True),
-            ("yes", bool, True),
-            ("1", bool, True),
-            ("no", bool, False),
-            ("hello", str, "hello"),
-        ],
-    )
-    def test_coerce(self, value, hint, expected) -> None:
-        """Coerce a raw string to the requested primitive type when possible."""
-        assert _coerce_url_value(value, hint) == expected
 
 
 class TestGetMultiValues:

--- a/tests/pages/test_urls.py
+++ b/tests/pages/test_urls.py
@@ -12,6 +12,8 @@ class TestURLPatternParser:
             ("simple", "simple/", {}),
             ("user/[id]", "user/<str:id>/", {"id": "id"}),
             ("user/[int:user-id]", "user/<int:user_id>/", {"user_id": "user_id"}),
+            ("user/[uuid:id]", "user/<uuid:id>/", {"id": "id"}),
+            ("post/[slug:post-slug]", "post/<slug:post_slug>/", {"post_slug": "post_slug"}),
             ("profile/[[args]]", "profile/<path:args>/", {"args": "args"}),
             (
                 "user/[int:id]/posts/[[args]]",
@@ -24,6 +26,8 @@ class TestURLPatternParser:
             "simple",
             "user_id",
             "user_int_id",
+            "user_uuid_id",
+            "post_slug",
             "profile_args",
             "user_id_posts_args",
             "empty",

--- a/tests/pages/test_urls.py
+++ b/tests/pages/test_urls.py
@@ -13,7 +13,11 @@ class TestURLPatternParser:
             ("user/[id]", "user/<str:id>/", {"id": "id"}),
             ("user/[int:user-id]", "user/<int:user_id>/", {"user_id": "user_id"}),
             ("user/[uuid:id]", "user/<uuid:id>/", {"id": "id"}),
-            ("post/[slug:post-slug]", "post/<slug:post_slug>/", {"post_slug": "post_slug"}),
+            (
+                "post/[slug:post-slug]",
+                "post/<slug:post_slug>/",
+                {"post_slug": "post_slug"},
+            ),
             ("profile/[[args]]", "profile/<path:args>/", {"args": "args"}),
             (
                 "user/[int:id]/posts/[[args]]",

--- a/tests/support/cases.py
+++ b/tests/support/cases.py
@@ -2,17 +2,24 @@ from __future__ import annotations
 
 import inspect
 from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import UUID
 
 from next.urls import DUrl
 
 
+_UUID_TEXT = "12345678-1234-5678-1234-567812345678"
+_UUID_VALUE = UUID(_UUID_TEXT)
+
+
 @dataclass(frozen=True, slots=True)
 class CoerceUrlValueCase:
-    """One row for ``TestCoerceUrlValue`` (raw string, type hint, expected value)."""
+    """One row for ``TestCoerceUrlValue`` (raw value, type hint, expected value)."""
 
     id: str
-    raw: str
-    hint: type
+    raw: object
+    hint: object
     expected: object
 
 
@@ -27,6 +34,24 @@ COERCE_URL_VALUE_CASES: tuple[CoerceUrlValueCase, ...] = (
     CoerceUrlValueCase("float_ok", "3.14", float, 3.14),
     CoerceUrlValueCase("float_bad", "x", float, "x"),
     CoerceUrlValueCase("str_pass", "hello", str, "hello"),
+    CoerceUrlValueCase("uuid_ok", _UUID_TEXT, UUID, _UUID_VALUE),
+    CoerceUrlValueCase("uuid_bad", "not-a-uuid", UUID, "not-a-uuid"),
+    CoerceUrlValueCase("decimal_ok", "3.14", Decimal, Decimal("3.14")),
+    CoerceUrlValueCase("decimal_bad", "x", Decimal, "x"),
+    CoerceUrlValueCase("date_ok", "2026-01-15", date, date(2026, 1, 15)),
+    CoerceUrlValueCase("date_bad", "x", date, "x"),
+    CoerceUrlValueCase(
+        "datetime_ok",
+        "2026-01-15T10:30:00+00:00",
+        datetime,
+        datetime(2026, 1, 15, 10, 30, tzinfo=UTC),
+    ),
+    CoerceUrlValueCase("datetime_bad", "x", datetime, "x"),
+    CoerceUrlValueCase("isinstance_uuid", _UUID_VALUE, UUID, _UUID_VALUE),
+    CoerceUrlValueCase("isinstance_int", 42, int, 42),
+    CoerceUrlValueCase("non_type_hint", "anything", "not-a-type", "anything"),
+    CoerceUrlValueCase("str_from_int", 42, str, "42"),
+    CoerceUrlValueCase("unsupported_type", "hello", bytes, "hello"),
 )
 
 
@@ -58,6 +83,10 @@ URL_KWARGS_RESOLVE_CASES: tuple[UrlKwargsResolveCase, ...] = (
         "str_annot", "slug", str, {"slug": "hello-world"}, "hello-world"
     ),
     UrlKwargsResolveCase("missing_key", "missing", str, {"other": "value"}, None),
+    UrlKwargsResolveCase(
+        "uuid_preserved", "id", UUID, {"id": _UUID_VALUE}, _UUID_VALUE
+    ),
+    UrlKwargsResolveCase("uuid_from_text", "id", UUID, {"id": _UUID_TEXT}, _UUID_VALUE),
 )
 
 
@@ -86,6 +115,20 @@ URL_BY_ANNOTATION_RESOLVE_CASES: tuple[UrlByAnnotationResolveCase, ...] = (
     ),
     UrlByAnnotationResolveCase(
         "two_arg_reads_named_key", "note_id", DUrl["id", int], {"note_id": "9"}, None
+    ),
+    UrlByAnnotationResolveCase(
+        "coerce_uuid_preserved",
+        "pk",
+        DUrl[UUID],
+        {"pk": _UUID_VALUE},
+        _UUID_VALUE,
+    ),
+    UrlByAnnotationResolveCase(
+        "coerce_uuid_from_text",
+        "pk",
+        DUrl[UUID],
+        {"pk": _UUID_TEXT},
+        _UUID_VALUE,
     ),
 )
 


### PR DESCRIPTION
## Description

This patch hardens `_coerce_url_value` shared by URL kwargs and typed query helpers. Parsing and providers now coerce `UUID`, `Decimal`, `date`, and `datetime`, keep original Python values when they already satisfy `isinstance`, and avoid blindly stringifying values that Django converters already decoded.

Documentation received a broad Sphinx pass aligned with runtime behavior plus small deployment wording updates for Gunicorn worker guidance. Dependency tests consolidate matrix coverage for coercion in `test_providers.py` with rows in `tests/support/cases.py`.

## How to test

Run `make ci` before merging. After doc edits run `make docs` or rely on the CI docs job.

## Related issues

<!-- Replace with Fixes #NNN or Closes #NNN when you have a ticket -->

## Checklist

- [ ] `make ci` passes locally
- [ ] New or changed `next/` code covered by tests (100% for package)
- [ ] Example + tests when adding public API or behavior users copy from `examples/`
- [ ] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable

---

Full guidelines: [CONTRIBUTING.md](https://github.com/next-dj/next-dj/blob/main/CONTRIBUTING.md)