### PR TITLE
feat(examples): cache wizard backend & success demos, forms docs & README polish

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         name: prettier
         entry: npm run format:check
         language: system
-        files: '\.(ts|mjs)$'
+        files: '(\.(ts|mjs)$|README\.md$)'
         pass_filenames: false
       - id: eslint
         name: eslint

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,7 @@
 # Vite build output. Hashed bundle names plus minified content
 # break Prettier and have nothing to gain from being formatted.
 **/static/**/dist/
+
+# Pytest writes a stock README.md into its cache. Prettier does not read
+# .gitignore, so exclude it here or format:check fails on a fresh cache.
+**/.pytest_cache/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,13 @@
 {
   "trailingComma": "all",
-  "printWidth": 88
+  "printWidth": 88,
+  "proseWrap": "never",
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "embeddedLanguageFormatting": "off"
+      }
+    }
+  ]
 }

--- a/docs/content/intro/tutorial04.rst
+++ b/docs/content/intro/tutorial04.rst
@@ -174,6 +174,10 @@ The dispatcher builds and validates that bound form before it calls ``update_not
 An ``id`` that matches no note makes ``get_object_or_404`` return Django's standard 404 response.
 See :doc:`/content/howto/customize-error-pages` for customising what the visitor sees.
 
+A ``ModelForm`` can express the same edit binding declaratively through ``Meta.instance_from_url``, which loads the instance from a URL parameter without a factory.
+This tutorial keeps the factory to show the general ``form_class`` mechanism.
+See :doc:`/content/topics/forms/modelforms` for the declarative alternative.
+
 .. code-block:: jinja
    :caption: notes/pages/notes/[id]/edit/template.djx
 

--- a/docs/content/misc/glossary.rst
+++ b/docs/content/misc/glossary.rst
@@ -55,6 +55,12 @@ Terms used throughout the next.dj documentation.
       The pipeline that turns a form submission into a handler invocation.
       A failed validation skips the handler and re-renders the origin page instead.
 
+   dynamic permission hook
+      A per-request access check declared on a form, ``check_permissions`` for the view level and ``has_object_permission`` for the bound instance.
+      Both resolve through the dependency injector and return ``PermissionOutcome``, the ``bool | HttpResponse | None`` alias.
+      They run as an additive layer after the static :term:`guard`.
+      See :ref:`topics-forms-actions-dynamic-guards`.
+
    FormSpec
       A frozen dataclass that describes a form layout.
       Used to render forms in custom templates.

--- a/docs/content/ref/forms.rst
+++ b/docs/content/ref/forms.rst
@@ -23,6 +23,7 @@ Stable.
    ``Form``, ``ModelForm``, ``BaseForm``, ``BaseModelForm``, ``@action``, ``redirect_to_origin``,
    ``FormWizard``, ``DForm``, ``FormActionNotFound``, and ``autodiscover_forms``.
    Use these in application code.
+   Form classes self-register, so reach for ``@action`` only for form-less handlers.
 
 Advanced.
    ``FormActionBackend``, ``RegistryFormActionBackend``,

--- a/docs/content/topics/forms/overview.rst
+++ b/docs/content/topics/forms/overview.rst
@@ -114,6 +114,9 @@ The method receives at least ``request`` and may declare any parameter the depen
 The default implementation redirects to the origin page, and a ModelForm saves first.
 See :doc:`actions` for the exact default behaviour and return contract.
 
+``Meta.success_url`` and ``Meta.success_message`` declare the redirect target and a flash message without writing ``on_valid`` by hand.
+The default ``on_valid`` reads both, so a save-and-redirect form can skip the method entirely.
+
 ``get_initial`` prepopulates the form before the first render.
 Declare it as a ``classmethod`` with the same DI-friendly signature.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,18 +4,18 @@ Each folder below is a self-contained Django project that runs on SQLite and Dja
 
 ## Shared UI kit
 
-* [`_shared/`](_shared/) — shadcn-inspired component palette every example consumes through `COMPONENT_BACKENDS["DIRS"]`. Tokens (`hsl(var(--background))`, `hsl(var(--primary))`, …) live in [`_shared/static/shared/css/tokens.css`](_shared/static/shared/css/tokens.css). Components (button, card, badge, input, alert, table primitives, nav_link, page_header, app_shell, dialog, dropdown, …) live in [`_shared/_components/`](_shared/_components/) and render through the same `{% component "name" %}` tag examples already use. See [`_shared/README.md`](_shared/README.md) for the full inventory and wiring contract.
+- [`_shared/`](_shared/) — shadcn-inspired component palette every example consumes through `COMPONENT_BACKENDS["DIRS"]`. Tokens (`hsl(var(--background))`, `hsl(var(--primary))`, …) live in [`_shared/static/shared/css/tokens.css`](_shared/static/shared/css/tokens.css). Components (button, card, badge, input, alert, table primitives, nav_link, page_header, app_shell, dialog, dropdown, …) live in [`_shared/_components/`](_shared/_components/) and render through the same `{% component "name" %}` tag examples already use. See [`_shared/README.md`](_shared/README.md) for the full inventory and wiring contract.
 
 ## Starter scaffold
 
-* [`_template/`](_template/) — empty skeleton. Copy, rename `myapp`, and fill in.
+- [`_template/`](_template/) — empty skeleton. Copy, rename `myapp`, and fill in.
 
 ## Examples
 
 Each example is a complete mini-product with e2e tests and a dedicated README.
 
 | Folder | Focus |
-|--------|-------|
+| --- | --- |
 | [`shortener/`](shortener/) | File router + DI providers + LocMemCache + management command + declarative `Meta.success_url` / `Meta.success_message` form contract |
 | [`markdown-blog/`](markdown-blog/) | Markdown posts, nested layouts, `@context(serialize=True)`, context processor, co-located `component.js` |
 | [`feature-flags/`](feature-flags/) | Composite `feature_guard`, signal receivers, cache invalidation |
@@ -41,8 +41,8 @@ Tailwind is loaded via the Play CDN (`https://cdn.tailwindcss.com`) from the roo
 
 ## Conventions every example follows
 
-* One custom `PAGES_DIR` (`routes`, `screens`, `panels`, …) and one custom components directory (`_widgets`, `_parts`, `_chunks`, …).
-* One project-level page root listed in `PAGE_BACKENDS["DIRS"]` (e.g. `host/`, `frame/`, `shell/`, `studio/`). The file router walks it alongside the per-app `PAGES_DIR`, and its `layout.djx` becomes the outermost wrapper around every page. The [`multi-tenant`](multi-tenant/) example goes one step further and also drops project-shared components inside this root (`root_blocks/header`, `root_blocks/footer`). The [`markdown-blog`](markdown-blog/) example shows the same trick with a `site/_parts/site_footer` registered through `COMPONENT_BACKENDS["DIRS"]`.
-* Co-located CSS/JS next to the `page.py`, `component.py`, or `layout.djx` they belong to. The `{% collect_styles %}` / `{% collect_scripts %}` tags place them in the rendered HTML, with deduplication.
-* E2E tests driven by `next.testing`: `eager_load_pages`, `reset_registries`, `NextClient`.
-* Forms redirect on success — either declaratively through `Meta.success_url` (plus an optional `Meta.success_message` flash, see [`shortener`](shortener/)) or by returning `HttpResponseRedirect` from `on_valid` when the target depends on the submission. The [`admin`](admin/) example shows the access side of the same surface: declarative `login_required=True` guards on every mutating action.
+- One custom `PAGES_DIR` (`routes`, `screens`, `panels`, …) and one custom components directory (`_widgets`, `_parts`, `_chunks`, …).
+- One project-level page root listed in `PAGE_BACKENDS["DIRS"]` (e.g. `host/`, `frame/`, `shell/`, `studio/`). The file router walks it alongside the per-app `PAGES_DIR`, and its `layout.djx` becomes the outermost wrapper around every page. The [`multi-tenant`](multi-tenant/) example goes one step further and also drops project-shared components inside this root (`root_blocks/header`, `root_blocks/footer`). The [`markdown-blog`](markdown-blog/) example shows the same trick with a `site/_parts/site_footer` registered through `COMPONENT_BACKENDS["DIRS"]`.
+- Co-located CSS/JS next to the `page.py`, `component.py`, or `layout.djx` they belong to. The `{% collect_styles %}` / `{% collect_scripts %}` tags place them in the rendered HTML, with deduplication.
+- E2E tests driven by `next.testing`: `eager_load_pages`, `reset_registries`, `NextClient`.
+- Forms redirect on success — either declaratively through `Meta.success_url` (plus an optional `Meta.success_message` flash, see [`shortener`](shortener/)) or by returning `HttpResponseRedirect` from `on_valid` when the target depends on the submission. The [`admin`](admin/) example shows the access side of the same surface: declarative `login_required=True` guards on every mutating action.

--- a/examples/_shared/README.md
+++ b/examples/_shared/README.md
@@ -143,7 +143,7 @@ The same inline config also exposes `rounded-lg`/`md`/`sm` mapped to `var(--radi
 Every entry below is a void call (`{% component "name" prop=value %}`) or a block call (`{% #component "name" %}{% #slot "content" %}…{% /slot %}{% /component %}`) depending on whether you need slots.
 
 | Component | Props | Slots |
-|---|---|---|
+| --- | --- | --- |
 | `page_head` | `title`, `tailwind_plugins` | `extra` (extra `<link>`/`<meta>`/`<style>` injected before `</head>`) |
 | `button` | `variant` (default/secondary/outline/ghost/destructive/link), `size` (sm/md/lg/icon), `type`, `href`, `target`, `name`/`value`, `disabled`, `text`, `extra` | `content` (falls back to `{{ text }}`) |
 | `card` | `title`, `description`, `extra` | `content`, `footer` |

--- a/examples/_template/README.md
+++ b/examples/_template/README.md
@@ -4,10 +4,10 @@ This folder is not a working example. It is the canonical skeleton copied for ev
 
 ## Conventions
 
-* `PAGES_DIR` is set to `routes`, `COMPONENTS_DIR` is set to `_widgets`. Every example overrides both to show that the naming is user-controlled. Pick names that fit the domain.
-* Tailwind is loaded via the Play CDN in the root layout. No build step.
-* `conftest.py` uses `next.testing.eager_load_pages` and `NextClient`.
-* Every file is intentionally short. Fill in what you need, drop what you do not.
+- `PAGES_DIR` is set to `routes`, `COMPONENTS_DIR` is set to `_widgets`. Every example overrides both to show that the naming is user-controlled. Pick names that fit the domain.
+- Tailwind is loaded via the Play CDN in the root layout. No build step.
+- `conftest.py` uses `next.testing.eager_load_pages` and `NextClient`.
+- Every file is intentionally short. Fill in what you need, drop what you do not.
 
 ## How to run
 

--- a/examples/admin/README.md
+++ b/examples/admin/README.md
@@ -1,41 +1,13 @@
 # Django admin on next.dj
 
-A full Django admin UI rebuilt on next.dj. Every page reads data straight
-from `django.contrib.admin` (`AdminSite._registry`,
-`ModelAdmin.get_changelist_instance`, `ModelAdmin.get_form`,
-`get_inline_instances`, `get_actions`, `save_model`, `delete_model`,
-`log_addition` / `log_change` / `log_deletions`), and none of
-`django/contrib/admin/templates/` ends up in the response. The HTML is
-shadcn-style Tailwind from the shared kit in
-[`../_shared/_components/`](../_shared/_components/).
+A full Django admin UI rebuilt on next.dj. Every page reads data straight from `django.contrib.admin` (`AdminSite._registry`, `ModelAdmin.get_changelist_instance`, `ModelAdmin.get_form`, `get_inline_instances`, `get_actions`, `save_model`, `delete_model`, `log_addition` / `log_change` / `log_deletions`), and none of `django/contrib/admin/templates/` ends up in the response. The HTML is shadcn-style Tailwind from the shared kit in [`../_shared/_components/`](../_shared/_components/).
 
-The example shows seven reusable patterns. A request-aware
-`@action(form_class=...)` factory that turns each `ModelAdmin.get_form`
-result into a per-request `Form` class. A shared actions module
-([`shadcn_admin/forms.py`](shadcn_admin/forms.py)) that owns the add and
-change factories and handlers, with all per-request state collapsed into
-one frozen `AdminFormSpec` dataclass shared through `Depends("admin_spec")`
-— the `admin_form` composite keeps only the template and its
-`form_state` render context. Declarative guards on every mutating
-action — `login_required=True` at registration plus the matching
-`ModelAdmin` permission check inside the handler. Inline-formset
-validation that runs inside
-the main form's `clean()`, so failures route through the framework's
-re-render path instead of a 400. A single layout that branches between
-admin chrome and the centered auth chrome through one `{% if
-is_auth_page %}` and one `{% block template %}`. An audit feed wired
-to `action_dispatched`, recording every admin dispatch through a single
-receiver without touching the handlers themselves. And
-`django.contrib.messages` plumbed end-to-end — handlers write through
-`messages.success` / `messages.error`, `ModelAdmin.message_user` from
-custom bulk actions flows through the same channel, and one
-`flash_messages` component drains the queue at the top of every
-page.
+The example shows seven reusable patterns. A request-aware `@action(form_class=...)` factory that turns each `ModelAdmin.get_form` result into a per-request `Form` class. A shared actions module ([`shadcn_admin/forms.py`](shadcn_admin/forms.py)) that owns the add and change factories and handlers, with all per-request state collapsed into one frozen `AdminFormSpec` dataclass shared through `Depends("admin_spec")` — the `admin_form` composite keeps only the template and its `form_state` render context. Declarative guards on every mutating action — `login_required=True` at registration plus the matching `ModelAdmin` permission check inside the handler. Inline-formset validation that runs inside the main form's `clean()`, so failures route through the framework's re-render path instead of a 400. A single layout that branches between admin chrome and the centered auth chrome through one `{% if is_auth_page %}` and one `{% block template %}`. An audit feed wired to `action_dispatched`, recording every admin dispatch through a single receiver without touching the handlers themselves. And `django.contrib.messages` plumbed end-to-end — handlers write through `messages.success` / `messages.error`, `ModelAdmin.message_user` from custom bulk actions flows through the same channel, and one `flash_messages` component drains the queue at the top of every page.
 
 ## What you will see
 
 | URL | Description |
-|-----|-------------|
+| --- | --- |
 | `/admin/login/` | Username and password sign-in. `AdminPermissionMiddleware` redirects every other path here for anonymous or non-staff users. |
 | `/admin/logout/` | Signed-out farewell page. The topbar Sign out form posts `admin:logout`, which clears the session and lands here. |
 | `/admin/` | Dashboard with one card per registered app and quick links to each model's changelist and Add page. |
@@ -46,18 +18,9 @@ page.
 | `/admin/<app_label>/<model_name>/<pk>/history/` | `LogEntry` rows for the object with Added / Changed / Deleted labels and the change message. |
 | `/admin/activity/` | Activity feed from `admin_audit.AdminActivityLog`, written by an `action_dispatched` receiver. One row per `admin:add` / `admin:change` / `admin:delete` / `admin:bulk_action`. |
 
-A `library` app ships demo models. `Author`, `Tag`, `Book` (FK to
-Author, M2M to Tag, `autocomplete_fields=("author",)`,
-`filter_horizontal=("tags",)`, `is_featured: BooleanField` for the
-checkbox flow, custom `mark_as_published` action), and `Chapter`
-(inline under Book). The combination exercises every flow above —
-text inputs, textarea, selects single and multi, checkbox, date,
-number, autocomplete, and tabular inlines.
+A `library` app ships demo models. `Author`, `Tag`, `Book` (FK to Author, M2M to Tag, `autocomplete_fields=("author",)`, `filter_horizontal=("tags",)`, `is_featured: BooleanField` for the checkbox flow, custom `mark_as_published` action), and `Chapter` (inline under Book). The combination exercises every flow above — text inputs, textarea, selects single and multi, checkbox, date, number, autocomplete, and tabular inlines.
 
-A second Django app `admin_audit` ships one model
-(`AdminActivityLog`) and one signal receiver. It hangs off the
-framework's `action_dispatched` signal and writes a row per dispatch.
-No change to `library` or `shadcn_admin` is required for it to work.
+A second Django app `admin_audit` ships one model (`AdminActivityLog`) and one signal receiver. It hangs off the framework's `action_dispatched` signal and writes a row per dispatch. No change to `library` or `shadcn_admin` is required for it to work.
 
 ## How to run
 
@@ -69,34 +32,18 @@ uv run python manage.py runserver     # http://127.0.0.1:8000/admin/
 uv run pytest
 ```
 
-Tailwind loads via the Play CDN in the shared
-[`page_head`](../_shared/_components/page_head/component.djx) component.
-No Node, no build step. Sessions and CSRF use the Django defaults set in
-[`config/settings.py`](config/settings.py).
+Tailwind loads via the Play CDN in the shared [`page_head`](../_shared/_components/page_head/component.djx) component. No Node, no build step. Sessions and CSRF use the Django defaults set in [`config/settings.py`](config/settings.py).
 
 ## Walking the code
 
 ### 1. Two-layer layout: chrome envelope, surfaces shell
 
-The router walks two roots, listed in
-[`config/settings.py`](config/settings.py) under
-`NEXT_FRAMEWORK["PAGE_BACKENDS"]`:
+The router walks two roots, listed in [`config/settings.py`](config/settings.py) under `NEXT_FRAMEWORK["PAGE_BACKENDS"]`:
 
-* `DIRS = ["chrome"]` — the project-level page root. It contains a
-  single [`chrome/layout.djx`](chrome/layout.djx) with the outermost
-  HTML envelope: `<!DOCTYPE html>`, `<body>`, `{% component "page_head" %}`,
-  and `{% collect_scripts %}`. Every page in the project gets wrapped
-  by this layer first.
-* `APP_DIRS = True` and `PAGES_DIR = "surfaces"` — each installed app
-  may ship a `surfaces/` tree. `shadcn_admin/surfaces/` owns the actual
-  pages (dashboard, login, logout, changelist, add, change, delete,
-  history, activity) and their per-section `layout.djx` files.
+- `DIRS = ["chrome"]` — the project-level page root. It contains a single [`chrome/layout.djx`](chrome/layout.djx) with the outermost HTML envelope: `<!DOCTYPE html>`, `<body>`, `{% component "page_head" %}`, and `{% collect_scripts %}`. Every page in the project gets wrapped by this layer first.
+- `APP_DIRS = True` and `PAGES_DIR = "surfaces"` — each installed app may ship a `surfaces/` tree. `shadcn_admin/surfaces/` owns the actual pages (dashboard, login, logout, changelist, add, change, delete, history, activity) and their per-section `layout.djx` files.
 
-[`shadcn_admin/surfaces/layout.djx`](shadcn_admin/surfaces/layout.djx) sits
-**inside** the chrome envelope and keeps a single `{% block template %}`
-wrapped differently based on a context flag. Django rejects two
-`{% block template %}` placeholders in the same template, so the chrome
-branches sit **around** the block, not inside two competing branches.
+[`shadcn_admin/surfaces/layout.djx`](shadcn_admin/surfaces/layout.djx) sits **inside** the chrome envelope and keeps a single `{% block template %}` wrapped differently based on a context flag. Django rejects two `{% block template %}` placeholders in the same template, so the chrome branches sit **around** the block, not inside two competing branches.
 
 ```djx
 {% if is_auth_page %}
@@ -112,66 +59,25 @@ branches sit **around** the block, not inside two competing branches.
 {% block template %}{% endblock template %}
 ```
 
-`is_auth_page` comes from
-[`shadcn_admin/surfaces/page.py`](shadcn_admin/surfaces/page.py) through
-`@context("is_auth_page", inherit_context=True)`. It returns
-`request.path.startswith` against `/admin/login/` and `/admin/logout/`,
-so every descendant page picks it up without restating the rule.
+`is_auth_page` comes from [`shadcn_admin/surfaces/page.py`](shadcn_admin/surfaces/page.py) through `@context("is_auth_page", inherit_context=True)`. It returns `request.path.startswith` against `/admin/login/` and `/admin/logout/`, so every descendant page picks it up without restating the rule.
 
-Component lookup is configured the same way:
-`shadcn_admin/_panels/` (admin-specific composites: `admin_form`,
-`admin_sidebar`, `data_table`, …) plus the shared shadcn kit in
-[`../_shared/_components/`](../_shared/_components/) (the `_panels` and
-`_components` names are deliberately different so the rename
-demonstrates that the directory names are user-controlled).
+Component lookup is configured the same way: `shadcn_admin/_panels/` (admin-specific composites: `admin_form`, `admin_sidebar`, `data_table`, …) plus the shared shadcn kit in [`../_shared/_components/`](../_shared/_components/) (the `_panels` and `_components` names are deliberately different so the rename demonstrates that the directory names are user-controlled).
 
 ### 2. Resolving `(model, ModelAdmin)` once
 
-[`shadcn_admin/utils.py`](shadcn_admin/utils.py) holds
-`resolve_model_admin(app_label, model_name)`. It calls
-`apps.get_model` (raising `Http404` for unknown apps through `LookupError`)
-and reads `admin.site._registry` (raising `Http404` for models that
-exist but are not registered). Every admin page imports the helper, so
-the 404 contract lives in one file.
+[`shadcn_admin/utils.py`](shadcn_admin/utils.py) holds `resolve_model_admin(app_label, model_name)`. It calls `apps.get_model` (raising `Http404` for unknown apps through `LookupError`) and reads `admin.site._registry` (raising `Http404` for models that exist but are not registered). Every admin page imports the helper, so the 404 contract lives in one file.
 
-`iter_app_list` in [`shadcn_admin/surfaces/page.py`](shadcn_admin/surfaces/page.py)
-rebuilds the structure of `AdminSite.get_app_list` without calling
-`reverse("admin:...")`. The classic admin URLConf is not mounted, and
-the dashboard URLs are written explicitly against our own routing.
+`iter_app_list` in [`shadcn_admin/surfaces/page.py`](shadcn_admin/surfaces/page.py) rebuilds the structure of `AdminSite.get_app_list` without calling `reverse("admin:...")`. The classic admin URLConf is not mounted, and the dashboard URLs are written explicitly against our own routing.
 
 ### 3. Changelist via `ModelAdmin.get_changelist_instance`
 
-[`shadcn_admin/surfaces/[str:app_label]/[str:model_name]/page.py`](shadcn_admin/surfaces/%5Bstr%3Aapp_label%5D/%5Bstr%3Amodel_name%5D/page.py)
-asks `ModelAdmin.get_changelist_instance(request)` and packs the result
-for the template. The `changelist_state` callable is a thin orchestrator
-that delegates to `_columns`, `_rows`, `_pagination`, `_filters`, and
-`_actions` helpers in the same file, so the response shape fits on one
-screen. The synthetic `action_checkbox` column that Django injects into
-`cl.list_display` is filtered out because we render selection ourselves
-through the `selectable=` prop on `data_table`. Action labels are
-interpolated against the model's `verbose_name` and `verbose_name_plural`
-so `delete_selected`'s `%(verbose_name_plural)s` placeholder becomes
-`Delete selected books`.
+[`shadcn_admin/surfaces/[str:app_label]/[str:model_name]/page.py`](shadcn_admin/surfaces/%5Bstr%3Aapp_label%5D/%5Bstr%3Amodel_name%5D/page.py) asks `ModelAdmin.get_changelist_instance(request)` and packs the result for the template. The `changelist_state` callable is a thin orchestrator that delegates to `_columns`, `_rows`, `_pagination`, `_filters`, and `_actions` helpers in the same file, so the response shape fits on one screen. The synthetic `action_checkbox` column that Django injects into `cl.list_display` is filtered out because we render selection ourselves through the `selectable=` prop on `data_table`. Action labels are interpolated against the model's `verbose_name` and `verbose_name_plural` so `delete_selected`'s `%(verbose_name_plural)s` placeholder becomes `Delete selected books`.
 
-The
-[`data_table`](shadcn_admin/_panels/data_table/component.djx)
-component renders rows plus selection checkboxes. Its
-[`.mjs`](shadcn_admin/_panels/data_table/component.mjs) wires a
-header checkbox that flips every row selection in vanilla DOM, no
-framework. The
-[`filters_panel`](shadcn_admin/_panels/filters_panel/component.djx),
-[`search_box`](shadcn_admin/_panels/search_box/component.djx), and
-[`admin_pagination`](shadcn_admin/_panels/admin_pagination/component.djx)
-components consume the same packed specs.
+The [`data_table`](shadcn_admin/_panels/data_table/component.djx) component renders rows plus selection checkboxes. Its [`.mjs`](shadcn_admin/_panels/data_table/component.mjs) wires a header checkbox that flips every row selection in vanilla DOM, no framework. The [`filters_panel`](shadcn_admin/_panels/filters_panel/component.djx), [`search_box`](shadcn_admin/_panels/search_box/component.djx), and [`admin_pagination`](shadcn_admin/_panels/admin_pagination/component.djx) components consume the same packed specs.
 
 ### 4. CRUD forms through a request-aware factory
 
-`ModelAdmin.get_form(request, obj, change=...)` is request-dependent
-(widgets, fieldsets, autocomplete choices). It cannot be captured as a
-static `form_class`. The shared actions module
-[`shadcn_admin/forms.py`](shadcn_admin/forms.py) exposes two factories,
-passes them to `@action(form_class=...)`, and the dispatcher resolves
-each one per request before binding POST data.
+`ModelAdmin.get_form(request, obj, change=...)` is request-dependent (widgets, fieldsets, autocomplete choices). It cannot be captured as a static `form_class`. The shared actions module [`shadcn_admin/forms.py`](shadcn_admin/forms.py) exposes two factories, passes them to `@action(form_class=...)`, and the dispatcher resolves each one per request before binding POST data.
 
 ```python
 @action("admin:add", form_class=admin_add_form_factory, login_required=True)
@@ -187,91 +93,35 @@ def handle_change(form, spec=Depends("admin_spec")):
     return _persist(form, spec, change=True)
 ```
 
-The factories, the handlers, and the `form_state` render context all
-route through one frozen dataclass — `AdminFormSpec(request, app_label,
-model_name, model, model_admin, instance)`. `AdminFormSpec.resolve(...)`
-calls `apps.get_model`, reads `admin.site._registry`, and calls
-`ModelAdmin.get_object(request, pk)` exactly once per dispatch: it is
-registered as a named dependency (`@resolver.dependency("admin_spec")`),
-so every `Depends("admin_spec")` parameter within the same POST shares a
-single resolution. The factory wraps the base form into an `AdminForm`
-whose `get_initial()` returns the instance, so dispatch's `_build_form`
-takes the ModelForm `instance=` branch.
+The factories, the handlers, and the `form_state` render context all route through one frozen dataclass — `AdminFormSpec(request, app_label, model_name, model, model_admin, instance)`. `AdminFormSpec.resolve(...)` calls `apps.get_model`, reads `admin.site._registry`, and calls `ModelAdmin.get_object(request, pk)` exactly once per dispatch: it is registered as a named dependency (`@resolver.dependency("admin_spec")`), so every `Depends("admin_spec")` parameter within the same POST shares a single resolution. The factory wraps the base form into an `AdminForm` whose `get_initial()` returns the instance, so dispatch's `_build_form` takes the ModelForm `instance=` branch.
 
-The [`admin_form` component](shadcn_admin/_panels/admin_form/component.py)
-keeps the render side. `@component.context("form_state")` rebuilds the
-same form on GET and POST so a re-render after a validation failure
-preserves user input, and serialises it through the core `form_spec()`
-helper. Each resulting `FieldSpec` maps its `BoundField` to a stable
-`kind` (`textarea`/`checkbox`/`select`/`select_multi`/`input`) plus an
-`input_type` read straight from the widget, so the
-[`form_field` template](shadcn_admin/_panels/form_field/component.djx)
-renders from `info.kind`, `info.bound`, and `info.is_extra` without
-knowing widget class names — Django's admin widget subclasses
-(`AdminTextareaWidget`, `AdminDateWidget`, …) and HTML5 input types
-(`email`, `number`, `date`, `password`, `url`) propagate without an
-extra lookup table.
+The [`admin_form` component](shadcn_admin/_panels/admin_form/component.py) keeps the render side. `@component.context("form_state")` rebuilds the same form on GET and POST so a re-render after a validation failure preserves user input, and serialises it through the core `form_spec()` helper. Each resulting `FieldSpec` maps its `BoundField` to a stable `kind` (`textarea`/`checkbox`/`select`/`select_multi`/`input`) plus an `input_type` read straight from the widget, so the [`form_field` template](shadcn_admin/_panels/form_field/component.djx) renders from `info.kind`, `info.bound`, and `info.is_extra` without knowing widget class names — Django's admin widget subclasses (`AdminTextareaWidget`, `AdminDateWidget`, …) and HTML5 input types (`email`, `number`, `date`, `password`, `url`) propagate without an extra lookup table.
 
-The single template file
-[`admin_form/component.djx`](shadcn_admin/_panels/admin_form/component.djx)
-uses one `{% form form_state.action_name %}` block. The tag takes the
-action name as its positional argument. Here it is a context variable,
-so the action name resolves at render time (see core change below).
+The single template file [`admin_form/component.djx`](shadcn_admin/_panels/admin_form/component.djx) uses one `{% form form_state.action_name %}` block. The tag takes the action name as its positional argument. Here it is a context variable, so the action name resolves at render time (see core change below).
 
 ### 5. Inline formsets validate alongside the main form
 
-`build_inline_formsets(spec)` in
-[`shadcn_admin/forms.py`](shadcn_admin/forms.py) walks
-`model_admin.get_inline_instances(request, obj)`, calls
-`inline.get_formset(request, obj)`, and binds the resulting formset to
-`request.POST` on POST. For empty extra rows (`form.empty_permitted and
-not form.instance.pk`) it drops `form.initial` and each
-`field.initial`, so the rendered inputs are blank and `has_changed()`
-stays `False` when the user submits an unfilled row. Without the reset,
-Django would treat the model-default values (for example
-`Chapter.word_count=0`) as `initial`, see them differ from the
-submitted empty string, mark the form as changed, and run required
-validation on the row.
+`build_inline_formsets(spec)` in [`shadcn_admin/forms.py`](shadcn_admin/forms.py) walks `model_admin.get_inline_instances(request, obj)`, calls `inline.get_formset(request, obj)`, and binds the resulting formset to `request.POST` on POST. For empty extra rows (`form.empty_permitted and not form.instance.pk`) it drops `form.initial` and each `field.initial`, so the rendered inputs are blank and `has_changed()` stays `False` when the user submits an unfilled row. Without the reset, Django would treat the model-default values (for example `Chapter.word_count=0`) as `initial`, see them differ from the submitted empty string, mark the form as changed, and run required validation on the row.
 
-Inline validation runs **inside the main form's `clean()`**. When any
-inline row fails, `clean()` raises `ValidationError`, so
-`form.is_valid()` returns `False` and the framework re-renders the
-origin page through its `form_validation_failed` machinery — the
-inputs stay populated, the inline rows show their per-field errors,
-and the user never sees a bare 400. No core change is required for
-this. `Form.clean()` raising `ValidationError` is the same path the
-framework already uses for field-level errors.
+Inline validation runs **inside the main form's `clean()`**. When any inline row fails, `clean()` raises `ValidationError`, so `form.is_valid()` returns `False` and the framework re-renders the origin page through its `form_validation_failed` machinery — the inputs stay populated, the inline rows show their per-field errors, and the user never sees a bare 400. No core change is required for this. `Form.clean()` raising `ValidationError` is the same path the framework already uses for field-level errors.
 
 ### 6. Save and continue / Save and add another
 
 The form template renders three submit buttons:
 
-* **Save** — default, redirects to the changelist on success.
-* **Save and continue editing** (`name="_save_continue"`) — redirects
-  to the change view for the just-saved object.
-* **Save and add another** (`name="_save_addanother"`) — redirects to
-  the add view so the operator can enter another record.
+- **Save** — default, redirects to the changelist on success.
+- **Save and continue editing** (`name="_save_continue"`) — redirects to the change view for the just-saved object.
+- **Save and add another** (`name="_save_addanother"`) — redirects to the add view so the operator can enter another record.
 
-`_redirect_after_save(spec, obj)` reads `request.POST` for the two
-button names and branches accordingly. Both add and change handlers
-share the same routing through `_persist`, so the buttons work in
-either flow.
+`_redirect_after_save(spec, obj)` reads `request.POST` for the two button names and branches accordingly. Both add and change handlers share the same routing through `_persist`, so the buttons work in either flow.
 
 ### 7. Custom bulk action `mark_as_published`
 
-[`library/admin.py`](library/admin.py) declares an `@admin.action` on
-`BookAdmin` that flips selected books to the `published` status. The
-existing changelist action bar (rendered from `model_admin.get_actions`)
-picks it up automatically and the `admin:bulk_action` handler routes the
-POST through `model_admin.response_action(...)`, the same code path as
-the built-in `delete_selected` action. The interpolated description
-"Mark selected books as published" comes from
-`%(verbose_name_plural)s` resolution inside the changelist serializer.
+[`library/admin.py`](library/admin.py) declares an `@admin.action` on `BookAdmin` that flips selected books to the `published` status. The existing changelist action bar (rendered from `model_admin.get_actions`) picks it up automatically and the `admin:bulk_action` handler routes the POST through `model_admin.response_action(...)`, the same code path as the built-in `delete_selected` action. The interpolated description "Mark selected books as published" comes from `%(verbose_name_plural)s` resolution inside the changelist serializer.
 
 ### 8. Audit feed driven by `action_dispatched`
 
-The [`admin_audit`](admin_audit/) Django app records every admin
-dispatch through a single signal receiver:
+The [`admin_audit`](admin_audit/) Django app records every admin dispatch through a single signal receiver:
 
 ```python
 @receiver(action_dispatched)
@@ -285,157 +135,57 @@ def log_admin_action(action_name="", form=None, url_kwargs=None,
     AdminActivityLog.objects.create(...)
 ```
 
-`action_dispatched` carries the bound `form`, a copy of `url_kwargs`,
-and `dep_cache` — the per-dispatch cache of resolved named dependencies
-— out of the box. The form-bearing actions (`admin:add`, `admin:change`)
-resolve `Depends("admin_spec")`, so the receiver reads the same
-`AdminFormSpec` the handler used from `dep_cache["admin_spec"]` and
-captures the user. The actions that never resolve that dependency
-(`admin:delete`, `admin:bulk_action`) come through without an
-`admin_spec` entry, so those rows record action + target + status but
-leave the user field empty. The
-[`/admin/activity/` page](shadcn_admin/surfaces/activity/) reads the log
-and renders the latest 50 rows.
+`action_dispatched` carries the bound `form`, a copy of `url_kwargs`, and `dep_cache` — the per-dispatch cache of resolved named dependencies — out of the box. The form-bearing actions (`admin:add`, `admin:change`) resolve `Depends("admin_spec")`, so the receiver reads the same `AdminFormSpec` the handler used from `dep_cache["admin_spec"]` and captures the user. The actions that never resolve that dependency (`admin:delete`, `admin:bulk_action`) come through without an `admin_spec` entry, so those rows record action + target + status but leave the user field empty. The [`/admin/activity/` page](shadcn_admin/surfaces/activity/) reads the log and renders the latest 50 rows.
 
 ### 9. Flash messages through `django.contrib.messages`
 
 Every success path writes a flash before redirecting:
 
-* `_persist` (add / change) →
-  `messages.success(request, "The book Sample was added successfully.")`
-* delete handler → `messages.success(request, "The book Sample was deleted successfully.")`
-* login handler → `messages.error(request, "Invalid username or password.")`
-  or `messages.success(request, "Welcome, admin.")`
-* `BookAdmin.mark_as_published` →
-  `self.message_user(request, "N book(s) marked as published.")`
-  (Django's stock `ModelAdmin.message_user` writes through the same
-  framework.)
+- `_persist` (add / change) → `messages.success(request, "The book Sample was added successfully.")`
+- delete handler → `messages.success(request, "The book Sample was deleted successfully.")`
+- login handler → `messages.error(request, "Invalid username or password.")` or `messages.success(request, "Welcome, admin.")`
+- `BookAdmin.mark_as_published` → `self.message_user(request, "N book(s) marked as published.")` (Django's stock `ModelAdmin.message_user` writes through the same framework.)
 
-The
-[`flash_messages` component](shadcn_admin/_panels/flash_messages/component.py)
-drains pending messages off the request, maps Django's level tags
-(`success` / `error` / `warning` / `info`) to the shared `alert`
-component's variants, and is invoked once from `layout.djx` so both
-the admin chrome and the auth chrome surface flashes without repeating
-HTML.
+The [`flash_messages` component](shadcn_admin/_panels/flash_messages/component.py) drains pending messages off the request, maps Django's level tags (`success` / `error` / `warning` / `info`) to the shared `alert` component's variants, and is invoked once from `layout.djx` so both the admin chrome and the auth chrome surface flashes without repeating HTML.
 
 ### 10. Delete with `get_deleted_objects`
 
-[`.../[int:pk]/delete/page.py`](shadcn_admin/surfaces/%5Bstr%3Aapp_label%5D/%5Bstr%3Amodel_name%5D/%5Bint%3Apk%5D/delete/page.py)
-calls
-`admin.utils.get_deleted_objects([obj], request, model_admin.admin_site)`
-to compute the dependency tree, protected references, and missing
-permissions. The confirmation template disables the submit button when
-the action is blocked. On confirm, `ModelAdmin.log_deletions` plus
-`delete_model` run and the user lands on the changelist.
+[`.../[int:pk]/delete/page.py`](shadcn_admin/surfaces/%5Bstr%3Aapp_label%5D/%5Bstr%3Amodel_name%5D/%5Bint%3Apk%5D/delete/page.py) calls `admin.utils.get_deleted_objects([obj], request, model_admin.admin_site)` to compute the dependency tree, protected references, and missing permissions. The confirmation template disables the submit button when the action is blocked. On confirm, `ModelAdmin.log_deletions` plus `delete_model` run and the user lands on the changelist.
 
 ### 11. History from `LogEntry`
 
-[`.../[int:pk]/history/page.py`](shadcn_admin/surfaces/%5Bstr%3Aapp_label%5D/%5Bstr%3Amodel_name%5D/%5Bint%3Apk%5D/history/page.py)
-queries
-`LogEntry.objects.filter(content_type=ct, object_id=pk).select_related("user")`
-and labels rows by `action_flag` (1 Added, 2 Changed, 3 Deleted).
+[`.../[int:pk]/history/page.py`](shadcn_admin/surfaces/%5Bstr%3Aapp_label%5D/%5Bstr%3Amodel_name%5D/%5Bint%3Apk%5D/history/page.py) queries `LogEntry.objects.filter(content_type=ct, object_id=pk).select_related("user")` and labels rows by `action_flag` (1 Added, 2 Changed, 3 Deleted).
 
 ### 12. Auth guard
 
 Authorization is split between page GETs and action POSTs.
 
-[`shadcn_admin/middleware.py`](shadcn_admin/middleware.py) is one class
-that calls `admin.site.has_permission(request)` for paths under
-`/admin/`, skipping `/admin/login/`, `/admin/logout/`, `/admin/_next/`
-(where next.dj mounts its form-action endpoints), and `/static/`.
-Failing requests redirect to `/admin/login/?next=<path>`.
+[`shadcn_admin/middleware.py`](shadcn_admin/middleware.py) is one class that calls `admin.site.has_permission(request)` for paths under `/admin/`, skipping `/admin/login/`, `/admin/logout/`, `/admin/_next/` (where next.dj mounts its form-action endpoints), and `/static/`. Failing requests redirect to `/admin/login/?next=<path>`.
 
-The `/admin/_next/` exemption means the middleware never sees an action
-POST, so the form-action endpoints carry their own guards. Every
-mutating action (`admin:add`, `admin:change`, `admin:delete`,
-`admin:bulk_action`) registers with `@action(..., login_required=True)`
-— an anonymous POST gets the framework's login redirect before any POST
-data is read — and re-checks the matching `ModelAdmin` permission inside
-the handler (`has_add_permission`, `has_change_permission`,
-`has_delete_permission`, `has_view_or_change_permission`), raising
-`PermissionDenied` for an authenticated user without the right perms.
-The custom bulk action `mark_as_published` additionally declares
-`permissions=["change"]`, so `ModelAdmin.response_action` filters it out
-of `get_actions(request)` for users who cannot change books.
-`admin:login` and `admin:logout` stay unguarded on purpose: one signs
-you in, the other only clears your own session and lands on the
-`/admin/logout/` farewell page.
+The `/admin/_next/` exemption means the middleware never sees an action POST, so the form-action endpoints carry their own guards. Every mutating action (`admin:add`, `admin:change`, `admin:delete`, `admin:bulk_action`) registers with `@action(..., login_required=True)` — an anonymous POST gets the framework's login redirect before any POST data is read — and re-checks the matching `ModelAdmin` permission inside the handler (`has_add_permission`, `has_change_permission`, `has_delete_permission`, `has_view_or_change_permission`), raising `PermissionDenied` for an authenticated user without the right perms. The custom bulk action `mark_as_published` additionally declares `permissions=["change"]`, so `ModelAdmin.response_action` filters it out of `get_actions(request)` for users who cannot change books. `admin:login` and `admin:logout` stay unguarded on purpose: one signs you in, the other only clears your own session and lands on the `/admin/logout/` farewell page.
 
-Login uses a plain `Form` (username and password) and authenticates
-manually inside the action handler. The handler is decoupled from
-`AuthenticationForm` on purpose. The latter's `__init__(self, request,
-data=...)` signature collides with the dispatcher's
-`form_class(post_data, files, ...)` call.
+Login uses a plain `Form` (username and password) and authenticates manually inside the action handler. The handler is decoupled from `AuthenticationForm` on purpose. The latter's `__init__(self, request, data=...)` signature collides with the dispatcher's `form_class(post_data, files, ...)` call.
 
 ## What is in core for this example
 
-Four pre-existing pieces of next.dj's form layer plus one small core
-fix carry the example.
+Four pre-existing pieces of next.dj's form layer plus one small core fix carry the example.
 
-* **`@action(form_class=callable)`.**
-  [`next/forms/dispatch.py`](../../next/forms/dispatch.py) accepts a
-  callable beside a `Form` subclass. `_resolve_form_class` runs the
-  factory through `resolver.resolve_dependencies` once per request, so
-  admin pages produce a class shaped by `ModelAdmin.get_form()` on the
-  fly.
-* **`{% form "action_name" %}`.** The tag takes a positional action
-  name — a string literal or a context variable — plus optional
-  `key="value"` HTML attributes rendered onto the opening `<form>` tag.
-  `action`, `method`, and the `data-next-*` prefix are reserved for the
-  framework. [`next/templatetags/forms.py`](../../next/templatetags/forms.py)
-  compiles the value through `parser.compile_filter`, so the
-  `admin_form` template keeps one `{% form %}` block and resolves
-  `admin:add` or `admin:change` from `form_state.action_name` at render
-  time, while [`action_bar`](shadcn_admin/_panels/action_bar/component.djx)
-  passes `id=` and `class=` straight on the tag. The companion
-  `{% action_url %}` tag resolves the dispatch URL by action name for
-  hand-crafted forms — the topbar Sign out form in
-  [`surfaces/layout.djx`](shadcn_admin/surfaces/layout.djx) uses it.
-* **`action_dispatched` carries `form` and `url_kwargs`.**
-  [`next/forms/dispatch.py`](../../next/forms/dispatch.py) sends both
-  fields on every successful dispatch (the form is `None` for handlers
-  without a `form_class`).
-  [`admin_audit.signals.log_admin_action`](admin_audit/signals.py) reads
-  them to write one `AdminActivityLog` row per dispatch without ever
-  touching the handlers it observes.
-* **`Form.clean()` → `ValidationError` re-renders the origin page.**
-  The same path the framework already uses for field-level errors lets
-  `AdminForm.clean()` validate inline formsets and surface their errors
-  on the bound form, with the user's typed data preserved.
-* **Virtual pages survive form re-render.**
-  The dispatcher resolves the posted `_next_form_origin` URL against the
-  URLconf and reads the page identity from the matched view, so a page
-  that exists only as a `template.djx` directory (no `page.py` anchor)
-  re-renders correctly on validation failure. That lets the add and
-  change views in this example live as `template.djx`-only directories.
+- **`@action(form_class=callable)`.** [`next/forms/dispatch.py`](../../next/forms/dispatch.py) accepts a callable beside a `Form` subclass. `_resolve_form_class` runs the factory through `resolver.resolve_dependencies` once per request, so admin pages produce a class shaped by `ModelAdmin.get_form()` on the fly.
+- **`{% form "action_name" %}`.** The tag takes a positional action name — a string literal or a context variable — plus optional `key="value"` HTML attributes rendered onto the opening `<form>` tag. `action`, `method`, and the `data-next-*` prefix are reserved for the framework. [`next/templatetags/forms.py`](../../next/templatetags/forms.py) compiles the value through `parser.compile_filter`, so the `admin_form` template keeps one `{% form %}` block and resolves `admin:add` or `admin:change` from `form_state.action_name` at render time, while [`action_bar`](shadcn_admin/_panels/action_bar/component.djx) passes `id=` and `class=` straight on the tag. The companion `{% action_url %}` tag resolves the dispatch URL by action name for hand-crafted forms — the topbar Sign out form in [`surfaces/layout.djx`](shadcn_admin/surfaces/layout.djx) uses it.
+- **`action_dispatched` carries `form` and `url_kwargs`.** [`next/forms/dispatch.py`](../../next/forms/dispatch.py) sends both fields on every successful dispatch (the form is `None` for handlers without a `form_class`). [`admin_audit.signals.log_admin_action`](admin_audit/signals.py) reads them to write one `AdminActivityLog` row per dispatch without ever touching the handlers it observes.
+- **`Form.clean()` → `ValidationError` re-renders the origin page.** The same path the framework already uses for field-level errors lets `AdminForm.clean()` validate inline formsets and surface their errors on the bound form, with the user's typed data preserved.
+- **Virtual pages survive form re-render.** The dispatcher resolves the posted `_next_form_origin` URL against the URLconf and reads the page identity from the matched view, so a page that exists only as a `template.djx` directory (no `page.py` anchor) re-renders correctly on validation failure. That lets the add and change views in this example live as `template.djx`-only directories.
 
-Existing form-action code is unaffected. Passing a `Form` subclass and a
-quoted action name keeps the original control flow.
+Existing form-action code is unaffected. Passing a `Form` subclass and a quoted action name keeps the original control flow.
 
 ## Further reading
 
-- [`next/forms/decorators.py`](../../next/forms/decorators.py) and
-  [`next/forms/dispatch.py`](../../next/forms/dispatch.py) for the
-  `@action` factory contract.
-- [`next/forms/signals.py`](../../next/forms/signals.py) for the
-  `action_dispatched` / `form_validation_failed` payload contracts.
-- [`next/templatetags/forms.py`](../../next/templatetags/forms.py) for
-  `{% form %}` argument compilation.
-- [`docs/content/topics/forms/actions.rst`](../../docs/content/topics/forms/actions.rst)
-  for the form-action lifecycle, including the guards and the factory
-  pattern used by sections 4 and 5 above.
-- [`docs/content/topics/layouts.rst`](../../docs/content/topics/layouts.rst)
-  and [`docs/content/topics/pages.rst`](../../docs/content/topics/pages.rst)
-  for the chrome / surfaces layering shown in section 1.
-- [`docs/content/topics/components.rst`](../../docs/content/topics/components.rst)
-  for the component lookup configured under `_panels/`.
-- [`docs/content/topics/context.rst`](../../docs/content/topics/context.rst)
-  for `@context` and `inherit_context` used by `app_list` and
-  `is_auth_page`.
-- [`docs/content/topics/dependency-injection.rst`](../../docs/content/topics/dependency-injection.rst)
-  for `@resolver.dependency` and `Depends("name")` used by the
-  `admin_spec` registration in section 4.
-- [`docs/content/topics/file-router.rst`](../../docs/content/topics/file-router.rst)
-  for the `[str:app_label]/[int:pk]/` directory naming under
-  `surfaces/`.
+- [`next/forms/decorators.py`](../../next/forms/decorators.py) and [`next/forms/dispatch.py`](../../next/forms/dispatch.py) for the `@action` factory contract.
+- [`next/forms/signals.py`](../../next/forms/signals.py) for the `action_dispatched` / `form_validation_failed` payload contracts.
+- [`next/templatetags/forms.py`](../../next/templatetags/forms.py) for `{% form %}` argument compilation.
+- [`docs/content/topics/forms/actions.rst`](../../docs/content/topics/forms/actions.rst) for the form-action lifecycle, including the guards and the factory pattern used by sections 4 and 5 above.
+- [`docs/content/topics/layouts.rst`](../../docs/content/topics/layouts.rst) and [`docs/content/topics/pages.rst`](../../docs/content/topics/pages.rst) for the chrome / surfaces layering shown in section 1.
+- [`docs/content/topics/components.rst`](../../docs/content/topics/components.rst) for the component lookup configured under `_panels/`.
+- [`docs/content/topics/context.rst`](../../docs/content/topics/context.rst) for `@context` and `inherit_context` used by `app_list` and `is_auth_page`.
+- [`docs/content/topics/dependency-injection.rst`](../../docs/content/topics/dependency-injection.rst) for `@resolver.dependency` and `Depends("name")` used by the `admin_spec` registration in section 4.
+- [`docs/content/topics/file-router.rst`](../../docs/content/topics/file-router.rst) for the `[str:app_label]/[int:pk]/` directory naming under `surfaces/`.

--- a/examples/audit-forms/README.md
+++ b/examples/audit-forms/README.md
@@ -12,9 +12,9 @@ backend wired through `NEXT_FRAMEWORK["FORM_ACTION_BACKENDS"]`, a
 declarative `FormWizard` that routes all three steps from one class, three
 composite components (`progress_bar` and `step_section` inside the form,
 `audit_row` shared between the admin and per-request audit pages),
-session-backed step state with a `request_id` correlation column on
-`AuditEntry`, and full coverage of the `next.testing` `SignalRecorder`
-API.
+cache-backed step state through a non-default `FORM_WIZARD_BACKEND` with a
+`request_id` correlation column on `AuditEntry`, and full coverage of the
+`next.testing` `SignalRecorder` API.
 
 ## What you will see
 
@@ -46,10 +46,12 @@ uv run pytest
 
 Tailwind loads via the Play CDN in
 [`portal/layout.djx`](portal/layout.djx). No Node, no build step. The
-wizard threads step data across requests through the configured
-`FORM_WIZARD_BACKEND`, which defaults to the session-backed
-`SessionFormWizardBackend`, so keep `SessionMiddleware` in `MIDDLEWARE`
-(it is by default in [`config/settings.py`](config/settings.py)).
+wizard threads step drafts across requests through the configured
+`FORM_WIZARD_BACKEND`, here the cache-backed `CacheFormWizardBackend` on a
+dedicated `wizards` cache alias (see section 7). `SessionMiddleware` stays in
+`MIDDLEWARE` because `done` still uses the session to hand the new request id
+to the audit backend (it is on by default in
+[`config/settings.py`](config/settings.py)).
 
 ## Walking the code
 
@@ -273,13 +275,26 @@ Each step posts only its visible fields plus the framework's hidden
 resolves that origin URL against the URLconf to recover the typed
 `step` kwarg, and `_step_from_origin` in the audit backend does the
 same for the audit rows. The wizard saves the cleaned data through the
-configured `FORM_WIZARD_BACKEND` (the session-backed
-`SessionFormWizardBackend` by default), so on `GET` of step 2 you can
-see "Computing" already filled into the team summary — that is what
-`tests/test_e2e.py::TestSessionResume` asserts. Point
-`FORM_WIZARD_BACKEND` at `CacheFormWizardBackend` when drafts need
-their own TTL or a Redis-backed cache, or at a custom backend, without
-touching any view code.
+configured `FORM_WIZARD_BACKEND`, here the cache-backed
+`CacheFormWizardBackend` pinned to a dedicated `wizards` cache alias with a
+30-minute lifetime:
+
+```python
+# config/settings.py
+"FORM_WIZARD_BACKEND": {
+    "BACKEND": "next.forms.CacheFormWizardBackend",
+    "OPTIONS": {"CACHE_ALIAS": "wizards", "TIMEOUT": 1800},
+},
+```
+
+Swapping wizard storage off the session is a settings-only change, no wizard
+class is touched. On `GET` of step 2 you still see "Computing" already filled
+into the team summary because the draft survives in the cache —
+`tests/test_e2e.py::TestCacheBackedDrafts` asserts that by reading the
+`wizards` alias directly, and `TestSessionResume` covers the resume behaviour
+end to end. Point `FORM_WIZARD_BACKEND` at the default
+`SessionFormWizardBackend`, a Redis-backed cache, or a custom backend the same
+way.
 
 ### 8. Admin filter by GET query
 
@@ -308,9 +323,9 @@ want decoupling and minimal coupling to the backend implementation.
 ## Further reading
 
 - [`next/forms/wizard.py`](../../next/forms/wizard.py) — the declarative
-  `FormWizard` base class, the `FormWizardBackend` contract, the default
-  `SessionFormWizardBackend` this example builds on, and the optional
-  `CacheFormWizardBackend`.
+  `FormWizard` base class, the `FormWizardBackend` contract, the
+  `CacheFormWizardBackend` this example configures, and the default
+  `SessionFormWizardBackend`.
 - [`next/forms/manager.py`](../../next/forms/manager.py) — the lazy,
   settings-driven `FormActionManager` used by every example.
 - [`next/forms/backends.py`](../../next/forms/backends.py) — the

--- a/examples/audit-forms/README.md
+++ b/examples/audit-forms/README.md
@@ -1,25 +1,13 @@
 # Audit-trail forms
 
-A three-step access-request workflow whose every dispatch and validation
-failure is recorded by **two parallel audit channels**: a custom
-`FormActionBackend` that writes synchronously inside `dispatch`, and signal
-receivers reacting to `action_dispatched`, `form_validation_failed`, and
-`form_access_denied`. The admin page interleaves rows from both channels so
-you can compare them side by side.
+A three-step access-request workflow whose every dispatch and validation failure is recorded by **two parallel audit channels**: a custom `FormActionBackend` that writes synchronously inside `dispatch`, and signal receivers reacting to `action_dispatched`, `form_validation_failed`, and `form_access_denied`. The admin page interleaves rows from both channels so you can compare them side by side.
 
-The example focuses on the form-action subsystem of next-dj: a custom
-backend wired through `NEXT_FRAMEWORK["FORM_ACTION_BACKENDS"]`, a
-declarative `FormWizard` that routes all three steps from one class, three
-composite components (`progress_bar` and `step_section` inside the form,
-`audit_row` shared between the admin and per-request audit pages),
-cache-backed step state through a non-default `FORM_WIZARD_BACKEND` with a
-`request_id` correlation column on `AuditEntry`, and full coverage of the
-`next.testing` `SignalRecorder` API.
+The example focuses on the form-action subsystem of next-dj: a custom backend wired through `NEXT_FRAMEWORK["FORM_ACTION_BACKENDS"]`, a declarative `FormWizard` that routes all three steps from one class, three composite components (`progress_bar` and `step_section` inside the form, `audit_row` shared between the admin and per-request audit pages), cache-backed step state through a non-default `FORM_WIZARD_BACKEND` with a `request_id` correlation column on `AuditEntry`, and full coverage of the `next.testing` `SignalRecorder` API.
 
 ## What you will see
 
 | URL | Description |
-|-----|-------------|
+| --- | --- |
 | `/` | Landing page. Recent requests link to their per-request audit. |
 | `/request/identity/` | Step 1 — full name, email, team. Saved sections show "✓ saved" pills. |
 | `/request/scope/` | Step 2 — project slug, free-form reason, expiry days. |
@@ -44,14 +32,7 @@ uv run python manage.py runserver     # http://127.0.0.1:8000/
 uv run pytest
 ```
 
-Tailwind loads via the Play CDN in
-[`portal/layout.djx`](portal/layout.djx). No Node, no build step. The
-wizard threads step drafts across requests through the configured
-`FORM_WIZARD_BACKEND`, here the cache-backed `CacheFormWizardBackend` on a
-dedicated `wizards` cache alias (see section 7). `SessionMiddleware` stays in
-`MIDDLEWARE` because `done` still uses the session to hand the new request id
-to the audit backend (it is on by default in
-[`config/settings.py`](config/settings.py)).
+Tailwind loads via the Play CDN in [`portal/layout.djx`](portal/layout.djx). No Node, no build step. The wizard threads step drafts across requests through the configured `FORM_WIZARD_BACKEND`, here the cache-backed `CacheFormWizardBackend` on a dedicated `wizards` cache alias (see section 7). `SessionMiddleware` stays in `MIDDLEWARE` because `done` still uses the session to hand the new request id to the audit backend (it is on by default in [`config/settings.py`](config/settings.py)).
 
 ## Walking the code
 
@@ -59,32 +40,12 @@ to the audit backend (it is on by default in
 
 `AuditEntry.source` distinguishes them.
 
-- `source="backend"` — written by `AuditedFormActionBackend.dispatch` in
-  [`access/backends.py`](access/backends.py). It runs synchronously inside
-  the dispatch path so it has direct access to `request.POST` and the
-  resolved `HttpResponse`. It writes two rows per dispatch:
-  `request_started` (with the captured POST payload) and `dispatched`
-  (with `response_status` and the redirect target).
-- `source="signal"` — written by the receivers in
-  [`access/receivers.py`](access/receivers.py). They subscribe to
-  `next.forms.signals.action_dispatched`, `form_validation_failed`, and
-  `form_access_denied`, using only the kwargs the framework ships in those
-  signals. They never see the raw request, which is the whole point: the
-  signal channel is decoupled from the backend class.
+- `source="backend"` — written by `AuditedFormActionBackend.dispatch` in [`access/backends.py`](access/backends.py). It runs synchronously inside the dispatch path so it has direct access to `request.POST` and the resolved `HttpResponse`. It writes two rows per dispatch: `request_started` (with the captured POST payload) and `dispatched` (with `response_status` and the redirect target).
+- `source="signal"` — written by the receivers in [`access/receivers.py`](access/receivers.py). They subscribe to `next.forms.signals.action_dispatched`, `form_validation_failed`, and `form_access_denied`, using only the kwargs the framework ships in those signals. They never see the raw request, which is the whole point: the signal channel is decoupled from the backend class.
 
-The two channels intentionally overlap on `kind="dispatched"` so the
-admin page can show them side by side. Pick whichever fits your project —
-or run both, like this example does.
+The two channels intentionally overlap on `kind="dispatched"` so the admin page can show them side by side. Pick whichever fits your project — or run both, like this example does.
 
-> **PII caveat.** `_safe_form_payload` strips control fields
-> (`csrfmiddlewaretoken`, `_next_form_origin`, and the
-> `policy_acknowledged` gate field) but stores every other POST value
-> verbatim, including emails and free-text
-> reasons. If you adopt this pattern in production, extend
-> `_RESERVED_FORM_KEYS` with any password / secret / personal-data field
-> name your forms collect, or hash sensitive values before persisting.
-> Multi-value fields (checkbox groups, multi-selects) are preserved via
-> `request.POST.lists()`.
+> **PII caveat.** `_safe_form_payload` strips control fields (`csrfmiddlewaretoken`, `_next_form_origin`, and the `policy_acknowledged` gate field) but stores every other POST value verbatim, including emails and free-text reasons. If you adopt this pattern in production, extend `_RESERVED_FORM_KEYS` with any password / secret / personal-data field name your forms collect, or hash sensitive values before persisting. Multi-value fields (checkbox groups, multi-selects) are preserved via `request.POST.lists()`.
 
 ### 2. Wiring a custom backend through settings
 
@@ -98,10 +59,7 @@ NEXT_FRAMEWORK = {
 }
 ```
 
-The framework loads each entry lazily on first access via
-`next.forms.backends.FormActionFactory`. `AuditedFormActionBackend` subclasses
-`RegistryFormActionBackend`, so all `@action` registrations are still
-honoured — the override only wraps `dispatch` to add the audit rows.
+The framework loads each entry lazily on first access via `next.forms.backends.FormActionFactory`. `AuditedFormActionBackend` subclasses `RegistryFormActionBackend`, so all `@action` registrations are still honoured — the override only wraps `dispatch` to add the audit rows.
 
 ```python
 # access/backends.py
@@ -113,10 +71,7 @@ class AuditedFormActionBackend(RegistryFormActionBackend):
         return response
 ```
 
-If the dotted path fails to import, the `next.E044` system check fires at
-`manage.py check`. If the resolved class is not a `FormActionBackend`,
-`next.E045` does. Both checks live in
-[`next/forms/checks.py`](../../next/forms/checks.py).
+If the dotted path fails to import, the `next.E044` system check fires at `manage.py check`. If the resolved class is not a `FormActionBackend`, `next.E045` does. Both checks live in [`next/forms/checks.py`](../../next/forms/checks.py).
 
 ### 3. One declarative `FormWizard` for three steps
 
@@ -137,11 +92,7 @@ class AccessRequestWizard(next.forms.FormWizard):
         return HttpResponseRedirect(f"/request/{access_request.pk}/audit/?just=1")
 ```
 
-The class declares itself as one action through `__init_subclass__`, so
-the auto-name `access_request_wizard` resolves with
-`resolve_action_url("access_request_wizard")`. A namespaced name does
-not — see `tests/test_e2e.py::TestNamespacedAction`. Adding a step is one
-edit to `Meta.steps`.
+The class declares itself as one action through `__init_subclass__`, so the auto-name `access_request_wizard` resolves with `resolve_action_url("access_request_wizard")`. A namespaced name does not — see `tests/test_e2e.py::TestNamespacedAction`. Adding a step is one edit to `Meta.steps`.
 
 ### 3a. A dynamic permission gate on the wizard
 
@@ -153,32 +104,11 @@ class AccessRequestWizard(next.forms.FormWizard):
         return request.POST.get("policy_acknowledged") == "on"
 ```
 
-`check_permissions` is a DI-resolved classmethod the framework runs on
-**every step POST, before the step form binds**. It declares only what it
-reads — here the `request` and its POST data. Return `None` or `True` to
-allow, `False` or `raise PermissionDenied` to deny with a 403, or return
-an `HttpResponse` to short-circuit verbatim. A denied step writes no
-draft, so the wizard storage stays untouched.
+`check_permissions` is a DI-resolved classmethod the framework runs on **every step POST, before the step form binds**. It declares only what it reads — here the `request` and its POST data. Return `None` or `True` to allow, `False` or `raise PermissionDenied` to deny with a 403, or return an `HttpResponse` to short-circuit verbatim. A denied step writes no draft, so the wizard storage stays untouched.
 
-The gate is the retention-policy acknowledgement. The step template
-renders a checked `policy_acknowledged` checkbox inside the form (the
-`data-policy-notice` block), so a normal submission carries the field and
-passes, while a replayed or forged action URL that never rendered the
-form omits it and is denied. The acknowledgement field is a control field,
-not user data, so `_RESERVED_FORM_KEYS` in `access/backends.py` strips it
-from the captured payload. That denial is exactly the kind of event an
-audit example should capture.
+The gate is the retention-policy acknowledgement. The step template renders a checked `policy_acknowledged` checkbox inside the form (the `data-policy-notice` block), so a normal submission carries the field and passes, while a replayed or forged action URL that never rendered the form omits it and is denied. The acknowledgement field is a control field, not user data, so `_RESERVED_FORM_KEYS` in `access/backends.py` strips it from the captured payload. That denial is exactly the kind of event an audit example should capture.
 
-The framework fires `next.forms.signals.form_access_denied` **only** on a
-dynamic-hook denial, never on the static `ActionGuard` fast-path. The
-sender is `FormActionDispatch` and the kwargs are `action_name`, `uid`,
-`request`, `layer` (`"view"` for `check_permissions`, `"object"` for
-`has_object_permission`), and `reason` (`"denied"` when the hook returned
-`False`, `"raised"` on `PermissionDenied`, `"response"` on an
-`HttpResponse` short-circuit). The receiver in
-[`access/receivers.py`](access/receivers.py) records one signal-sourced
-`AuditEntry` per denial with `kind="access_denied"`, storing `layer` and
-`reason` in the dedicated `access_layer` / `access_reason` columns:
+The framework fires `next.forms.signals.form_access_denied` **only** on a dynamic-hook denial, never on the static `ActionGuard` fast-path. The sender is `FormActionDispatch` and the kwargs are `action_name`, `uid`, `request`, `layer` (`"view"` for `check_permissions`, `"object"` for `has_object_permission`), and `reason` (`"denied"` when the hook returned `False`, `"raised"` on `PermissionDenied`, `"response"` on an `HttpResponse` short-circuit). The receiver in [`access/receivers.py`](access/receivers.py) records one signal-sourced `AuditEntry` per denial with `kind="access_denied"`, storing `layer` and `reason` in the dedicated `access_layer` / `access_reason` columns:
 
 ```python
 # access/receivers.py
@@ -193,91 +123,37 @@ def _on_form_access_denied(action_name, layer, reason, **_):
     )
 ```
 
-Because the denied step writes no draft and no `dispatched` row, this
-`access_denied` row is the only trace that records *why* the request was
-refused — the backend channel still leaves a `request_started` row (with
-no `reason`) before `super().dispatch` reaches the denying hook, which is
-the whole point of the signal channel. Filter the admin log to the denial
-with `/admin/audit/?kind=access_denied`.
+Because the denied step writes no draft and no `dispatched` row, this `access_denied` row is the only trace that records _why_ the request was refused — the backend channel still leaves a `request_started` row (with no `reason`) before `super().dispatch` reaches the denying hook, which is the whole point of the signal channel. Filter the admin log to the denial with `/admin/audit/?kind=access_denied`.
 
 ### 4. Three ordinary forms, one per step
 
-Each step is a bare `django.forms.ModelForm` (or `Form`) — the wizard
-owns dispatching, so step forms never register as standalone actions
-and need none of the `next.forms` base classes (a step that does
-subclass `next.forms` and ends up registered trips the `next.W057`
-check):
+Each step is a bare `django.forms.ModelForm` (or `Form`) — the wizard owns dispatching, so step forms never register as standalone actions and need none of the `next.forms` base classes (a step that does subclass `next.forms` and ends up registered trips the `next.W057` check):
 
 - `IdentityStep` — a `ModelForm` on `["full_name", "email", "team"]`.
 - `ScopeStep` — a `ModelForm` on `["project_slug", "reason", "expires_in_days"]`.
 - `ApprovalStep` — a fieldless `Form` that only confirms the merged request.
 
-The wizard binds the current step's form to the POST, validates only
-that step's fields, and saves the cleaned data through the wizard
-backend. On a non-final step it 302-redirects to the next step's URL, computed by
-swapping the `[step]` segment of the origin path. On the final step it
-calls `done(request, cleaned_data)` with the merged dict of every step,
-so `AccessRequest.objects.create(**cleaned_data)` builds the row once.
-No per-step `.save()`, no hidden id fields, no hand-written routing.
+The wizard binds the current step's form to the POST, validates only that step's fields, and saves the cleaned data through the wizard backend. On a non-final step it 302-redirects to the next step's URL, computed by swapping the `[step]` segment of the origin path. On the final step it calls `done(request, cleaned_data)` with the merged dict of every step, so `AccessRequest.objects.create(**cleaned_data)` builds the row once. No per-step `.save()`, no hidden id fields, no hand-written routing.
 
 ### 5. Two composite components, two patterns
 
-The example ships three composite components that demonstrate two
-different ways the framework lets a component contribute logic:
+The example ships three composite components that demonstrate two different ways the framework lets a component contribute logic:
 
-- **`progress_bar/` — synthesised state from wizard truth.** Lives at
-  `views/request/[step]/_blocks/progress_bar/`. Its `@component.context`
-  functions take the `wizard` instance (pushed into the template context
-  by the `{% form %}` tag) and read `current_step()`, `step_names()`, and
-  `completed_steps()`. A step is `current` when it is the active step,
-  `saved` when it has stored data, otherwise `pending`. No page-level
-  step context is needed — all step knowledge lives in the wizard.
+- **`progress_bar/` — synthesised state from wizard truth.** Lives at `views/request/[step]/_blocks/progress_bar/`. Its `@component.context` functions take the `wizard` instance (pushed into the template context by the `{% form %}` tag) and read `current_step()`, `step_names()`, and `completed_steps()`. A step is `current` when it is the active step, `saved` when it has stored data, otherwise `pending`. No page-level step context is needed — all step knowledge lives in the wizard.
 
-- **`step_section/` — Python `render()` gating on wizard state.** Lives
-  next to `progress_bar`. Has only a `component.py` (no `.djx`); the
-  `render()` function takes `form` and `wizard` via DI, then assembles
-  HTML through inline `django.template.Template` instances. It owns the
-  section chrome: red border on validation errors, "✓ saved" pill plus a
-  compact value summary when a step is past, slate placeholder for steps
-  not yet visited. The page template calls `{% component "step_section" %}`
-  once and the component renders every step.
+- **`step_section/` — Python `render()` gating on wizard state.** Lives next to `progress_bar`. Has only a `component.py` (no `.djx`); the `render()` function takes `form` and `wizard` via DI, then assembles HTML through inline `django.template.Template` instances. It owns the section chrome: red border on validation errors, "✓ saved" pill plus a compact value summary when a step is past, slate placeholder for steps not yet visited. The page template calls `{% component "step_section" %}` once and the component renders every step.
 
-- **`audit_row/` — `@component.context` deriving display data.** Lives
-  at `views/_blocks/audit_row/` (one scope above the admin and
-  per-request pages so both can use it). Takes an `AuditEntry` from
-  the parent loop and exposes `kind_class`, `source_class`,
-  `summary`, `payload_keys`, `request_link`, and `data_attrs`. The
-  template stays markup-only.
+- **`audit_row/` — `@component.context` deriving display data.** Lives at `views/_blocks/audit_row/` (one scope above the admin and per-request pages so both can use it). Takes an `AuditEntry` from the parent loop and exposes `kind_class`, `source_class`, `summary`, `payload_keys`, `request_link`, and `data_attrs`. The template stays markup-only.
 
 ### 6. Per-request audit trail (`AuditEntry.request` FK)
 
-The audit log can be read globally at `/admin/audit/` or per-request at
-`/request/<id>/audit/`. The router walks the file tree and emits both
-patterns from one app — `views/request/[step]/page.py` becomes
-`request/<str:step>/`, `views/request/[int:id]/audit/page.py` becomes
-`request/<int:id>/audit/`. Django's URL resolver picks the int variant
-first, so `/request/5/audit/` reaches the per-request page even though
-`5` would also be a valid `<str:step>`.
+The audit log can be read globally at `/admin/audit/` or per-request at `/request/<id>/audit/`. The router walks the file tree and emits both patterns from one app — `views/request/[step]/page.py` becomes `request/<str:step>/`, `views/request/[int:id]/audit/page.py` becomes `request/<int:id>/audit/`. Django's URL resolver picks the int variant first, so `/request/5/audit/` reaches the per-request page even though `5` would also be a valid `<str:step>`.
 
-The correlation column on `AuditEntry.request` is **only** populated by
-the backend channel, on the **dispatched** row of the final step. The
-wizard's `done` stores `request.session["access_request_just_created"]`
-right after `AccessRequest.objects.create(...)`, and
-`AuditedFormActionBackend.dispatch` pops that key after `super()`
-returns. Signal-channel rows stay unlinked by design — that is a
-teaching point in itself: the signal channel sees only the kwargs the
-signal ships, and `AccessRequest.id` is not among them.
+The correlation column on `AuditEntry.request` is **only** populated by the backend channel, on the **dispatched** row of the final step. The wizard's `done` stores `request.session["access_request_just_created"]` right after `AccessRequest.objects.create(...)`, and `AuditedFormActionBackend.dispatch` pops that key after `super()` returns. Signal-channel rows stay unlinked by design — that is a teaching point in itself: the signal channel sees only the kwargs the signal ships, and `AccessRequest.id` is not among them.
 
 ### 7. Wizard backend, not hidden form fields
 
-Each step posts only its visible fields plus the framework's hidden
-`_next_form_origin` (emitted by the `{% form %}` tag). The dispatcher
-resolves that origin URL against the URLconf to recover the typed
-`step` kwarg, and `_step_from_origin` in the audit backend does the
-same for the audit rows. The wizard saves the cleaned data through the
-configured `FORM_WIZARD_BACKEND`, here the cache-backed
-`CacheFormWizardBackend` pinned to a dedicated `wizards` cache alias with a
-30-minute lifetime:
+Each step posts only its visible fields plus the framework's hidden `_next_form_origin` (emitted by the `{% form %}` tag). The dispatcher resolves that origin URL against the URLconf to recover the typed `step` kwarg, and `_step_from_origin` in the audit backend does the same for the audit rows. The wizard saves the cleaned data through the configured `FORM_WIZARD_BACKEND`, here the cache-backed `CacheFormWizardBackend` pinned to a dedicated `wizards` cache alias with a 30-minute lifetime:
 
 ```python
 # config/settings.py
@@ -287,26 +163,16 @@ configured `FORM_WIZARD_BACKEND`, here the cache-backed
 },
 ```
 
-Swapping wizard storage off the session is a settings-only change, no wizard
-class is touched. On `GET` of step 2 you still see "Computing" already filled
-into the team summary because the draft survives in the cache —
-`tests/test_e2e.py::TestCacheBackedDrafts` asserts that by reading the
-`wizards` alias directly, and `TestSessionResume` covers the resume behaviour
-end to end. Point `FORM_WIZARD_BACKEND` at the default
-`SessionFormWizardBackend`, a Redis-backed cache, or a custom backend the same
-way.
+Swapping wizard storage off the session is a settings-only change, no wizard class is touched. On `GET` of step 2 you still see "Computing" already filled into the team summary because the draft survives in the cache — `tests/test_e2e.py::TestCacheBackedDrafts` asserts that by reading the `wizards` alias directly, and `TestSessionResume` covers the resume behaviour end to end. Point `FORM_WIZARD_BACKEND` at the default `SessionFormWizardBackend`, a Redis-backed cache, or a custom backend the same way.
 
 ### 8. Admin filter by GET query
 
-`/admin/audit/?kind=validation_failed` narrows the table to one kind
-through a plain GET form. The `@context("active_kind")` function reads
-`request.GET` and the template uses it to mark the matching `<option>`
-as `selected`. No JavaScript, no AJAX.
+`/admin/audit/?kind=validation_failed` narrows the table to one kind through a plain GET form. The `@context("active_kind")` function reads `request.GET` and the template uses it to mark the matching `<option>` as `selected`. No JavaScript, no AJAX.
 
 ### 9. Comparing the two audit channels
 
-| | Backend channel | Signal channel |
-|---|---|---|
+|  | Backend channel | Signal channel |
+| --- | --- | --- |
 | Where written | inside `AuditedFormActionBackend.dispatch` | `@receiver(action_dispatched / form_validation_failed / form_access_denied)` |
 | Sees raw POST? | yes | no — only the signal kwargs |
 | Sees response status? | yes | yes (via signal kwarg) |
@@ -315,29 +181,14 @@ as `selected`. No JavaScript, no AJAX.
 | Coupled to backend class? | yes — only fires when this backend dispatches | no — fires whatever backend is configured |
 | When to pick | compliance, full request payloads, transactional rollback | metrics, side effects on action lifecycle, decoupled from backend swap |
 
-The example runs both because it is a *demonstration*. In production,
-pick the channel that matches your need: backend if you want raw
-inputs and atomicity with the form's database write, signal if you
-want decoupling and minimal coupling to the backend implementation.
+The example runs both because it is a _demonstration_. In production, pick the channel that matches your need: backend if you want raw inputs and atomicity with the form's database write, signal if you want decoupling and minimal coupling to the backend implementation.
 
 ## Further reading
 
-- [`next/forms/wizard.py`](../../next/forms/wizard.py) — the declarative
-  `FormWizard` base class, the `FormWizardBackend` contract, the
-  `CacheFormWizardBackend` this example configures, and the default
-  `SessionFormWizardBackend`.
-- [`next/forms/manager.py`](../../next/forms/manager.py) — the lazy,
-  settings-driven `FormActionManager` used by every example.
-- [`next/forms/backends.py`](../../next/forms/backends.py) — the
-  `FormActionBackend` ABC and `RegistryFormActionBackend` superclass.
-- [`next/forms/dispatch.py`](../../next/forms/dispatch.py) — where
-  `action_dispatched`, `form_validation_failed`, `wizard_step_submitted`,
-  `wizard_completed`, and `form_access_denied` are sent, and where the
-  `check_permissions` / `has_object_permission` hooks run.
-- [`next/forms/checks.py`](../../next/forms/checks.py) — `next.E041`
-  (duplicate handlers), `next.E044` (bad backend config), `next.E045`
-  (wrong backend type).
-- [`next/testing/signals.py`](../../next/testing/signals.py) —
-  `SignalRecorder` and `capture_signals` helpers used in the tests.
-- [`docs/content/topics/testing.rst`](../../docs/content/topics/testing.rst)
-  — canonical conftest scaffold mirrored in this example.
+- [`next/forms/wizard.py`](../../next/forms/wizard.py) — the declarative `FormWizard` base class, the `FormWizardBackend` contract, the `CacheFormWizardBackend` this example configures, and the default `SessionFormWizardBackend`.
+- [`next/forms/manager.py`](../../next/forms/manager.py) — the lazy, settings-driven `FormActionManager` used by every example.
+- [`next/forms/backends.py`](../../next/forms/backends.py) — the `FormActionBackend` ABC and `RegistryFormActionBackend` superclass.
+- [`next/forms/dispatch.py`](../../next/forms/dispatch.py) — where `action_dispatched`, `form_validation_failed`, `wizard_step_submitted`, `wizard_completed`, and `form_access_denied` are sent, and where the `check_permissions` / `has_object_permission` hooks run.
+- [`next/forms/checks.py`](../../next/forms/checks.py) — `next.E041` (duplicate handlers), `next.E044` (bad backend config), `next.E045` (wrong backend type).
+- [`next/testing/signals.py`](../../next/testing/signals.py) — `SignalRecorder` and `capture_signals` helpers used in the tests.
+- [`docs/content/topics/testing.rst`](../../docs/content/topics/testing.rst) — canonical conftest scaffold mirrored in this example.

--- a/examples/audit-forms/access/views/request/[step]/page.py
+++ b/examples/audit-forms/access/views/request/[step]/page.py
@@ -1,13 +1,13 @@
 from typing import Any, ClassVar
 
 from access.models import AccessRequest
-from django import forms
+from django import forms as django_forms
 from django.http import HttpRequest, HttpResponseRedirect
 
 from next.forms import ComponentWidget, FormWizard, PermissionOutcome
 
 
-class IdentityStep(forms.ModelForm):
+class IdentityStep(django_forms.ModelForm):
     """First wizard step capturing who is asking for access."""
 
     class Meta:
@@ -20,7 +20,7 @@ class IdentityStep(forms.ModelForm):
         }
 
 
-class ScopeStep(forms.ModelForm):
+class ScopeStep(django_forms.ModelForm):
     """Second wizard step capturing what access is requested and for how long."""
 
     class Meta:
@@ -33,12 +33,12 @@ class ScopeStep(forms.ModelForm):
         }
 
 
-class ApprovalStep(forms.Form):
+class ApprovalStep(django_forms.Form):
     """Final wizard step that only confirms the merged request."""
 
 
 class AccessRequestWizard(FormWizard):
-    """Three-step access-request wizard with session-backed drafts."""
+    """Three-step access-request wizard with cache-backed step drafts."""
 
     class Meta:
         steps: ClassVar = [

--- a/examples/audit-forms/config/settings.py
+++ b/examples/audit-forms/config/settings.py
@@ -60,6 +60,12 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "audit-forms",
     },
+    # A dedicated alias for wizard drafts so step data has its own store and
+    # lifetime, separate from the application cache.
+    "wizards": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "audit-forms-wizards",
+    },
 }
 
 LANGUAGE_CODE = "en-us"
@@ -99,4 +105,10 @@ NEXT_FRAMEWORK = {
     "FORM_ACTION_BACKENDS": [
         {"BACKEND": "access.backends.AuditedFormActionBackend"},
     ],
+    # Wizard step drafts live in the dedicated `wizards` cache alias rather
+    # than the session, with a short lifetime that fits a PII-carrying flow.
+    "FORM_WIZARD_BACKEND": {
+        "BACKEND": "next.forms.CacheFormWizardBackend",
+        "OPTIONS": {"CACHE_ALIAS": "wizards", "TIMEOUT": 1800},
+    },
 }

--- a/examples/audit-forms/tests/test_e2e.py
+++ b/examples/audit-forms/tests/test_e2e.py
@@ -1,7 +1,11 @@
+import importlib.util
 import re
+from pathlib import Path
 
 import pytest
 from access.models import AccessRequest, AuditEntry
+from django.core.cache import caches
+from django.http import HttpRequest
 
 from next.forms import FormActionNotFound
 from next.forms.signals import (
@@ -13,6 +17,27 @@ from next.testing import SignalRecorder, resolve_action_url
 
 
 WIZARD_ACTION = "access_request_wizard"
+
+_STEP_PAGE_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "access"
+    / "views"
+    / "request"
+    / "[step]"
+    / "page.py"
+)
+
+
+def _load_step_page():
+    spec = importlib.util.spec_from_file_location("audit_step_page_e2e", _STEP_PAGE_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+step_page = _load_step_page()
 
 IDENTITY = {
     "full_name": "Ada Lovelace",
@@ -230,6 +255,55 @@ class TestSessionResume:
         assert "Computing" in body
         assert 'data-step-section="identity" data-state="saved"' in body
         assert "data-saved-badge" in body
+
+
+def _wizard_storage_id() -> str:
+    wizard = step_page.AccessRequestWizard(
+        request=HttpRequest(),
+        url_kwargs={"step": "identity"},
+        base_path="/request/identity/",
+    )
+    return wizard.storage_id
+
+
+def _cached_draft(session_key: str) -> dict:
+    key = f"next_wizard:{session_key}:{_wizard_storage_id()}"
+    return caches["wizards"].get(key) or {}
+
+
+class TestCacheBackedDrafts:
+    def test_step_draft_lands_in_the_wizards_cache(self, client) -> None:
+        _post_step(client, "identity", IDENTITY)
+        session_key = client.session.session_key
+        assert session_key is not None
+        bucket = _cached_draft(session_key)
+        assert set(bucket) == {"identity"}
+        assert bucket["identity"]["team"] == "Computing"
+        assert bucket["identity"]["email"] == "ada@example.com"
+
+    def test_drafts_stay_out_of_the_default_cache(self, client) -> None:
+        _post_step(client, "identity", IDENTITY)
+        session_key = client.session.session_key
+        key = f"next_wizard:{session_key}:{_wizard_storage_id()}"
+        assert caches["default"].get(key) is None
+
+    def test_drafts_round_trip_across_steps_through_the_cache(self, client) -> None:
+        _post_step(client, "identity", IDENTITY)
+        _post_step(client, "scope", SCOPE)
+        bucket = _cached_draft(client.session.session_key)
+        assert set(bucket) == {"identity", "scope"}
+        assert bucket["scope"]["project_slug"] == "engine"
+        assert bucket["identity"]["full_name"] == "Ada Lovelace"
+
+    def test_three_step_flow_completes_and_clears_the_cache(self, client) -> None:
+        session_key_seen = []
+        _post_step(client, "identity", IDENTITY)
+        session_key_seen.append(client.session.session_key)
+        _post_step(client, "scope", SCOPE)
+        response = _post_step(client, "approval", APPROVAL)
+        assert response.status_code == 302
+        assert AccessRequest.objects.count() == 1
+        assert _cached_draft(session_key_seen[0]) == {}
 
 
 class TestSuccessRedirect:

--- a/examples/feature-flags/README.md
+++ b/examples/feature-flags/README.md
@@ -10,7 +10,9 @@ The example focuses on the signal / receiver / cache layer of the framework:
 a composite component with a Python `render()` that returns empty to hide
 gated content, a custom DI provider that resolves a `Flag` by name, a
 bulk-toggle form whose view-level `check_permissions` hook is gated by a
-feature flag, a nested admin layout, and signal receivers (`post_save` for
+feature flag and whose success redirect and flash use the declarative
+`success_url` / `success_message` contract, a nested admin layout, and
+signal receivers (`post_save` for
 cache invalidation, `page_rendered` for metrics, `form_access_denied` for
 the gated action).
 
@@ -19,7 +21,7 @@ the gated action).
 | URL | Description |
 |-----|-------------|
 | `/` | Two columns — enabled flags on the left, disabled on the right. |
-| `/admin/` | Bulk-toggle form, gated by the `admin_writes` flag. Each row shows a live "on/off" preview component. |
+| `/admin/` | Bulk-toggle form, gated by the `admin_writes` flag. Each row shows a live "on/off" preview component, and a success banner confirms each save. |
 | `/admin/metrics/` | Per-page render counters from the `page_rendered` receiver plus the `form_access_denied` denial count. |
 | `/demo/` | `feature_guard` components for three demo flags. Disabled flags render nothing. |
 
@@ -223,6 +225,10 @@ class BulkToggleForm(Form):
         widget=forms.CheckboxSelectMultiple(attrs={"class": "hidden"}),
     )
 
+    class Meta:
+        success_url = "/admin/"
+        success_message = "Flag toggles saved."
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["enabled_names"].choices = [
@@ -236,16 +242,23 @@ class BulkToggleForm(Form):
             if flag.enabled != should_be_on:
                 flag.enabled = should_be_on
                 flag.save(update_fields=["enabled", "updated_at"])
-        return HttpResponseRedirect("/admin/")
+        return super().on_valid(request)
 ```
 
-Two details worth noting:
+Three details worth noting:
 
 - `choices` is populated in `__init__` rather than at class-define time so
   the field reflects the current set of flags on every request.
 - Only **changed** flags are saved. Untouched rows do not fire `post_save`,
   which keeps the cache-invalidation receiver honest — nothing gets
   invalidated unless there is a real state transition.
+- The redirect and the flash come from the declarative success contract.
+  `Meta.success_url` and `Meta.success_message` let the overridden `on_valid`
+  end with `super().on_valid(request)` instead of a hand-built
+  `HttpResponseRedirect`. The base method redirects to `/admin/` and flashes
+  "Flag toggles saved." through Django's messages framework. A
+  `flash_messages` context drains the queue and the admin template renders it
+  in an `alert` banner.
 
 The widget has Tailwind `class="hidden"` so each checkbox is visually
 replaced by an inline `<input type="checkbox">` in the template — the label

--- a/examples/feature-flags/README.md
+++ b/examples/feature-flags/README.md
@@ -1,25 +1,13 @@
 # Feature flags admin
 
-A small feature-flag console built on **next-dj**. Toggle flags in an admin
-panel and watch them gate content on a demo page. Values live in
-`LocMemCache` with a `post_save` receiver invalidating each entry on write,
-and every page render bumps a counter so you can see the `page_rendered`
-signal firing in real time.
+A small feature-flag console built on **next-dj**. Toggle flags in an admin panel and watch them gate content on a demo page. Values live in `LocMemCache` with a `post_save` receiver invalidating each entry on write, and every page render bumps a counter so you can see the `page_rendered` signal firing in real time.
 
-The example focuses on the signal / receiver / cache layer of the framework:
-a composite component with a Python `render()` that returns empty to hide
-gated content, a custom DI provider that resolves a `Flag` by name, a
-bulk-toggle form whose view-level `check_permissions` hook is gated by a
-feature flag and whose success redirect and flash use the declarative
-`success_url` / `success_message` contract, a nested admin layout, and
-signal receivers (`post_save` for
-cache invalidation, `page_rendered` for metrics, `form_access_denied` for
-the gated action).
+The example focuses on the signal / receiver / cache layer of the framework: a composite component with a Python `render()` that returns empty to hide gated content, a custom DI provider that resolves a `Flag` by name, a bulk-toggle form whose view-level `check_permissions` hook is gated by a feature flag and whose success redirect and flash use the declarative `success_url` / `success_message` contract, a nested admin layout, and signal receivers (`post_save` for cache invalidation, `page_rendered` for metrics, `form_access_denied` for the gated action).
 
 ## What you will see
 
 | URL | Description |
-|-----|-------------|
+| --- | --- |
 | `/` | Two columns — enabled flags on the left, disabled on the right. |
 | `/admin/` | Bulk-toggle form, gated by the `admin_writes` flag. Each row shows a live "on/off" preview component, and a success banner confirms each save. |
 | `/admin/metrics/` | Per-page render counters from the `page_rendered` receiver plus the `form_access_denied` denial count. |
@@ -34,8 +22,7 @@ uv run python manage.py runserver     # http://127.0.0.1:8000/
 uv run pytest
 ```
 
-Tailwind loads via the Play CDN in
-[`panels/layout.djx`](flags/panels/layout.djx). No Node, no build step.
+Tailwind loads via the Play CDN in [`panels/layout.djx`](flags/panels/layout.djx). No Node, no build step.
 
 Seed a few flags from the Django shell:
 
@@ -53,16 +40,13 @@ Flag.objects.create(name='admin_writes', label='Admin writes',
 "
 ```
 
-The `admin_writes` flag gates the bulk-toggle action. Leave it off and the
-admin form returns `403` on submit. See section 7 for the
-`check_permissions` hook.
+The `admin_writes` flag gates the bulk-toggle action. Leave it off and the admin form returns `403` on submit. See section 7 for the `check_permissions` hook.
 
 ## Walking the code
 
 ### 1. Rename `pages/` and `_components/` to fit the domain
 
-[`config/settings.py`](config/settings.py) reshapes the conventional folders
-through `NEXT_FRAMEWORK`:
+[`config/settings.py`](config/settings.py) reshapes the conventional folders through `NEXT_FRAMEWORK`:
 
 ```python
 NEXT_FRAMEWORK = {
@@ -77,16 +61,11 @@ NEXT_FRAMEWORK = {
 }
 ```
 
-Both keys are strings (not paths). The file router and components backend
-look up `panels/` inside every installed app. Any directory name works — the
-word "pages" is just a default, not a framework requirement.
+Both keys are strings (not paths). The file router and components backend look up `panels/` inside every installed app. Any directory name works — the word "pages" is just a default, not a framework requirement.
 
 ### 2. `Flag` model and cache-through lookup
 
-[`flags/models.py`](flags/models.py) holds a tiny `Flag(name, label,
-description, enabled, updated_at)` table.
-[`flags/cache.py`](flags/cache.py) wraps the model with a read-through
-`LocMemCache` layer:
+[`flags/models.py`](flags/models.py) holds a tiny `Flag(name, label, description, enabled, updated_at)` table. [`flags/cache.py`](flags/cache.py) wraps the model with a read-through `LocMemCache` layer:
 
 ```python
 def get_cached_flag(name: str) -> Flag | None:
@@ -105,14 +84,11 @@ def get_cached_flag(name: str) -> Flag | None:
     return flag
 ```
 
-The sentinel for "flag does not exist" (`"__missing__"`) is stored the same
-way as a hit. That way a repeated lookup for a typo-ed flag name never
-re-queries the database until the cache invalidates.
+The sentinel for "flag does not exist" (`"__missing__"`) is stored the same way as a hit. That way a repeated lookup for a typo-ed flag name never re-queries the database until the cache invalidates.
 
 ### 3. DI provider — `DFlag[Flag]`
 
-[`flags/providers.py`](flags/providers.py) registers a generic marker and a
-resolver that reads the flag name from two places:
+[`flags/providers.py`](flags/providers.py) registers a generic marker and a resolver that reads the flag name from two places:
 
 ```python
 class DFlag[T](DDependencyBase[T]):
@@ -133,31 +109,16 @@ class FlagProvider(RegisteredParameterProvider):
 
 Two call sites drive the same provider:
 
-- **Pages / URL kwargs**: not used here, but the pattern
-  `panels/admin/flags/[name]/` would resolve `flag: DFlag[Flag]` from
-  `context.url_kwargs["name"]`. Mirrors the `DLink[Link]` pattern from the
-  URL shortener example.
-- **Components / template props**: the `feature_guard` component is called
-  as `{% component "feature_guard" flag_name="beta_checkout" %}`, and the
-  literal string flows into the component's template context. The provider
-  reads `context.context_data["flag_name"]`.
+- **Pages / URL kwargs**: not used here, but the pattern `panels/admin/flags/[name]/` would resolve `flag: DFlag[Flag]` from `context.url_kwargs["name"]`. Mirrors the `DLink[Link]` pattern from the URL shortener example.
+- **Components / template props**: the `feature_guard` component is called as `{% component "feature_guard" flag_name="beta_checkout" %}`, and the literal string flows into the component's template context. The provider reads `context.context_data["flag_name"]`.
 
-When the flag does not exist, the provider returns a **disabled placeholder**
-(`Flag(name=..., enabled=False)`) instead of `None`. Guard components can
-then blindly check `flag.enabled` without three-way `None` logic at every
-usage site. It is a deliberate choice — a `None` would force every call
-site to handle a ternary (on / off / unknown), and "unknown" is always
-treated as off here anyway.
+When the flag does not exist, the provider returns a **disabled placeholder** (`Flag(name=..., enabled=False)`) instead of `None`. Guard components can then blindly check `flag.enabled` without three-way `None` logic at every usage site. It is a deliberate choice — a `None` would force every call site to handle a ternary (on / off / unknown), and "unknown" is always treated as off here anyway.
 
-Because the annotation is inspected at DI time, the component module
-**must not use** `from __future__ import annotations` — PEP 563 would
-string-ify `DFlag[Flag]` and `get_origin` would return `None`. That is the
-same gotcha any custom DI marker runs into in this codebase.
+Because the annotation is inspected at DI time, the component module **must not use** `from __future__ import annotations` — PEP 563 would string-ify `DFlag[Flag]` and `get_origin` would return `None`. That is the same gotcha any custom DI marker runs into in this codebase.
 
 ### 4. Composite `feature_guard` — Python `render()` returns empty to hide
 
-[`flags/panels/_chunks/feature_guard/component.py`](flags/panels/_chunks/feature_guard/component.py)
-has no `component.djx` — it is a pure-Python composite:
+[`flags/panels/_chunks/feature_guard/component.py`](flags/panels/_chunks/feature_guard/component.py) has no `component.djx` — it is a pure-Python composite:
 
 ```python
 def render(flag: DFlag[Flag]) -> str:
@@ -166,23 +127,13 @@ def render(flag: DFlag[Flag]) -> str:
     return _BANNER.render(Context({"flag": flag, "label": ..., "description": ...}))
 ```
 
-`CompositeComponentRenderer` detects the `render` attribute on
-`component.py`, resolves `flag` through the DI chain above, and replaces the
-`{% component ... %}` tag with whatever `render()` returns. Empty string
-means the component is invisible — no wrapper `<div>`, no comments, no
-whitespace in the output. This is the cleanest way to gate content server
-side.
+`CompositeComponentRenderer` detects the `render` attribute on `component.py`, resolves `flag` through the DI chain above, and replaces the `{% component ... %}` tag with whatever `render()` returns. Empty string means the component is invisible — no wrapper `<div>`, no comments, no whitespace in the output. This is the cleanest way to gate content server side.
 
-The HTML is a pre-parsed `django.template.Template`. Django's auto-escape
-handles `flag.name`, `flag.label`, and `flag.description` — the same values
-could come from user input with no extra `escape()` calls. Never register a
-loader or component that returns user-supplied HTML without this guarantee.
+The HTML is a pre-parsed `django.template.Template`. Django's auto-escape handles `flag.name`, `flag.label`, and `flag.description` — the same values could come from user input with no extra `escape()` calls. Never register a loader or component that returns user-supplied HTML without this guarantee.
 
 ### 5. Composite `toggle_preview` — template + `@component.context`
 
-The admin form uses a second composite to show an "on / off" badge next to
-every row. It takes the template path instead of the Python-render path
-because the badge has no conditional logic around whether to render at all:
+The admin form uses a second composite to show an "on / off" badge next to every row. It takes the template path instead of the Python-render path because the badge has no conditional logic around whether to render at all:
 
 ```python
 # _chunks/toggle_preview/component.py
@@ -200,23 +151,13 @@ def _state(flag: DFlag[Flag]) -> dict[str, str]:
 </span>
 ```
 
-Two composites, two render strategies. `CompositeComponentRenderer` prefers
-`render()` when present, otherwise it loads the sibling `component.djx` and
-evaluates `@component.context` callables before rendering. Both paths share
-the DI chain — `flag: DFlag[Flag]` works identically in each.
+Two composites, two render strategies. `CompositeComponentRenderer` prefers `render()` when present, otherwise it loads the sibling `component.djx` and evaluates `@component.context` callables before rendering. Both paths share the DI chain — `flag: DFlag[Flag]` works identically in each.
 
-Inside the admin `template.djx` the `for`-loop binds `flag` to each Flag
-row. `{% component "toggle_preview" flag_name=flag.name %}` passes that
-name as a literal prop, flattening the parent's `flag` variable out of the
-child context so `DFlag[Flag]` resolves via the prop rather than via
-`ContextByNameProvider` matching on the parameter name.
+Inside the admin `template.djx` the `for`-loop binds `flag` to each Flag row. `{% component "toggle_preview" flag_name=flag.name %}` passes that name as a literal prop, flattening the parent's `flag` variable out of the child context so `DFlag[Flag]` resolves via the prop rather than via `ContextByNameProvider` matching on the parameter name.
 
 ### 6. Bulk-toggle form
 
-[`flags/panels/admin/page.py`](flags/panels/admin/page.py) declares a
-single self-registering `BulkToggleForm` (auto-name `bulk_toggle_form`,
-rendered with `{% form "bulk_toggle_form" %}`) handling a checkbox grid.
-The submit logic lives in `on_valid`:
+[`flags/panels/admin/page.py`](flags/panels/admin/page.py) declares a single self-registering `BulkToggleForm` (auto-name `bulk_toggle_form`, rendered with `{% form "bulk_toggle_form" %}`) handling a checkbox grid. The submit logic lives in `on_valid`:
 
 ```python
 class BulkToggleForm(Form):
@@ -247,30 +188,15 @@ class BulkToggleForm(Form):
 
 Three details worth noting:
 
-- `choices` is populated in `__init__` rather than at class-define time so
-  the field reflects the current set of flags on every request.
-- Only **changed** flags are saved. Untouched rows do not fire `post_save`,
-  which keeps the cache-invalidation receiver honest — nothing gets
-  invalidated unless there is a real state transition.
-- The redirect and the flash come from the declarative success contract.
-  `Meta.success_url` and `Meta.success_message` let the overridden `on_valid`
-  end with `super().on_valid(request)` instead of a hand-built
-  `HttpResponseRedirect`. The base method redirects to `/admin/` and flashes
-  "Flag toggles saved." through Django's messages framework. A
-  `flash_messages` context drains the queue and the admin template renders it
-  in an `alert` banner.
+- `choices` is populated in `__init__` rather than at class-define time so the field reflects the current set of flags on every request.
+- Only **changed** flags are saved. Untouched rows do not fire `post_save`, which keeps the cache-invalidation receiver honest — nothing gets invalidated unless there is a real state transition.
+- The redirect and the flash come from the declarative success contract. `Meta.success_url` and `Meta.success_message` let the overridden `on_valid` end with `super().on_valid(request)` instead of a hand-built `HttpResponseRedirect`. The base method redirects to `/admin/` and flashes "Flag toggles saved." through Django's messages framework. A `flash_messages` context drains the queue and the admin template renders it in an `alert` banner.
 
-The widget has Tailwind `class="hidden"` so each checkbox is visually
-replaced by an inline `<input type="checkbox">` in the template — the label
-wraps the whole row so the entire card is clickable.
+The widget has Tailwind `class="hidden"` so each checkbox is visually replaced by an inline `<input type="checkbox">` in the template — the label wraps the whole row so the entire card is clickable.
 
 ### 7. Flag-gated `check_permissions` — a feature flag guards the action
 
-A second flag controls whether the bulk-toggle action may run at all. The
-form declares a view-level `check_permissions` classmethod that the
-dispatcher resolves with dependency injection, exactly like `get_initial`.
-It runs after the static guard and before binding, and injects the flag
-service through `Depends`:
+A second flag controls whether the bulk-toggle action may run at all. The form declares a view-level `check_permissions` classmethod that the dispatcher resolves with dependency injection, exactly like `get_initial`. It runs after the static guard and before binding, and injects the flag service through `Depends`:
 
 ```python
 class BulkToggleForm(Form):
@@ -280,15 +206,9 @@ class BulkToggleForm(Form):
             raise PermissionDenied
 ```
 
-`WRITE_GATE_FLAG` is `"admin_writes"`. When that flag is absent or off the
-hook raises `PermissionDenied` and the action returns `403`, so no flag is
-touched. Enable `admin_writes` and the same POST succeeds and redirects. The
-gate uses the example's own flag mechanism — the same `Flag` rows and the
-same read-through cache — so toggling the gate is itself an ordinary flag
-edit.
+`WRITE_GATE_FLAG` is `"admin_writes"`. When that flag is absent or off the hook raises `PermissionDenied` and the action returns `403`, so no flag is touched. Enable `admin_writes` and the same POST succeeds and redirects. The gate uses the example's own flag mechanism — the same `Flag` rows and the same read-through cache — so toggling the gate is itself an ordinary flag edit.
 
-[`flags/providers.py`](flags/providers.py) registers the injected service as
-a named dependency:
+[`flags/providers.py`](flags/providers.py) registers the injected service as a named dependency:
 
 ```python
 @resolver.dependency("flag_service")
@@ -296,28 +216,15 @@ def flag_service() -> FlagService:
     return FlagService()
 ```
 
-`FlagService.is_enabled(name)` reads through `get_cached_flag`, so the gate
-check shares the same LocMemCache layer as everything else. The hook
-declares only what it reads — here a single `Depends("flag_service")`
-parameter. It could equally take `request` or a captured URL kwarg.
+`FlagService.is_enabled(name)` reads through `get_cached_flag`, so the gate check shares the same LocMemCache layer as everything else. The hook declares only what it reads — here a single `Depends("flag_service")` parameter. It could equally take `request` or a captured URL kwarg.
 
-The return contract mirrors a Django permission check. `None` or `True`
-allows. `False` or a raised `PermissionDenied` denies with `403`. Returning
-an `HttpResponse` short-circuits the dispatch with that response verbatim,
-which is the seam for redirecting to an upgrade page instead of a bare
-`403`. Any other return type raises `TypeError`.
+The return contract mirrors a Django permission check. `None` or `True` allows. `False` or a raised `PermissionDenied` denies with `403`. Returning an `HttpResponse` short-circuits the dispatch with that response verbatim, which is the seam for redirecting to an upgrade page instead of a bare `403`. Any other return type raises `TypeError`.
 
-A denial emits `next.signals.form_access_denied` with `action_name`, `uid`,
-`request`, `layer` (`"view"` here), and `reason` (`"raised"` for the
-`PermissionDenied` path). The `_count_access_denied` receiver in
-[`flags/receivers.py`](flags/receivers.py) bumps a counter, and the
-`/admin/metrics/` page surfaces it as a stat card next to the render
-counters.
+A denial emits `next.signals.form_access_denied` with `action_name`, `uid`, `request`, `layer` (`"view"` here), and `reason` (`"raised"` for the `PermissionDenied` path). The `_count_access_denied` receiver in [`flags/receivers.py`](flags/receivers.py) bumps a counter, and the `/admin/metrics/` page surfaces it as a stat card next to the render counters.
 
 ### 8. Receivers — `post_save`, `post_delete`, `page_rendered`
 
-[`flags/receivers.py`](flags/receivers.py) wires its database and render
-receivers at app ready time:
+[`flags/receivers.py`](flags/receivers.py) wires its database and render receivers at app ready time:
 
 ```python
 @receiver(post_save, sender=Flag)
@@ -333,25 +240,13 @@ def _count_page_render(sender, file_path, **_):
     record_render(_page_key(file_path))
 ```
 
-The two database receivers mean the cache and the DB can never drift apart.
-Toggle a flag, the row saves, the cache entry disappears, the next read
-refetches — in that order, in under a millisecond.
+The two database receivers mean the cache and the DB can never drift apart. Toggle a flag, the row saves, the cache entry disappears, the next read refetches — in that order, in under a millisecond.
 
-`page_rendered` is a `next.pages.signals` signal, not a Django one. It
-fires at the end of every page render and carries the full `file_path` of
-the `page.py` that produced it. Because every page file is literally named
-`page.py`, the receiver derives the key from the path segments *under*
-`panels/` — the root page becomes `"/"`, `admin/page.py` becomes
-`"admin"`, `admin/metrics/page.py` becomes `"admin/metrics"`. The
-`/admin/metrics/` page reads the counters through `render_counts()`, and
-because the signal fires *after* rendering, the metrics page's own entry
-only appears on the next visit.
+`page_rendered` is a `next.pages.signals` signal, not a Django one. It fires at the end of every page render and carries the full `file_path` of the `page.py` that produced it. Because every page file is literally named `page.py`, the receiver derives the key from the path segments _under_ `panels/` — the root page becomes `"/"`, `admin/page.py` becomes `"admin"`, `admin/metrics/page.py` becomes `"admin/metrics"`. The `/admin/metrics/` page reads the counters through `render_counts()`, and because the signal fires _after_ rendering, the metrics page's own entry only appears on the next visit.
 
 ### 9. Shared `nav_link` component — active state from `request.resolver_match`
 
-Same pattern as the other examples — no duplication, no manual "current
-page" flags. The link component reads the view name from the resolver and
-compares:
+Same pattern as the other examples — no duplication, no manual "current page" flags. The link component reads the view name from the resolver and compares:
 
 ```python
 @component.context("is_active")
@@ -362,71 +257,43 @@ def _is_active(url_name: str, request: HttpRequest, active_when: str = "") -> bo
     return view_name == url_name
 ```
 
-The root header uses `active_when="page_admin"` so `/admin/` and
-`/admin/metrics/` both highlight the "Admin" tab. The subnav inside the
-admin layout uses exact matches (`next:page_admin`, `next:page_admin_metrics`).
+The root header uses `active_when="page_admin"` so `/admin/` and `/admin/metrics/` both highlight the "Admin" tab. The subnav inside the admin layout uses exact matches (`next:page_admin`, `next:page_admin_metrics`).
 
 ### 10. URL names from the file router
 
-| File | URL | Name |
-|------|-----|------|
-| `panels/page.py` | `/` | `next:page_` |
-| `panels/admin/page.py` | `/admin/` | `next:page_admin` |
+| File                           | URL               | Name                      |
+| ------------------------------ | ----------------- | ------------------------- |
+| `panels/page.py`               | `/`               | `next:page_`              |
+| `panels/admin/page.py`         | `/admin/`         | `next:page_admin`         |
 | `panels/admin/metrics/page.py` | `/admin/metrics/` | `next:page_admin_metrics` |
-| `panels/demo/page.py` | `/demo/` | `next:page_demo` |
+| `panels/demo/page.py`          | `/demo/`          | `next:page_demo`          |
 
-The bulk-toggle action is mounted at the framework's action URL. Tests use
-`NextClient.post_action("bulk_toggle_form", {...})` instead of a hardcoded path.
+The bulk-toggle action is mounted at the framework's action URL. Tests use `NextClient.post_action("bulk_toggle_form", {...})` instead of a hardcoded path.
 
 ## Gotchas
 
 ### `DFlag` needs the annotation at runtime
 
-Any module that declares a parameter `flag: DFlag[Flag]` **must not** start
-with `from __future__ import annotations`. PEP 563 would string-ify the
-annotation and `get_origin(...)` in `FlagProvider.can_handle` returns
-`None` on strings. The two component modules in this example skip that
-import on purpose.
+Any module that declares a parameter `flag: DFlag[Flag]` **must not** start with `from __future__ import annotations`. PEP 563 would string-ify the annotation and `get_origin(...)` in `FlagProvider.can_handle` returns `None` on strings. The two component modules in this example skip that import on purpose.
 
 ### `{% component %}` props are literal strings
 
-`{% component "feature_guard" flag_name="beta_checkout" %}` passes the
-literal `"beta_checkout"`. Inside a loop, use the parent variable binding
-instead: `flag_name=flag.name` resolves to the loop-iteration value
-because Django evaluates the expression during template rendering. The
-admin template uses this pattern.
+`{% component "feature_guard" flag_name="beta_checkout" %}` passes the literal `"beta_checkout"`. Inside a loop, use the parent variable binding instead: `flag_name=flag.name` resolves to the loop-iteration value because Django evaluates the expression during template rendering. The admin template uses this pattern.
 
 ### `manage.py check` enforces the "one body source" rule
 
-A page with both `render()` and `template.djx` emits `next.W043`. If a
-page has none of (render / template attribute / registered loader that
-matches), `next.E012` fails. Every page in this example declares exactly
-one body source — the `page.py` modules all ship `template.djx` siblings
-and no `template` attribute.
+A page with both `render()` and `template.djx` emits `next.W043`. If a page has none of (render / template attribute / registered loader that matches), `next.E012` fails. Every page in this example declares exactly one body source — the `page.py` modules all ship `template.djx` siblings and no `template` attribute.
 
 ### Receivers are imported in `apps.ready()`, not at module level
 
-`FlagsConfig.ready()` imports `flags.providers` and `flags.receivers`. If
-you move those imports to the top of `flags/__init__.py`, Django will try
-to load them before the app registry is populated and `@receiver(post_save,
-sender=Flag)` will crash looking up `Flag`.
+`FlagsConfig.ready()` imports `flags.providers` and `flags.receivers`. If you move those imports to the top of `flags/__init__.py`, Django will try to load them before the app registry is populated and `@receiver(post_save, sender=Flag)` will crash looking up `Flag`.
 
 ## Further reading
 
-- [next/components/renderers.py](../../next/components/renderers.py) —
-  `CompositeComponentRenderer` and the render-function branch used by
-  `feature_guard`.
-- [next/deps/resolver.py](../../next/deps/resolver.py) — how DI providers
-  are instantiated lazily and iterated per parameter.
-- [next/deps/providers.py](../../next/deps/providers.py) —
-  `RegisteredParameterProvider` base and auto-registration.
-- [next/pages/signals.py](../../next/pages/signals.py) — `page_rendered`
-  payload documentation.
-- [next/forms/manager.py](../../next/forms/manager.py) — form-action
-  registration, dispatch, and the CSRF + form-class contract.
-- [next/forms/dispatch.py](../../next/forms/dispatch.py) — where
-  `check_permissions` runs in the dispatch sequence and how its return is
-  normalised into an allow / `403` / verbatim response.
-- [next/signals.py](../../next/signals.py) — aggregate re-export covering
-  every signal the framework emits, including `page_rendered` and
-  `form_access_denied`.
+- [next/components/renderers.py](../../next/components/renderers.py) — `CompositeComponentRenderer` and the render-function branch used by `feature_guard`.
+- [next/deps/resolver.py](../../next/deps/resolver.py) — how DI providers are instantiated lazily and iterated per parameter.
+- [next/deps/providers.py](../../next/deps/providers.py) — `RegisteredParameterProvider` base and auto-registration.
+- [next/pages/signals.py](../../next/pages/signals.py) — `page_rendered` payload documentation.
+- [next/forms/manager.py](../../next/forms/manager.py) — form-action registration, dispatch, and the CSRF + form-class contract.
+- [next/forms/dispatch.py](../../next/forms/dispatch.py) — where `check_permissions` runs in the dispatch sequence and how its return is normalised into an allow / `403` / verbatim response.
+- [next/signals.py](../../next/signals.py) — aggregate re-export covering every signal the framework emits, including `page_rendered` and `form_access_denied`.

--- a/examples/feature-flags/flags/panels/admin/page.py
+++ b/examples/feature-flags/flags/panels/admin/page.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.messages import get_messages
 from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponseRedirect
 from flags.models import Flag
@@ -15,6 +16,10 @@ class BulkToggleForm(Form):
         widget=forms.CheckboxSelectMultiple(attrs={"class": "hidden"}),
     )
 
+    class Meta:
+        success_url = "/admin/"
+        success_message = "Flag toggles saved."
+
     @classmethod
     def check_permissions(cls, flags: FlagService = Depends("flag_service")) -> None:
         """Deny the toggle action while the `admin_writes` gate flag is off."""
@@ -29,16 +34,22 @@ class BulkToggleForm(Form):
         ]
 
     def on_valid(self, request: HttpRequest) -> HttpResponseRedirect:
-        """Toggle each flag to match the submitted set and redirect back."""
+        """Toggle each flag to match the submitted set, then follow the contract."""
         enabled_names = set(self.cleaned_data["enabled_names"])
         for flag in Flag.objects.all():
             should_be_on = flag.name in enabled_names
             if flag.enabled != should_be_on:
                 flag.enabled = should_be_on
                 flag.save(update_fields=["enabled", "updated_at"])
-        return HttpResponseRedirect("/admin/")
+        return super().on_valid(request)
 
 
 @context("flags")
 def flags() -> list[Flag]:
     return list(Flag.objects.all())
+
+
+@context("flash_messages")
+def flash_messages(request: HttpRequest) -> list[str]:
+    """Drain the pending Meta.success_message flashes for the admin banner."""
+    return [str(m) for m in get_messages(request)]

--- a/examples/feature-flags/flags/panels/admin/template.djx
+++ b/examples/feature-flags/flags/panels/admin/template.djx
@@ -1,4 +1,8 @@
 <div class="space-y-6">
+  {% for message in flash_messages %}
+    {% component "alert" variant="success" text=message %}
+  {% endfor %}
+
   {% #component "section" title="Bulk toggle" description="Check the rows you want enabled and submit. Saving triggers a post_save receiver that invalidates the per-flag cache entry, so the next read reflects the new state." %}
     {% #slot "content" %}
       {% if flags %}

--- a/examples/feature-flags/tests/test_e2e.py
+++ b/examples/feature-flags/tests/test_e2e.py
@@ -67,6 +67,16 @@ class TestAdminBulkToggle:
         assert Flag.objects.get(name="beta").enabled is True
         assert Flag.objects.get(name="alpha").enabled is False
 
+    def test_save_flashes_success_message(self, client) -> None:
+        _open_write_gate()
+        Flag.objects.create(name="beta", label="Beta", enabled=False)
+
+        response = client.post_action(
+            "bulk_toggle_form", {"enabled_names": ["beta"]}, follow=True
+        )
+
+        assert "Flag toggles saved." in response.content.decode()
+
     def test_save_invalidates_cache(self, client) -> None:
         _open_write_gate()
         Flag.objects.create(name="beta", label="Beta", enabled=True)

--- a/examples/kanban/README.md
+++ b/examples/kanban/README.md
@@ -1,20 +1,11 @@
 # Kanban
 
-A drag-and-drop Kanban board powered by co-located React components and
-a Vite build pipeline. The example demonstrates that adding a brand-new
-asset type (`.jsx`) to next.dj requires no changes to the framework
-core. A single custom `StaticFilesBackend` subclass for URL resolution,
-two registry calls in `AppConfig.ready()`, and one signal receiver are
-the entire integration layer. Rendering uses the framework built-in
-`render_module_tag`, so the example registers no custom renderers.
-Server rendering keeps every page useful without JavaScript, and the
-React layer adds native HTML5 drag-and-drop with optimistic updates on
-top.
+A drag-and-drop Kanban board powered by co-located React components and a Vite build pipeline. The example demonstrates that adding a brand-new asset type (`.jsx`) to next.dj requires no changes to the framework core. A single custom `StaticFilesBackend` subclass for URL resolution, two registry calls in `AppConfig.ready()`, and one signal receiver are the entire integration layer. Rendering uses the framework built-in `render_module_tag`, so the example registers no custom renderers. Server rendering keeps every page useful without JavaScript, and the React layer adds native HTML5 drag-and-drop with optimistic updates on top.
 
 ## What you will see
 
 | URL | Description |
-|-----|-------------|
+| --- | --- |
 | `/` | List of active boards. Archived boards are hidden. |
 | `/board/<id>/` | Server-rendered columns and cards plus React-mounted drag-and-drop with optimistic move. |
 | `/board/<id>/settings/` | Forms to rename a board, archive it, or add a column with a WIP limit. |
@@ -24,9 +15,7 @@ top.
 | `POST rename_board_form` | Update the board title. |
 | `POST archive_board_form` | Toggle the archived flag. Archived boards drop out of the index. |
 
-Three demo boards seed via a data migration. Two are active
-(`engineering-roadmap` and `marketing-launch`) and one is archived
-(`old-experiments`).
+Three demo boards seed via a data migration. Two are active (`engineering-roadmap` and `marketing-launch`) and one is archived (`old-experiments`).
 
 ## How to run
 
@@ -36,8 +25,7 @@ uv run python manage.py migrate
 uv run python manage.py runserver     # http://127.0.0.1:8000/
 ```
 
-The first `migrate` run seeds three demo boards. Open the index to land
-on the board list.
+The first `migrate` run seeds three demo boards. Open the index to land on the board list.
 
 For the React layer to hot-reload, start the Vite dev server:
 
@@ -46,10 +34,7 @@ npm install
 npm run dev                            # http://localhost:5173
 ```
 
-With the dev server running, Django resolves every `.jsx` asset to the
-Vite dev-server URL and the React Refresh preamble plus the
-`@vite/client` HMR script load through the `collector_finalized` signal.
-Override the Vite origin with the `VITE_ORIGIN` environment variable.
+With the dev server running, Django resolves every `.jsx` asset to the Vite dev-server URL and the React Refresh preamble plus the `@vite/client` HMR script load through the `collector_finalized` signal. Override the Vite origin with the `VITE_ORIGIN` environment variable.
 
 For a production-shaped build:
 
@@ -58,10 +43,7 @@ npm run build                          # writes hashed files into kanban/static/
 uv run python manage.py runserver
 ```
 
-The backend reads `dist/.vite/manifest.json` and delegates URL
-resolution to Django staticfiles. If the manifest file is missing, the
-backend logs a single warning and falls back to staticfiles so dev
-workflows stay unblocked.
+The backend reads `dist/.vite/manifest.json` and delegates URL resolution to Django staticfiles. If the manifest file is missing, the backend logs a single warning and falls back to staticfiles so dev workflows stay unblocked.
 
 ## Walking the code
 
@@ -112,15 +94,11 @@ class KanbanConfig(AppConfig):
         from kanban import providers, signals  # noqa: F401
 ```
 
-`render_module_tag` is the framework's built-in renderer for ES module
-assets, so jsx files reuse it without a custom renderer. The `signals`
-import wires the dev-mode `collector_finalized` receiver. No other
-integration point in the framework is touched.
+`render_module_tag` is the framework's built-in renderer for ES module assets, so jsx files reuse it without a custom renderer. The `signals` import wires the dev-mode `collector_finalized` receiver. No other integration point in the framework is touched.
 
 ### 3. `ViteManifestBackend`
 
-The custom backend resolves URLs only — rendering is delegated to the
-built-in `render_module_tag`:
+The custom backend resolves URLs only — rendering is delegated to the built-in `render_module_tag`:
 
 ```python
 class ViteManifestBackend(StaticFilesBackend):
@@ -134,10 +112,7 @@ class ViteManifestBackend(StaticFilesBackend):
         return super().register_file(source_path, logical_name, kind)
 ```
 
-Three resolution modes: a Vite dev-server URL when `DEV_ORIGIN` is set,
-a hashed manifest entry in production, or unmodified Django staticfiles
-when neither applies. Missing manifest emits a single warning and falls
-back to staticfiles.
+Three resolution modes: a Vite dev-server URL when `DEV_ORIGIN` is set, a hashed manifest entry in production, or unmodified Django staticfiles when neither applies. Missing manifest emits a single warning and falls back to staticfiles.
 
 ### 4. `@vite/client` via guarded signal
 
@@ -153,13 +128,11 @@ def inject_vite_dev_assets(sender, **kwargs):
     )
 ```
 
-`sender` is the collector instance. The `assets_in_slot` guard keeps
-dev plumbing off pages with no jsx scripts, including the index page.
+`sender` is the collector instance. The `assets_in_slot` guard keeps dev plumbing off pages with no jsx scripts, including the index page.
 
 ### 5. React receives data from `window.Next.context.board`
 
-`page.py` builds the board payload in one `prefetch_related` chain and
-flags it serialisable:
+`page.py` builds the board payload in one `prefetch_related` chain and flags it serialisable:
 
 ```python
 @context("board", inherit_context=True, serialize=True)
@@ -178,60 +151,27 @@ def board_payload(active_board: DBoard[Board], request: HttpRequest) -> dict:
     }
 ```
 
-`page.jsx` reads it at mount time, never owns URL constants or CSRF
-tokens, and re-uses the same payload to drive optimistic updates.
+`page.jsx` reads it at mount time, never owns URL constants or CSRF tokens, and re-uses the same payload to drive optimistic updates.
 
-`DeepMergePolicy` is configured as the JS-context policy in
-`config/settings.py`, so the layout-level `active_boards_count` from
-`boards/page.py` and the page-level `board` payload merge into one
-`window.Next.context` object.
+`DeepMergePolicy` is configured as the JS-context policy in `config/settings.py`, so the layout-level `active_boards_count` from `boards/page.py` and the page-level `board` payload merge into one `window.Next.context` object.
 
 ### 6. Optimistic move with rollback
 
-`Board` keeps `columns` in `useState`. A drop applies the move locally
-through a pure `applyMoveLocally(columns, cardId, targetColumnId,
-targetPosition)` helper before the `fetch` resolves, so the UI never
-waits on the network. On `!response.ok` or a thrown fetch the previous
-snapshot is restored and an inline error banner appears. The
-`?moved=<card_id>` query parameter still drives the SSR `preview`
-composite as a graceful fallback when JavaScript is unavailable.
+`Board` keeps `columns` in `useState`. A drop applies the move locally through a pure `applyMoveLocally(columns, cardId, targetColumnId, targetPosition)` helper before the `fetch` resolves, so the UI never waits on the network. On `!response.ok` or a thrown fetch the previous snapshot is restored and an inline error banner appears. The `?moved=<card_id>` query parameter still drives the SSR `preview` composite as a graceful fallback when JavaScript is unavailable.
 
 ### 7. WIP-limit invariant in two layers
 
-`CreateCardForm.clean()` performs a best-effort count check so common
-posts surface a friendly error before the save runs. The
-authoritative check sits inside `CreateCardForm.on_valid()` under
-`Column.objects.select_for_update()` and returns
-`HttpResponseBadRequest` if a concurrent post fills the slot between
-form validation and insertion. All five form classes live in the
-app-level [`kanban/forms.py`](kanban/forms.py) picked up by
-autodiscover, because every one of them is shared across pages or
-components. The React layer reflects the limit live
-through the WIP badge that turns red when `cards.length` exceeds
-`wip_limit`.
+`CreateCardForm.clean()` performs a best-effort count check so common posts surface a friendly error before the save runs. The authoritative check sits inside `CreateCardForm.on_valid()` under `Column.objects.select_for_update()` and returns `HttpResponseBadRequest` if a concurrent post fills the slot between form validation and insertion. All five form classes live in the app-level [`kanban/forms.py`](kanban/forms.py) picked up by autodiscover, because every one of them is shared across pages or components. The React layer reflects the limit live through the WIP badge that turns red when `cards.length` exceeds `wip_limit`.
 
 ### 8. DI provider used in URL routes and form actions
 
-`BoardProvider` resolves `DBoard[Board]` from `url_kwargs["id"]` for
-page rendering and from POST `board_id` for action handlers, so
-settings handlers receive a board through DI without
-`Board.objects.get(...)`. `CardProvider` mirrors the pattern for
-`DCard[Card]` against POST `card_id`.
+`BoardProvider` resolves `DBoard[Board]` from `url_kwargs["id"]` for page rendering and from POST `board_id` for action handlers, so settings handlers receive a board through DI without `Board.objects.get(...)`. `CardProvider` mirrors the pattern for `DCard[Card]` against POST `card_id`.
 
-Page modules that use these markers do not start with
-`from __future__ import annotations`, because the DI resolver compares
-parameter annotations by identity.
+Page modules that use these markers do not start with `from __future__ import annotations`, because the DI resolver compares parameter annotations by identity.
 
 ### Known limitation: sibling-form input is not preserved on a failed submit
 
-The settings page hosts three independent `<form>` blocks. Each one
-posts to its own action URL, so a submit sends only that form's fields.
-If a user starts typing into "Add column", then submits "Rename board"
-and rename fails validation, the re-rendered page shows the rename
-errors but the "Add column" text is gone. The browser never transmitted
-the unsubmitted form's input, so the server has nothing to restore. This
-is inherent to the server-side post-and-rerender model and is best
-addressed client-side. Submitting a single form at a time is unaffected.
+The settings page hosts three independent `<form>` blocks. Each one posts to its own action URL, so a submit sends only that form's fields. If a user starts typing into "Add column", then submits "Rename board" and rename fails validation, the re-rendered page shows the rename errors but the "Add column" text is gone. The browser never transmitted the unsubmitted form's input, so the server has nothing to restore. This is inherent to the server-side post-and-rerender model and is best addressed client-side. Submitting a single form at a time is unaffected.
 
 ## Further reading
 

--- a/examples/live-polls/README.md
+++ b/examples/live-polls/README.md
@@ -1,25 +1,18 @@
 # Live polls
 
-A polling app where the chart on every open tab updates the moment
-someone votes. Server-Sent Events stream snapshots out of an
-in-process broker. A locally bundled Vue 3 component subscribes
-through a single `EventSource` and reacts to each frame. The example
-demonstrates how a streaming endpoint, a signal-driven fan-out, and a
-Vite-bundled Vue layer compose into one cohesive feature without any
-ad-hoc plumbing in the framework core.
+A polling app where the chart on every open tab updates the moment someone votes. Server-Sent Events stream snapshots out of an in-process broker. A locally bundled Vue 3 component subscribes through a single `EventSource` and reacts to each frame. The example demonstrates how a streaming endpoint, a signal-driven fan-out, and a Vite-bundled Vue layer compose into one cohesive feature without any ad-hoc plumbing in the framework core.
 
 ## What you will see
 
 | URL | Description |
-|-----|-------------|
+| --- | --- |
 | `/` | Redirects to `/polls/` so the bare site root is never empty. |
 | `/polls/` | Server-rendered list of polls. Each card shows choice count and total votes. |
 | `/polls/<id>/` | Vote page with the live chart and a button-per-choice form. Vue takes over the chart on mount. |
 | `/polls/<id>/stream/` | Server-Sent Events endpoint. First frame is the cached snapshot, then `update` frames flow on every vote. |
 | `POST vote_form` | Atomically increments a choice via `F("votes") + 1`, publishes a fresh snapshot to the broker, redirects to the poll page. |
 
-Two demo polls seed via a data migration (`tabs-or-spaces` and
-`vim-or-emacs`) so the index page is never empty on a fresh database.
+Two demo polls seed via a data migration (`tabs-or-spaces` and `vim-or-emacs`) so the index page is never empty on a fresh database.
 
 ## How to run
 
@@ -33,12 +26,7 @@ npm run dev                            # terminal A: http://localhost:5173
 uv run python manage.py runserver     # terminal B: http://127.0.0.1:8000/polls/
 ```
 
-`migrate` seeds two demo polls. With `DEBUG=True` Django defaults to
-the Vite dev server at `http://localhost:5173`, so editing
-`component.vue` hot-reloads in the browser without restarts. The
-`@vite/client` script loads through the `collector_finalized` signal
-on every page that carries Vue assets. The Django reloader picks up
-Python edits on its own.
+`migrate` seeds two demo polls. With `DEBUG=True` Django defaults to the Vite dev server at `http://localhost:5173`, so editing `component.vue` hot-reloads in the browser without restarts. The `@vite/client` script loads through the `collector_finalized` signal on every page that carries Vue assets. The Django reloader picks up Python edits on its own.
 
 Production-shaped run (no Vite dev server):
 
@@ -47,24 +35,11 @@ DJANGO_DEBUG=0 npm run build           # writes hashed bundles + manifest
 DJANGO_DEBUG=0 uv run python manage.py runserver
 ```
 
-With `DEBUG=False` (or `VITE_DEV_ORIGIN=` empty) the
-`ViteManifestBackend` reads `dist/.vite/manifest.json` and delegates
-URL resolution to Django staticfiles. If the manifest is missing the
-backend raises a clear error pointing at `npm run build`. The kanban
-example falls back to staticfiles instead because raw `.jsx` is at
-least loadable as plain JavaScript. A raw `.vue` file is unrenderable
-without compilation, so live-polls refuses to serve a broken bundle
-and tells the operator how to fix the deployment instead.
+With `DEBUG=False` (or `VITE_DEV_ORIGIN=` empty) the `ViteManifestBackend` reads `dist/.vite/manifest.json` and delegates URL resolution to Django staticfiles. If the manifest is missing the backend raises a clear error pointing at `npm run build`. The kanban example falls back to staticfiles instead because raw `.jsx` is at least loadable as plain JavaScript. A raw `.vue` file is unrenderable without compilation, so live-polls refuses to serve a broken bundle and tells the operator how to fix the deployment instead.
 
-The `runserver` command is a single-process toy in both modes. The
-SSE endpoint blocks one Django dev thread per open subscriber, which
-is fine for a demo or `pytest` and unsafe for any real workload. A
-production deployment runs an ASGI server with an async `subscribe`
-generator and an `asyncio` wake primitive.
+The `runserver` command is a single-process toy in both modes. The SSE endpoint blocks one Django dev thread per open subscriber, which is fine for a demo or `pytest` and unsafe for any real workload. A production deployment runs an ASGI server with an async `subscribe` generator and an `asyncio` wake primitive.
 
-Override the Vite origin on either side with
-`VITE_DEV_ORIGIN=http://host:port` when the dev server runs on a
-non-default address.
+Override the Vite origin on either side with `VITE_DEV_ORIGIN=http://host:port` when the dev server runs on a non-default address.
 
 To peek at the SSE stream from a second terminal:
 
@@ -72,14 +47,9 @@ To peek at the SSE stream from a second terminal:
 curl -N http://127.0.0.1:8000/polls/1/stream/
 ```
 
-The `-N` flag disables curl output buffering so frames appear as the
-server flushes them. Vote in the browser, watch the curl output.
+The `-N` flag disables curl output buffering so frames appear as the server flushes them. Vote in the browser, watch the curl output.
 
-Tests run on two stacks. `uv run pytest` exercises the page modules,
-the broker, the receiver-driven fan-out, and one frame off the actual
-`StreamingHttpResponse`. `npm test` runs the Vitest suite that mounts
-`poll_chart/component.vue` under `@vue/test-utils` and verifies the
-reactive update path against a stub `EventSource`.
+Tests run on two stacks. `uv run pytest` exercises the page modules, the broker, the receiver-driven fan-out, and one frame off the actual `StreamingHttpResponse`. `npm test` runs the Vitest suite that mounts `poll_chart/component.vue` under `@vue/test-utils` and verifies the reactive update path against a stub `EventSource`.
 
 ## Walking the code
 
@@ -110,11 +80,7 @@ polls/screens/
             └── component.css
 ```
 
-The directory walks the full feature surface of next.dj end to end.
-The framework discovers every co-located `.djx`, `.css`, and `.vue`
-asset automatically. The `_widgets` directory is a sibling of the
-detail page so both the index and detail templates can reach into it
-through the same `{% component "name" %}` call.
+The directory walks the full feature surface of next.dj end to end. The framework discovers every co-located `.djx`, `.css`, and `.vue` asset automatically. The `_widgets` directory is a sibling of the detail page so both the index and detail templates can reach into it through the same `{% component "name" %}` call.
 
 ### 2. Two calls in `apps.py`
 
@@ -132,11 +98,7 @@ class PollsConfig(AppConfig):
         from polls import providers, signals  # noqa: F401, PLC0415
 ```
 
-The `vue` kind binds the `.vue` extension to the `scripts` slot and
-reuses the framework built-in `render_module_tag`. No custom
-renderer is needed because Vite emits standard ES modules. The
-`signals` import wires both the Vite dev-asset injector and the
-`action_dispatched` listener that drives the broker fan-out.
+The `vue` kind binds the `.vue` extension to the `scripts` slot and reuses the framework built-in `render_module_tag`. No custom renderer is needed because Vite emits standard ES modules. The `signals` import wires both the Vite dev-asset injector and the `action_dispatched` listener that drives the broker fan-out.
 
 ### 3. SSE through the page escape hatch
 
@@ -152,18 +114,9 @@ def render(poll: DPoll[Poll]) -> StreamingHttpResponse:
     )
 ```
 
-The page module returns a `StreamingHttpResponse` directly. The
-framework escape hatch in `next/pages/manager.py` returns any
-`HttpResponseBase` subclass verbatim, which means the layout chain
-and the static collector are bypassed for streaming endpoints. No
-template, no asset injection, no buffering.
+The page module returns a `StreamingHttpResponse` directly. The framework escape hatch in `next/pages/manager.py` returns any `HttpResponseBase` subclass verbatim, which means the layout chain and the static collector are bypassed for streaming endpoints. No template, no asset injection, no buffering.
 
-The endpoint stays sync because the broker waits on
-`threading.Condition` and the example targets `runserver` and
-`pytest`. An ASGI deployment swaps the wake primitive for an
-`asyncio.Condition` (or one `asyncio.Queue` per subscriber) and
-yields from an async generator without touching the page or the
-signal layer.
+The endpoint stays sync because the broker waits on `threading.Condition` and the example targets `runserver` and `pytest`. An ASGI deployment swaps the wake primitive for an `asyncio.Condition` (or one `asyncio.Queue` per subscriber) and yields from an async generator without touching the page or the signal layer.
 
 ### 4. Broker on `threading.Condition` and LocMemCache
 
@@ -203,22 +156,9 @@ class PollBroker:
             yield format_event(payload, event="update")
 ```
 
-The cache holds the latest snapshot per poll. Each `publish` bumps a
-monotonic revision and `notify_all` wakes every subscriber. Each
-subscriber captures its own `last_revision` *before* yielding the
-initial snapshot so a publish that lands while the consumer is still
-holding the snapshot frame still wakes the subscriber on the next
-`next()` instead of being absorbed silently. A 15-second timeout on
-`wait_for` produces an SSE comment frame (`: keepalive\n\n`) so
-proxies and the browser keep an idle connection open. The pattern is
-single-process by design. A multi-process deployment swaps the
-broker for Redis Pub/Sub or Postgres `LISTEN`/`NOTIFY` without
-touching the page or the signal layer.
+The cache holds the latest snapshot per poll. Each `publish` bumps a monotonic revision and `notify_all` wakes every subscriber. Each subscriber captures its own `last_revision` _before_ yielding the initial snapshot so a publish that lands while the consumer is still holding the snapshot frame still wakes the subscriber on the next `next()` instead of being absorbed silently. A 15-second timeout on `wait_for` produces an SSE comment frame (`: keepalive\n\n`) so proxies and the browser keep an idle connection open. The pattern is single-process by design. A multi-process deployment swaps the broker for Redis Pub/Sub or Postgres `LISTEN`/`NOTIFY` without touching the page or the signal layer.
 
-A naive `threading.Event` plus `clear()` looks attractive here but
-loses events under fan-out: the first subscriber to clear the flag
-hides the wake from the others. The condition + revision pair is
-the canonical fix and costs the same number of lines.
+A naive `threading.Event` plus `clear()` looks attractive here but loses events under fan-out: the first subscriber to clear the flag hides the wake from the others. The condition + revision pair is the canonical fix and costs the same number of lines.
 
 ### 5. Signal-driven fan-out using the bound form
 
@@ -233,16 +173,7 @@ def broadcast_vote(action_name="", form=None, **_):
     broker.publish(build_snapshot(poll))
 ```
 
-The `action_dispatched` signal carries the bound form post-validation
-plus the resolved URL kwargs. Without those fields the receiver could
-not tell which poll changed without reissuing the query. The receiver
-is the *single* publish point for the broker. The vote handler runs
-the atomic `UPDATE` and returns the redirect, then the dispatcher
-fires `action_dispatched` and the receiver builds the fresh snapshot
-and calls `broker.publish`. Every open SSE subscriber wakes within
-milliseconds. Concentrating the publish in the receiver keeps the
-write path observable through one signal hook and avoids the double
-cache write a handler-side `store_snapshot` would cause.
+The `action_dispatched` signal carries the bound form post-validation plus the resolved URL kwargs. Without those fields the receiver could not tell which poll changed without reissuing the query. The receiver is the _single_ publish point for the broker. The vote handler runs the atomic `UPDATE` and returns the redirect, then the dispatcher fires `action_dispatched` and the receiver builds the fresh snapshot and calls `broker.publish`. Every open SSE subscriber wakes within milliseconds. Concentrating the publish in the receiver keeps the write path observable through one signal hook and avoids the double cache write a handler-side `store_snapshot` would cause.
 
 ### 6. Vue layer reads `window.Next.context.results`
 
@@ -257,27 +188,11 @@ def results(poll: Poll) -> dict[str, object]:
     }
 ```
 
-`serialize=True` injects this dict into `window.Next.context.results`.
-Voting itself stays server-side through the `{% form %}` tag in the
-component template, so the payload carries no vote URL or CSRF token.
-The Vue `<script setup>` block reads it on mount, opens a single
-`EventSource(stream_url)`, and binds `snapshot` and `update`
-listeners that swap a reactive `choices` ref. The chart renders bar
-widths from a `computed` percentage so the SFC has zero direct DOM
-work. `page.vue` mounts the SFC into the `[data-poll-chart-app]`
-hook the SSR template provides, so the page degrades to plain
-server-rendered bars when JavaScript is disabled.
+`serialize=True` injects this dict into `window.Next.context.results`. Voting itself stays server-side through the `{% form %}` tag in the component template, so the payload carries no vote URL or CSRF token. The Vue `<script setup>` block reads it on mount, opens a single `EventSource(stream_url)`, and binds `snapshot` and `update` listeners that swap a reactive `choices` ref. The chart renders bar widths from a `computed` percentage so the SFC has zero direct DOM work. `page.vue` mounts the SFC into the `[data-poll-chart-app]` hook the SSR template provides, so the page degrades to plain server-rendered bars when JavaScript is disabled.
 
 ### 7. Inherit context across the layout chain
 
-`polls/page.py` declares `active_polls_count` with
-`inherit_context=True` so descendant pages, including the detail
-page and its child stream endpoint, share the same value without a
-second query. The root layout reads it for the header badge. The
-`[int:id]/page.py` adds `poll` with `inherit_context=True`. The
-nested `[int:id]/layout.djx` and the inner template both consume
-`poll` directly, demonstrating context flow without a context
-processor.
+`polls/page.py` declares `active_polls_count` with `inherit_context=True` so descendant pages, including the detail page and its child stream endpoint, share the same value without a second query. The root layout reads it for the header badge. The `[int:id]/page.py` adds `poll` with `inherit_context=True`. The nested `[int:id]/layout.djx` and the inner template both consume `poll` directly, demonstrating context flow without a context processor.
 
 ### 8. DI through `DPoll[Poll]`
 
@@ -297,25 +212,13 @@ class PollProvider(RegisteredParameterProvider):
             raise Http404 from exc
 ```
 
-`DPoll[Poll]` resolves the URL kwarg `id` for page rendering and
-falls back to a POST `poll_id` field when the dispatcher hands a
-form-action request without resolved URL kwargs. The vote handler,
-the stream endpoint, and the page-level `poll` callable all consume
-the same provider, so the model fetch lives in one place.
+`DPoll[Poll]` resolves the URL kwarg `id` for page rendering and falls back to a POST `poll_id` field when the dispatcher hands a form-action request without resolved URL kwargs. The vote handler, the stream endpoint, and the page-level `poll` callable all consume the same provider, so the model fetch lives in one place.
 
-Page and component modules that use `DPoll[Poll]` do not import
-`from __future__ import annotations`. The DI resolver compares
-annotations by identity and lazy strings would silently break the
-match.
+Page and component modules that use `DPoll[Poll]` do not import `from __future__ import annotations`. The DI resolver compares annotations by identity and lazy strings would silently break the match.
 
 ### 9. Two composites at the same widgets directory
 
-`poll_card` is the index list composite with no Vue. `poll_chart`
-is the detail composite that mounts the Vue layer. Both live under
-one `_widgets` directory at the section root, which lets either
-template reach into either composite through `{% component "name" %}`
-without import gymnastics. The framework discovers both directories
-during component registration.
+`poll_card` is the index list composite with no Vue. `poll_chart` is the detail composite that mounts the Vue layer. Both live under one `_widgets` directory at the section root, which lets either template reach into either composite through `{% component "name" %}` without import gymnastics. The framework discovers both directories during component registration.
 
 ## Further reading
 

--- a/examples/markdown-blog/README.md
+++ b/examples/markdown-blog/README.md
@@ -1,24 +1,17 @@
 # Markdown blog
 
-A tiny blog built on **next-dj**. Every article is a plain `template.md` file
-next to a `page.py`, and a custom `MarkdownTemplateLoader` registered under
-`NEXT_FRAMEWORK["TEMPLATE_LOADERS"]` teaches the framework to read `.md` files
-as page bodies and renders them to HTML on request.
+A tiny blog built on **next-dj**. Every article is a plain `template.md` file next to a `page.py`, and a custom `MarkdownTemplateLoader` registered under `NEXT_FRAMEWORK["TEMPLATE_LOADERS"]` teaches the framework to read `.md` files as page bodies and renders them to HTML on request.
 
-The example focuses on the reading side of the framework: custom
-`TemplateLoader` plug-in, nested layouts, `@context(serialize=True)` feeding
-`window.Next.context` for a share button, co-located `component.js`, a Django
-context processor, virtual pages, bodyless composite components, and shared
-nav components.
+The example focuses on the reading side of the framework: custom `TemplateLoader` plug-in, nested layouts, `@context(serialize=True)` feeding `window.Next.context` for a share button, co-located `component.js`, a Django context processor, virtual pages, bodyless composite components, and shared nav components.
 
 ## What you will see
 
-| URL | Description |
-|-----|-------------|
-| `/` | Latest posts — one entry per folder under `screens/posts/`. |
-| `/posts/welcome/` | A longer post. Headings, lists, and reading-time meta. |
-| `/posts/hello-world/` | A minimal post with a fenced code block. |
-| `/about/` | Virtual "about" page (no `page.py`, only `template.djx`). |
+| URL                   | Description                                                 |
+| --------------------- | ----------------------------------------------------------- |
+| `/`                   | Latest posts — one entry per folder under `screens/posts/`. |
+| `/posts/welcome/`     | A longer post. Headings, lists, and reading-time meta.      |
+| `/posts/hello-world/` | A minimal post with a fenced code block.                    |
+| `/about/`             | Virtual "about" page (no `page.py`, only `template.djx`).   |
 
 ## How to run
 
@@ -29,16 +22,13 @@ uv run python manage.py runserver     # http://127.0.0.1:8000/
 uv run pytest
 ```
 
-Tailwind loads via the Play CDN in [`screens/layout.djx`](blog/screens/layout.djx).
-No Node, no build step.
+Tailwind loads via the Play CDN in [`screens/layout.djx`](blog/screens/layout.djx). No Node, no build step.
 
 ## Walking the code
 
 ### 1. Rename directories to fit the domain
 
-[`config/settings.py`](config/settings.py) renames the conventional folders,
-wires a per-router context processor, and registers the custom Markdown loader
-alongside the built-in djx loader:
+[`config/settings.py`](config/settings.py) renames the conventional folders, wires a per-router context processor, and registers the custom Markdown loader alongside the built-in djx loader:
 
 ```python
 NEXT_FRAMEWORK = {
@@ -63,20 +53,13 @@ NEXT_FRAMEWORK = {
 }
 ```
 
-`OPTIONS.context_processors` is the Next-router extension point for per-page
-context processors. It is merged with Django's own
-`TEMPLATES[0].OPTIONS.context_processors`, where entries from the Next router take
-priority and duplicates are dropped.
+`OPTIONS.context_processors` is the Next-router extension point for per-page context processors. It is merged with Django's own `TEMPLATES[0].OPTIONS.context_processors`, where entries from the Next router take priority and duplicates are dropped.
 
-`TEMPLATE_LOADERS` is a list of dotted paths to
-`next.pages.loaders.TemplateLoader` subclasses. When the user supplies this
-key, it **replaces** the default `["next.pages.loaders.DjxTemplateLoader"]` —
-keep the djx loader in the list if you still want `template.djx` support.
+`TEMPLATE_LOADERS` is a list of dotted paths to `next.pages.loaders.TemplateLoader` subclasses. When the user supplies this key, it **replaces** the default `["next.pages.loaders.DjxTemplateLoader"]` — keep the djx loader in the list if you still want `template.djx` support.
 
 ### 2. Custom `MarkdownTemplateLoader`
 
-[`blog/loaders.py`](blog/loaders.py) subclasses `TemplateLoader` and teaches
-the framework to treat a sibling `template.md` as the page body:
+[`blog/loaders.py`](blog/loaders.py) subclasses `TemplateLoader` and teaches the framework to treat a sibling `template.md` as the page body:
 
 ```python
 from pathlib import Path
@@ -105,22 +88,15 @@ class MarkdownTemplateLoader(TemplateLoader):
 
 Three methods, three responsibilities:
 
-- **`can_load`** — cheap check that returns `True` when the file this loader
-  backs is present next to `page.py`.
-- **`load_template`** — reads the file and returns the rendered body
-  string. Returning `None` lets the chain fall through to the next loader.
-- **`source_path`** — points at the on-disk file for the framework's
-  stale-cache detector. When the file's mtime changes, the composed
-  template is recomputed on the next request.
+- **`can_load`** — cheap check that returns `True` when the file this loader backs is present next to `page.py`.
+- **`load_template`** — reads the file and returns the rendered body string. Returning `None` lets the chain fall through to the next loader.
+- **`source_path`** — points at the on-disk file for the framework's stale-cache detector. When the file's mtime changes, the composed template is recomputed on the next request.
 
-`source_name = "template.md"` is the human label surfaced in
-[`next.W043`](../../docs/content/reference/system-checks.rst) when a page
-declares both `template.md` and, say, a `template` module attribute.
+`source_name = "template.md"` is the human label surfaced in [`next.W043`](../../docs/content/reference/system-checks.rst) when a page declares both `template.md` and, say, a `template` module attribute.
 
 ### 3. Markdown helpers — pure, still used for metadata and reading-time
 
-The loader handles the body. Post metadata (title, slug, URL name) and reading
-time are still computed per-request by the per-post `page.py`:
+The loader handles the body. Post metadata (title, slug, URL name) and reading time are still computed per-request by the per-post `page.py`:
 
 ```python
 def post_metadata(post_path: Path) -> dict[str, str]:
@@ -159,22 +135,16 @@ def read() -> int:
     return reading_minutes(read_post_body(_POST))
 ```
 
-No `template = "..."`, no `@context("post_html")`, no `render_markdown` call.
-The body comes from the loader, and this module only exposes metadata for the
-layout chrome and the JS share button.
+No `template = "..."`, no `@context("post_html")`, no `render_markdown` call. The body comes from the loader, and this module only exposes metadata for the layout chrome and the JS share button.
 
-- `post` (`serialize=True`) lands in `window.Next.context.post` for the share
-  button — `{slug, url_name, title}`, small JSON payload.
+- `post` (`serialize=True`) lands in `window.Next.context.post` for the share button — `{slug, url_name, title}`, small JSON payload.
 - `reading_minutes` is server-only, shown in the meta bar.
 
-Import is cheap — only a `Path` is computed. No file is opened until a
-request comes in.
+Import is cheap — only a `Path` is computed. No file is opened until a request comes in.
 
 ### 5. Nested layout provides the chrome and wraps the Markdown HTML
 
-[`screens/posts/layout.djx`](blog/screens/posts/layout.djx) wraps every
-article with the back link, meta bar, share button, and a `prose` container
-that receives the rendered Markdown:
+[`screens/posts/layout.djx`](blog/screens/posts/layout.djx) wraps every article with the back link, meta bar, share button, and a `prose` container that receives the rendered Markdown:
 
 ```djx
 <article class="space-y-6">
@@ -193,31 +163,19 @@ that receives the rendered Markdown:
 </article>
 ```
 
-The `MarkdownTemplateLoader` returns raw HTML (no wrapper) and the layout puts
-that HTML inside the `prose` container. This is the cleanest split — the
-loader does one thing (Markdown → HTML), the layout does one thing (chrome).
+The `MarkdownTemplateLoader` returns raw HTML (no wrapper) and the layout puts that HTML inside the `prose` container. This is the cleanest split — the loader does one thing (Markdown → HTML), the layout does one thing (chrome).
 
-The outer `screens/layout.djx` wraps this article in turn —
-`screens/posts/layout.djx` is the *inner* layout in a two-level composition.
+The outer `screens/layout.djx` wraps this article in turn — `screens/posts/layout.djx` is the _inner_ layout in a two-level composition.
 
 ### 6. Page body priority — `render()` > `template` attr > registered loaders
 
 next.dj resolves the page body in this order:
 
-1. A `render(request, ...)` function returning `str` (composed through the
-   layout) or any `HttpResponse` subclass (returned verbatim — escape hatch
-   for redirects, JSON, streaming).
+1. A `render(request, ...)` function returning `str` (composed through the layout) or any `HttpResponse` subclass (returned verbatim — escape hatch for redirects, JSON, streaming).
 2. A `template = "..."` module attribute on the page.
-3. First registered `TemplateLoader` whose `can_load(page)` returns `True`.
-   In this blog that is `MarkdownTemplateLoader` (followed by the built-in
-   `DjxTemplateLoader`). Used by the home index and `/about/` (`template.djx`)
-   and by every post (`template.md`).
+3. First registered `TemplateLoader` whose `can_load(page)` returns `True`. In this blog that is `MarkdownTemplateLoader` (followed by the built-in `DjxTemplateLoader`). Used by the home index and `/about/` (`template.djx`) and by every post (`template.md`).
 
-The highest-priority present source wins. If a page declares more than one,
-`manage.py check` emits
-[`next.W043`](../../docs/content/reference/system-checks.rst#compatibility)
-naming the winner so the shadow is never silent. Misconfigured loaders
-surface as `next.E042` / `next.E043` at check time.
+The highest-priority present source wins. If a page declares more than one, `manage.py check` emits [`next.W043`](../../docs/content/reference/system-checks.rst#compatibility) naming the winner so the shadow is never silent. Misconfigured loaders surface as `next.E042` / `next.E043` at check time.
 
 ### 7. `{% url %}` with a variable name
 
@@ -229,10 +187,7 @@ The index template links to each post dynamically:
 {% endfor %}
 ```
 
-Django's `{% url %}` accepts a **variable** name (unquoted). `post.url_name`
-is computed inside `post_metadata` as `"next:page_posts_<slug_with_underscores>"`
-and matches the file-router-generated URL name. Renaming a folder becomes a
-search-and-replace in one file — templates stay correct.
+Django's `{% url %}` accepts a **variable** name (unquoted). `post.url_name` is computed inside `post_metadata` as `"next:page_posts_<slug_with_underscores>"` and matches the file-router-generated URL name. Renaming a folder becomes a search-and-replace in one file — templates stay correct.
 
 ### 8. Share button composite — bodyless, reads `window.Next.context`
 
@@ -244,24 +199,18 @@ share_button/
 └── component.js     # click handler, attached on page load
 ```
 
-A composite component without `component.py` is fine — the framework treats any
-directory with a `component.djx` as a component. The click handler reads the
-serialized post meta:
+A composite component without `component.py` is fine — the framework treats any directory with a `component.djx` as a component. The click handler reads the serialized post meta:
 
 ```js
 const post = window.Next?.context?.post;
 await navigator.clipboard.writeText(`${post.title} — ${location.href}`);
 ```
 
-`component.js` is auto-collected by `{% collect_scripts %}` in the root layout
-only on pages that actually render the component — the homepage does not ship
-this script.
+`component.js` is auto-collected by `{% collect_scripts %}` in the root layout only on pages that actually render the component — the homepage does not ship this script.
 
 ### 9. Context processor — site-wide template variables
 
-[`blog/context_processors.py`](blog/context_processors.py) is a standard Django
-context processor. It receives `request` and returns a dict that is merged into
-every template context:
+[`blog/context_processors.py`](blog/context_processors.py) is a standard Django context processor. It receives `request` and returns a dict that is merged into every template context:
 
 ```python
 def site_nav(request: HttpRequest) -> dict[str, object]:  # noqa: ARG001
@@ -271,28 +220,20 @@ def site_nav(request: HttpRequest) -> dict[str, object]:  # noqa: ARG001
     }
 ```
 
-Wired under `NEXT_FRAMEWORK["PAGE_BACKENDS"][0]["OPTIONS"]["context_processors"]`.
-The framework's [`next.E040`](../../docs/content/reference/system-checks.rst)
-check fails at `manage.py check` time if the processor signature does not
-accept `request`.
+Wired under `NEXT_FRAMEWORK["PAGE_BACKENDS"][0]["OPTIONS"]["context_processors"]`. The framework's [`next.E040`](../../docs/content/reference/system-checks.rst) check fails at `manage.py check` time if the processor signature does not accept `request`.
 
-`request` is not used here (the processor returns constants), but the
-signature is fixed by the Django contract. We explicitly allow the unused
-argument with `# noqa: ARG001` so the rule that *actual* unused params are
-dropped still holds everywhere else.
+`request` is not used here (the processor returns constants), but the signature is fixed by the Django contract. We explicitly allow the unused argument with `# noqa: ARG001` so the rule that _actual_ unused params are dropped still holds everywhere else.
 
 ### 10. Shared `nav_link` component
 
-Same idiom as the URL shortener: a composite component that reads
-`request.resolver_match.view_name` and toggles classes.
+Same idiom as the URL shortener: a composite component that reads `request.resolver_match.view_name` and toggles classes.
 
 ```djx
 {% component "nav_link" url_name="next:page_" label="Home" %}
 {% component "nav_link" url_name="next:page_about" label="About" %}
 ```
 
-The Python side resolves `href` via `reverse()` and compares the current view
-name exactly:
+The Python side resolves `href` via `reverse()` and compares the current view name exactly:
 
 ```python
 @component.context("is_active")
@@ -300,72 +241,44 @@ def _is_active(url_name: str, request: HttpRequest) -> bool:
     return request.resolver_match.view_name == url_name
 ```
 
-This blog only needs exact match — the shortener example shows the prefix-match
-variant via an `active_when` prop.
+This blog only needs exact match — the shortener example shows the prefix-match variant via an `active_when` prop.
 
 ### 11. URL names from the file router
 
 | File | URL | Name |
-|------|-----|------|
+| --- | --- | --- |
 | `screens/page.py` | `/` | `next:page_` |
 | `screens/about/template.djx` (virtual) | `/about/` | `next:page_about` |
 | `screens/posts/welcome/page.py` | `/posts/welcome/` | `next:page_posts_welcome` |
 | `screens/posts/hello-world/page.py` | `/posts/hello-world/` | `next:page_posts_hello_world` |
 
-Hyphens in folder names become underscores in the name: `hello-world` →
-`page_posts_hello_world`.
+Hyphens in folder names become underscores in the name: `hello-world` → `page_posts_hello_world`.
 
 ## Gotchas
 
 ### `{% component %}` props are literal strings
 
-`{% component "nav_link" url_name="next:page_about" %}` works;
-`{% component "nav_link" url_name=some_var %}` passes the literal string
-`"some_var"`. To drive a component from a list in a loop, either hardcode
-the literal prop values (as the root nav does) or rely on the parent
-template context being forwarded into the child render, and read
-`some_var` directly inside `component.py`.
+`{% component "nav_link" url_name="next:page_about" %}` works; `{% component "nav_link" url_name=some_var %}` passes the literal string `"some_var"`. To drive a component from a list in a loop, either hardcode the literal prop values (as the root nav does) or rely on the parent template context being forwarded into the child render, and read `some_var` directly inside `component.py`.
 
 ### `manage.py check` warns if a page has no body source
 
-`next.E012` fails when a `page.py` has none of: `render()`, `template`
-attribute, or a registered `TemplateLoader` that can load it. An **ancestor**
-`layout.djx` alone is not enough. In this blog `MarkdownTemplateLoader`
-satisfies the check for every post directory that has a `template.md`.
+`next.E012` fails when a `page.py` has none of: `render()`, `template` attribute, or a registered `TemplateLoader` that can load it. An **ancestor** `layout.djx` alone is not enough. In this blog `MarkdownTemplateLoader` satisfies the check for every post directory that has a `template.md`.
 
-If you declare more than one source on the same page, `manage.py check`
-emits [`next.W043`](../../docs/content/reference/system-checks.rst) naming the
-winner: `render()` > `template` > (registered loaders in declaration order).
-Misconfigured loader dotted paths surface as `next.E042` / `next.E043`.
+If you declare more than one source on the same page, `manage.py check` emits [`next.W043`](../../docs/content/reference/system-checks.rst) naming the winner: `render()` > `template` > (registered loaders in declaration order). Misconfigured loader dotted paths surface as `next.E042` / `next.E043`.
 
 ### Virtual pages and bodyless components
 
-The file router routes a directory that contains only a `template.djx` (no
-`page.py`) as a **virtual page** — see `/about/` in this example. Likewise, a
-component directory with just `component.djx` is a **composite component** and
-the framework does not require an empty `component.py`. Skip any file that would
-hold no code.
+The file router routes a directory that contains only a `template.djx` (no `page.py`) as a **virtual page** — see `/about/` in this example. Likewise, a component directory with just `component.djx` is a **composite component** and the framework does not require an empty `component.py`. Skip any file that would hold no code.
 
 ### Loader output is trusted — no `|safe` needed
 
-`MarkdownTemplateLoader.load_template` returns HTML, and that HTML is the
-**template body**. The framework places it inside the `posts/layout.djx` slot
-and hands the composed string to Django's template engine, which treats it as
-part of the template source — not as a Django variable — so there is no double
-escaping. Never register a loader that returns user-supplied HTML without
-sanitising — this example trusts the files on disk.
+`MarkdownTemplateLoader.load_template` returns HTML, and that HTML is the **template body**. The framework places it inside the `posts/layout.djx` slot and hands the composed string to Django's template engine, which treats it as part of the template source — not as a Django variable — so there is no double escaping. Never register a loader that returns user-supplied HTML without sanitising — this example trusts the files on disk.
 
 ## Further reading
 
-- [next/pages/manager.py](../../next/pages/manager.py) — unified view, body
-  resolution (`_resolve_page_body`), layout composition entry point.
-- [next/pages/loaders.py](../../next/pages/loaders.py) — `TemplateLoader` ABC,
-  `build_registered_loaders`, `compose_body`, and layout discovery.
-- [next/pages/processors.py](../../next/pages/processors.py) — context-processor
-  discovery (Next router + Django `TEMPLATES`).
-- [next/static/serializers.py](../../next/static/serializers.py) — how
-  `@context(serialize=True)` values reach `window.Next.context`.
-- [next/components/context.py](../../next/components/context.py) —
-  `@component.context` and prop/parent flattening rules.
-- [docs/content/topics/pages.rst](../../docs/content/topics/pages.rst)
-  — "Custom Template Loaders" section with a more detailed loader walkthrough.
+- [next/pages/manager.py](../../next/pages/manager.py) — unified view, body resolution (`_resolve_page_body`), layout composition entry point.
+- [next/pages/loaders.py](../../next/pages/loaders.py) — `TemplateLoader` ABC, `build_registered_loaders`, `compose_body`, and layout discovery.
+- [next/pages/processors.py](../../next/pages/processors.py) — context-processor discovery (Next router + Django `TEMPLATES`).
+- [next/static/serializers.py](../../next/static/serializers.py) — how `@context(serialize=True)` values reach `window.Next.context`.
+- [next/components/context.py](../../next/components/context.py) — `@component.context` and prop/parent flattening rules.
+- [docs/content/topics/pages.rst](../../docs/content/topics/pages.rst) — "Custom Template Loaders" section with a more detailed loader walkthrough.

--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -1,30 +1,23 @@
 # Multi-tenant notes
 
-A workspace for two independent tenants (Acme and Globex) that share the same
-Django project, the same page tree, and the same static pipeline. Each
-request is scoped to one tenant, the page tree resolves notes through that
-tenant, the static pipeline rewrites every asset URL with a per-tenant
-prefix, and the chrome reads its accent color from a request-derived CSS
-variable.
+A workspace for two independent tenants (Acme and Globex) that share the same Django project, the same page tree, and the same static pipeline. Each request is scoped to one tenant, the page tree resolves notes through that tenant, the static pipeline rewrites every asset URL with a per-tenant prefix, and the chrome reads its accent color from a request-derived CSS variable.
 
 ## What you will see
 
 | URL | Description |
-|-----|-------------|
+| --- | --- |
 | `/` | Workspace landing for the active tenant. Welcome card plus the five most recent notes. |
 | `/notes/` | All notes that belong to the active tenant, rendered as `note_card` composites. |
 | `/notes/<id>/edit/` | Note editor with title and body inputs and a live `markdown_preview` pane. |
 
 Two tenants ship with the example via a data migration:
 
-| slug | name | accent |
-|------|------|--------|
-| `acme` | Acme Industries | `#2563eb` (blue) |
+| slug     | name               | accent            |
+| -------- | ------------------ | ----------------- |
+| `acme`   | Acme Industries    | `#2563eb` (blue)  |
 | `globex` | Globex Corporation | `#16a34a` (green) |
 
-The header pill carries the tenant name, the accent strip and accent text use
-the CSS variable surfaced by the `tenant_theme` context processor, and every
-`<link>` and `<script>` URL is prefixed with `/_t/acme/` or `/_t/globex/`.
+The header pill carries the tenant name, the accent strip and accent text use the CSS variable surfaced by the `tenant_theme` context processor, and every `<link>` and `<script>` URL is prefixed with `/_t/acme/` or `/_t/globex/`.
 
 ## How to run
 
@@ -35,22 +28,11 @@ uv run python manage.py runserver     # http://127.0.0.1:8000/
 uv run pytest
 ```
 
-The migration step seeds two tenants and three demo notes through
-[`notes/migrations/0002_demo_data.py`](notes/migrations/0002_demo_data.py).
-A later migration
-([`notes/migrations/0004_lock_demo_note.py`](notes/migrations/0004_lock_demo_note.py))
-locks the Acme `Status update` note so the editor's object-level guard has
-something to refuse.
+The migration step seeds two tenants and three demo notes through [`notes/migrations/0002_demo_data.py`](notes/migrations/0002_demo_data.py). A later migration ([`notes/migrations/0004_lock_demo_note.py`](notes/migrations/0004_lock_demo_note.py)) locks the Acme `Status update` note so the editor's object-level guard has something to refuse.
 
 There are two ways to drive the app:
 
-- **Browser (DEBUG only).** Open
-  `http://127.0.0.1:8000/notes/?tenant=acme`. The middleware sets a
-  `next_tenant` cookie and redirects to a clean URL. Subsequent navigation
-  reuses the cookie. Switch tenants with `?tenant=globex`. The query
-  parameter and cookie path are guarded by `settings.DEBUG=True` and exist
-  only to make the demo viewable without a header-injecting browser
-  extension.
+- **Browser (DEBUG only).** Open `http://127.0.0.1:8000/notes/?tenant=acme`. The middleware sets a `next_tenant` cookie and redirects to a clean URL. Subsequent navigation reuses the cookie. Switch tenants with `?tenant=globex`. The query parameter and cookie path are guarded by `settings.DEBUG=True` and exist only to make the demo viewable without a header-injecting browser extension.
 - **API / production.** Send the `X-Tenant` header explicitly:
 
   ```bash
@@ -58,11 +40,9 @@ There are two ways to drive the app:
   curl -H 'X-Tenant: globex' http://127.0.0.1:8000/notes/
   ```
 
-  The query and cookie fallbacks are disabled outside `DEBUG`. A request
-  without the header returns `400 Missing X-Tenant header.`.
+  The query and cookie fallbacks are disabled outside `DEBUG`. A request without the header returns `400 Missing X-Tenant header.`.
 
-Tailwind loads via the Play CDN in
-[`root_pages/layout.djx`](root_pages/layout.djx). No Node, no build step.
+Tailwind loads via the Play CDN in [`root_pages/layout.djx`](root_pages/layout.djx). No Node, no build step.
 
 ## Walking the code
 
@@ -70,14 +50,8 @@ Tailwind loads via the Play CDN in
 
 The chain has three links:
 
-1. [`notes/middleware.py`](notes/middleware.py) parses `X-Tenant` and looks
-   up the matching `Tenant` row. Missing slug → `400`. Unknown slug →
-   `404`. Match → `request.tenant = tenant`.
-2. [`notes/providers.py`](notes/providers.py) defines `DTenant` (a
-   `DDependencyBase` marker) and `TenantProvider`, a
-   `RegisteredParameterProvider`. The provider matches when
-   `param.annotation is DTenant` and `request.tenant` is set. `apps.py`
-   imports the module on startup so the auto-registry picks it up.
+1. [`notes/middleware.py`](notes/middleware.py) parses `X-Tenant` and looks up the matching `Tenant` row. Missing slug → `400`. Unknown slug → `404`. Match → `request.tenant = tenant`.
+2. [`notes/providers.py`](notes/providers.py) defines `DTenant` (a `DDependencyBase` marker) and `TenantProvider`, a `RegisteredParameterProvider`. The provider matches when `param.annotation is DTenant` and `request.tenant` is set. `apps.py` imports the module on startup so the auto-registry picks it up.
 3. Pages and form actions request the tenant by name and type:
 
    ```python
@@ -86,17 +60,11 @@ The chain has three links:
        return list(Note.objects.filter(tenant=active_tenant))
    ```
 
-   The framework injects the `Tenant` instance directly. Page modules in
-   the example do not start with `from __future__ import annotations`,
-   because the DI resolver compares parameter annotations by identity.
+   The framework injects the `Tenant` instance directly. Page modules in the example do not start with `from __future__ import annotations`, because the DI resolver compares parameter annotations by identity.
 
 ### 2. Per-tenant static URL prefix
 
-The custom backend lives in [`notes/backends.py`](notes/backends.py). It
-overrides only the `render_*_tag` methods of `StaticFilesBackend`. The
-`request` keyword argument is the hook that core threads through
-`StaticManager.inject(...)`. For absolute URLs (CDN strings) the helper
-falls back to the unmodified URL.
+The custom backend lives in [`notes/backends.py`](notes/backends.py). It overrides only the `render_*_tag` methods of `StaticFilesBackend`. The `request` keyword argument is the hook that core threads through `StaticManager.inject(...)`. For absolute URLs (CDN strings) the helper falls back to the unmodified URL.
 
 ```python
 class TenantPrefixStaticBackend(StaticFilesBackend):
@@ -115,17 +83,11 @@ The settings entry is a single line:
 ]
 ```
 
-The `next.static` collector caches deduplicated URLs once. The
-`render_*_tag` hook lets you decorate URLs at injection time without
-forking that cache.
+The `next.static` collector caches deduplicated URLs once. The `render_*_tag` hook lets you decorate URLs at injection time without forking that cache.
 
 ### 3. Shared root layout via `DIRS`
 
-The `notes` Django app does not own its HTML shell. The root template lives
-under [`root_pages/layout.djx`](root_pages/layout.djx) and the global
-components live under [`root_blocks/header/`](root_blocks/header/) and
-[`root_blocks/footer/`](root_blocks/footer/). The page and component
-backends pick them up through the `DIRS` setting:
+The `notes` Django app does not own its HTML shell. The root template lives under [`root_pages/layout.djx`](root_pages/layout.djx) and the global components live under [`root_blocks/header/`](root_blocks/header/) and [`root_blocks/footer/`](root_blocks/footer/). The page and component backends pick them up through the `DIRS` setting:
 
 ```python
 "PAGE_BACKENDS": [
@@ -146,14 +108,11 @@ backends pick them up through the `DIRS` setting:
 ],
 ```
 
-This is the canonical way to share chrome across multiple Django apps. See
-[`docs/content/topics/project-layout.rst`](../../docs/content/topics/project-layout.rst)
-for the broader pattern.
+This is the canonical way to share chrome across multiple Django apps. See [`docs/content/topics/project-layout.rst`](../../docs/content/topics/project-layout.rst) for the broader pattern.
 
 ### 4. Inherit context for the active tenant
 
-[`notes/workspaces/page.py`](notes/workspaces/page.py) registers two
-`@context(..., inherit_context=True)` callables:
+[`notes/workspaces/page.py`](notes/workspaces/page.py) registers two `@context(..., inherit_context=True)` callables:
 
 ```python
 @context("tenant", inherit_context=True)
@@ -166,35 +125,17 @@ def recent_notes(active_tenant: DTenant) -> list[Note]:
     return list(Note.objects.filter(tenant=active_tenant)[:5])
 ```
 
-Every descendant page (`/notes/`, `/notes/<id>/edit/`) sees `tenant` in its
-template context. The `notes/template.djx` and the `note_card` component
-read it without re-resolving the tenant, and `NoteCreateForm.on_valid` in
-[`notes/new/page.py`](notes/workspaces/notes/new/page.py) receives it as a
-typed `active_tenant: DTenant` parameter through DI.
+Every descendant page (`/notes/`, `/notes/<id>/edit/`) sees `tenant` in its template context. The `notes/template.djx` and the `note_card` component read it without re-resolving the tenant, and `NoteCreateForm.on_valid` in [`notes/new/page.py`](notes/workspaces/notes/new/page.py) receives it as a typed `active_tenant: DTenant` parameter through DI.
 
 ### 5. The note edit form with a composite preview
 
-[`notes/workspaces/notes/[int:id]/edit/page.py`](notes/workspaces/notes/[int:id]/edit/page.py)
-defines `NoteEditForm`, a `ModelForm` whose `Meta.fields` lists only
-`title` and `body`. There is no `note_id` field. The form binds to an
-instance through `get_initial`, which reads the URL kwarg `id`, derives the
-tenant from the request via `get_active_tenant(request)`, and routes the
-lookup through `get_object_or_404(Note, pk=id, tenant=tenant)`,
-so a tenant requesting another tenant's note id receives a `404`. On a
-valid submission `on_valid` calls `self.save()` and redirects back to the
-editor.
+[`notes/workspaces/notes/[int:id]/edit/page.py`](notes/workspaces/notes/[int:id]/edit/page.py) defines `NoteEditForm`, a `ModelForm` whose `Meta.fields` lists only `title` and `body`. There is no `note_id` field. The form binds to an instance through `get_initial`, which reads the URL kwarg `id`, derives the tenant from the request via `get_active_tenant(request)`, and routes the lookup through `get_object_or_404(Note, pk=id, tenant=tenant)`, so a tenant requesting another tenant's note id receives a `404`. On a valid submission `on_valid` calls `self.save()` and redirects back to the editor.
 
-The body textarea is rendered side by side with the
-`markdown_preview` composite ([`_blocks/markdown_preview/`](notes/workspaces/notes/_blocks/markdown_preview/)).
-The composite imports the `markdown` package and renders the body through
-`mark_safe` after letting the renderer escape raw HTML.
+The body textarea is rendered side by side with the `markdown_preview` composite ([`_blocks/markdown_preview/`](notes/workspaces/notes/_blocks/markdown_preview/)). The composite imports the `markdown` package and renders the body through `mark_safe` after letting the renderer escape raw HTML.
 
 ### 6. Dynamic permission hooks on the edit form
 
-The `get_object_or_404` in `get_initial` keeps one tenant from loading
-another tenant's note id. It does not cover two rules that are not about
-ownership. `NoteEditForm` layers those as the framework's two DI-resolved
-permission hooks.
+The `get_object_or_404` in `get_initial` keeps one tenant from loading another tenant's note id. It does not cover two rules that are not about ownership. `NoteEditForm` layers those as the framework's two DI-resolved permission hooks.
 
 ```python
 class NoteEditForm(ModelForm):
@@ -206,31 +147,13 @@ class NoteEditForm(ModelForm):
         return not self.instance.locked
 ```
 
-`check_permissions` is the view-level gate. The dispatcher resolves its
-parameters the same way it resolves `get_initial`, so the hook receives the
-active `Tenant` through the `DTenant` provider and declares nothing else. It
-runs after the static `ActionGuard` and before `get_initial`, so a suspended
-tenant (`is_active=False`) is refused before any note is loaded. The
-middleware resolves a suspended tenant exactly like an active one, and the
-ownership `404` would still let a suspended tenant reach its own notes, so
-this rule exists only at the hook layer. Returning `False` denies with `403`.
+`check_permissions` is the view-level gate. The dispatcher resolves its parameters the same way it resolves `get_initial`, so the hook receives the active `Tenant` through the `DTenant` provider and declares nothing else. It runs after the static `ActionGuard` and before `get_initial`, so a suspended tenant (`is_active=False`) is refused before any note is loaded. The middleware resolves a suspended tenant exactly like an active one, and the ownership `404` would still let a suspended tenant reach its own notes, so this rule exists only at the hook layer. Returning `False` denies with `403`.
 
-`has_object_permission` is the object-level gate. It runs after binding, so
-`self.instance` is the loaded note. A `locked` note belongs to its tenant and
-loads without a `404`, yet must stay read-only, so the hook returns `False`
-to deny with a bare `403` and no re-render. Returning `True` allows the edit
-through to `is_valid`.
+`has_object_permission` is the object-level gate. It runs after binding, so `self.instance` is the loaded note. A `locked` note belongs to its tenant and loads without a `404`, yet must stay read-only, so the hook returns `False` to deny with a bare `403` and no re-render. Returning `True` allows the edit through to `is_valid`.
 
-Both hooks emit `next.signals.form_access_denied` on a denial, carrying the
-`action_name`, `uid`, `request`, the `layer` (`"view"` or `"object"`), and
-the `reason` (`"raised"`, `"denied"`, or `"response"`). The signal stays
-silent when both hooks allow the request.
+Both hooks emit `next.signals.form_access_denied` on a denial, carrying the `action_name`, `uid`, `request`, the `layer` (`"view"` or `"object"`), and the `reason` (`"raised"`, `"denied"`, or `"response"`). The signal stays silent when both hooks allow the request.
 
-The `notes` app consumes that signal. [`notes/receivers.py`](notes/receivers.py)
-connects a receiver that logs each denial under the `notes.access` logger,
-reading the active tenant through `get_active_tenant` so the line names the
-tenant whose edit was refused. `NotesConfig.ready` imports the module so the
-connection is live at startup.
+The `notes` app consumes that signal. [`notes/receivers.py`](notes/receivers.py) connects a receiver that logs each denial under the `notes.access` logger, reading the active tenant through `get_active_tenant` so the line names the tenant whose edit was refused. `NotesConfig.ready` imports the module so the connection is live at startup.
 
 ```python
 from .access import get_active_tenant
@@ -251,24 +174,13 @@ def _on_form_access_denied(action_name, layer, reason, request, **_):
 
 ## Further reading
 
-- [`next/static/backends.py`](../../next/static/backends.py) — the
-  `StaticBackend` ABC with the `request=` kwarg.
-- [`next/static/manager.py`](../../next/static/manager.py) — the
-  `StaticManager.inject` call site that threads `request`.
-- [`next/urls/backends.py`](../../next/urls/backends.py) — the
-  `FileRouterBackend.DIRS` handling that makes `root_pages/` work.
-- [`next/components/backends.py`](../../next/components/backends.py) — the
-  matching `FileComponentsBackend.DIRS` handling for `root_blocks/`.
-- [`next/deps/providers.py`](../../next/deps/providers.py) — the
-  `RegisteredParameterProvider` ABC used by `TenantProvider`.
-- [`next/pages/registry.py`](../../next/pages/registry.py) — the
-  `inherit_context` walk that lifts `tenant` to every descendant page.
-- [`docs/content/topics/static-assets/backends.rst`](../../docs/content/topics/static-assets/backends.rst)
-  — the request-aware output section that this example anchors.
-- [`docs/content/topics/dependency-injection.rst`](../../docs/content/topics/dependency-injection.rst)
-  — the request-scoped provider pattern.
-- [`docs/content/howto/enforce-object-level-permissions.rst`](../../docs/content/howto/enforce-object-level-permissions.rst)
-  — the `check_permissions` and `has_object_permission` hooks used in
-  section 6.
-- [`docs/content/topics/forms/signals.rst`](../../docs/content/topics/forms/signals.rst)
-  — the `form_access_denied` payload contract.
+- [`next/static/backends.py`](../../next/static/backends.py) — the `StaticBackend` ABC with the `request=` kwarg.
+- [`next/static/manager.py`](../../next/static/manager.py) — the `StaticManager.inject` call site that threads `request`.
+- [`next/urls/backends.py`](../../next/urls/backends.py) — the `FileRouterBackend.DIRS` handling that makes `root_pages/` work.
+- [`next/components/backends.py`](../../next/components/backends.py) — the matching `FileComponentsBackend.DIRS` handling for `root_blocks/`.
+- [`next/deps/providers.py`](../../next/deps/providers.py) — the `RegisteredParameterProvider` ABC used by `TenantProvider`.
+- [`next/pages/registry.py`](../../next/pages/registry.py) — the `inherit_context` walk that lifts `tenant` to every descendant page.
+- [`docs/content/topics/static-assets/backends.rst`](../../docs/content/topics/static-assets/backends.rst) — the request-aware output section that this example anchors.
+- [`docs/content/topics/dependency-injection.rst`](../../docs/content/topics/dependency-injection.rst) — the request-scoped provider pattern.
+- [`docs/content/howto/enforce-object-level-permissions.rst`](../../docs/content/howto/enforce-object-level-permissions.rst) — the `check_permissions` and `has_object_permission` hooks used in section 6.
+- [`docs/content/topics/forms/signals.rst`](../../docs/content/topics/forms/signals.rst) — the `form_access_denied` payload contract.

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -1,29 +1,13 @@
 # Observability dashboard
 
-A self-hosted dashboard that watches the framework from the inside.
-Every signal next.dj emits during a render flows through one of eight
-receivers, lands in an in-process counter store, and surfaces in a
-table, a Chart.js bar chart, or a React sparkline. The example is the
-most compact proof that the public extension surface is enough to
-instrument an entire request lifecycle without monkey-patching.
+A self-hosted dashboard that watches the framework from the inside. Every signal next.dj emits during a render flows through one of eight receivers, lands in an in-process counter store, and surfaces in a table, a Chart.js bar chart, or a React sparkline. The example is the most compact proof that the public extension surface is enough to instrument an entire request lifecycle without monkey-patching.
 
-The page tree is `dashboards/`. The components live next to the pages
-that use them. The `JS_CONTEXT_SERIALIZER` setting points at a custom
-class. One co-located component declares its CDN dependencies through
-`scripts = [...]` so the framework collects them, dedupes them, and
-emits them through `{% collect_scripts %}`. Two co-located components
-read `window.Next.context.<key>` through a per-decorator serializer
-override that wraps the payload in a versioned envelope, while a
-sibling key on the same page stays flat through the global default.
-The entire frontend arrives from CDNs, so the dashboard runs without
-`npm`. The static collector picks up `.css`, `.js`, and `.jsx` files,
-the last through a custom `BabelJsxBackend` that emits
-`<script type="text/babel">` tags.
+The page tree is `dashboards/`. The components live next to the pages that use them. The `JS_CONTEXT_SERIALIZER` setting points at a custom class. One co-located component declares its CDN dependencies through `scripts = [...]` so the framework collects them, dedupes them, and emits them through `{% collect_scripts %}`. Two co-located components read `window.Next.context.<key>` through a per-decorator serializer override that wraps the payload in a versioned envelope, while a sibling key on the same page stays flat through the global default. The entire frontend arrives from CDNs, so the dashboard runs without `npm`. The static collector picks up `.css`, `.js`, and `.jsx` files, the last through a custom `BabelJsxBackend` that emits `<script type="text/babel">` tags.
 
 ## What you will see
 
 | URL | Description |
-|-----|-------------|
+| --- | --- |
 | `/` | Overview with four headline counters and a React sparkline. |
 | `/stats/` | Live page with the Chart.js bar chart and a filter form. |
 | `/stats/?window=1h` | Same page, real time-bucketed aggregation across the last hour. |
@@ -33,9 +17,7 @@ the last through a custom `BabelJsxBackend` that emits
 | `/stats/static/` | Asset, dedup, and HTML-injection totals. |
 | `POST` to `window_filter_form` | Persists the chosen window via querystring and redirects back. |
 
-The filter form uses the framework `{% form "window_filter_form" %}` tag.
-Submitting it fires `forms.action_dispatched` so the example exercises
-the full form path without adding a model write.
+The filter form uses the framework `{% form "window_filter_form" %}` tag. Submitting it fires `forms.action_dispatched` so the example exercises the full form path without adding a model write.
 
 ## How to run
 
@@ -45,25 +27,15 @@ uv run python manage.py migrate
 uv run python manage.py runserver        # http://127.0.0.1:8000/
 ```
 
-Click around `/`, `/stats/`, the four sub-pages. Apply different
-windows. Counters move on every render, and the windowed view actually
-narrows to the chosen aggregation slice.
+Click around `/`, `/stats/`, the four sub-pages. Apply different windows. Counters move on every render, and the windowed view actually narrows to the chosen aggregation slice.
 
 ```bash
 uv run python manage.py flush_metrics
 ```
 
-Drains both the cumulative and the bucketed counters into the
-`obs.MetricSnapshot` table and empties the cache. The next render
-starts at zero.
+Drains both the cumulative and the bucketed counters into the `obs.MetricSnapshot` table and empties the cache. The next render starts at zero.
 
-Tailwind loads from a CDN in `obs/dashboards/layout.djx`. Chart.js
-arrives through the framework static collector — the URL is declared
-in `obs/dashboards/_widgets/render_chart/component.py` as
-`scripts = [...]` and reaches the page via `{% collect_scripts %}`.
-React, ReactDOM, and Babel-standalone follow the same path from
-`obs/dashboards/_widgets/sparkline/component.py`. There is no build
-step.
+Tailwind loads from a CDN in `obs/dashboards/layout.djx`. Chart.js arrives through the framework static collector — the URL is declared in `obs/dashboards/_widgets/render_chart/component.py` as `scripts = [...]` and reaches the page via `{% collect_scripts %}`. React, ReactDOM, and Babel-standalone follow the same path from `obs/dashboards/_widgets/sparkline/component.py`. There is no build step.
 
 ## Walking the code
 
@@ -101,20 +73,13 @@ obs/
         └── static/
 ```
 
-The `_widgets/` directory sits directly under `dashboards/` so the
-overview page and every nested page see the same set. Co-located CSS,
-JS, and JSX files are picked up by the static collector automatically.
-The dedup policy filters duplicates so a CDN script referenced by four
-components still ships once.
+The `_widgets/` directory sits directly under `dashboards/` so the overview page and every nested page see the same set. Co-located CSS, JS, and JSX files are picked up by the static collector automatically. The dedup policy filters duplicates so a CDN script referenced by four components still ships once.
 
 [obs/dashboards/](obs/dashboards/) is the page tree.
 
 ### 2. The custom components backend
 
-`CountingComponentsBackend` extends `FileComponentsBackend` and
-records one event per successful name resolution. The dashboard reads
-those counters straight from the metrics store, no extra collector,
-no second log channel.
+`CountingComponentsBackend` extends `FileComponentsBackend` and records one event per successful name resolution. The dashboard reads those counters straight from the metrics store, no extra collector, no second log channel.
 
 ```python
 class CountingComponentsBackend(FileComponentsBackend):
@@ -125,14 +90,11 @@ class CountingComponentsBackend(FileComponentsBackend):
         return info
 ```
 
-Wired through `COMPONENT_BACKENDS` in
-[config/settings.py](config/settings.py).
+Wired through `COMPONENT_BACKENDS` in [config/settings.py](config/settings.py).
 
 ### 3. The custom static backend and JSX kind
 
-`BabelJsxBackend` extends `StaticFilesBackend`. The framework asset
-registry is type-agnostic, so `apps.py` registers a new `jsx` kind
-that points at the new renderer:
+`BabelJsxBackend` extends `StaticFilesBackend`. The framework asset registry is type-agnostic, so `apps.py` registers a new `jsx` kind that points at the new renderer:
 
 ```python
 default_kinds.register(
@@ -143,11 +105,7 @@ default_kinds.register(
 )
 ```
 
-`render_babel_script_tag` returns a `<script type="text/babel">` tag.
-Babel-standalone parses the tag in the browser and executes the JSX,
-no npm required. The custom backend installs through the same
-`STATIC_BACKENDS` slot the framework's default backend uses,
-and pairs with `InstrumentedDedup` through the `OPTIONS` block:
+`render_babel_script_tag` returns a `<script type="text/babel">` tag. Babel-standalone parses the tag in the browser and executes the JSX, no npm required. The custom backend installs through the same `STATIC_BACKENDS` slot the framework's default backend uses, and pairs with `InstrumentedDedup` through the `OPTIONS` block:
 
 ```python
 "STATIC_BACKENDS": [
@@ -160,8 +118,7 @@ and pairs with `InstrumentedDedup` through the `OPTIONS` block:
 ],
 ```
 
-[obs/backends.py](obs/backends.py) and
-[obs/static_policies.py](obs/static_policies.py).
+[obs/backends.py](obs/backends.py) and [obs/static_policies.py](obs/static_policies.py).
 
 ### 4. The pluggable JS context serializer at three levels
 
@@ -172,11 +129,7 @@ NEXT_FRAMEWORK = {
 }
 ```
 
-The global default produces flat JSON for every key reaching
-`window.Next.context`. Two `@context` callables override it with
-`WrappedJsContextSerializer`, which wraps the payload in
-`{"v": 1, "data": ...}`. The first override sits on a page-level
-callable in `obs/dashboards/stats/page.py`:
+The global default produces flat JSON for every key reaching `window.Next.context`. Two `@context` callables override it with `WrappedJsContextSerializer`, which wraps the payload in `{"v": 1, "data": ...}`. The first override sits on a page-level callable in `obs/dashboards/stats/page.py`:
 
 ```python
 @context(
@@ -189,8 +142,7 @@ def live_stats(window: str = "5m") -> dict[str, Any]:
     ...
 ```
 
-The second sits on a component-level callable in
-`_widgets/sparkline/component.py`:
+The second sits on a component-level callable in `_widgets/sparkline/component.py`:
 
 ```python
 @component.context(
@@ -202,24 +154,14 @@ def totals_chart(totals: dict[str, int]) -> dict[str, Any]:
     ...
 ```
 
-The framework records each override at the static collector level.
-At inject time the rendered HTML carries
-`"live_stats":{"v":1,"data":{...}}` and
-`"totals_chart":{"v":1,"data":{...}}`, while the sibling
-`render_rates` key from `_widgets/render_chart/component.py` stays
-flat through the global default. Three demonstrations, one HTML
-response, no per-key code branching.
+The framework records each override at the static collector level. At inject time the rendered HTML carries `"live_stats":{"v":1,"data":{...}}` and `"totals_chart":{"v":1,"data":{...}}`, while the sibling `render_rates` key from `_widgets/render_chart/component.py` stays flat through the global default. Three demonstrations, one HTML response, no per-key code branching.
 
 ### 5. The eight receiver blocks
 
-[obs/receivers.py](obs/receivers.py) wires one receiver per signal
-group. Every receiver delegates to `metrics.incr`, which bumps both
-the cumulative counter and the current minute bucket. The handlers
-stay thin because the example is a map between signal names and
-metric keys.
+[obs/receivers.py](obs/receivers.py) wires one receiver per signal group. Every receiver delegates to `metrics.incr`, which bumps both the cumulative counter and the current minute bucket. The handlers stay thin because the example is a map between signal names and metric keys.
 
 | Signal group | Sample receiver | Counter kind |
-|--------------|-----------------|--------------|
+| --- | --- | --- |
 | conf | `settings_reloaded` | `conf.settings_reloaded` |
 | deps | `provider_registered` | `deps.provider_registered` |
 | pages | `template_loaded`, `context_registered`, `page_rendered` | `pages.template`, `pages.context`, `pages.rendered`, `pages.duration_ms_total` |
@@ -229,37 +171,15 @@ metric keys.
 | static | `asset_registered`, `backend_loaded`, `collector_finalized`, `html_injected` | `static.asset_registered`, `static.backend_loaded`, `static.collector_finalized`, `static.html_injected`, `static.injected_bytes_total` |
 | server | `watch_specs_ready` | `server.watch_specs_ready` |
 
-Every group has at least one receiver. The bundled signal-group test
-proves it by walking the dashboard and asserting that every signal in
-the table fires at least once during the walk.
+Every group has at least one receiver. The bundled signal-group test proves it by walking the dashboard and asserting that every signal in the table fires at least once during the walk.
 
 ### 6. The filter form, time-bucketing, and `action_dispatched`
 
-`WindowFilterForm` carries one `ChoiceField`. Subclassing
-`next.forms.Form` in [obs/forms.py](obs/forms.py) auto-registers the
-action as `window_filter_form`. Its `on_valid` method redirects with
-`?window=...` and returns a `HttpResponseRedirect` so subsequent
-renders inherit the new window through the
-`@context("window", inherit_context=True)` callable in
-`obs/dashboards/stats/page.py`.
+`WindowFilterForm` carries one `ChoiceField`. Subclassing `next.forms.Form` in [obs/forms.py](obs/forms.py) auto-registers the action as `window_filter_form`. Its `on_valid` method redirects with `?window=...` and returns a `HttpResponseRedirect` so subsequent renders inherit the new window through the `@context("window", inherit_context=True)` callable in `obs/dashboards/stats/page.py`.
 
-Behind the form, `metrics.incr` writes both a cumulative counter and
-a minute-floor bucket key. `metrics.read_window(kind, minutes)` sums
-every bucket whose timestamp is inside `[now - minutes, now]`. The
-`live_stats` page-level context calls `read_window` so the chosen
-window narrows the aggregation in real time. The four cumulative
-sub-pages (`/stats/pages/`, `/stats/components/`, `/stats/forms/`,
-`/stats/static/`) keep using `read_kind` for the lifetime totals.
+Behind the form, `metrics.incr` writes both a cumulative counter and a minute-floor bucket key. `metrics.read_window(kind, minutes)` sums every bucket whose timestamp is inside `[now - minutes, now]`. The `live_stats` page-level context calls `read_window` so the chosen window narrows the aggregation in real time. The four cumulative sub-pages (`/stats/pages/`, `/stats/components/`, `/stats/forms/`, `/stats/static/`) keep using `read_kind` for the lifetime totals.
 
-The form component lives under
-[`_widgets/filter_window/`](obs/dashboards/_widgets/filter_window/).
-It uses `{% form "window_filter_form" %}` so submission goes through
-the framework dispatcher and `forms.action_dispatched` fires end to
-end, not only in tests. Inside the block the template renders the
-bound field as `{{ form.window }}` — the styled `Select` widget
-declared on the form — and `WindowFilterForm.get_initial(request)`
-seeds it with the window currently on the query string, so the select
-always shows the active choice.
+The form component lives under [`_widgets/filter_window/`](obs/dashboards/_widgets/filter_window/). It uses `{% form "window_filter_form" %}` so submission goes through the framework dispatcher and `forms.action_dispatched` fires end to end, not only in tests. Inside the block the template renders the bound field as `{{ form.window }}` — the styled `Select` widget declared on the form — and `WindowFilterForm.get_initial(request)` seeds it with the window currently on the query string, so the select always shows the active choice.
 
 ### 7. The flush command
 
@@ -275,23 +195,15 @@ def handle(self, *_args, **_options):
     self.stdout.write(self.style.SUCCESS(f"flushed {len(rows)} counters"))
 ```
 
-The command drains every counter (cumulative and bucketed) and clears
-the index in a single pass. Calling it twice in a row is safe: the
-second call sees an empty store and exits immediately.
+The command drains every counter (cumulative and bucketed) and clears the index in a single pass. Calling it twice in a row is safe: the second call sees an empty store and exits immediately.
 
 [obs/management/commands/flush_metrics.py](obs/management/commands/flush_metrics.py).
 
 ## Out of scope
 
-The dashboard renders every counter without pagination, so a long-
-lived process with thousands of distinct page paths will eventually
-need a top-N filter. The bucket index also grows unboundedly until
-the next `flush_metrics` run, which is fine for an example but worth
-calling out before adopting the pattern in production.
+The dashboard renders every counter without pagination, so a long- lived process with thousands of distinct page paths will eventually need a top-N filter. The bucket index also grows unboundedly until the next `flush_metrics` run, which is fine for an example but worth calling out before adopting the pattern in production.
 
 ## Further reading
 
-- Aggregated signal catalogue at
-  [docs/content/ref/signals.rst](../../docs/content/ref/signals.rst).
-- JS context serialization and the per-decorator serializer override at
-  [docs/content/topics/static-assets/js-context.rst](../../docs/content/topics/static-assets/js-context.rst).
+- Aggregated signal catalogue at [docs/content/ref/signals.rst](../../docs/content/ref/signals.rst).
+- JS context serialization and the per-decorator serializer override at [docs/content/topics/static-assets/js-context.rst](../../docs/content/topics/static-assets/js-context.rst).

--- a/examples/search-catalog/README.md
+++ b/examples/search-catalog/README.md
@@ -1,26 +1,13 @@
 # Search catalog
 
-A faceted product catalog with search, brand filters, price range, in-stock
-toggle, sort, and pagination. The listing renders six cards per page with
-deduplicated co-located CSS, the category and product detail routes thread
-an inherited `Category` instance through the `[category]/[slug]/` chain
-without re-querying, and identical search requests share a single
-`LocMemCache` entry through the lifetime of one process.
+A faceted product catalog with search, brand filters, price range, in-stock toggle, sort, and pagination. The listing renders six cards per page with deduplicated co-located CSS, the category and product detail routes thread an inherited `Category` instance through the `[category]/[slug]/` chain without re-querying, and identical search requests share a single `LocMemCache` entry through the lifetime of one process.
 
-The example focuses on the file-router and DI subsystems of next-dj.
-It dogfoods a new core `DQuery[T]` provider that mirrors `DUrl[T]` for
-query-string parameters. Two domain providers, `DFilters` and `DPage`,
-build typed snapshots from `request.GET` with `DFilters` reusing
-`QueryParamProvider` for the brand list. A `cached_search` helper is
-keyed by a stable hash of the filter set. An `active_filters` context
-processor surfaces a chip strip with a precomputed drop URL per chip.
-A three-level nested layout chain (`storefront` then `catalog` then
-`[category]`) wires the rest of the page tree.
+The example focuses on the file-router and DI subsystems of next-dj. It dogfoods a new core `DQuery[T]` provider that mirrors `DUrl[T]` for query-string parameters. Two domain providers, `DFilters` and `DPage`, build typed snapshots from `request.GET` with `DFilters` reusing `QueryParamProvider` for the brand list. A `cached_search` helper is keyed by a stable hash of the filter set. An `active_filters` context processor surfaces a chip strip with a precomputed drop URL per chip. A three-level nested layout chain (`storefront` then `catalog` then `[category]`) wires the rest of the page tree.
 
 ## What you will see
 
 | URL | Description |
-|-----|-------------|
+| --- | --- |
 | `/` | Landing. Three featured products plus a category grid. |
 | `/catalog/` | All products with sidebar filters, chips, and pagination. |
 | `/catalog/?brand=Acme&brand=Globex` | Plain repeated-key brand filter. |
@@ -45,38 +32,17 @@ uv run python manage.py runserver      # http://127.0.0.1:8000/
 uv run pytest
 ```
 
-Tailwind loads via the Play CDN in
-[`catalog/storefront/layout.djx`](catalog/storefront/layout.djx). No
-Node, no build step. Components carry co-located CSS and JS that the
-static collector picks up, deduplicates, and emits exactly once per
-page. The `filter_panel` component ships a small `component.js` that
-auto-submits the form when any checkbox or dropdown changes and runs
-live constraint validation on the search field (minimum 3 characters)
-through the native Constraint Validation API, with a help text that
-narrates exactly how many more characters are needed.
+Tailwind loads via the Play CDN in [`catalog/storefront/layout.djx`](catalog/storefront/layout.djx). No Node, no build step. Components carry co-located CSS and JS that the static collector picks up, deduplicates, and emits exactly once per page. The `filter_panel` component ships a small `component.js` that auto-submits the form when any checkbox or dropdown changes and runs live constraint validation on the search field (minimum 3 characters) through the native Constraint Validation API, with a help text that narrates exactly how many more characters are needed.
 
 ## Walking the code
 
 ### 1. Why search is plain HTML, not `@action`
 
-Search is idempotent. A bookmark of `?q=iphone&brand=Acme&page=2`
-should reproduce the same listing. That is the natural shape of
-`<form method="get">` posting back to the same page. `@action` is for
-POST side effects such as creating, updating, or deleting rows.
-[`catalog/storefront/catalog/_cards/filter_panel/component.djx`](catalog/storefront/catalog/_cards/filter_panel/component.djx)
-renders a regular HTML form. The `submit_url` value comes from
-[`catalog/storefront/catalog/_cards/filter_panel/component.py`](catalog/storefront/catalog/_cards/filter_panel/component.py)
-which reverses the current category page when scoped, otherwise the
-all-products listing. Pagination uses
-[`catalog/templatetags/catalog_qs.py`](catalog/templatetags/catalog_qs.py)
-to keep every other query parameter intact.
+Search is idempotent. A bookmark of `?q=iphone&brand=Acme&page=2` should reproduce the same listing. That is the natural shape of `<form method="get">` posting back to the same page. `@action` is for POST side effects such as creating, updating, or deleting rows. [`catalog/storefront/catalog/_cards/filter_panel/component.djx`](catalog/storefront/catalog/_cards/filter_panel/component.djx) renders a regular HTML form. The `submit_url` value comes from [`catalog/storefront/catalog/_cards/filter_panel/component.py`](catalog/storefront/catalog/_cards/filter_panel/component.py) which reverses the current category page when scoped, otherwise the all-products listing. Pagination uses [`catalog/templatetags/catalog_qs.py`](catalog/templatetags/catalog_qs.py) to keep every other query parameter intact.
 
 ### 2. The new `DQuery[T]` provider
 
-[`next/urls/markers.py`](../../next/urls/markers.py) ships a marker
-that mirrors `DUrl[T]` and reads `request.GET`. Any GET listing page
-can declare a typed parameter and skip the `request.GET.get(...)`
-plumbing.
+[`next/urls/markers.py`](../../next/urls/markers.py) ships a marker that mirrors `DUrl[T]` and reads `request.GET`. Any GET listing page can declare a typed parameter and skip the `request.GET.get(...)` plumbing.
 
 ```python
 from next.pages import context
@@ -91,17 +57,11 @@ def search(
     ...
 ```
 
-The list form accepts three wire formats. Plain repeated keys
-`?brand=a&brand=b` produced by `<form method="get">` win first. The
-qs-style bracket suffix `?brand[]=a&brand[]=b` emitted by axios is the
-second fallback. The comma-delimited form `?brand=a,b` produced by
-`qs.stringify` with the comma array format is the third fallback.
-Empty segments around commas are dropped.
+The list form accepts three wire formats. Plain repeated keys `?brand=a&brand=b` produced by `<form method="get">` win first. The qs-style bracket suffix `?brand[]=a&brand[]=b` emitted by axios is the second fallback. The comma-delimited form `?brand=a,b` produced by `qs.stringify` with the comma array format is the third fallback. Empty segments around commas are dropped.
 
 ### 3. Domain providers built on top of the core
 
-[`catalog/providers.py`](catalog/providers.py) wraps the raw query
-string in two typed snapshots so handlers stay declarative.
+[`catalog/providers.py`](catalog/providers.py) wraps the raw query string in two typed snapshots so handlers stay declarative.
 
 ```python
 @dataclass(frozen=True, slots=True)
@@ -117,26 +77,13 @@ class DFilters(DDependencyBase["Filters"]): ...
 class DPage(DDependencyBase["PageRequest"]): ...
 ```
 
-`FiltersProvider.resolve` runs `parse_filters(request)` which is also
-reused by the active-filter context processor. The brand list inside
-`parse_filters` delegates to `QueryParamProvider`, so all three wire
-formats supported by `DQuery` (plain repeated, bracket suffix,
-comma-delimited) flow through one helper. `PageProvider.resolve`
-returns a clamped `PageRequest` whose `per_page` is bounded by
-`MAX_PER_PAGE = 60`.
+`FiltersProvider.resolve` runs `parse_filters(request)` which is also reused by the active-filter context processor. The brand list inside `parse_filters` delegates to `QueryParamProvider`, so all three wire formats supported by `DQuery` (plain repeated, bracket suffix, comma-delimited) flow through one helper. `PageProvider.resolve` returns a clamped `PageRequest` whose `per_page` is bounded by `MAX_PER_PAGE = 60`.
 
-The landing page exercises `DQuery` directly. The `featured`
-callable in
-[`catalog/storefront/page.py`](catalog/storefront/page.py) accepts an
-optional `?show=N` parameter through `show: DQuery[int] = 3`, with no
-manual `request.GET.get` plumbing.
+The landing page exercises `DQuery` directly. The `featured` callable in [`catalog/storefront/page.py`](catalog/storefront/page.py) accepts an optional `?show=N` parameter through `show: DQuery[int] = 3`, with no manual `request.GET.get` plumbing.
 
 ### 4. Three-level nested layouts
 
-The compose chain is automatic. When a listing is rendered the body
-is substituted into the innermost layout that has a
-`{% block template %}{% endblock %}` slot, then the next ancestor, and
-so on. For `/catalog/electronics/iphone-15/` the chain is
+The compose chain is automatic. When a listing is rendered the body is substituted into the innermost layout that has a `{% block template %}{% endblock %}` slot, then the next ancestor, and so on. For `/catalog/electronics/iphone-15/` the chain is
 
 ```
 catalog/storefront/catalog/[category]/[slug]/template.djx
@@ -145,15 +92,11 @@ catalog/storefront/catalog/[category]/[slug]/template.djx
           └─ catalog/storefront/layout.djx                # Tailwind chrome
 ```
 
-Each layer contributes a meaningful piece of UI. None of the layouts
-are decorative wrappers added "in case we need them later".
+Each layer contributes a meaningful piece of UI. None of the layouts are decorative wrappers added "in case we need them later".
 
 ### 5. `inherit_context=True` in a real flow
 
-[`catalog/storefront/catalog/[category]/page.py`](catalog/storefront/catalog/%5Bcategory%5D/page.py)
-registers `category` as inherit-context. Three downstream callables
-on the same page (`page_obj`, `all_brands`, plus the breadcrumb on the
-template) receive the same `Category` instance through DI.
+[`catalog/storefront/catalog/[category]/page.py`](catalog/storefront/catalog/%5Bcategory%5D/page.py) registers `category` as inherit-context. Three downstream callables on the same page (`page_obj`, `all_brands`, plus the breadcrumb on the template) receive the same `Category` instance through DI.
 
 ```python
 @context("category", inherit_context=True)
@@ -166,120 +109,37 @@ def category(category: object) -> Category:
         raise Http404 from exc
 ```
 
-The parameter is annotated `object` because
-`_collect_inherited_context` evaluates the callable twice when the
-page itself is being rendered (once for the URL slug, once for the
-already-resolved instance from `context_data`). The
-`isinstance(category, Category)` short-circuit covers the second pass.
+The parameter is annotated `object` because `_collect_inherited_context` evaluates the callable twice when the page itself is being rendered (once for the URL slug, once for the already-resolved instance from `context_data`). The `isinstance(category, Category)` short-circuit covers the second pass.
 
-The product detail page in
-[`catalog/storefront/catalog/[category]/[slug]/page.py`](catalog/storefront/catalog/%5Bcategory%5D/%5Bslug%5D/page.py)
-declares `category: Category` and gets the inherited instance through
-[`next/pages/context.py`](../../next/pages/context.py)'s
-`ContextByDefaultProvider`. No re-query, no kwargs threading, no
-helper.
+The product detail page in [`catalog/storefront/catalog/[category]/[slug]/page.py`](catalog/storefront/catalog/%5Bcategory%5D/%5Bslug%5D/page.py) declares `category: Category` and gets the inherited instance through [`next/pages/context.py`](../../next/pages/context.py)'s `ContextByDefaultProvider`. No re-query, no kwargs threading, no helper.
 
 ### 6. Co-located CSS, JS, and scoped components
 
-`product_card` is rendered six times on the catalog listing and three
-more times on the landing page. Its
-[`component.css`](catalog/storefront/_cards/product_card/component.css)
-emits `transition` and `:hover` rules. The static collector emits
-exactly one `<link rel="stylesheet">` per asset URL across both
-pages. The
-[`tests/test_e2e.py::TestRouting::test_product_card_css_dedup`](tests/test_e2e.py)
-and
-[`test_landing_reuses_product_card_css`](tests/test_e2e.py)
-tests assert this directly. The component lives at
-[`storefront/_cards/`](catalog/storefront/_cards/) one level above
-the catalog tree because both the landing and the listing render it.
+`product_card` is rendered six times on the catalog listing and three more times on the landing page. Its [`component.css`](catalog/storefront/_cards/product_card/component.css) emits `transition` and `:hover` rules. The static collector emits exactly one `<link rel="stylesheet">` per asset URL across both pages. The [`tests/test_e2e.py::TestRouting::test_product_card_css_dedup`](tests/test_e2e.py) and [`test_landing_reuses_product_card_css`](tests/test_e2e.py) tests assert this directly. The component lives at [`storefront/_cards/`](catalog/storefront/_cards/) one level above the catalog tree because both the landing and the listing render it.
 
-`pagination` is a template-only component — it has `component.djx`
-but no `component.py`. It reads `page_obj` directly from template
-context without any Python-side registration. This is valid: a
-`component.py` is only needed when the component must compute derived
-values or perform DI lookups.
+`pagination` is a template-only component — it has `component.djx` but no `component.py`. It reads `page_obj` directly from template context without any Python-side registration. This is valid: a `component.py` is only needed when the component must compute derived values or perform DI lookups.
 
-`filter_panel` lives at
-[`storefront/catalog/_cards/filter_panel/`](catalog/storefront/catalog/_cards/filter_panel/)
-— a nested `_cards/` folder inside the `catalog/` subtree. The
-framework's dispatcher registers any `_cards/` directory it encounters
-during the route tree walk, scoping each to its containing subtree.
-`filter_panel` is therefore visible to `/catalog/` and
-`/catalog/<category>/` but invisible on the landing page. The
-[`test_filter_panel_scoped_to_catalog`](tests/test_e2e.py) test
-verifies that `filter_panel` CSS appears in catalog pages but not on
-the landing page.
+`filter_panel` lives at [`storefront/catalog/_cards/filter_panel/`](catalog/storefront/catalog/_cards/filter_panel/) — a nested `_cards/` folder inside the `catalog/` subtree. The framework's dispatcher registers any `_cards/` directory it encounters during the route tree walk, scoping each to its containing subtree. `filter_panel` is therefore visible to `/catalog/` and `/catalog/<category>/` but invisible on the landing page. The [`test_filter_panel_scoped_to_catalog`](tests/test_e2e.py) test verifies that `filter_panel` CSS appears in catalog pages but not on the landing page.
 
-`filter_panel` also ships
-[`component.js`](catalog/storefront/catalog/_cards/filter_panel/component.js).
-It does two things. First, it attaches a `change` listener to
-`[data-filter-form]` and auto-submits the form when a checkbox or
-`<select>` changes (only if the form passes `checkValidity()`).
-Number inputs and the text query field are excluded so that
-partially-typed values do not trigger a reload mid-entry — those
-commit on Enter, and the "Apply filters" button submits everything
-at once.
+`filter_panel` also ships [`component.js`](catalog/storefront/catalog/_cards/filter_panel/component.js). It does two things. First, it attaches a `change` listener to `[data-filter-form]` and auto-submits the form when a checkbox or `<select>` changes (only if the form passes `checkValidity()`). Number inputs and the text query field are excluded so that partially-typed values do not trigger a reload mid-entry — those commit on Enter, and the "Apply filters" button submits everything at once.
 
-Second, it runs live validation on the query field using the native
-Constraint Validation API. The `<input>` declares `minlength="3"`, so
-the browser already enforces the rule on submit and shows the
-`invalid:` Tailwind variant (rose border on a red-tinted background).
-The script layers a contextual help message on top: it reads
-`data-help-default` and `data-help-tooshort` from the input,
-calls `setCustomValidity()` with a tailored message ("Need 2 more —
-at least 3 characters in total"), and updates the help paragraph
-with three colour states (`text-slate-500` idle, `text-rose-600` too
-short, `text-emerald-600` valid). The empty string is treated as
-"no filter" so the user can clear the field without seeing an error.
-The script is injected via `{% collect_scripts %}` in
-[`storefront/layout.djx`](catalog/storefront/layout.djx).
+Second, it runs live validation on the query field using the native Constraint Validation API. The `<input>` declares `minlength="3"`, so the browser already enforces the rule on submit and shows the `invalid:` Tailwind variant (rose border on a red-tinted background). The script layers a contextual help message on top: it reads `data-help-default` and `data-help-tooshort` from the input, calls `setCustomValidity()` with a tailored message ("Need 2 more — at least 3 characters in total"), and updates the help paragraph with three colour states (`text-slate-500` idle, `text-rose-600` too short, `text-emerald-600` valid). The empty string is treated as "no filter" so the user can clear the field without seeing an error. The script is injected via `{% collect_scripts %}` in [`storefront/layout.djx`](catalog/storefront/layout.djx).
 
-[`catalog/layout.css`](catalog/storefront/catalog/layout.css) is a
-co-located layout stylesheet. It applies `position: sticky; top: 1rem`
-to the sidebar on large screens, keeping the filter panel in view as
-the product grid scrolls. This style belongs in `layout.css` rather
-than a utility class because the `top` offset must be a concrete pixel
-value that Tailwind's `top-*` utilities do not express cleanly. The
-file is injected automatically for every page in the `catalog/`
-subtree through the layout chain and is absent on the landing page,
-as the
-[`test_catalog_layout_css_absent_on_landing`](tests/test_e2e.py)
-test verifies.
+[`catalog/layout.css`](catalog/storefront/catalog/layout.css) is a co-located layout stylesheet. It applies `position: sticky; top: 1rem` to the sidebar on large screens, keeping the filter panel in view as the product grid scrolls. This style belongs in `layout.css` rather than a utility class because the `top` offset must be a concrete pixel value that Tailwind's `top-*` utilities do not express cleanly. The file is injected automatically for every page in the `catalog/` subtree through the layout chain and is absent on the landing page, as the [`test_catalog_layout_css_absent_on_landing`](tests/test_e2e.py) test verifies.
 
 ### 7. `cached_search` and the LocMem hit path
 
-[`catalog/queries.py`](catalog/queries.py) materialises the page slice
-into a list so the cached payload does not depend on a queryset
-closure that can grow stale across requests. The cache key is a
-stable blake2b hash of a sorted JSON encoding of the filter set, page
-number, page size, and category PK. Two identical GETs produce one
-cache key and serve the second request from memory, which the
-[`tests/test_e2e.py::TestCacheHit`](tests/test_e2e.py) tests verify
-through the cache backend's internal map.
+[`catalog/queries.py`](catalog/queries.py) materialises the page slice into a list so the cached payload does not depend on a queryset closure that can grow stale across requests. The cache key is a stable blake2b hash of a sorted JSON encoding of the filter set, page number, page size, and category PK. Two identical GETs produce one cache key and serve the second request from memory, which the [`tests/test_e2e.py::TestCacheHit`](tests/test_e2e.py) tests verify through the cache backend's internal map.
 
 ### 8. Active filter chips
 
-[`catalog/context_processors.py`](catalog/context_processors.py)
-returns a `chips` list and a `drop_filter_qs` map keyed by
-`"key=value"`. The map stores the query string with that one pair
-removed, which the layout consumes through the `kv` template filter.
-Clicking a chip drops one filter at a time without disturbing the
-rest.
+[`catalog/context_processors.py`](catalog/context_processors.py) returns a `chips` list and a `drop_filter_qs` map keyed by `"key=value"`. The map stores the query string with that one pair removed, which the layout consumes through the `kv` template filter. Clicking a chip drops one filter at a time without disturbing the rest.
 
-The default `sort=newest` is filtered out of the chip list to avoid
-permanent noise.
+The default `sort=newest` is filtered out of the chip list to avoid permanent noise.
 
 ## Further reading
 
-- [`next/urls/markers.py`](../../next/urls/markers.py) ships both the
-  `DUrl` provider for URL path segments and the new `DQuery` provider
-  for query-string parameters. The narrative section lives in
-  [`docs/content/topics/dependency-injection.rst`](../../docs/content/topics/dependency-injection.rst).
-- [`next/pages/registry.py`](../../next/pages/registry.py) hosts the
-  `_collect_inherited_context` walk used by `inherit_context=True`.
-- [`next/pages/context.py`](../../next/pages/context.py) hosts the
-  `ContextByDefaultProvider` that injects inherited values into
-  downstream callables by parameter name.
-- [`next/static/collector.py`](../../next/static/collector.py) hosts
-  the static collector that deduplicates co-located component CSS.
+- [`next/urls/markers.py`](../../next/urls/markers.py) ships both the `DUrl` provider for URL path segments and the new `DQuery` provider for query-string parameters. The narrative section lives in [`docs/content/topics/dependency-injection.rst`](../../docs/content/topics/dependency-injection.rst).
+- [`next/pages/registry.py`](../../next/pages/registry.py) hosts the `_collect_inherited_context` walk used by `inherit_context=True`.
+- [`next/pages/context.py`](../../next/pages/context.py) hosts the `ContextByDefaultProvider` that injects inherited values into downstream callables by parameter name.
+- [`next/static/collector.py`](../../next/static/collector.py) hosts the static collector that deduplicates co-located component CSS.

--- a/examples/shortener/README.md
+++ b/examples/shortener/README.md
@@ -7,7 +7,7 @@ The example is small on purpose. It is a tour of the framework surface you will 
 ## What you will see
 
 | URL | Description |
-|-----|-------------|
+| --- | --- |
 | `/` | Form to shorten a URL, list of the latest entries. |
 | `/s/<slug>/` | 302 redirect to the original URL, bumps the click counter. |
 | `/admin/` | Top links and unflushed click counters. Nested admin layout with a subnav. |
@@ -212,7 +212,7 @@ No `request.path` string-munging, no custom template tag, no context processor. 
 Every anchor in the project goes through `{% url %}`. File-router URLs sit under the `next` namespace. The name format is `page_<prepare_url_name(url_path)>`:
 
 | File | URL | Name |
-|------|-----|------|
+| --- | --- | --- |
 | `routes/page.py` | `/` | `next:page_` |
 | `routes/admin/page.py` | `/admin/` | `next:page_admin` |
 | `routes/admin/stats/page.py` | `/admin/stats/` | `next:page_admin_stats` |

--- a/examples/wiki/README.md
+++ b/examples/wiki/README.md
@@ -1,13 +1,11 @@
 # DB-backed wiki
 
-A wiki served from two stores at once. Some pages live as files in
-`wiki/routes/`. The rest live in the database as `Article` rows. Both
-kinds share one router, one root layout, and one search page.
+A wiki served from two stores at once. Some pages live as files in `wiki/routes/`. The rest live in the database as `Article` rows. Both kinds share one router, one root layout, and one search page.
 
 ## What you will see
 
 | URL | Description |
-|-----|-------------|
+| --- | --- |
 | `/` | Index with a curated list of file documentation and every article in the database. |
 | `/docs/routing/` | File-backed page describing how the file router works. |
 | `/docs/components/` | File-backed page describing the composite component pattern. |
@@ -16,9 +14,7 @@ kinds share one router, one root layout, and one search page.
 | `/wiki/<slug>/` | Public article view rendered from the database row. |
 | `/search/?q=routing` | Mixed search across the file catalogue and article titles plus bodies. |
 
-Articles persist in SQLite. After every create, edit, or delete the
-router rebuilds itself in-process and the new URL is reachable on the
-next request.
+Articles persist in SQLite. After every create, edit, or delete the router rebuilds itself in-process and the new URL is reachable on the next request.
 
 ## How to run
 
@@ -29,103 +25,56 @@ uv run python manage.py runserver     # http://127.0.0.1:8000/
 uv run pytest
 ```
 
-Tailwind loads via the Play CDN in [`wiki/routes/layout.djx`](wiki/routes/layout.djx).
-No Node, no build step.
+Tailwind loads via the Play CDN in [`wiki/routes/layout.djx`](wiki/routes/layout.djx). No Node, no build step.
 
-Open the index, click `New article`, write some Markdown, and submit.
-The new article becomes available at `/wiki/<slug>/` immediately. Open
-the search page with `?q=...` to see both file and database matches in
-the same response.
+Open the index, click `New article`, write some Markdown, and submit. The new article becomes available at `/wiki/<slug>/` immediately. Open the search page with `?q=...` to see both file and database matches in the same response.
 
 ## Walking the code
 
 ### 1. Two URL sources, one router
 
-`wiki.backends.HybridRouterBackend.generate_urls` returns
-`super().generate_urls()` plus one named pattern per existing article.
-Each alias targets the catchall callback at `wiki/[slug]/` and binds a
-fixed `slug` kwarg so `DArticle` resolves the right row. The catchall
-file route `wiki/routes/wiki/[slug]/page.py` owns the rendering logic.
-The aliases give templates a per-slug `reverse()` name and keep the
-public URL space tidy at `/wiki/<slug>/`.
+`wiki.backends.HybridRouterBackend.generate_urls` returns `super().generate_urls()` plus one named pattern per existing article. Each alias targets the catchall callback at `wiki/[slug]/` and binds a fixed `slug` kwarg so `DArticle` resolves the right row. The catchall file route `wiki/routes/wiki/[slug]/page.py` owns the rendering logic. The aliases give templates a per-slug `reverse()` name and keep the public URL space tidy at `/wiki/<slug>/`.
 
-The catchall view never has to know whether it was reached through the
-generic `<slug>` capture or through a hybrid alias. Both paths feed the
-same DI flow.
+The catchall view never has to know whether it was reached through the generic `<slug>` capture or through a hybrid alias. Both paths feed the same DI flow.
 
 ### 2. Reloading after data changes
 
-`wiki/receivers.py` listens to `post_save` and `post_delete` of
-`Article` and calls `router_manager.reload()`. The reload path is one
-public method that:
+`wiki/receivers.py` listens to `post_save` and `post_delete` of `Article` and calls `router_manager.reload()`. The reload path is one public method that:
 
 1. Drops the cached backend list.
 2. Reinstantiates every backend from `PAGE_BACKENDS`.
 3. Clears Django's URL resolver caches.
 4. Sends the `router_reloaded` signal.
 
-The next request observes the fresh URL tree without a process restart.
-Tests confirm the loop end-to-end through `SignalRecorder`.
+The next request observes the fresh URL tree without a process restart. Tests confirm the loop end-to-end through `SignalRecorder`.
 
 ### 3. DI provider for the slug
 
-`wiki.providers.ArticleProvider` claims any parameter annotated as
-`DArticle[Article]`. It reads `context.url_kwargs["slug"]` and either
-returns the matching row or raises `Http404`. The catchall page,
-the edit form, and the preview context all use the same provider,
-so the slug-to-row lookup lives in one place.
+`wiki.providers.ArticleProvider` claims any parameter annotated as `DArticle[Article]`. It reads `context.url_kwargs["slug"]` and either returns the matching row or raises `Http404`. The catchall page, the edit form, and the preview context all use the same provider, so the slug-to-row lookup lives in one place.
 
 ### 4. Live preview through parent context
 
-`articles/new/page.py` and `articles/edit/[slug]/page.py` both register
-a context entry named `body`. The `markdown_preview` component reads
-`body` from the parent template context, runs it through
-`render_markdown`, and emits the safe HTML. No explicit prop is
-needed because the parent context flows into the component scope. The
-JavaScript layer wires the textarea to the preview pane for keystroke
-updates without round-tripping the server.
+`articles/new/page.py` and `articles/edit/[slug]/page.py` both register a context entry named `body`. The `markdown_preview` component reads `body` from the parent template context, runs it through `render_markdown`, and emits the safe HTML. No explicit prop is needed because the parent context flows into the component scope. The JavaScript layer wires the textarea to the preview pane for keystroke updates without round-tripping the server.
 
 ### 5. Slug reservations
 
-`Article.clean()` rejects slugs that collide with file-route prefixes
-(`docs`, `articles`, `search`, `wiki`). Both forms enforce the same
-rule plus a uniqueness check against `Article.slug`. A reserved slug
-re-renders the form with the error message and the live preview pane
-intact.
+`Article.clean()` rejects slugs that collide with file-route prefixes (`docs`, `articles`, `search`, `wiki`). Both forms enforce the same rule plus a uniqueness check against `Article.slug`. A reserved slug re-renders the form with the error message and the live preview pane intact.
 
 ### 6. LIKE search across two stores
 
-`wiki/routes/search/page.py` runs two scans for each query. A literal
-substring match against a curated catalogue surfaces matching file
-pages. A `Q(title__icontains) | Q(body_md__icontains)` query against
-`Article` surfaces matching rows. The same template renders both lists
-side by side.
+`wiki/routes/search/page.py` runs two scans for each query. A literal substring match against a curated catalogue surfaces matching file pages. A `Q(title__icontains) | Q(body_md__icontains)` query against `Article` surfaces matching rows. The same template renders both lists side by side.
 
 ### 7. Object-level edit permission
 
-`Article` carries a `locked` boolean. The edit form in
-`wiki/routes/articles/edit/[slug]/page.py` declares
-`has_object_permission(self)`, an object-level hook that the framework
-resolves like `on_valid` and runs after the form binds, so
-`self.instance` is the loaded target row. The override reads only what it
-needs from `self.instance` and returns `not self.instance.locked`. A
-locked article short-circuits to a bare 403 before validation runs, so
-there is no form re-render. The create form has no such hook and stays
-open.
+`Article` carries a `locked` boolean. The edit form in `wiki/routes/articles/edit/[slug]/page.py` declares `has_object_permission(self)`, an object-level hook that the framework resolves like `on_valid` and runs after the form binds, so `self.instance` is the loaded target row. The override reads only what it needs from `self.instance` and returns `not self.instance.locked`. A locked article short-circuits to a bare 403 before validation runs, so there is no form re-render. The create form has no such hook and stays open.
 
 ### 8. No nested layout
 
-The example wires only one `layout.djx` at the routes root. A nested
-layout is not needed and would add noise. Examples that do need nested
-layouts are `examples/multi-tenant` and `examples/markdown-blog`.
+The example wires only one `layout.djx` at the routes root. A nested layout is not needed and would add noise. Examples that do need nested layouts are `examples/multi-tenant` and `examples/markdown-blog`.
 
 ## Further reading
 
-- [next/urls/manager.py](../../next/urls/manager.py) — `RouterManager.reload`
-  emits the `router_reloaded` signal.
-- [next/urls/backends.py](../../next/urls/backends.py) —
-  `FileRouterBackend.generate_urls` is the public extension surface.
-- [next/deps/providers.py](../../next/deps/providers.py) — DI provider
-  contract used by `ArticleProvider`.
-- [next/components/context.py](../../next/components/context.py) —
-  `@component.context` wiring used by `markdown_preview`.
+- [next/urls/manager.py](../../next/urls/manager.py) — `RouterManager.reload` emits the `router_reloaded` signal.
+- [next/urls/backends.py](../../next/urls/backends.py) — `FileRouterBackend.generate_urls` is the public extension surface.
+- [next/deps/providers.py](../../next/deps/providers.py) — DI provider contract used by `ArticleProvider`.
+- [next/components/context.py](../../next/components/context.py) — `@component.context` wiring used by `markdown_preview`.

--- a/next/forms/__init__.py
+++ b/next/forms/__init__.py
@@ -1,8 +1,10 @@
 """Form actions and helpers for next-dj.
 
-Register handlers with `@action`. Each action gets a stable UID
-endpoint. Valid submissions run the handler. Invalid forms re-render
-with errors. CSRF is applied for posted forms.
+Subclass `Form`, `ModelForm`, or `FormWizard` to auto-register an
+action through `__init_subclass__`. Use `@action` for form-less
+handlers. Each action gets a stable UID endpoint. Valid submissions
+run the handler. Invalid forms re-render with errors. CSRF is applied
+for posted forms.
 
 Any public `django.forms` name resolves through `next.forms` unless
 next.dj deliberately overrides it. The formset and modelform factories

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "test:js": "vitest run",
     "lint:js": "eslint \"{next,examples}/**/*.{mjs,ts,js,css}\"",
     "lint:js:fix": "eslint --fix \"{next,examples}/**/*.{mjs,ts,js,css}\"",
-    "format": "prettier --write \"{next,examples}/**/*.{mjs,ts,js,css}\" \"vitest.config.ts\" \"eslint.config.mjs\"",
-    "format:check": "prettier --check \"{next,examples}/**/*.{mjs,ts,js,css}\" \"vitest.config.ts\" \"eslint.config.mjs\""
+    "format": "prettier --write \"{next,examples}/**/*.{mjs,ts,js,css}\" \"{next,examples}/**/README.md\" \"vitest.config.ts\" \"eslint.config.mjs\"",
+    "format:check": "prettier --check \"{next,examples}/**/*.{mjs,ts,js,css}\" \"{next,examples}/**/README.md\" \"vitest.config.ts\" \"eslint.config.mjs\""
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Description

Two follow-up passes on the forms v2 work (#121, #124) ahead of the v0.7 release: a consistency sweep that brings the examples and reference docs in line with the class-bound forms model, and a Prettier pass that unwraps the example README prose. No core behaviour changes — the only `next/` edit is a package docstring.

### Examples — close the two demo gaps left by forms v2

- **Custom wizard storage backend (`audit-forms`).** No example demonstrated a non-default `FORM_WIZARD_BACKEND`, so the pluggable wizard-storage story shipped in #121 had no runnable proof. The access-request wizard now persists its step drafts through the bundled `CacheFormWizardBackend` on a dedicated `wizards` cache alias with a 30-minute TTL, configured entirely through settings without touching a wizard class. A new `TestCacheBackedDrafts` asserts drafts land in the `wizards` cache, stay out of `default`, round-trip across steps, and clear on completion.
- **Declarative success contract (`feature-flags`).** `Meta.success_url` / `Meta.success_message` were demonstrated only in `shortener`. The bulk-toggle form now follows the declarative contract — `Meta.success_url = "/admin/"` plus a flashed `success_message`, with `on_valid` ending in `super().on_valid(request)` instead of a hand-built redirect. A `flash_messages` context drains the queue and the panel renders it in an `alert` banner.
- **Import-idiom fix (`audit-forms`).** The wizard step module was the lone file importing `from django import forms` unaliased — normalised to `from django import forms as django_forms` to match every sibling example.

Both example suites stay at 100% coverage.

### Docs — reconcile with the class-bound model

- `topics/forms/overview` now mentions the `success_url` / `success_message` contract under "Handling Submissions".
- New `dynamic permission hook` glossary term for `check_permissions` / `has_object_permission` / `PermissionOutcome`.
- `ref/forms` Stable tier notes that `@action` is for form-less handlers, since class-bound forms self-register.
- `intro/tutorial04` cross-links `Meta.instance_from_url` as the declarative alternative to the edit-flow factory.
- The `next/forms` package docstring leads with class auto-registration instead of `@action`.

### Tooling — unwrap example README prose

The example READMEs were hand-wrapped at a fixed ~72–76 column mid-sentence. That renders fine on GitHub but reads ragged in the raw source and never reflows to the viewport, and nothing enforced it — Prettier's globs covered only `*.{mjs,ts,js,css}`. This pass sets `proseWrap: "never"`, extends the `format` / `format:check` globs and the pre-commit hook to `README.md`, and reflows every example README to one line per paragraph. Code fences are left untouched (`embeddedLanguageFormatting: off` for `*.md`), the markdown-blog `template.md` content files stay out of scope, and `.pytest_cache/` is added to `.prettierignore` so a freshly generated cache README never fails `format:check`.

## How to test

Verified locally on the changed surface (full `make ci` not run here, CI covers the rest):

- `uv run mypy next/` — clean, 107 files.
- `uv run ruff check` and `ruff format --check` on the changed module — clean.
- `make docs` (`-W`) — builds clean.
- `examples/audit-forms` — `uv run pytest tests/ -n auto --cov=. --cov-config=../.coveragerc --cov-fail-under=100` → 66 passed, 100%.
- `examples/feature-flags` — same command → 45 passed, 100%.
- `npm run format:check` — all matched files use Prettier code style.

## Related issues

<!-- none -->

## Checklist

- [ ] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [x] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable

---

Full guidelines: [CONTRIBUTING.md](https://github.com/next-dj/next-dj/blob/main/CONTRIBUTING.md)
