### PR TITLE
fix(partial): some fixes partial and freeze api for next release

### DIFF
--- a/docs/content/howto/stream-live-updates-with-sse.rst
+++ b/docs/content/howto/stream-live-updates-with-sse.rst
@@ -142,7 +142,7 @@ The signal carries the bound form after validation and the request, so the recei
    from django.http import HttpRequest
 
    from next.forms.signals import action_dispatched
-   from next.partial import REQUEST_ID
+   from next.partial.headers import REQUEST_ID
    from polls.broker import broker, build_snapshot
 
    VOTE_ACTION_NAME = "vote_form"

--- a/docs/content/ref/partial.rst
+++ b/docs/content/ref/partial.rst
@@ -22,20 +22,27 @@ The autodoc blocks under `Public API`_ are the exhaustive surface.
 
 Stable.
    ``Patches``, ``PatchResponse``, ``PatchEventStream``, ``render_zone``,
-   ``zone_requested``, ``is_partial_request``, ``partial_intent``,
-   ``resolve_partial_origin``, ``register_patch_op``, ``UnknownZoneError``, and
-   ``ForeignPageNotAuthorizedError``.
-   Use these in page modules, action handlers, and stream sources.
+   ``ZoneRenderResult``, ``zone_requested``, ``is_partial_request``, ``partial_intent``,
+   ``register_patch_op``, ``UnknownZoneError``, and ``ForeignPageNotAuthorizedError``.
+   ``Envelope``, ``Patch``, ``Asset``, and ``FormMeta`` are the frozen value objects of
+   the wire contract.
+   Import all of these from ``next.partial``.
+   Use them in page modules, action handlers, and stream sources.
 
 Advanced.
-   ``shape_partial``, ``PartialProtocolBackend``, ``Envelope``, ``Patch``, ``Asset``,
-   ``FormMeta``, ``OriginSource``, ``ZoneInfo``, ``ZoneRenderResult``, ``zones_of``,
-   the custom-verb exceptions in ``next.partial.patches``, and the ``signals`` and
-   ``checks`` submodules.
+   ``shape_partial`` and ``PartialProtocolBackend`` are imported from ``next.partial``.
+   ``resolve_partial_origin`` stays in ``next.partial`` as a thin helper that reads the
+   host page out of the ``X-Next-Origin`` header so a ``done`` step can pass it to
+   ``morph(page=)``.
+   ``OriginSource`` lives in ``next.partial.origin``.
+   ``ZoneInfo`` and ``zones_of`` live in ``next.partial.registry``.
+   The custom-verb exceptions live in ``next.partial.patches``.
+   The ``signals`` and ``checks`` submodules carry the partial telemetry.
    Use these when writing a custom protocol backend, a wire-format plugin, or telemetry.
 
 Framework machinery.
-   ``REQUEST_ID`` is the ``X-Next-Request-Id`` header name.
+   ``REQUEST_ID`` is the ``X-Next-Request-Id`` header name and lives in
+   ``next.partial.headers``.
    ``PartialIntent`` and ``MergeMode`` live in ``next.partial.headers``.
    ``PartialOrigin`` lives in ``next.partial.origin``.
    ``shape_validate`` and ``drain_messages`` live in ``next.partial.shaping``.
@@ -113,29 +120,32 @@ Zones
 
 ``render_zone`` renders one or more zones of a page standalone with the full page context,
 returning a ``ZoneRenderResult`` that carries the wrapped HTML and the collected assets.
-``zones_of`` returns the compiled zones of a template as a mapping of ``ZoneInfo``.
+``zones_of`` returns the compiled zones of a template as a mapping of ``ZoneInfo``, both
+reached through ``next.partial.registry``.
 
 .. autofunction:: next.partial.render_zone
 
 .. autoclass:: next.partial.ZoneRenderResult
    :members:
 
-.. autoclass:: next.partial.ZoneInfo
+.. autoclass:: next.partial.registry.ZoneInfo
    :members:
 
-.. autofunction:: next.partial.zones_of
+.. autofunction:: next.partial.registry.zones_of
 
 Origin and Authorisation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``resolve_partial_origin`` resolves the host page that owns a zone for an out-of-band
-morph, reading the same-site ``X-Next-Origin`` header and falling back to the posted form
-origin.
-``OriginSource`` discriminates the two.
+``resolve_partial_origin`` is a thin helper that reads the host page that owns a zone out
+of the same-site ``X-Next-Origin`` header, falling back to the posted form origin, so a
+``done`` step can hand the path to ``morph(page=)`` for a server out-of-band swap.
+It stays importable from ``next.partial`` but sits in the Advanced tier, the canonical
+done choreography addresses the foreign zone through ``morph(page=, url_kwargs=)``.
+``OriginSource``, which discriminates the two sources, lives in ``next.partial.origin``.
 
 .. autofunction:: next.partial.resolve_partial_origin
 
-.. autoclass:: next.partial.OriginSource
+.. autoclass:: next.partial.origin.OriginSource
    :members:
 
 .. autoclass:: next.partial.origin.PartialOrigin
@@ -176,13 +186,16 @@ Subclass it and serialise a different envelope shape to support another wire for
 Exceptions
 ~~~~~~~~~~
 
+``UnknownZoneError`` and ``ForeignPageNotAuthorizedError`` are curated ``next.partial``
+exceptions.
 ``UnknownZoneError`` is raised when a partial request names a zone the template does not
 declare, surfacing as a 400 before any render.
 ``ForeignPageNotAuthorizedError`` is raised when an out-of-band morph of a foreign page
 fails that page's own authorisation, so a zone never travels in a response the page would
 have denied.
-The remaining eight guard the custom-verb contract, the event-name and dedupe
-vocabularies, and the foreign-page and href rules, and live in ``next.partial.patches``.
+The remaining eight are rarely caught and stay out of the curated surface.
+They guard the custom-verb contract, the event-name and dedupe vocabularies, and the
+foreign-page and href rules, and live in ``next.partial.patches``.
 
 .. autoexception:: next.partial.UnknownZoneError
    :members:

--- a/docs/content/topics/partial-rendering/done-choreographies.rst
+++ b/docs/content/topics/partial-rendering/done-choreographies.rst
@@ -66,11 +66,12 @@ The cost is one extra GET after the modal closes, which the dialog animation hid
 Server OOB Through Page Addressing
 ----------------------------------
 
-The alternative.
+The canonical server-driven done choreography.
 The wizard puts the morph of the list's zone into its own response, so one envelope closes the layer, refreshes the list, and shows the toast.
 
-This addresses a zone of a foreign page.
+This addresses a zone of a foreign page through ``morph(page=, url_kwargs=)``, the one path the server takes to refresh a host-page zone from a ``done`` step.
 The builder takes ``page=`` and ``url_kwargs=`` alongside ``zone=``, and the request carries ``X-Next-Origin`` with the path of the page that hosts the layer.
+``resolve_partial_origin`` is the thin helper that reads that header back into the ``page_path`` and ``url_kwargs`` the morph needs, nothing more.
 
 .. code-block:: python
    :caption: request/[step]/page.py

--- a/docs/content/topics/partial-rendering/reference.rst
+++ b/docs/content/topics/partial-rendering/reference.rst
@@ -295,13 +295,21 @@ The ``next:mounted``, ``next:removed``, and ``next:morph-*`` node events live on
        still mounted what did change. Observe ``ok``, not the bare fact of apply.
    * - ``partial:error``
      - No
-     - ``{status, body, error, kind}``, where ``kind`` is one of ``network``,
-       ``http``, ``parse``, ``op``, ``asset``. ``network`` is a fetch reject, an
-       aborted neighbour, or a dropped stream connection. ``http`` is a 4xx or
-       5xx or a mutating reply that is not an envelope. ``parse`` is a malformed
-       JSON body. ``op`` is a thrown or unknown verb mid-apply. ``asset`` is a
-       stylesheet that failed to load or a version mismatch surviving a reload.
-       An ``AbortError`` does not reach it.
+     - A discriminated union on ``kind``, where each cause carries only its own
+       fields.
+       ``{kind: "network", error}`` is a fetch reject or a dropped stream
+       connection, with no status or body to report.
+       ``{kind: "http", status, body}`` is a 5xx or a mutating reply that is not
+       an envelope.
+       ``{kind: "parse", body, error}`` is a malformed JSON body.
+       ``{kind: "op", op, error}`` is a thrown or unknown verb mid-apply, where
+       ``op`` names the verb.
+       ``{kind: "asset", error, url?}`` is a stylesheet that failed to load or a
+       version mismatch surviving a reload, where ``url`` is present only on a
+       version mismatch.
+       The ``status`` and ``body`` fields belong to ``http`` alone, and ``body``
+       also to ``parse``, so a listener branches on ``kind`` before reading them.
+       An ``AbortError`` never reaches this event.
    * - ``partial:layer-opened``
      - No
      - ``{opener}``

--- a/examples/live-polls/polls/signals.py
+++ b/examples/live-polls/polls/signals.py
@@ -4,7 +4,7 @@ from django.dispatch import receiver
 from django.http import HttpRequest
 
 from next.forms.signals import action_dispatched
-from next.partial import REQUEST_ID
+from next.partial.headers import REQUEST_ID
 from next.static import StaticCollector
 from next.static.assets import StaticAsset
 from next.static.signals import collector_finalized

--- a/examples/live-polls/tests/test_e2e.py
+++ b/examples/live-polls/tests/test_e2e.py
@@ -16,7 +16,7 @@ from polls.broker import (
 from polls.models import Choice, Poll
 
 from next.forms.signals import action_dispatched, form_validation_failed
-from next.partial import REQUEST_ID
+from next.partial.headers import REQUEST_ID
 from next.testing import (
     NextClient,
     SignalRecorder,

--- a/next/client/apply.test.ts
+++ b/next/client/apply.test.ts
@@ -192,6 +192,8 @@ describe("Applier verbs", () => {
     expect(document.querySelector('[data-next-zone="z"]')!.textContent).toBe("new");
     const err = dispatched.find((d) => d.event === "partial:error");
     expect(err!.detail.kind).toBe("op");
+    expect(err!.detail.op).toBe("frobnicate");
+    expect((err!.detail.error as Error).message).toBe("unknown op frobnicate");
   });
 
   it("marks partial:applied as degraded when an unknown op is skipped", () => {
@@ -260,6 +262,7 @@ describe("Applier verbs", () => {
     const err = dispatched.find((d) => d.event === "partial:error");
     expect((err!.detail.error as Error).message).toBe("op blew up");
     expect(err!.detail.kind).toBe("op");
+    expect(err!.detail.op).toBe("boom");
     const applied = dispatched.find((d) => d.event === "partial:applied");
     expect(applied!.detail.ok).toBe(false);
   });

--- a/next/client/apply.ts
+++ b/next/client/apply.ts
@@ -452,7 +452,7 @@ export class Applier {
         if (!this.#applyOp(op, state)) ok = false;
       } catch (error) {
         ok = false;
-        this.#emit("partial:error", { status: 0, body: "", error, kind: "op" }, false);
+        this.#emit("partial:error", { kind: "op", op: op.op, error }, false);
       }
     }
     if (envelope.csrf) this.#rotateCsrf(envelope.csrf);
@@ -496,7 +496,7 @@ export class Applier {
     // An unknown verb is a single skipped op, never a poisoned envelope.
     this.#emit(
       "partial:error",
-      { status: 0, body: "", error: new Error(`unknown op ${patch.op}`), kind: "op" },
+      { kind: "op", op: patch.op, error: new Error(`unknown op ${patch.op}`) },
       false,
     );
     return false;

--- a/next/client/assets.test.ts
+++ b/next/client/assets.test.ts
@@ -183,6 +183,7 @@ describe("version safeguard and reload-once", () => {
     expect(second.assets.versionMismatch("v2", "/here/")).toBe(true);
     const err = second.dispatched.find((d) => d.event === "partial:error");
     expect(err!.detail.kind).toBe("asset");
+    expect(err!.detail.url).toBe("/here/");
     expect(navigate).toHaveBeenCalledTimes(1);
   });
 

--- a/next/client/assets.ts
+++ b/next/client/assets.ts
@@ -140,10 +140,8 @@ export function createAssets(deps: AssetsDeps): Assets {
       // ops still run, partial:error reports the styling gap.
       if (errored) {
         deps.dispatch("partial:error", {
-          status: 0,
-          body: "",
-          error: new Error("a stylesheet failed to load"),
           kind: "asset",
+          error: new Error("a stylesheet failed to load"),
         });
       }
       done();
@@ -176,10 +174,9 @@ export function createAssets(deps: AssetsDeps): Assets {
       // CDN is serving the old bundle. Degrade to plain navigation, no loop.
       clearFlag();
       deps.dispatch("partial:error", {
-        status: 0,
-        body: "",
-        error: new Error("asset version mismatch after reload"),
         kind: "asset",
+        url,
+        error: new Error("asset version mismatch after reload"),
       });
       return true;
     }

--- a/next/client/next.ts
+++ b/next/client/next.ts
@@ -11,13 +11,23 @@ import type { Envelope } from "./apply";
 // csrf meta merge into.
 export type NextContext = Readonly<Record<string, unknown>>;
 
-// The nature of a partial:error, so a listener branches on the cause rather than
-// sniffing status and body. network is a fetch reject, an abort neighbour, or a
-// dropped SSE connection (status 0). http is a 4xx/5xx or a mutating reply that
-// is not an envelope. parse is a malformed JSON body. op is a thrown or unknown
-// verb mid-apply. asset is a stylesheet that failed to load or a version
-// mismatch surviving a reload.
-export type PartialErrorKind = "network" | "http" | "parse" | "op" | "asset";
+// A partial:error as a discriminated union on kind, so a listener branches on
+// the cause and reads only the fields that cause carries. network is a fetch
+// reject or a dropped SSE connection, with no status or body to report. http is
+// a 5xx or a mutating reply that is not an envelope, carrying the status and
+// body. parse is a malformed JSON body. op is a thrown or unknown verb mid-apply,
+// naming the verb. asset is a stylesheet that failed to load or a version
+// mismatch surviving a reload, optionally naming the url.
+export type PartialError =
+  | { kind: "network"; error: unknown }
+  | { kind: "http"; status: number; body: string }
+  | { kind: "parse"; body: string; error: unknown }
+  | { kind: "op"; op: string; error: unknown }
+  | { kind: "asset"; url?: string; error: unknown };
+
+// The discriminant of PartialError, kept as a named alias for listeners that
+// switch on the kind before reading the cause-specific fields.
+export type PartialErrorKind = PartialError["kind"];
 
 // The payload of every runtime event reaching the Next.on bus, keyed by event
 // name, so a known event types its listener argument. This is only the bus
@@ -36,12 +46,7 @@ export interface NextEventMap {
   // ok is false when any op threw or was an unknown verb, so a listener can tell
   // a clean apply from a degraded one that still mounted what did change.
   "partial:applied": { envelope: Envelope; ok: boolean };
-  "partial:error": {
-    status: number;
-    body: string;
-    error: unknown;
-    kind: PartialErrorKind;
-  };
+  "partial:error": PartialError;
   "partial:layer-opened": { opener: HTMLElement | null };
   "partial:layer-accepted": { result: unknown };
   "partial:layer-dismissed": { reason: string };

--- a/next/client/protocol.ts
+++ b/next/client/protocol.ts
@@ -31,12 +31,10 @@ export const ATTR_ZONE = "data-next-zone";
 export const ATTR_ACTION = "data-next-action";
 export const ATTR_KEY = "data-next-key";
 
-// The wire-body keys the envelope parser reads (version, ops, assets, op, target,
-// html, kind, url, and the rest) mirror next/partial/keys.py, the server-side
-// source of truth. They are inlined as string literals at their read sites rather
-// than centralised here because moving them into shared constants is the 0.9 sync
-// step, not this freeze. A rename on either side is a wire break and the two must
-// move in lockstep.
+// The wire-body keys the envelope parser reads mirror next/partial/keys.py, the
+// server-side source of truth, so a rename on either side is a wire break and the
+// two move in lockstep. They stay inlined as string literals here rather than
+// shared constants until the 0.9 sync step.
 
 // The boundary predicates the wire parsers share. Several modules narrow an
 // unknown JSON value the same way, so the checks live here next to the wire

--- a/next/client/protocol.ts
+++ b/next/client/protocol.ts
@@ -31,6 +31,13 @@ export const ATTR_ZONE = "data-next-zone";
 export const ATTR_ACTION = "data-next-action";
 export const ATTR_KEY = "data-next-key";
 
+// The wire-body keys the envelope parser reads (version, ops, assets, op, target,
+// html, kind, url, and the rest) mirror next/partial/keys.py, the server-side
+// source of truth. They are inlined as string literals at their read sites rather
+// than centralised here because moving them into shared constants is the 0.9 sync
+// step, not this freeze. A rename on either side is a wire break and the two must
+// move in lockstep.
+
 // The boundary predicates the wire parsers share. Several modules narrow an
 // unknown JSON value the same way, so the checks live here next to the wire
 // vocabulary rather than being copied per module.

--- a/next/client/sse.ts
+++ b/next/client/sse.ts
@@ -131,7 +131,7 @@ export function createSse(deps: SseDeps): Sse {
     try {
       raw = JSON.parse(data);
     } catch (error) {
-      deps.dispatch("partial:error", { status: 0, body: data, error, kind: "parse" });
+      deps.dispatch("partial:error", { kind: "parse", body: data, error });
       return;
     }
     if (isRecord(raw)) {
@@ -163,12 +163,7 @@ export function createSse(deps: SseDeps): Sse {
     if (!fatal) return;
     connection.control.close();
     connections.delete(connection.url);
-    deps.dispatch("partial:error", {
-      status: 0,
-      body: "",
-      error: null,
-      kind: "network",
-    });
+    deps.dispatch("partial:error", { kind: "network", error: null });
   }
 
   // Open a stream to a url, carrying over the bound zones and page URL of a

--- a/next/client/wire.test.ts
+++ b/next/client/wire.test.ts
@@ -189,9 +189,10 @@ describe("Wire classification", () => {
     });
     await h.wire.fetch({ url: "/list/", zone: "z" });
     const err = h.dispatched.find((d) => d.event === "partial:error");
-    expect(err!.detail.status).toBe(0);
-    expect(err!.detail.error).toBeInstanceOf(TypeError);
     expect(err!.detail.kind).toBe("network");
+    expect(err!.detail.error).toBeInstanceOf(TypeError);
+    expect(err!.detail.status).toBeUndefined();
+    expect(err!.detail.body).toBeUndefined();
   });
 
   it("emits partial:error on malformed JSON", async () => {

--- a/next/client/wire.ts
+++ b/next/client/wire.ts
@@ -213,7 +213,7 @@ export class Wire {
     } catch (error) {
       // AbortError is never an error: the user moved on, no toast, no event.
       if (isAbortError(error)) return;
-      this.#dispatch("partial:error", { status: 0, body: "", error, kind: "network" });
+      this.#dispatch("partial:error", { kind: "network", error });
       return;
     }
     // A stale safe-GET response that lost its race is dropped silently.
@@ -238,10 +238,9 @@ export class Wire {
     if (response.status >= 500) {
       const body = await this.#text(response);
       this.#dispatch("partial:error", {
+        kind: "http",
         status: response.status,
         body,
-        error: null,
-        kind: "http",
       });
       return;
     }
@@ -266,10 +265,9 @@ export class Wire {
       }
       const body = await this.#text(response);
       this.#dispatch("partial:error", {
+        kind: "http",
         status: response.status,
         body,
-        error: null,
-        kind: "http",
       });
       return;
     }
@@ -278,12 +276,7 @@ export class Wire {
     try {
       raw = JSON.parse(body);
     } catch (error) {
-      this.#dispatch("partial:error", {
-        status: response.status,
-        body,
-        error,
-        kind: "parse",
-      });
+      this.#dispatch("partial:error", { kind: "parse", body, error });
       return;
     }
     this.#onEnvelope(raw, response, snapshot, request.key);

--- a/next/partial/__init__.py
+++ b/next/partial/__init__.py
@@ -2,57 +2,34 @@
 
 from . import signals
 from .backends import PartialProtocolBackend
-from .headers import (
-    REQUEST_ID,
-    is_partial_request,
-    partial_intent,
-)
-from .origin import OriginSource, resolve_partial_origin
+from .headers import is_partial_request, partial_intent
+from .origin import resolve_partial_origin
 from .patches import (
     Asset,
-    BuiltinPatchOpError,
-    CrossSiteHrefError,
-    DynamicForeignPageError,
     Envelope,
     ForeignPageNotAuthorizedError,
     FormMeta,
     Patch,
     Patches,
     PatchResponse,
-    ReservedEventNameError,
-    ReservedPatchKeyError,
-    UnknownContextNameError,
-    UnknownDedupeError,
-    UnknownPatchOpError,
 )
-from .registry import ZoneInfo, register_patch_op, zone_requested, zones_of
+from .registry import register_patch_op, zone_requested
 from .render import UnknownZoneError, ZoneRenderResult, render_zone
 from .shaping import shape_partial
 from .sse import PatchEventStream
 
 
 __all__ = [
-    "REQUEST_ID",
     "Asset",
-    "BuiltinPatchOpError",
-    "CrossSiteHrefError",
-    "DynamicForeignPageError",
     "Envelope",
     "ForeignPageNotAuthorizedError",
     "FormMeta",
-    "OriginSource",
     "PartialProtocolBackend",
     "Patch",
     "PatchEventStream",
     "PatchResponse",
     "Patches",
-    "ReservedEventNameError",
-    "ReservedPatchKeyError",
-    "UnknownContextNameError",
-    "UnknownDedupeError",
-    "UnknownPatchOpError",
     "UnknownZoneError",
-    "ZoneInfo",
     "ZoneRenderResult",
     "is_partial_request",
     "partial_intent",
@@ -62,5 +39,4 @@ __all__ = [
     "shape_partial",
     "signals",
     "zone_requested",
-    "zones_of",
 ]

--- a/next/partial/checks.py
+++ b/next/partial/checks.py
@@ -56,6 +56,7 @@ W_WITH_OVER_ZONE: Final = "next.W067"
 W_FORM_BACKEND_NOT_AWARE: Final = "next.W068"
 W_MANIFEST_VERSION_NO_STORAGE: Final = "next.W069"
 W_FORM_IN_FOR_NO_KEY: Final = "next.W070"
+W_TOO_MANY_BACKENDS: Final = "next.W071"
 
 _MIN_DUPLICATE_COUNT: Final = 2
 _FORM_TARGET_ATTR: Final = "data-next-target"
@@ -74,6 +75,7 @@ CHECK_IDS: Final = (
     W_FORM_BACKEND_NOT_AWARE,
     W_MANIFEST_VERSION_NO_STORAGE,
     W_FORM_IN_FOR_NO_KEY,
+    W_TOO_MANY_BACKENDS,
 )
 
 
@@ -500,6 +502,33 @@ def _partial_backends_active() -> bool:
     )
 
 
+@register(Tags.compatibility)
+def check_single_partial_backend(
+    *_args: object,
+    **_kwargs: object,
+) -> list[CheckMessage]:
+    """Warn when more than one partial protocol backend is configured (`next.W071`).
+
+    Partial rendering uses a single protocol backend. Only the first valid
+    PARTIAL_BACKENDS entry is instantiated, so a second entry is dead config
+    that silently never runs.
+    """
+    configs = getattr(next_framework_settings, "PARTIAL_BACKENDS", [])
+    if not isinstance(configs, list):
+        return []
+    valid = [config for config in configs if isinstance(config, dict)]
+    if len(valid) <= 1:
+        return []
+    return [
+        DjangoWarning(
+            "PARTIAL_BACKENDS has more than one backend entry, but partial "
+            "rendering uses a single protocol backend. Only the first entry "
+            "runs, the rest are ignored. Keep one PARTIAL_BACKENDS entry.",
+            id=W_TOO_MANY_BACKENDS,
+        )
+    ]
+
+
 _VERSION_OPTION: Final = "VERSION"
 _MANIFEST_VERSION: Final = "manifest"
 _STATICFILES_ALIAS: Final = "staticfiles"
@@ -592,6 +621,7 @@ __all__ = [
     "W_FORM_BACKEND_NOT_AWARE",
     "W_FORM_IN_FOR_NO_KEY",
     "W_MANIFEST_VERSION_NO_STORAGE",
+    "W_TOO_MANY_BACKENDS",
     "W_WITH_OVER_ZONE",
     "check_custom_patch_ops_well_formed",
     "check_duplicate_zone_names",
@@ -600,6 +630,7 @@ __all__ = [
     "check_manifest_version_has_manifest_storage",
     "check_no_zone_in_component",
     "check_repeated_form_has_key",
+    "check_single_partial_backend",
     "check_with_directly_over_zone",
     "check_zone_name_is_slug",
     "check_zone_not_in_if",

--- a/next/partial/keys.py
+++ b/next/partial/keys.py
@@ -1,0 +1,53 @@
+"""Wire-key constants shared by the patch serializer and the test envelope view.
+
+These names are the frozen partial wire contract. The TypeScript runtime mirrors
+them in next/client/protocol.ts and the per-op fields in next/client/apply.ts, so
+a change here is a wire break that must move in lockstep with the client.
+"""
+
+from typing import Final
+
+
+VERSION: Final = "version"
+OPS: Final = "ops"
+ASSETS: Final = "assets"
+FORM: Final = "form"
+CSRF: Final = "csrf"
+REQUEST_ID: Final = "request_id"
+
+OP: Final = "op"
+TARGET: Final = "target"
+HTML: Final = "html"
+
+KIND: Final = "kind"
+URL: Final = "url"
+
+UID: Final = "uid"
+VALID: Final = "valid"
+ERRORS: Final = "errors"
+
+ZONE: Final = "zone"
+FORM_SELECTOR: Final = "form"
+
+RESERVED_PATCH_KEYS: Final[frozenset[str]] = frozenset({OP, TARGET, HTML})
+
+
+__all__ = [
+    "ASSETS",
+    "CSRF",
+    "ERRORS",
+    "FORM",
+    "FORM_SELECTOR",
+    "HTML",
+    "KIND",
+    "OP",
+    "OPS",
+    "REQUEST_ID",
+    "RESERVED_PATCH_KEYS",
+    "TARGET",
+    "UID",
+    "URL",
+    "VALID",
+    "VERSION",
+    "ZONE",
+]

--- a/next/partial/manager.py
+++ b/next/partial/manager.py
@@ -42,7 +42,11 @@ class PartialProtocolFactory:
 
 
 class PartialBackendManager:
-    """Lazily instantiates the first configured protocol backend."""
+    """Lazily instantiates the single configured protocol backend.
+
+    Only the first valid PARTIAL_BACKENDS entry is used, a second entry is
+    reported by next.W071.
+    """
 
     def __init__(self) -> None:
         """Initialise an empty backend cache."""

--- a/next/partial/patches.py
+++ b/next/partial/patches.py
@@ -235,12 +235,7 @@ class Patch:
     extras: "Mapping[str, Any]" = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Refuse an extras payload that names a structural wire key.
-
-        The `op`, `target`, and `html` keys carry the patch structure, so a
-        payload that names one of them is refused at construction rather than
-        silently overwriting the structural key on serialization.
-        """
+        """Refuse an extras payload that names a structural wire key."""
         collision = keys.RESERVED_PATCH_KEYS & self.extras.keys()
         if collision:
             raise ReservedPatchKeyError(self.op, frozenset(collision))

--- a/next/partial/patches.py
+++ b/next/partial/patches.py
@@ -12,6 +12,7 @@ from next.forms.origin import resolve_origin, resolve_url_to_page
 from next.pages import page
 from next.static.serializers import resolve_serializer
 
+from . import keys
 from .headers import (
     CONTENT_TYPE,
     RESPONSE_VERSION,
@@ -34,7 +35,6 @@ if TYPE_CHECKING:
 
 
 _SEE_OTHER = 303
-_RESERVED_PATCH_KEYS: frozenset[str] = frozenset({"op", "target", "html"})
 
 # Each morph() route owns its selector keywords, so a stray key is refused.
 _ZONE_MORPH_KEYS: frozenset[str] = frozenset({"zone", "overrides"})
@@ -234,21 +234,24 @@ class Patch:
     html: str | None = None
     extras: "Mapping[str, Any]" = field(default_factory=dict)
 
-    def as_dict(self) -> dict[str, Any]:
-        """Return the wire form of the patch as an ordered mapping.
+    def __post_init__(self) -> None:
+        """Refuse an extras payload that names a structural wire key.
 
-        The `op`, `target`, and `html` keys are reserved for the structural
-        wire fields, so an extras payload that names one of them is refused
-        rather than silently overwriting the structural key.
+        The `op`, `target`, and `html` keys carry the patch structure, so a
+        payload that names one of them is refused at construction rather than
+        silently overwriting the structural key on serialization.
         """
-        collision = _RESERVED_PATCH_KEYS & self.extras.keys()
+        collision = keys.RESERVED_PATCH_KEYS & self.extras.keys()
         if collision:
             raise ReservedPatchKeyError(self.op, frozenset(collision))
-        data: dict[str, Any] = {"op": self.op}
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the wire form of the patch as an ordered mapping."""
+        data: dict[str, Any] = {keys.OP: self.op}
         if self.target is not None:
-            data["target"] = dict(self.target)
+            data[keys.TARGET] = dict(self.target)
         if self.html is not None:
-            data["html"] = self.html
+            data[keys.HTML] = self.html
         data.update(self.extras)
         return data
 
@@ -262,7 +265,7 @@ class Asset:
 
     def as_dict(self) -> dict[str, str]:
         """Return the wire form of the asset entry."""
-        return {"kind": self.kind, "url": self.url}
+        return {keys.KIND: self.kind, keys.URL: self.url}
 
 
 @dataclass(frozen=True, slots=True)
@@ -276,9 +279,9 @@ class FormMeta:
     def as_dict(self) -> dict[str, Any]:
         """Return the wire form of the form meta object."""
         return {
-            "uid": self.uid,
-            "valid": self.valid,
-            "errors": {name: list(msgs) for name, msgs in self.errors.items()},
+            keys.UID: self.uid,
+            keys.VALID: self.valid,
+            keys.ERRORS: {name: list(msgs) for name, msgs in self.errors.items()},
         }
 
 
@@ -301,15 +304,15 @@ class Envelope:
     def as_dict(self) -> dict[str, Any]:
         """Return the wire form of the envelope as an ordered mapping."""
         data: dict[str, Any] = {
-            "version": self.version,
-            "ops": [op.as_dict() for op in self.ops],
-            "assets": [asset.as_dict() for asset in self.assets],
-            "form": self.form.as_dict() if self.form is not None else None,
+            keys.VERSION: self.version,
+            keys.OPS: [op.as_dict() for op in self.ops],
+            keys.ASSETS: [asset.as_dict() for asset in self.assets],
+            keys.FORM: self.form.as_dict() if self.form is not None else None,
         }
         if self.csrf is not None:
-            data["csrf"] = dict(self.csrf)
+            data[keys.CSRF] = dict(self.csrf)
         if self.request_id is not None:
-            data["request_id"] = self.request_id
+            data[keys.REQUEST_ID] = self.request_id
         return data
 
 
@@ -351,6 +354,7 @@ class Patches:
         self._request_id: str | None = echo_of
         self._origin: OriginMatch | None = None
         self._origin_resolved = False
+        self._render_context: dict[str, object] | None = None
 
     @property
     def version(self) -> str:
@@ -454,7 +458,7 @@ class Patches:
         """Render the named zone of the origin page and morph it in place."""
         result = self._render_zone(zone, overrides)
         self._collect_assets(result)
-        return self._append_morph({"zone": zone}, result.html[zone], extract=False)
+        return self._append_morph({keys.ZONE: zone}, result.html[zone], extract=False)
 
     def morph_foreign_zone(
         self,
@@ -485,7 +489,7 @@ class Patches:
             raise DynamicForeignPageError(foreign_path)
         result = self._render_foreign_zone(foreign_path, zone, request, kwargs)
         self._collect_assets(result)
-        return self._append_morph({"zone": zone}, result.html[zone], extract=False)
+        return self._append_morph({keys.ZONE: zone}, result.html[zone], extract=False)
 
     def _foreign_page_path(self, page: "Path | str") -> "Path":
         """Return the page path named by a path or a URL of the foreign page."""
@@ -526,7 +530,7 @@ class Patches:
 
     def morph_form(self, uid: str, html: str) -> "Patches":
         """Extract-morph the form addressed by its uid into the given HTML."""
-        return self._append_morph({"form": uid}, html, extract=True)
+        return self._append_morph({keys.FORM_SELECTOR: uid}, html, extract=True)
 
     def replace(self, target: "Mapping[str, Any]", html: str) -> "Patches":
         """Replace the target node wholesale with the given HTML."""
@@ -585,7 +589,7 @@ class Patches:
 
     def refresh(self, *, zone: str) -> "Patches":
         """Ask the client to refetch the named zone with its own cookies."""
-        self._ops.append(Patch(op="refresh", extras={"zone": zone}))
+        self._ops.append(Patch(op="refresh", extras={keys.ZONE: zone}))
         return self
 
     def context(self, **names: object) -> "Patches":
@@ -798,6 +802,21 @@ class Patches:
         match = self._origin_match()
         return dict(match.url_kwargs) if match is not None else {}
 
+    def _origin_render_context(self) -> dict[str, object]:
+        """Return the origin page render context, built once per builder.
+
+        A handler that pairs `context()` with `morph(zone=...)` resolves the
+        origin context through both paths, so the build is memoised and a
+        fresh copy is handed out because consumers mutate the mapping.
+        """
+        if self._render_context is None:
+            self._render_context = page.build_render_context(
+                self._resolve_page_path(),
+                self._require_request(),
+                **self._origin_url_kwargs(),
+            )
+        return dict(self._render_context)
+
     def _render_zone(
         self,
         zone: str,
@@ -810,15 +829,12 @@ class Patches:
             self._require_request(),
             url_kwargs=self._origin_url_kwargs(),
             overrides=dict(overrides) if overrides else None,
+            context_data=self._origin_render_context(),
         )
 
     def _serializable_names(self) -> frozenset[str]:
         """Return the serialize=True provider names of the origin page."""
-        request = self._require_request()
-        context_data = page.build_render_context(
-            self._resolve_page_path(), request, **self._origin_url_kwargs()
-        )
-        js_context = context_data.get("_next_js_context", {})
+        js_context = self._origin_render_context().get("_next_js_context", {})
         return frozenset(js_context) if isinstance(js_context, dict) else frozenset()
 
     def _collect_assets(self, result: "ZoneRenderResult") -> None:

--- a/next/partial/patches.py
+++ b/next/partial/patches.py
@@ -72,11 +72,11 @@ class ReservedPatchKeyError(ValueError):
     payload that names one of them is refused rather than overwriting it.
     """
 
-    def __init__(self, op: str, keys: frozenset[str]) -> None:
+    def __init__(self, op: str, reserved: frozenset[str]) -> None:
         """Store the offending verb and the reserved keys it collided with."""
         self.op = op
-        self.keys = keys
-        names = ", ".join(sorted(keys))
+        self.keys = reserved
+        names = ", ".join(sorted(reserved))
         super().__init__(
             f'Patch op "{op}" payload names the reserved wire key(s) {names}. '
             "Use a different payload key, op/target/html are structural."
@@ -622,7 +622,7 @@ class Patches:
         """
         extras: dict[str, Any] = {}
         if zone is not None:
-            extras["zone"] = zone
+            extras[keys.ZONE] = zone
         if href is not None:
             extras["href"] = self._require_same_site(href)
         self._ops.append(Patch(op="layer.open", extras=extras))

--- a/next/partial/render.py
+++ b/next/partial/render.py
@@ -70,15 +70,19 @@ def render_zone(
     request: "HttpRequest",
     url_kwargs: dict[str, object] | None = None,
     overrides: dict[str, object] | None = None,
+    *,
+    context_data: dict[str, object] | None = None,
 ) -> ZoneRenderResult:
     """Render the named zones of a page with the full page context.
 
     The context is collected once for the whole batch of names through
     `build_render_context` and a fresh collector is seeded by the same
     convention as the canonical render path, so co-located assets of the
-    zone bodies are gathered. The manifest travels outward in the result
-    rather than through inject, which is a no-op for fragments. An
-    unknown zone name raises before any body renders.
+    zone bodies are gathered. A caller that already built the origin context
+    passes it as `context_data` so it is reused rather than rebuilt. The
+    manifest travels outward in the result rather than through inject, which
+    is a no-op for fragments. An unknown zone name raises before any body
+    renders.
     """
     start = time.perf_counter()
     kwargs = url_kwargs or {}
@@ -88,7 +92,8 @@ def render_zone(
         if name not in zones:
             raise UnknownZoneError(name, tuple(sorted(zones)))
 
-    context_data = page.build_render_context(page_path, request, **kwargs)
+    if context_data is None:
+        context_data = page.build_render_context(page_path, request, **kwargs)
     if overrides:
         context_data.update(overrides)
 

--- a/next/partial/shaping.py
+++ b/next/partial/shaping.py
@@ -16,6 +16,7 @@ from next.forms.uid import FORM_ORIGIN_OVERRIDE_KEY
 from next.pages import page
 from next.static.scripts import csrf_payload
 
+from . import keys
 from .headers import RESPONSE_ACTION, RESPONSE_FORM, partial_intent, set_partial_vary
 from .manager import partial_backend_manager
 from .patches import FormMeta, Patches, PatchResponse
@@ -120,7 +121,7 @@ def shape_validate(
             page_path,
             url_kwargs,
         )
-        patches.morph({"form": uid}, html, extract=True)
+        patches.morph({keys.FORM_SELECTOR: uid}, html, extract=True)
     patches.set_form(_form_meta(uid, form))
     _stamp_csrf(request, patches, rotated=rotated)
     _emit_field_validated(request, action, requested, form)
@@ -170,7 +171,7 @@ def _shape_invalid(
             outcome.page_path,
             outcome.url_kwargs,
         )
-        patches.morph({"form": uid}, html, extract=True)
+        patches.morph({keys.FORM_SELECTOR: uid}, html, extract=True)
     if form is not None:
         patches.set_form(_form_meta(uid, form))
     response = _envelope_response(patches, request=request, rotated=rotated)
@@ -231,7 +232,7 @@ def _shape_advance(
         result = render_zone(
             page_path, (zone,), request, url_kwargs=url_kwargs, overrides=overrides
         )
-        patches.morph({"zone": zone}, result.html[zone])
+        patches.morph({keys.ZONE: zone}, result.html[zone])
     if _should_push_steps(wizard):
         patches.push_url(redirect_to)
     return _envelope_response(patches, request=request, rotated=rotated)
@@ -310,7 +311,7 @@ def _success_funnel(
             page_path,
             url_kwargs,
         )
-        patches.morph({"form": uid}, html, extract=True)
+        patches.morph({keys.FORM_SELECTOR: uid}, html, extract=True)
     drain_messages(request, patches)
     return _envelope_response(patches, request=request, rotated=rotated)
 

--- a/next/partial/shaping.py
+++ b/next/partial/shaping.py
@@ -16,7 +16,7 @@ from next.forms.uid import FORM_ORIGIN_OVERRIDE_KEY
 from next.pages import page
 from next.static.scripts import csrf_payload
 
-from .headers import RESPONSE_ACTION, RESPONSE_FORM, partial_intent
+from .headers import RESPONSE_ACTION, RESPONSE_FORM, partial_intent, set_partial_vary
 from .manager import partial_backend_manager
 from .patches import FormMeta, Patches, PatchResponse
 from .registry import zones_of
@@ -199,12 +199,18 @@ def _shape_advance(
     wizard = outcome.wizard
     redirect_to = outcome.redirect_to
     if redirect_to is None:
-        return HttpResponse(status=204)
+        response = HttpResponse(status=204)
+        set_partial_vary(response)
+        return response
     if wizard is None:
-        return HttpResponseRedirect(redirect_to)
+        response = HttpResponseRedirect(redirect_to)
+        set_partial_vary(response)
+        return response
     target = _resolve_step_target(request, redirect_to)
     if target is None:
-        return HttpResponseRedirect(redirect_to)
+        response = HttpResponseRedirect(redirect_to)
+        set_partial_vary(response)
+        return response
     page_path, url_kwargs = target
     next_wizard = type(wizard)(
         request=request,

--- a/next/partial/view.py
+++ b/next/partial/view.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from django.http import HttpResponse
 
+from . import keys
 from .headers import MergeMode, set_partial_vary
 from .manager import partial_backend_manager
 from .patches import Asset, Envelope, Patches, PatchResponse
@@ -93,7 +94,7 @@ def _patch_zone(
     merge: "MergeMode | None",
 ) -> None:
     """Patch one zone in place, morphing it or merging deduplicated children."""
-    target = {"zone": name}
+    target = {keys.ZONE: name}
     if merge is MergeMode.APPEND:
         patches.append(target, html)
     elif merge is MergeMode.PREPEND:

--- a/next/testing/client.py
+++ b/next/testing/client.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 from django.test import Client
 
 from next.forms.uid import ORIGIN_FIELD_NAME
+from next.partial import keys
 from next.partial.headers import CONTENT_TYPE, REQUEST_FLAG, VERSION, ZONE
 
 from .actions import resolve_action_url
@@ -37,56 +38,57 @@ class PartialEnvelope:
     @property
     def version(self) -> str:
         """Return the asset version stamped in the envelope."""
-        return cast("str", self.data["version"])
+        return cast("str", self.data[keys.VERSION])
 
     @property
     def ops(self) -> list[dict[str, Any]]:
         """Return the ordered list of op objects."""
-        return cast("list[dict[str, Any]]", self.data.get("ops", []))
+        return cast("list[dict[str, Any]]", self.data.get(keys.OPS, []))
 
     @property
     def assets(self) -> list[dict[str, Any]]:
         """Return the asset manifest entries."""
-        return cast("list[dict[str, Any]]", self.data.get("assets", []))
+        return cast("list[dict[str, Any]]", self.data.get(keys.ASSETS, []))
 
     def op_verbs(self) -> list[str]:
         """Return the verb of every op in order."""
-        return [op["op"] for op in self.ops]
+        return [op[keys.OP] for op in self.ops]
 
     def targets(self) -> list[dict[str, Any] | None]:
         """Return the target object of every op in order."""
-        return [op.get("target") for op in self.ops]
+        return [op.get(keys.TARGET) for op in self.ops]
 
     def zone_targets(self) -> list[str]:
         """Return the zone name of every op that addresses a zone, in order."""
         return [
-            op["target"]["zone"]
+            op[keys.TARGET][keys.ZONE]
             for op in self.ops
-            if isinstance(op.get("target"), dict) and "zone" in op["target"]
+            if isinstance(op.get(keys.TARGET), dict) and keys.ZONE in op[keys.TARGET]
         ]
 
     def form_targets(self) -> list[str]:
         """Return the form uid of every op that addresses a form, in order."""
         return [
-            op["target"]["form"]
+            op[keys.TARGET][keys.FORM_SELECTOR]
             for op in self.ops
-            if isinstance(op.get("target"), dict) and "form" in op["target"]
+            if isinstance(op.get(keys.TARGET), dict)
+            and keys.FORM_SELECTOR in op[keys.TARGET]
         ]
 
     def form_meta(self) -> dict[str, Any] | None:
         """Return the machine-readable form meta object of the envelope."""
-        return cast("dict[str, Any] | None", self.data.get("form"))
+        return cast("dict[str, Any] | None", self.data.get(keys.FORM))
 
     def toasts(self) -> list[dict[str, Any]]:
         """Return the payload of every toast op in order."""
-        return [op for op in self.ops if op.get("op") == "toast"]
+        return [op for op in self.ops if op.get(keys.OP) == "toast"]
 
     def html_for_zone(self, zone: str) -> str:
         """Return the HTML payload of the op morphing the named zone."""
         for op in self.ops:
-            target = op.get("target")
-            if isinstance(target, dict) and target.get("zone") == zone:
-                return cast("str", op.get("html", ""))
+            target = op.get(keys.TARGET)
+            if isinstance(target, dict) and target.get(keys.ZONE) == zone:
+                return cast("str", op.get(keys.HTML, ""))
         msg = f"no op targets zone {zone!r}"
         raise AssertionError(msg)
 

--- a/tests/partial/test_builder.py
+++ b/tests/partial/test_builder.py
@@ -2,19 +2,21 @@ import pytest
 from django.test import RequestFactory
 
 from next.partial import (
-    BuiltinPatchOpError,
-    CrossSiteHrefError,
     Patches,
     PatchResponse,
+    UnknownZoneError,
+    register_patch_op,
+)
+from next.partial.headers import CONTENT_TYPE
+from next.partial.patches import (
+    BuiltinPatchOpError,
+    CrossSiteHrefError,
     ReservedEventNameError,
     ReservedPatchKeyError,
     UnknownContextNameError,
     UnknownDedupeError,
     UnknownPatchOpError,
-    UnknownZoneError,
-    register_patch_op,
 )
-from next.partial.headers import CONTENT_TYPE
 from next.partial.registry import patch_op_registry
 from tests.support import partial_request, plain_request
 
@@ -269,7 +271,7 @@ class TestCustomOp:
 
     def test_payload_naming_a_reserved_wire_key_raises(self, custom_op: str) -> None:
         with pytest.raises(ReservedPatchKeyError) as exc:
-            Patches("v1").op(custom_op, target="spoof").envelope().ops[0].as_dict()
+            Patches("v1").op(custom_op, target="spoof")
         assert exc.value.keys == frozenset({"target"})
 
 

--- a/tests/partial/test_checks.py
+++ b/tests/partial/test_checks.py
@@ -424,6 +424,47 @@ class TestManifestVersionStorageCheck:
             assert checks.check_manifest_version_has_manifest_storage() == []
 
 
+@contextmanager
+def _partial_backends(configs: object) -> Iterator[None]:
+    """Point the W071 check at the given PARTIAL_BACKENDS config value."""
+    settings_ns = MagicMock()
+    settings_ns.PARTIAL_BACKENDS = configs
+    with patch("next.partial.checks.next_framework_settings", settings_ns):
+        yield
+
+
+_BACKEND_DICT = {"BACKEND": "next.partial.PartialProtocolBackend"}
+
+
+class TestSinglePartialBackendCheck:
+    """`next.W071` warns on more than one valid PARTIAL_BACKENDS entry."""
+
+    def test_two_valid_dicts_warn(self) -> None:
+        with _partial_backends([_BACKEND_DICT, dict(_BACKEND_DICT)]):
+            ids = [m.id for m in checks.check_single_partial_backend()]
+        assert ids == [checks.W_TOO_MANY_BACKENDS]
+
+    def test_one_dict_is_silent(self) -> None:
+        with _partial_backends([_BACKEND_DICT]):
+            assert checks.check_single_partial_backend() == []
+
+    def test_no_backends_is_silent(self) -> None:
+        with _partial_backends([]):
+            assert checks.check_single_partial_backend() == []
+
+    def test_only_invalid_entries_are_silent(self) -> None:
+        with _partial_backends([1, "x"]):
+            assert checks.check_single_partial_backend() == []
+
+    def test_one_dict_one_non_dict_is_silent(self) -> None:
+        with _partial_backends([_BACKEND_DICT, "x"]):
+            assert checks.check_single_partial_backend() == []
+
+    def test_non_list_config_is_silent(self) -> None:
+        with _partial_backends("not-a-list"):
+            assert checks.check_single_partial_backend() == []
+
+
 class TestChecksSilentOnValidComposite:
     """A page with well-formed zones triggers none of the zone checks."""
 

--- a/tests/partial/test_foreign_zone.py
+++ b/tests/partial/test_foreign_zone.py
@@ -3,12 +3,12 @@ from pathlib import Path
 import pytest
 
 from next.partial import (
-    DynamicForeignPageError,
     ForeignPageNotAuthorizedError,
-    OriginSource,
     Patches,
     resolve_partial_origin,
 )
+from next.partial.origin import OriginSource
+from next.partial.patches import DynamicForeignPageError
 from tests.support import partial_request
 
 

--- a/tests/partial/test_init_surface.py
+++ b/tests/partial/test_init_surface.py
@@ -1,0 +1,110 @@
+import pytest
+
+import next.partial
+import next.partial.headers
+import next.partial.origin
+import next.partial.patches
+import next.partial.registry
+from next.partial import (
+    Asset,
+    Envelope,
+    ForeignPageNotAuthorizedError,
+    FormMeta,
+    Patch,
+    Patches,
+    PatchResponse,
+    UnknownZoneError,
+)
+
+
+_CURATED = frozenset(
+    {
+        "Asset",
+        "Envelope",
+        "ForeignPageNotAuthorizedError",
+        "FormMeta",
+        "Patch",
+        "PartialProtocolBackend",
+        "PatchEventStream",
+        "PatchResponse",
+        "Patches",
+        "UnknownZoneError",
+        "ZoneRenderResult",
+        "is_partial_request",
+        "partial_intent",
+        "register_patch_op",
+        "render_zone",
+        "resolve_partial_origin",
+        "shape_partial",
+        "signals",
+        "zone_requested",
+    }
+)
+
+_DEMOTED = {
+    "OriginSource": next.partial.origin,
+    "ZoneInfo": next.partial.registry,
+    "zones_of": next.partial.registry,
+    "REQUEST_ID": next.partial.headers,
+    "BuiltinPatchOpError": next.partial.patches,
+    "CrossSiteHrefError": next.partial.patches,
+    "DynamicForeignPageError": next.partial.patches,
+    "ReservedEventNameError": next.partial.patches,
+    "ReservedPatchKeyError": next.partial.patches,
+    "UnknownContextNameError": next.partial.patches,
+    "UnknownDedupeError": next.partial.patches,
+    "UnknownPatchOpError": next.partial.patches,
+}
+
+
+class TestCuratedSurface:
+    """`next.partial.__all__` is the frozen curated surface."""
+
+    def test_all_matches_curated_set(self) -> None:
+        assert frozenset(next.partial.__all__) == _CURATED
+
+    def test_all_has_no_duplicates(self) -> None:
+        assert len(next.partial.__all__) == len(set(next.partial.__all__))
+
+    @pytest.mark.parametrize("name", sorted(_CURATED))
+    def test_every_curated_name_resolves(self, name: str) -> None:
+        assert getattr(next.partial, name) is not None
+
+
+class TestDemotedNames:
+    """Demoted names leave the facade but stay reachable by submodule."""
+
+    @pytest.mark.parametrize("name", sorted(_DEMOTED))
+    def test_name_not_in_all(self, name: str) -> None:
+        assert name not in next.partial.__all__
+
+    @pytest.mark.parametrize("name", sorted(_DEMOTED))
+    def test_name_not_a_facade_reexport(self, name: str) -> None:
+        assert not hasattr(next.partial, name)
+
+    @pytest.mark.parametrize("name", sorted(_DEMOTED))
+    def test_name_reachable_on_submodule(self, name: str) -> None:
+        assert getattr(_DEMOTED[name], name) is not None
+
+
+class TestFrozenImportPaths:
+    """Value objects and public errors import from the aggregator facade.
+
+    These import paths are frozen against the 0.9 split of the god-module,
+    so the test pins them on `next.partial` rather than `next.partial.patches`.
+    """
+
+    def test_value_objects_import_from_facade(self) -> None:
+        assert Patch is next.partial.patches.Patch
+        assert Envelope is next.partial.patches.Envelope
+        assert Asset is next.partial.patches.Asset
+        assert FormMeta is next.partial.patches.FormMeta
+        assert Patches is next.partial.patches.Patches
+        assert PatchResponse is next.partial.patches.PatchResponse
+
+    def test_public_errors_import_from_facade(self) -> None:
+        assert (
+            ForeignPageNotAuthorizedError
+            is next.partial.patches.ForeignPageNotAuthorizedError
+        )
+        assert UnknownZoneError is not None

--- a/tests/partial/test_keys.py
+++ b/tests/partial/test_keys.py
@@ -1,4 +1,5 @@
-from next.partial import Asset, Envelope, FormMeta, Patch, keys
+from next.partial import Asset, Envelope, FormMeta, Patch, Patches, keys
+from next.partial.view import _patch_zone
 from next.testing.client import PartialEnvelope
 
 
@@ -70,3 +71,25 @@ class TestSerializerEnvelopeShareKeys:
         data = Envelope(version="v1", csrf={"token": "t"}, request_id="r1").as_dict()
         assert data[keys.CSRF] == {"token": "t"}
         assert data[keys.REQUEST_ID] == "r1"
+
+
+class TestProducersWriteTargetSelectorKeys:
+    """Every target/extras producer writes the wire keys from keys.py."""
+
+    def test_view_zone_patch_targets_zone_key(self) -> None:
+        patches = Patches("v1")
+        _patch_zone(patches, "list", "<ul></ul>", None)
+        view = PartialEnvelope(patches.envelope().as_dict())
+        assert view.zone_targets() == ["list"]
+        assert view.targets() == [{keys.ZONE: "list"}]
+
+    def test_morph_form_targets_form_selector_key(self) -> None:
+        patches = Patches("v1").morph_form("ab12", "<form></form>")
+        view = PartialEnvelope(patches.envelope().as_dict())
+        assert view.form_targets() == ["ab12"]
+        assert view.targets() == [{keys.FORM_SELECTOR: "ab12"}]
+
+    def test_layer_open_seeds_zone_extras_key(self) -> None:
+        patches = Patches("v1").layer_open(zone="cart")
+        view = PartialEnvelope(patches.envelope().as_dict())
+        assert view.ops[0][keys.ZONE] == "cart"

--- a/tests/partial/test_keys.py
+++ b/tests/partial/test_keys.py
@@ -1,0 +1,72 @@
+from next.partial import Asset, Envelope, FormMeta, Patch, keys
+from next.testing.client import PartialEnvelope
+
+
+class TestWireKeyConstants:
+    """The wire-key constants carry the frozen literal strings."""
+
+    def test_reserved_patch_keys(self) -> None:
+        assert frozenset({"op", "target", "html"}) == keys.RESERVED_PATCH_KEYS
+
+    def test_envelope_key_values(self) -> None:
+        assert keys.VERSION == "version"
+        assert keys.OPS == "ops"
+        assert keys.ASSETS == "assets"
+        assert keys.FORM == "form"
+        assert keys.CSRF == "csrf"
+        assert keys.REQUEST_ID == "request_id"
+
+    def test_patch_key_values(self) -> None:
+        assert keys.OP == "op"
+        assert keys.TARGET == "target"
+        assert keys.HTML == "html"
+
+    def test_asset_key_values(self) -> None:
+        assert keys.KIND == "kind"
+        assert keys.URL == "url"
+
+    def test_form_meta_key_values(self) -> None:
+        assert keys.UID == "uid"
+        assert keys.VALID == "valid"
+        assert keys.ERRORS == "errors"
+
+    def test_target_selector_values(self) -> None:
+        assert keys.ZONE == "zone"
+        assert keys.FORM_SELECTOR == "form"
+
+
+class TestSerializerEnvelopeShareKeys:
+    """The serializer and the test envelope view read the same wire keys."""
+
+    def test_round_trip_through_partial_envelope(self) -> None:
+        envelope = Envelope(
+            version="v1",
+            ops=(Patch(op="morph", target={"zone": "list"}, html="<div></div>"),),
+            assets=(Asset(kind="css", url="/a.css"),),
+            form=FormMeta(uid="ab12", valid=False, errors={"name": ["required"]}),
+            csrf={"token": "t"},
+            request_id="r1",
+        )
+        view = PartialEnvelope(envelope.as_dict())
+        assert view.version == "v1"
+        assert view.op_verbs() == ["morph"]
+        assert view.zone_targets() == ["list"]
+        assert view.assets == [{"kind": "css", "url": "/a.css"}]
+        assert view.form_meta() == {
+            "uid": "ab12",
+            "valid": False,
+            "errors": {"name": ["required"]},
+        }
+
+    def test_form_selector_round_trips(self) -> None:
+        envelope = Envelope(
+            version="v1",
+            ops=(Patch(op="morph", target={"form": "ab12"}, html="<form></form>"),),
+        )
+        view = PartialEnvelope(envelope.as_dict())
+        assert view.form_targets() == ["ab12"]
+
+    def test_csrf_and_request_id_keys_match(self) -> None:
+        data = Envelope(version="v1", csrf={"token": "t"}, request_id="r1").as_dict()
+        assert data[keys.CSRF] == {"token": "t"}
+        assert data[keys.REQUEST_ID] == "r1"

--- a/tests/partial/test_patches.py
+++ b/tests/partial/test_patches.py
@@ -1,5 +1,6 @@
 import pytest
 
+import next.pages
 import next.partial
 import next.partial.patches
 from next.partial import (
@@ -9,8 +10,12 @@ from next.partial import (
     Patch,
     Patches,
     PatchResponse,
+    register_patch_op,
 )
 from next.partial.headers import CONTENT_TYPE
+from next.partial.patches import ReservedPatchKeyError
+from next.partial.registry import patch_op_registry
+from tests.support import partial_request
 
 
 class TestPatchAsDict:
@@ -197,13 +202,12 @@ class TestPatchResponse:
 
 
 class TestBuilderExceptionSurface:
-    """Every public builder exception reaches the package facade."""
+    """Demoted builder exceptions live only on the submodule, not the facade."""
 
-    builder_exceptions = (
+    demoted_exceptions = (
         "BuiltinPatchOpError",
         "CrossSiteHrefError",
         "DynamicForeignPageError",
-        "ForeignPageNotAuthorizedError",
         "ReservedEventNameError",
         "ReservedPatchKeyError",
         "UnknownContextNameError",
@@ -211,7 +215,82 @@ class TestBuilderExceptionSurface:
         "UnknownPatchOpError",
     )
 
-    @pytest.mark.parametrize("name", builder_exceptions)
-    def test_exception_is_exported_and_identical(self, name: str) -> None:
-        assert name in next.partial.__all__
-        assert getattr(next.partial, name) is getattr(next.partial.patches, name)
+    @pytest.mark.parametrize("name", demoted_exceptions)
+    def test_demoted_exception_not_on_facade(self, name: str) -> None:
+        assert name not in next.partial.__all__
+        assert not hasattr(next.partial, name)
+        assert isinstance(getattr(next.partial.patches, name), type)
+
+    def test_foreign_page_error_stays_on_facade(self) -> None:
+        assert "ForeignPageNotAuthorizedError" in next.partial.__all__
+        assert (
+            next.partial.ForeignPageNotAuthorizedError
+            is next.partial.patches.ForeignPageNotAuthorizedError
+        )
+
+
+@pytest.fixture()
+def custom_op():
+    """Register a custom patch verb for the test and drop it afterwards."""
+    register_patch_op("confetti")
+    yield "confetti"
+    patch_op_registry._ops.discard("confetti")
+    patch_op_registry._custom.discard("confetti")
+
+
+class TestReservedPatchKey:
+    """A reserved structural key in a payload is refused at build time."""
+
+    def test_constructor_refuses_reserved_extras_key(self) -> None:
+        with pytest.raises(ReservedPatchKeyError) as exc:
+            Patch(op="x", extras={"target": 1})
+        assert exc.value.keys == frozenset({"target"})
+
+    def test_op_frame_refuses_reserved_payload_key(self, custom_op: str) -> None:
+        with pytest.raises(ReservedPatchKeyError) as exc:
+            Patches("v1").op(custom_op, op="boom")
+        assert exc.value.keys == frozenset({"op"})
+
+    def test_valid_patch_as_dict_does_not_raise(self) -> None:
+        patch = Patch(op="event", extras={"name": "ping"})
+        assert patch.as_dict() == {"op": "event", "name": "ping"}
+
+    def test_multiple_reserved_keys_are_sorted_in_message(self) -> None:
+        with pytest.raises(ReservedPatchKeyError) as exc:
+            Patch(op="x", extras={"target": 1, "op": 2, "html": 3})
+        assert exc.value.keys == frozenset({"op", "target", "html"})
+        assert "html, op, target" in str(exc.value)
+
+
+class TestOriginRenderContextMemoised:
+    """The origin render context is built once per builder."""
+
+    def test_context_then_morph_builds_render_context_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = 0
+        original = next.pages.page.build_render_context
+
+        def _counting(*args: object, **kwargs: object) -> object:
+            nonlocal calls
+            calls += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(next.pages.page, "build_render_context", _counting)
+        Patches(partial_request()).context(flag=True).morph(zone="alpha").envelope()
+        assert calls == 1
+
+    def test_context_only_builds_render_context_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = 0
+        original = next.pages.page.build_render_context
+
+        def _counting(*args: object, **kwargs: object) -> object:
+            nonlocal calls
+            calls += 1
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(next.pages.page, "build_render_context", _counting)
+        Patches(partial_request()).context(flag=True).envelope()
+        assert calls == 1

--- a/tests/partial/test_registry.py
+++ b/tests/partial/test_registry.py
@@ -2,8 +2,14 @@ from django.template import Context
 from django.template.base import Template
 from django.test import RequestFactory
 
-from next.partial import ZoneInfo, register_patch_op, zone_requested, zones_of
-from next.partial.registry import BUILTIN_OPS, PatchOpRegistry, patch_op_registry
+from next.partial import register_patch_op, zone_requested
+from next.partial.registry import (
+    BUILTIN_OPS,
+    PatchOpRegistry,
+    ZoneInfo,
+    patch_op_registry,
+    zones_of,
+)
 from next.partial.signals import patch_op_registered, zone_registered
 
 

--- a/tests/partial/test_shaping_units.py
+++ b/tests/partial/test_shaping_units.py
@@ -8,6 +8,7 @@ from django.urls import set_script_prefix
 from next.forms.dispatch import ActionOutcome, ActionOutcomeKind
 from next.forms.manager import form_action_manager
 from next.partial import Patches, shape_partial, shaping as shaping_module
+from next.partial.headers import VARY_HEADERS
 from next.partial.shaping import (
     _CSRF_ROTATED_FLAG,
     ActionRef,
@@ -45,6 +46,16 @@ def _bound_formset():
     return formset
 
 
+def _assert_partial_vary(response: HttpResponse) -> None:
+    """Assert the response carries the four partial Vary header names."""
+    varied = {part.strip() for part in response.get("Vary", "").split(",")}
+    assert set(VARY_HEADERS) <= varied
+    assert "X-Next-Request" in varied
+    assert "X-Next-Zone" in varied
+    assert "X-Next-Merge" in varied
+    assert "X-Next-Version" in varied
+
+
 class _PushWizard:
     class Meta:
         push_steps = True
@@ -66,6 +77,7 @@ class TestAdvanceWithoutAResolvableTarget:
         backend = form_action_manager.default_backend
         response = shape_partial(backend, partial_request(origin=None), outcome)
         assert response.status_code == 204
+        _assert_partial_vary(response)
 
     def test_missing_wizard_returns_the_step_redirect(self) -> None:
         outcome = ActionOutcome(
@@ -77,6 +89,7 @@ class TestAdvanceWithoutAResolvableTarget:
         response = shape_partial(backend, partial_request(origin=None), outcome)
         assert isinstance(response, HttpResponseRedirect)
         assert response["Location"] == "/wizard/scope/"
+        _assert_partial_vary(response)
 
     def test_unresolvable_target_returns_the_step_redirect(self) -> None:
         outcome = ActionOutcome(
@@ -89,6 +102,7 @@ class TestAdvanceWithoutAResolvableTarget:
         response = shape_partial(backend, partial_request(origin=None), outcome)
         assert isinstance(response, HttpResponseRedirect)
         assert response["Location"] == "/no/such/route/"
+        _assert_partial_vary(response)
 
 
 class TestPushStepsGate:

--- a/tests/partial/test_zone_observability.py
+++ b/tests/partial/test_zone_observability.py
@@ -11,8 +11,8 @@ from django.test import RequestFactory
 
 from next.pages import Page
 from next.pages.loaders import _load_python_module_memo
-from next.partial import zone_requested, zones_of
-from next.partial.registry import _zone_cache
+from next.partial import zone_requested
+from next.partial.registry import _zone_cache, zones_of
 from next.partial.zone import ZONE_ATTR, ZoneNode
 
 


### PR DESCRIPTION
Curate the partial aggregator __all__ down to the stable surface and demote OriginSource, ZoneInfo, zones_of, REQUEST_ID, and the rarely caught builder exceptions to submodule access. Add next/partial/keys.py as the single source of truth for the wire keys, wired into the four as_dict serializers and the test envelope view, and rebuild the reserved patch key set from it.

Move the reserved-key guard into Patch.__post_init__ so a bad custom verb fails at build time in the op() frame, not on serialization, and leave as_dict a clean getter. Memoise the origin render context on the builder so context() plus morph_zone() in one handler build it once. Stamp the partial Vary headers on the _shape_advance 204 and redirect branches. Add next.W071 warning for a second PARTIAL_BACKENDS entry and document the single-backend contract.

Turn the partial:error payload into a discriminated union keyed by kind so network, http, parse, op, and asset failures each carry their own fields instead of a flat status and body that lied for most causes. Align the ref tiers and the done-choreography canon with the curated surface, and point the live-polls example and the SSE howto at next.partial.headers.REQUEST_ID.

## Description

<!-- What changed and why. -->

## How to test

<!-- e.g. `make ci` before opening the PR. If you changed docs, run `make docs` or rely on the CI docs job. -->

## Related issues

<!-- e.g. Fixes #123 / Closes #456 -->

## Checklist

- [ ] `make ci` passes locally
- [ ] New or changed `next/` code covered by tests (100% for package)
- [ ] Example + tests when adding public API or behavior users copy from `examples/`
- [ ] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable

---

Full guidelines: [CONTRIBUTING.md](https://github.com/next-dj/next-dj/blob/main/CONTRIBUTING.md)
