### PR TITLE
fix(partial): keep query and harden the client partial bus

### DIFF
--- a/next/client/apply.merge.test.ts
+++ b/next/client/apply.merge.test.ts
@@ -19,6 +19,19 @@ function envelope(ops: unknown[], extra: Record<string, unknown> = {}): unknown 
   return { version: "v1", ops, assets: [], form: null, ...extra };
 }
 
+// A document whose location is overridden but whose DOM surface delegates to the
+// real jsdom document, so the default #here reads our pathname and search while
+// the apply pipeline keeps a working createElement and dispatchEvent.
+function docAt(pathname: string, search: string): Document {
+  return new Proxy(document, {
+    get(target, prop, receiver) {
+      if (prop === "location") return { pathname, search } as Location;
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
 describe("append and prepend dedup", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -198,6 +211,30 @@ describe("refresh verb", () => {
     const { applier } = makeApplier({ refresh });
     applier.apply(envelope([{ op: "refresh" }]));
     expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("default here keeps the query of the current URL on a re-GET", () => {
+    const refresh = vi.fn<ZoneFetch>();
+    const doc = docAt("/feed", "?q=foo");
+    const { applier } = makeApplier({ refresh, document: doc });
+    applier.apply(envelope([{ op: "refresh", zone: "feed" }]));
+    expect(refresh).toHaveBeenCalledWith({
+      url: "/feed?q=foo",
+      zone: "feed",
+      headers: { "X-Next-Zone": "feed" },
+    });
+  });
+
+  it("default here is the bare path when there is no query", () => {
+    const refresh = vi.fn<ZoneFetch>();
+    const doc = docAt("/feed", "");
+    const { applier } = makeApplier({ refresh, document: doc });
+    applier.apply(envelope([{ op: "refresh", zone: "feed" }]));
+    expect(refresh).toHaveBeenCalledWith({
+      url: "/feed",
+      zone: "feed",
+      headers: { "X-Next-Zone": "feed" },
+    });
   });
 });
 

--- a/next/client/apply.ts
+++ b/next/client/apply.ts
@@ -10,6 +10,7 @@ import {
   HEADER_ZONE,
   asString,
   cssEscape,
+  currentUrl,
   isRecord,
 } from "./protocol";
 import type { Navigate } from "./wire";
@@ -386,7 +387,7 @@ export class Applier {
     this.#assets = deps.assets;
     this.#mount = deps.mount;
     this.#refresh = deps.refresh;
-    this.#here = deps.here ?? (() => this.#document.location.pathname);
+    this.#here = deps.here ?? (() => currentUrl(this.#document));
   }
 
   // Drop every custom op so vitest files do not leak registrations into one

--- a/next/client/layers.flow.test.ts
+++ b/next/client/layers.flow.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createPartial } from "./partial";
 import type { PartialSurface } from "./partial";
 import type { DialogAdapter } from "./layers";
@@ -78,6 +78,10 @@ describe("layer flow through the partial surface", () => {
         return respond(call);
       },
     });
+  });
+
+  afterEach(() => {
+    partial._reset();
   });
 
   function headerOf(call: Call, name: string): string | undefined {

--- a/next/client/layers.test.ts
+++ b/next/client/layers.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLayers } from "./layers";
 import type { DialogAdapter, LayerStack, PopStateAdapter } from "./layers";
 import { HEADER_ORIGIN, HEADER_ZONE } from "./protocol";
@@ -405,6 +405,10 @@ describe("layer intercepting URL lifecycle", () => {
     fire = () => handler?.();
   });
 
+  afterEach(() => {
+    layers._reset();
+  });
+
   it("pushes the honest URL of the layer body on open", async () => {
     await layers.open(null, "/photos/1/", "photo");
     expect(window.location.pathname).toBe("/photos/1/");
@@ -451,5 +455,87 @@ describe("layer intercepting URL lifecycle", () => {
     expect(layers.size()).toBe(0);
     fire();
     expect(layers.size()).toBe(0);
+  });
+});
+
+describe("layer open is single-flight and rolls back on failure", () => {
+  function makeHistory() {
+    const pushed: string[] = [];
+    const replaced: string[] = [];
+    const history = {
+      push: (href: string) => pushed.push(href),
+      replace: (href: string) => replaced.push(href),
+    };
+    return { history, pushed, replaced };
+  }
+
+  let layers: LayerStack;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    window.history.replaceState(null, "", "/feed/");
+  });
+
+  afterEach(() => {
+    layers._reset();
+  });
+
+  it("a double click opens one dialog and pushes history once", () => {
+    const { history, pushed } = makeHistory();
+    layers = createLayers({
+      dispatch: () => undefined,
+      fetch: () => new Promise<void>(() => undefined),
+      document,
+      dialog: mockDialog().adapter,
+      history,
+    });
+    const opener = document.createElement("a");
+    opener.setAttribute("href", "/photos/1/");
+    opener.setAttribute("data-next-layer", "photo");
+    document.body.append(opener);
+    layers.install(document);
+    opener.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    opener.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    expect(document.querySelectorAll("[data-next-dialog]")).toHaveLength(1);
+    expect(pushed).toEqual(["/photos/1/"]);
+    expect(layers.size()).toBe(1);
+  });
+
+  it("a second open for a busy opener is dropped before any mutation", async () => {
+    const { history, pushed } = makeHistory();
+    layers = createLayers({
+      dispatch: () => undefined,
+      fetch: () => new Promise<void>(() => undefined),
+      document,
+      dialog: mockDialog().adapter,
+      history,
+    });
+    const opener = document.createElement("a");
+    opener.setAttribute("href", "/photos/1/");
+    document.body.append(opener);
+    void layers.open(opener, "/photos/1/", "photo");
+    await layers.open(opener, "/photos/1/", "photo");
+    expect(document.querySelectorAll("[data-next-dialog]")).toHaveLength(1);
+    expect(pushed).toEqual(["/photos/1/"]);
+  });
+
+  it("a fetch failure tears down the orphan and rolls the URL back to the host", async () => {
+    const { history, replaced } = makeHistory();
+    layers = createLayers({
+      dispatch: () => undefined,
+      fetch: () => Promise.reject(new Error("boom")),
+      document,
+      dialog: mockDialog().adapter,
+      history,
+    });
+    const opener = document.createElement("a");
+    opener.setAttribute("href", "/photos/1/");
+    document.body.append(opener);
+    await expect(layers.open(opener, "/photos/1/", "photo")).rejects.toThrow("boom");
+    expect(document.querySelector("[data-next-dialog]")).toBeNull();
+    expect(layers.size()).toBe(0);
+    expect(replaced).toEqual(["/feed/"]);
+    expect(opener.hasAttribute("data-next-busy")).toBe(false);
+    expect(opener.hasAttribute("aria-busy")).toBe(false);
   });
 });

--- a/next/client/layers.test.ts
+++ b/next/client/layers.test.ts
@@ -538,4 +538,38 @@ describe("layer open is single-flight and rolls back on failure", () => {
     expect(opener.hasAttribute("data-next-busy")).toBe(false);
     expect(opener.hasAttribute("aria-busy")).toBe(false);
   });
+
+  it("a dismiss during an in-flight open then a fetch reject tears down once", async () => {
+    const { history, replaced } = makeHistory();
+    const { adapter, dismissed } = mockDialog();
+    let rejectFetch: ((reason: Error) => void) | undefined;
+    layers = createLayers({
+      dispatch: () => undefined,
+      fetch: () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectFetch = reject;
+        }),
+      document,
+      dialog: adapter,
+      history,
+    });
+    const opener = document.createElement("a");
+    opener.setAttribute("href", "/photos/1/");
+    document.body.append(opener);
+    const pending = layers.open(opener, "/photos/1/", "photo");
+    // Dismiss the dialog (Esc, backdrop) while the body fetch is still in
+    // flight, the first remove that splices the layer and rolls the URL back.
+    dismissed[0]?.("escape");
+    expect(layers.size()).toBe(0);
+    expect(replaced).toEqual(["/feed/"]);
+    rejectFetch?.(new Error("boom"));
+    await expect(pending).rejects.toThrow("boom");
+    // The catch arm hands remove the already-spliced layer, so the index===-1
+    // early return makes the second teardown a no-op: no second URL rollback.
+    expect(replaced).toEqual(["/feed/"]);
+    expect(document.querySelector("[data-next-dialog]")).toBeNull();
+    expect(layers.size()).toBe(0);
+    expect(opener.hasAttribute("data-next-busy")).toBe(false);
+    expect(opener.hasAttribute("aria-busy")).toBe(false);
+  });
 });

--- a/next/client/layers.ts
+++ b/next/client/layers.ts
@@ -258,11 +258,13 @@ export function createLayers(deps: LayerDeps): LayerStack {
   // Splice the layer out, end its dialog, and return focus to the opener.
   function remove(layer: Layer): void {
     const index = stack.indexOf(layer);
-    // The miss arm is a defensive guard: every caller (close, dismissFrom,
-    // _reset) hands remove a layer that is still on the stack, so indexOf never
-    // returns -1 through the public surface.
-    /* v8 ignore next */
-    if (index !== -1) stack.splice(index, 1);
+    // remove can land twice on one layer: a dismiss gesture (Esc, backdrop)
+    // tears it down while open's fetch is still in flight, then that fetch
+    // rejects and the catch arm calls remove again on the already-spliced
+    // layer. The early return makes the second call a true no-op so close,
+    // dialog.remove, focus, and the history rollback never run twice.
+    if (index === -1) return;
+    stack.splice(index, 1);
     layer.close();
     layer.dialog.remove();
     if (layer.returnFocus instanceof HTMLElement) layer.returnFocus.focus();

--- a/next/client/layers.ts
+++ b/next/client/layers.ts
@@ -13,7 +13,12 @@
 
 import { defaultDialog, defaultHistory, defaultPopState } from "./adapters";
 import type { HistoryAdapter } from "./apply";
-import { HEADER_ORIGIN, HEADER_ZONE, cssEscape } from "./protocol";
+import {
+  HEADER_ORIGIN,
+  HEADER_ZONE,
+  cssEscape,
+  currentUrl as pageUrl,
+} from "./protocol";
 
 const LAYER_ATTR = "data-next-layer";
 const ACCEPTED_ATTR = "data-next-accepted";
@@ -126,7 +131,7 @@ export function createLayers(deps: LayerDeps): LayerStack {
   }
 
   function currentUrl(): string {
-    return doc.location.pathname + doc.location.search;
+    return pageUrl(doc);
   }
 
   function resolveZone(name: string, root: ParentNode): Element | null {
@@ -164,6 +169,14 @@ export function createLayers(deps: LayerDeps): LayerStack {
     href: string,
     zone: string,
   ): Promise<void> {
+    // Mark the opener busy before any dialog or history mutation, the single
+    // source of truth the double-click guard reads. A second open for the same
+    // opener is dropped here too, so neither path stacks a second modal.
+    if (opener !== null) {
+      if (opener.hasAttribute(BUSY_ATTR)) return;
+      opener.setAttribute(BUSY_ATTR, "");
+      opener.setAttribute("aria-busy", "true");
+    }
     const dialog = doc.createElement("dialog");
     dialog.setAttribute("data-next-dialog", "");
     const root = doc.createElement("div");
@@ -187,15 +200,27 @@ export function createLayers(deps: LayerDeps): LayerStack {
     history.push(href);
     layer.pushedUrl = currentUrl();
     emit("partial:layer-opened", { opener });
-    const release = busy(opener, root);
+    // The opener already carries busy, so only the target zone is marked here.
+    const release = busy(null, root);
     try {
       await deps.fetch({
         url: href,
         zone,
         headers: { [HEADER_ZONE]: zone, [HEADER_ORIGIN]: host },
       });
+    } catch (e) {
+      // The request died after the URL was pushed and the dialog opened. Tear
+      // down the orphaned layer: remove already rolls the URL back through
+      // history.replace(host) while the current URL still equals pushedUrl, so
+      // Back does not land on a dead modal URL.
+      remove(layer);
+      throw e;
     } finally {
       release();
+      if (opener !== null) {
+        opener.removeAttribute(BUSY_ATTR);
+        opener.removeAttribute("aria-busy");
+      }
     }
   }
 
@@ -297,6 +322,9 @@ export function createLayers(deps: LayerDeps): LayerStack {
     // No zone or no href is a plain navigation: the no-JS path is untouched.
     if (zone === null || zone === "" || href === null || href === "") return;
     event.preventDefault();
+    // A second click while the first request is in flight is dropped, so a
+    // double click stacks neither a second dialog nor a second history entry.
+    if (opener.hasAttribute(BUSY_ATTR)) return;
     void open(opener, href, zone);
   }
 

--- a/next/client/next.test.ts
+++ b/next/client/next.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import "./next";
 
 type NextStatic = {
@@ -160,6 +160,34 @@ describe("Next.on", () => {
     win.Next._init({});
     expect(a).toBe(1);
     expect(b).toBe(1);
+  });
+
+  it("isolates a throwing listener so the rest still receive the payload", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const seen: string[] = [];
+    win.Next.on("context-updated", () => seen.push("first"));
+    win.Next.on("context-updated", () => {
+      throw new Error("boom");
+    });
+    win.Next.on("context-updated", () => seen.push("third"));
+    win.Next._init({});
+    expect(seen).toEqual(["first", "third"]);
+    expect(error).toHaveBeenCalledWith("[next] listener threw", expect.any(Error));
+    error.mockRestore();
+  });
+
+  it("snapshots the bucket so a listener subscribing mid-dispatch waits a round", () => {
+    let lateCalls = 0;
+    const late = (): void => {
+      lateCalls += 1;
+    };
+    win.Next.on("context-updated", () => {
+      win.Next.on("context-updated", late);
+    });
+    win.Next._init({});
+    expect(lateCalls).toBe(0);
+    win.Next._init({});
+    expect(lateCalls).toBeGreaterThan(0);
   });
 
   it("returns an unsubscribe function that stops future dispatches", () => {

--- a/next/client/next.ts
+++ b/next/client/next.ts
@@ -122,8 +122,15 @@ class Next {
   static #dispatch(event: string, payload: Record<string, unknown>): void {
     const bucket = Next.#listeners.get(event);
     if (bucket === undefined) return;
-    for (const listener of bucket) {
-      listener(payload);
+    // Snapshot so a listener that subscribes or unsubscribes mid-fan-out cannot
+    // mutate the Set under iteration, and isolate each call so one throwing
+    // plugin does not abort delivery to the rest.
+    for (const listener of [...bucket]) {
+      try {
+        listener(payload);
+      } catch (e) {
+        console.error("[next] listener threw", e);
+      }
     }
   }
 }

--- a/next/client/partial.test.ts
+++ b/next/client/partial.test.ts
@@ -478,7 +478,7 @@ describe("createPartial surface", () => {
     made.partial._reset();
   });
 
-  it("a refresh op falls back to the global document path when none is injected", async () => {
+  it("a refresh op falls back to the global document path and query when none is injected", async () => {
     document.body.innerHTML = '<div data-next-zone="poll">old</div>';
     const calls: { url: string }[] = [];
     partial._configure({
@@ -496,7 +496,7 @@ describe("createPartial surface", () => {
     });
     await Promise.resolve();
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.url).toBe(document.location.pathname);
+    expect(calls[0]!.url).toBe(document.location.pathname + document.location.search);
   });
 });
 

--- a/next/client/partial.ts
+++ b/next/client/partial.ts
@@ -30,6 +30,7 @@ import type { ConfirmAdapter, IntersectionAdapter } from "./triggers";
 import { createSse } from "./sse";
 import type { EventSourceAdapter, Sse, VisibilityAdapter } from "./sse";
 import { defaultHistory, defaultNavigate } from "./adapters";
+import { currentUrl } from "./protocol";
 
 export interface PartialDeps {
   dispatch: (event: string, detail: Record<string, unknown>) => void;
@@ -172,7 +173,7 @@ export function createPartial(deps: PartialDeps): PartialSurface {
       assets,
       mount: { run: runMount },
       refresh: (request) => void wire.fetch(request),
-      here: () => (adapters?.document ?? document).location.pathname,
+      here: () => currentUrl(adapters?.document ?? document),
     };
   }
 

--- a/next/client/protocol.ts
+++ b/next/client/protocol.ts
@@ -53,3 +53,10 @@ export function asString(value: unknown): string | undefined {
 export function cssEscape(value: string): string {
   return value.replace(/["\\]/g, "\\$&");
 }
+
+// The one canon for "the URL the page is on": pathname plus search. Refresh
+// re-GETs, SSE resume revalidation, and the layer history seam all key off this,
+// so a query filter survives a re-GET instead of collapsing to the bare path.
+export function currentUrl(doc: Document): string {
+  return doc.location.pathname + doc.location.search;
+}

--- a/next/client/sse.test.ts
+++ b/next/client/sse.test.ts
@@ -332,6 +332,46 @@ describe("createSse", () => {
     expect(fetched.map((f) => f.zone)).toEqual(["poll"]);
   });
 
+  it("resume copies bound zones so a late event on the paused stream does not leak", () => {
+    document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
+    const { adapter, opened } = mockSource();
+    const visibility = mockVisibility();
+    let clock = 0;
+    const sse = makeSse(adapter, visibility.adapter, () => clock);
+    sse.scan(document);
+    opened[0]!.message(envelope([{ op: "refresh", zone: "poll" }]));
+    visibility.set(true);
+    clock = 5000;
+    visibility.set(false);
+    fetched.length = 0;
+    // The paused predecessor still holds its message closure. A stray event on
+    // it must not bind into the resumed connection, which carries its own copy.
+    opened[0]!.message(envelope([{ op: "refresh", zone: "stale" }]));
+    clock = 10000;
+    visibility.set(true);
+    clock = 15000;
+    visibility.set(false);
+    expect(fetched.map((f) => f.zone)).toEqual(["poll"]);
+  });
+
+  it("caps the bound registry so a long sleep does not re-GET an unbounded set", () => {
+    document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
+    const { adapter, opened } = mockSource();
+    const visibility = mockVisibility();
+    let clock = 0;
+    const sse = makeSse(adapter, visibility.adapter, () => clock);
+    sse.scan(document);
+    const ops = Array.from({ length: 100 }, (_, i) => ({
+      op: "refresh",
+      zone: `zone-${i}`,
+    }));
+    opened[0]!.message(envelope(ops));
+    visibility.set(true);
+    clock = 5000;
+    visibility.set(false);
+    expect(fetched).toHaveLength(64);
+  });
+
   it("ignores a data-next-sse container with an empty url", () => {
     document.body.innerHTML = '<div data-next-sse=""></div>';
     const { adapter, opened } = mockSource();

--- a/next/client/sse.ts
+++ b/next/client/sse.ts
@@ -25,6 +25,8 @@ const RESUME_REVALIDATE_MS = 3000;
 // lets the registry grow unbounded, and resume would re-GET every accumulated
 // zone at once, a thundering herd on the server. Past the cap a new zone is
 // dropped, so resume revalidates a bounded slice rather than the whole backlog.
+// This keeps the earliest bound zones, not the freshest: it is a plain cap, not
+// an LRU, since any bounded slice serves the anti-thundering-herd goal.
 const MAX_BOUND = 64;
 // The transient placeholder control between openConnection setting it and the
 // synchronous source.open returning the real one. Its close is never reached:

--- a/next/client/sse.ts
+++ b/next/client/sse.ts
@@ -11,7 +11,7 @@
 // the stream lives on.
 
 import { defaultEventSource, defaultVisibility } from "./adapters";
-import { HEADER_ZONE, asString, isRecord } from "./protocol";
+import { HEADER_ZONE, asString, currentUrl, isRecord } from "./protocol";
 
 const SSE_ATTR = "data-next-sse";
 // The ring holds the last 25 own request ids, matching the server-side echo
@@ -21,6 +21,11 @@ const ECHO_LIMIT = 25;
 // reconnects the stream but skips the zone re-GET, so flicking between tabs does
 // not storm the server. A longer pause may have missed events, so it converges.
 const RESUME_REVALIDATE_MS = 3000;
+// The cap on bound zones a connection tracks. Without it a long background sleep
+// lets the registry grow unbounded, and resume would re-GET every accumulated
+// zone at once, a thundering herd on the server. Past the cap a new zone is
+// dropped, so resume revalidates a bounded slice rather than the whole backlog.
+const MAX_BOUND = 64;
 // The transient placeholder control between openConnection setting it and the
 // synchronous source.open returning the real one. Its close is never reached:
 // nothing closes a connection between those two statements in the same tick.
@@ -148,7 +153,11 @@ export function createSse(deps: SseDeps): Sse {
       if (!isRecord(op)) continue;
       const target = isRecord(op.target) ? op.target : undefined;
       const zone = asString(op.zone) ?? asString(target?.zone);
-      if (zone !== undefined) connection.bound.add(zone);
+      if (zone === undefined) continue;
+      if (connection.bound.size >= MAX_BOUND && !connection.bound.has(zone)) {
+        continue;
+      }
+      connection.bound.add(zone);
     }
   }
 
@@ -173,8 +182,11 @@ export function createSse(deps: SseDeps): Sse {
     const connection: Connection = {
       url,
       control: NOOP,
-      pageUrl: previous?.pageUrl ?? doc.location.pathname + doc.location.search,
-      bound: previous?.bound ?? new Set(),
+      pageUrl: previous?.pageUrl ?? currentUrl(doc),
+      // An independent copy per connection, never the predecessor's Set by
+      // reference, so a mutation on the resumed stream cannot leak back into a
+      // paused one that was never re-GET.
+      bound: new Set(previous?.bound),
     };
     connections.set(url, connection);
     connection.control = source.open(

--- a/next/client/triggers.ts
+++ b/next/client/triggers.ts
@@ -20,6 +20,7 @@ import {
   HEADER_MERGE,
   HEADER_VERSION,
   HEADER_ZONE,
+  currentUrl,
 } from "./protocol";
 import type { Clock } from "./wire";
 
@@ -109,7 +110,7 @@ export function createTriggers(deps: TriggerDeps): Triggers {
   let detach: (() => void) | null = null;
 
   function here(): string {
-    return doc.location.pathname + doc.location.search;
+    return currentUrl(doc);
   }
 
   // The abortable zone key of a form's inline validation, shared by the sender


### PR DESCRIPTION
## Description

The refresh verb and SSE resume re-GET a zone from location.pathname without the search string, so a filtered zone lost its query after a fan-out refresh. Fold the current-url definitions into one currentUrl helper that returns pathname plus search and reuse it everywhere.

Snapshot the listener Set and isolate each call in Next.#dispatch so a broken plugin no longer breaks the fan-out and a re-entrant Next.on does not mutate the Set mid-iteration.

Mark the layer opener busy before the dialog and history push so a double click opens one dialog, and tear the orphaned layer down through remove when the open fetch fails so Back never lands on a dead modal url.

Copy the SSE bound set per connection instead of sharing it by reference and cap its growth so resume after a long sleep does not storm the server with a re-GET of every accumulated zone.


## How to test

<!-- e.g. `make ci` before opening the PR. If you changed docs, run `make docs` or rely on the CI docs job. -->

## Related issues

<!-- e.g. Fixes #123 / Closes #456 -->

## Checklist

- [ ] `make ci` passes locally
- [ ] New or changed `next/` code covered by tests (100% for package)
- [ ] Example + tests when adding public API or behavior users copy from `examples/`
- [ ] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable

---

Full guidelines: [CONTRIBUTING.md](https://github.com/next-dj/next-dj/blob/main/CONTRIBUTING.md)
