### PR TITLE
fix(partial): ship inline assets and js-context delta on zone-GET

### DIFF
--- a/docs/content/contributing/writing-documentation.rst
+++ b/docs/content/contributing/writing-documentation.rst
@@ -205,6 +205,9 @@ The table below lists the public package, its primary narrative page, and its re
    * - ``next.static``
      - :doc:`/content/topics/static-assets/index`
      - :doc:`/content/ref/static`
+   * - ``next.partial``
+     - :doc:`/content/topics/partial-rendering/index`
+     - :doc:`/content/ref/partial`
    * - ``next.deps``
      - :doc:`/content/topics/dependency-injection`
      - :doc:`/content/ref/deps`

--- a/docs/content/deployment/settings.rst
+++ b/docs/content/deployment/settings.rst
@@ -31,9 +31,11 @@ Eager Component Loading
 
    NEXT_FRAMEWORK["LAZY_COMPONENT_MODULES"] = False
 
-Keep ``LAZY_COMPONENT_MODULES: False`` (the default) in production so every ``component.py`` is imported during startup and registrations exist before traffic.
-When ``True``, each ``component.py`` is imported on the first render that resolves the component rather than during startup.
-Component discovery and registration still happen eagerly in both modes.
+``LAZY_COMPONENT_MODULES: False`` is the default, and production confirms it.
+The framework discovers the component tree eagerly in both modes, so the registry knows every component name before traffic.
+The flag controls only when each ``component.py`` module is imported.
+With the default ``False``, every ``component.py`` is imported during startup, so any import-time error surfaces before the first request.
+With ``True``, a ``component.py`` is imported on the first render that resolves the component rather than during startup.
 Reference for lazy behaviour and testing helpers: :ref:`ref-settings` and :doc:`/content/topics/testing`.
 
 Static Backend
@@ -132,7 +134,7 @@ When several recommendations apply at once, merge them into a single ``NEXT_FRAM
 Keep only the keys the deployment changes.
 The framework supplies the default for every key left out, so there is no need to duplicate the full default structures documented on :doc:`/content/ref/settings`.
 
-Runtime script overrides
+Runtime Script Overrides
 ------------------------
 
 Strict content security policies sometimes need nonces or manual ordering for the bundled ``next.min.js`` shell.

--- a/docs/content/faq/general.rst
+++ b/docs/content/faq/general.rst
@@ -38,7 +38,6 @@ Discussions and feature requests live on GitHub Discussions.
 How Is This Different From Plain Django Forms
 ---------------------------------------------
 
-Three things.
 A next.dj form needs no URL entry and no view.
 Subclassing ``next.forms.Form`` or ``next.forms.ModelForm`` registers it and attaches a POST endpoint, CSRF, and a re-render-on-failure pipeline (see :doc:`/content/topics/forms/overview`).
 A failed submission re-renders the origin page with the entered values and field errors instead of an error page, so you write no re-render code (see :doc:`/content/topics/forms/validation-rerender`).

--- a/docs/content/faq/troubleshooting.rst
+++ b/docs/content/faq/troubleshooting.rst
@@ -197,8 +197,9 @@ The snippet below uses ``fetch_note``, the ``@context("note")`` callable from th
 .. code-block:: python
 
    from next.testing import resolve_call, make_resolution_context
+   from next.urls import DUrl
 
-   def fetch_note(note_id):
+   def fetch_note(note_id: DUrl["id", int]):
        return None
 
    resolved = resolve_call(fetch_note, url_kwargs={"id": "1"})

--- a/docs/content/faq/usage.rst
+++ b/docs/content/faq/usage.rst
@@ -75,7 +75,6 @@ See :doc:`/content/howto/integrate-django-admin`.
 How Do I Split Routes Across Applications
 -----------------------------------------
 
-Two strategies.
 Use ``APP_DIRS=True`` so every application contributes its own page tree.
 Use ``DIRS`` to add project level page roots.
 See :doc:`/content/topics/file-router`.
@@ -128,7 +127,7 @@ Can a Form Action Return a Custom HTTP Status Code
 Return any ``HttpResponseBase`` subclass.
 
 .. code-block:: python
-   :caption: notes/pages/page.py
+   :caption: notes/forms.py
 
    from django.http import HttpRequest, HttpResponse
    from notes.models import Note

--- a/docs/content/howto/build-a-custom-asset-backend.rst
+++ b/docs/content/howto/build-a-custom-asset-backend.rst
@@ -179,7 +179,7 @@ Ship the Asset
 Drop a ``component.jsx`` file next to the ``component.py`` it belongs to.
 Discovery finds it because ``component`` is a registered stem and ``.jsx`` is now a registered extension.
 
-.. code-block:: jinja
+.. code-block:: jsx
    :caption: kanban/boards/board/[int:id]/_pieces/card/component.jsx
 
    import { useState } from "react";

--- a/docs/content/howto/extend-a-default-backend.rst
+++ b/docs/content/howto/extend-a-default-backend.rst
@@ -35,8 +35,10 @@ Pick the backend list.
      - Static collector and asset rendering.
    * - ``FORM_ACTION_BACKENDS``
      - Form action dispatch.
+   * - ``PARTIAL_BACKENDS``
+     - Partial rendering protocol and patch wire format.
 
-The helper supports these four backend list settings.
+The helper supports these five backend list settings.
 
 Call the helper with the setting name and the keys to override.
 

--- a/docs/content/howto/index.rst
+++ b/docs/content/howto/index.rst
@@ -141,9 +141,9 @@ Topic guides cover the underlying concepts, see :doc:`/content/topics/index`.
    internationalize-routes
    customize-error-pages
    share-context-across-pages
+   resolve-feature-flags-with-di
    build-a-composite-component
    share-components-across-projects
-   resolve-feature-flags-with-di
    add-a-new-asset-kind
    add-a-custom-stem
    write-a-static-backend

--- a/docs/content/howto/resolve-feature-flags-with-di.rst
+++ b/docs/content/howto/resolve-feature-flags-with-di.rst
@@ -113,11 +113,11 @@ The next ``get_cached_flag`` call refetches from the database.
    from .cache import invalidate_flag
    from .models import Flag
 
-   def _invalidate_on_save(sender: type[Flag], instance: Flag, **_: object) -> None:  # noqa: ARG001
+   def _invalidate_on_save(instance: Flag, **_: object) -> None:
        """Drop the cached entry so the next read reflects the updated row."""
        invalidate_flag(instance.name)
 
-   def _invalidate_on_delete(sender: type[Flag], instance: Flag, **_: object) -> None:  # noqa: ARG001
+   def _invalidate_on_delete(instance: Flag, **_: object) -> None:
        """Drop the cached entry when the flag is removed from the database."""
        invalidate_flag(instance.name)
 
@@ -224,7 +224,8 @@ The banner appears.
 Set ``enabled`` to ``False`` and save.
 The ``post_save`` receiver drops the cached entry, the next ``get_cached_flag`` call refetches, and the banner collapses to an empty string.
 
-A second context function that also asks for ``DFlag[Flag]`` triggers the provider again on the same request, but ``get_cached_flag`` shares Django's :class:`~django.core.cache.backends.locmem.LocMemCache` entry, so the lookup is served from process memory rather than the database.
+A second context function that also asks for ``DFlag[Flag]`` triggers the provider again on the same request.
+``get_cached_flag`` shares Django's :class:`~django.core.cache.backends.locmem.LocMemCache` entry, so the lookup is served from process memory rather than the database.
 The framework's per-resolution cache only memoises ``Depends("name")`` callables, so identity across calls comes from the LocMem cache the helper builds.
 
 See Also

--- a/docs/content/howto/split-settings-per-environment.rst
+++ b/docs/content/howto/split-settings-per-environment.rst
@@ -100,7 +100,7 @@ Override a single ``NEXT_FRAMEWORK`` key without rewriting the whole block by co
    :caption: config/settings/dev.py
 
    NEXT_FRAMEWORK = {**NEXT_FRAMEWORK}  # noqa: F405
-   NEXT_FRAMEWORK["STRICT_CONTEXT"] = False
+   NEXT_FRAMEWORK["STRICT_CONTEXT"] = True
 
 Because ``{**NEXT_FRAMEWORK}`` is a shallow copy, mutate only flat keys this way.
 For nested backend lists use ``extend_default_backend`` or ``copy.deepcopy``.

--- a/docs/content/howto/write-a-form-action-backend.rst
+++ b/docs/content/howto/write-a-form-action-backend.rst
@@ -147,6 +147,7 @@ A from-scratch backend overrides the hook so its actions participate in checks s
    :caption: notes/backends.py
 
    from collections.abc import Iterable
+   from next.forms import FormActionBackend
    from next.forms.backends import ActionMeta
 
    class CustomBackend(FormActionBackend):

--- a/docs/content/howto/write-a-static-backend.rst
+++ b/docs/content/howto/write-a-static-backend.rst
@@ -102,6 +102,7 @@ Tenant URL Prefix
 A common multi-tenant pattern is to prefix every collected URL with a tenant slug so static files are scoped per tenant.
 Override all three renderer methods and delegate to the parent after rewriting the URL.
 Leave absolute URLs untouched.
+The shipped multi-tenant example omits ``render_module_tag`` because it serves no ``.mjs`` assets.
 
 .. code-block:: python
    :caption: notes/backends.py

--- a/docs/content/internals/action-dispatch.rst
+++ b/docs/content/internals/action-dispatch.rst
@@ -143,7 +143,8 @@ Origin Resolution
 
 The hidden ``_next_form_origin`` field on every rendered form carries the URL path of the origin page.
 At dispatch the field is validated as a same-site path, the script prefix from :func:`django.urls.get_script_prefix` is stripped, and the remainder is resolved through :func:`django.urls.resolve` with the per-request URLconf from ``request.urlconf`` when one is set.
-The resolved match yields two things: the typed URL kwargs through the real URL converters, and the origin page source from the ``next_page_path`` attribute that the file router sets on every routed view, including the synthesised ``page.py`` location of virtual ``template.djx`` routes.
+The resolved match yields two things.
+The typed URL kwargs come through the real URL converters, and the origin page source comes from the ``next_page_path`` attribute that the file router sets on every routed view, including the synthesised ``page.py`` location of virtual ``template.djx`` routes.
 The result is memoised on the request, because the invalid re-render reads it from the dispatcher and from every ``{% form %}`` tag on the page.
 
 A missing field, an off-site value, a path that does not resolve, or a resolved view without ``next_page_path`` all yield no origin match.
@@ -184,7 +185,8 @@ Signals
 
 Six signals fire: ``action_registered`` at import time, the other five per request.
 
-- ``action_registered`` fires at import time, once per registration when the registry stores the action target: a handler, a form class, or a wizard class.
+- ``action_registered`` fires at import time, once per registration when the registry stores the action target.
+  The target is a handler, a form class, or a wizard class.
 - ``form_validation_failed`` fires at request time, once per failing submission, including a failing wizard step.
 - ``action_dispatched`` fires at request time, once per successful handler invocation and once per valid wizard step, with the action name, the action uid, the live request, the bound form (``None`` for form-less actions), the URL kwargs, the handler duration, the response status, and the dispatch dependency cache in the payload.
   A wizard step advance runs no handler and reports ``duration_ms`` as ``0.0``.

--- a/docs/content/internals/component-pipeline.rst
+++ b/docs/content/internals/component-pipeline.rst
@@ -67,6 +67,12 @@ Modules
    ``FileComponentsBackend`` default implementation.
    ``ComponentsFactory`` instantiates a backend from its ``BACKEND`` dotted path.
 
+``next.components.manager``.
+   ``ComponentsManager`` orchestrates the backends, shares one render pipeline between them, and rebuilds on ``settings_reloaded``.
+
+``next.components.checks``.
+   The components system checks, including ``next.E020`` and ``next.E034``.
+
 ``next.components.watch``.
    Watch specs exposed to the autoreloader.
 
@@ -102,7 +108,8 @@ Component Context Resolution
 
 Each ``@component.context("key")`` function runs once per component render.
 When a component's ``component.py`` fails to import, the renderer falls back to plain template rendering and the ``@component.context`` callables in that module do not run.
-On the template render path the resolver shares the request-scoped dependency cache through ``get_request_dep_cache``, so DI parameters resolved earlier in the request are reused inside the component callables.
+On the template render path the resolver shares the request-scoped dependency cache through ``get_request_dep_cache``.
+DI parameters resolved earlier in the request are reused inside the component callables.
 Page context values reach the component through the template scope, not through the DI cache.
 A component whose ``component.py`` defines a ``render`` function uses a fresh ``DependencyCache`` for that call instead of the shared request cache.
 The surrounding template scope (props and page context variables) is still forwarded to the resolver as DI parameters.

--- a/docs/content/internals/di-resolver.rst
+++ b/docs/content/internals/di-resolver.rst
@@ -23,20 +23,19 @@ Pipeline
 
    flowchart TB
        Callable[Decorated callable] --> Sig[Inspect signature]
-       Sig --> Markers[Scan markers]
-       Markers --> Providers[Provider registry]
+       Sig --> Providers[Providers in priority order]
        Providers --> Resolution[ResolutionContext]
        Resolution --> Cache{Cache hit}
        Cache -- yes --> Value[Cached value]
        Cache -- no --> Provider[Provider.resolve]
        Provider --> Value
        Value --> Inject[Inject parameter]
-       Markers -- Depends --> NamedDep[Named dependency]
-       Markers -- Context --> CtxByKey[Context by key]
-       Markers -- DUrl --> UrlProv[URL provider]
-       Markers -- DQuery --> QueryProv[Query provider]
-       Markers -- form or DForm or class --> FormProv[Form provider]
-       Markers -- name match --> NameProv[Context or URL kwargs by name]
+       Providers -- Depends --> NamedDep[Named dependency]
+       Providers -- Context --> CtxByKey[Context by key]
+       Providers -- DUrl --> UrlProv[URL provider]
+       Providers -- DQuery --> QueryProv[Query provider]
+       Providers -- form or DForm or class --> FormProv[Form provider]
+       Providers -- name match --> NameProv[Context or URL kwargs by name]
 
 Modules
 -------
@@ -45,7 +44,7 @@ Modules
    ``DependencyResolver`` plus the singleton ``resolver`` instance.
    Exposes ``resolve``, ``resolve_dependencies``, and ``resolve_with_template_context`` to run a callable with resolved parameters.
    ``resolve_with_template_context`` is the component entry point.
-   Like ``resolve_dependencies``, it strips ``EXPLICIT_RESOLVE_KEYS`` from the injectable context so a context key cannot shadow a dedicated provider such as ``request`` or ``form``.
+   It strips ``EXPLICIT_RESOLVE_KEYS`` from the template context it injects, so a context key cannot shadow a dedicated provider such as ``request`` or ``form``.
 
 ``next.deps.providers``.
    The ``ParameterProvider`` protocol and the ``RegisteredParameterProvider`` base class.

--- a/docs/content/internals/index.rst
+++ b/docs/content/internals/index.rst
@@ -8,7 +8,7 @@ Each page traces one pipeline with a mermaid diagram, lists the modules involved
 The pages read top to bottom, from a whole-framework map down to each subsystem pipeline.
 
 :doc:`overview`
-   Map of every subsystem with a signals fan out diagram.
+   Map of every subsystem with a signals fan-out diagram.
 
 :doc:`request-lifecycle`
    End to end path of an HTTP request.

--- a/docs/content/internals/overview.rst
+++ b/docs/content/internals/overview.rst
@@ -41,6 +41,9 @@ Subsystems
    * - Static
      - Asset discovery, collector, kinds, backends, JS context.
      - ``next.static``
+   * - Partial
+     - Zones, patches, SSE streams, partial protocol backend.
+     - ``next.partial``
    * - Dependencies
      - Parameter resolver, providers, request cache.
      - ``next.deps``
@@ -61,7 +64,9 @@ Bootstrap
 ---------
 
 Django calls ``NextFrameworkConfig.ready()`` once per process after all applications load.
-The hook registers the framework system checks, runs five installers that wire the subsystems into the Django runtime, and calls ``autodiscover_forms()`` so shared forms register before the first request arrives.
+The hook calls ``register_all()`` to register the framework system checks.
+It then runs five startup hooks in a fixed order that wire the subsystems into the Django runtime, autoreload, templates, staticfiles, components, and form autodiscovery.
+The final hook ``autodiscover_forms()`` registers shared forms before the first request arrives.
 See :doc:`/content/ref/apps` for the canonical ordering and the full API.
 
 How They Compose
@@ -69,6 +74,7 @@ How They Compose
 
 A request hands off ``next.urls`` to ``next.pages`` to ``next.deps`` to ``next.static`` and ``next.components`` before the final HTML returns to the client.
 Form submissions take a parallel path through ``next.forms``, which on validation failure reuses the same render pipeline.
+Partial requests take a zone-patch path through ``next.partial``, which renders the targeted zones through the same render pipeline and returns patches instead of a full page.
 :doc:`request-lifecycle` traces both paths end to end.
 
 Signals Fan Out
@@ -85,6 +91,7 @@ The diagram below shows which subsystem emits each signal and the typical receiv
        URLs["next.urls"]
        Forms["next.forms"]
        Static["next.static"]
+       Partial["next.partial"]
        Deps["next.deps"]
        Server["next.server"]
        Conf["next.conf"]
@@ -95,9 +102,10 @@ The diagram below shows which subsystem emits each signal and the typical receiv
        Pages -- "template_loaded, context_registered, page_rendered" --> Audit
        Components -- "component_registered, components_registered, component_rendered, component_backend_loaded" --> Audit
        URLs -- "route_registered, router_reloaded" --> Watch
-       Forms -- "action_registered, action_dispatched, form_validation_failed" --> Audit
+       Forms -- "action_registered, action_dispatched, form_validation_failed, form_access_denied, wizard_step_submitted, wizard_completed" --> Audit
        Forms -- "action_dispatched" --> Cache
        Static -- "asset_registered, collector_finalized, html_injected, backend_loaded" --> Audit
+       Partial -- "zone_registered, zone_rendered, patch_op_registered, field_validated, sse_stream_opened, sse_stream_closed" --> Audit
        Deps -- "provider_registered" --> Audit
        Server -- "watch_specs_ready" --> Watch
        Conf -- "settings_reloaded" --> Watch
@@ -118,6 +126,7 @@ The dependency graph between subsystems is shallow.
 - ``next.pages``, ``next.components``, ``next.static`` depend on ``next.conf`` and ``next.deps``.
 - ``next.forms`` depends on ``next.pages`` and ``next.deps``.
 - ``next.urls`` depends on ``next.conf``, ``next.deps``, ``next.pages``, ``next.components``, and ``next.forms``.
+- ``next.partial`` depends on ``next.conf``, ``next.deps``, ``next.pages``, ``next.components``, ``next.static``, ``next.forms``, and ``next.urls`` to render zones and shape patches.
 - ``next.server`` depends on ``next.conf``, ``next.pages``, ``next.urls``, and ``next.components``, the subsystems whose trees it watches.
 - ``next.testing`` depends on the page, component, form, dependency, and static subsystems to drive isolation and rendering helpers.
 - ``next.apps`` depends on every subsystem.
@@ -141,9 +150,11 @@ Each subsystem keeps a flat module layout.
    * - ``next.urls``
      - ``manager``, ``backends``, ``dispatcher``, ``parser``, ``markers``, ``reverse``, ``checks``, ``signals``.
    * - ``next.forms``
-     - ``manager``, ``dispatch``, ``backends``, ``decorators``, ``base``, ``markers``, ``serializers``, ``formsets``, ``uid``, ``rendering``, ``autodiscover``, ``checks``, ``signals``.
+     - ``manager``, ``dispatch``, ``backends``, ``decorators``, ``base``, ``markers``, ``serializers``, ``formsets``, ``uid``, ``rendering``, ``autodiscover``, ``wizard``, ``widgets``, ``origin``, ``diagnostics``, ``checks``, ``signals``.
    * - ``next.static``
      - ``manager``, ``collector``, ``discovery``, ``backends``, ``assets``, ``scripts``, ``serializers``, ``defaults``, ``finders``, ``checks``, ``signals``.
+   * - ``next.partial``
+     - ``manager``, ``registry``, ``backends``, ``zone``, ``render``, ``patches``, ``shaping``, ``sse``, ``view``, ``headers``, ``keys``, ``origin``, ``checks``, ``signals``.
    * - ``next.deps``
      - ``resolver``, ``providers``, ``cache``, ``context``, ``markers``, ``signals``. The ``checks`` module is a reserved stub with no checks registered yet.
    * - ``next.server``
@@ -157,7 +168,7 @@ Each subsystem keeps a flat module layout.
    * - ``next.checks``
      - ``__init__`` aggregates system-check registration across every subpackage. ``common`` provides shared helpers used by individual ``checks`` modules.
    * - ``next.templatetags``
-     - ``components``, ``forms``, ``next_static``.
+     - ``components``, ``forms``, ``next_static``, ``partial``.
 
 See Also
 --------

--- a/docs/content/intro/overview.rst
+++ b/docs/content/intro/overview.rst
@@ -12,36 +12,32 @@ Read it once before the tutorial, then refer back when the layout of a real proj
 What next.dj Adds
 -----------------
 
-next.dj layers four things on top of a regular Django project.
+next.dj layers five things on top of a regular Django project.
 
 File router.
-   Every directory under a configured page root becomes a URL.
-   A ``page.py`` in that directory turns it into a navigable page.
+   Every directory under a configured page root becomes a URL, and a ``page.py`` turns it into a navigable page.
    A bracketed segment such as ``[slug]`` becomes a captured URL parameter.
+   See :doc:`/content/topics/file-router`.
 
 Layouts and context.
-   A ``layout.djx`` wraps every page under its directory.
-   Layouts nest down the tree.
-   A ``@context`` decorator publishes named values into the template scope.
-   A context value can also be inherited, so every page below the directory that declares it can read it.
+   A ``layout.djx`` wraps every page under its directory, and layouts nest down the tree.
+   A ``@context`` decorator publishes named values into the template scope, optionally inherited by every descendant page.
+   See :doc:`/content/topics/layouts` and :doc:`/content/topics/context`.
 
 Components.
-   A folder under the configured components root becomes a reusable template fragment.
-   Components carry a template plus optional Python, CSS, and JS files in one folder.
-   The framework discovers them by name and renders them through the ``{% component %}`` tag.
+   A folder under the configured components root becomes a reusable template fragment with optional Python, CSS, and JS files.
+   The framework discovers components by name and renders them through the ``{% component %}`` tag.
+   See :doc:`/content/topics/components`.
 
 Form actions.
-   Subclassing ``next.forms.Form`` or ``next.forms.ModelForm`` automatically registers the form under a ``snake_case`` name derived from the class name.
-   The ``{% form "name" %}`` template tag renders that form by name.
-   The framework validates the submitted data and calls the ``on_valid`` method, injecting only the parameters the method signature asks for.
-   ``Meta`` keys declare access guards (``login_required``, ``permission_required``) and success feedback (``success_url``, ``success_message``).
+   Subclassing ``next.forms.Form`` or ``next.forms.ModelForm`` registers the form under a ``snake_case`` name, rendered by ``{% form "name" %}`` and validated into its ``on_valid`` method.
    Plain functions with no form can also register as actions with ``@action("name")``.
-   This is useful for logout buttons and simple confirmations.
+   See :doc:`/content/topics/forms/overview`.
 
 Partial rendering.
-   A ``{% zone %}`` block names a slice of a page the server can re-render on its own.
-   A form, filter, or link targets a zone, and the server ships the DOM patches the client applies, so a selector or swap strategy never crosses the wire.
+   A ``{% zone %}`` block names a slice of a page the server can re-render on its own, and a form, filter, or link targets that zone.
    Every interaction degrades to a full page cycle when JavaScript is off.
+   See :doc:`/content/topics/partial-rendering/index`.
 
 .. _intro-overview-django-unchanged:
 
@@ -69,7 +65,8 @@ When to Read the Tutorial
 -------------------------
 
 If you have used Django before and want to feel the framework, jump to :doc:`tutorial01`.
-The five tutorial parts build a small Notes application that exercises every core subsystem.
+The six tutorial parts build a small Notes application that exercises every core subsystem.
+The first five wire up routing, layouts, components, forms, and editing, and the sixth makes the Notes index update in place with partial rendering.
 
 .. seealso::
 

--- a/docs/content/intro/tutorial02.rst
+++ b/docs/content/intro/tutorial02.rst
@@ -96,7 +96,7 @@ Add the Detail Page
 
 Create a new directory ``notes/pages/notes/[id]/``.
 The bracketed segment is a URL parameter that the file router captures as ``id``.
-The untyped ``[id]`` segment matches any string, and ``DUrl["id", int]`` in the page module coerces it to an integer.
+The untyped ``[id]`` segment matches any non-slash string, and ``DUrl["id", int]`` in the page module coerces it to an integer.
 The typed ``[int:id]`` directory form rejects non-numeric URLs at routing time before any page code runs, see :doc:`/content/topics/file-router`.
 
 .. code-block:: python

--- a/docs/content/intro/tutorial04.rst
+++ b/docs/content/intro/tutorial04.rst
@@ -38,15 +38,10 @@ Create ``notes/forms.py``.
            model = Note
            fields = ("title", "body")
 
-       # The inherited ModelForm.on_valid already saves and redirects to origin,
-       # so CreateNoteForm needs no override.
-
    class DeleteNoteForm(Form):
        confirm = BooleanField(required=True)
 
        def on_valid(self, request: HttpRequest):
-           # Stub: redirect only, no delete yet. The Delete a Note section
-           # below replaces this with the real delete logic.
            return redirect_to_origin(request)
 
 ``next.forms.ModelForm`` and ``next.forms.Form`` are the framework form base classes.
@@ -268,8 +263,6 @@ The complete file now looks like this.
        class Meta:
            model = Note
            fields = ("title", "body")
-
-       # ModelForm.on_valid saves and redirects to origin by default.
 
    class DeleteNoteForm(Form):
        confirm = BooleanField(required=True)

--- a/docs/content/intro/tutorial06.rst
+++ b/docs/content/intro/tutorial06.rst
@@ -16,7 +16,7 @@ Prerequisites
 You have finished :doc:`tutorial05`.
 The Notes application creates, edits, and deletes notes through registered actions.
 
-The layout from :doc:`tutorial03` already pulls ``{% collect_scripts %}`` into ``<head>``, and the static pipeline injects the client runtime through that tag.
+The layout from :doc:`tutorial03` already pulls ``{% collect_scripts %}`` into the bottom of ``<body>``, and the static pipeline injects the client runtime through that tag.
 There is nothing new to install.
 
 Partial rendering layers on top of the ``POST`` then ``303`` then ``GET`` flow the framework already serves, covered in depth in :doc:`/content/topics/partial-rendering/index`.
@@ -214,7 +214,7 @@ Common Pitfalls
 ---------------
 
 The filter reloads the whole page instead of swapping the list.
-   Check that ``data-next-target`` names the same string as the ``{% zone %}`` tag, and that ``{% collect_scripts %}`` sits in the layout ``<head>`` so the runtime loads.
+   Check that ``data-next-target`` names the same string as the ``{% zone %}`` tag, and that ``{% collect_scripts %}`` sits at the bottom of the layout ``<body>`` so the runtime loads.
 
 Creating a note redirects instead of updating in place.
    The handler only returns a patch inside the ``is_partial_request`` branch.

--- a/docs/content/misc/design-philosophy.rst
+++ b/docs/content/misc/design-philosophy.rst
@@ -59,9 +59,7 @@ A form action is wired the same way a page is.
 The class is the unit of registration, file scope decides its reach, and ``__init_subclass__`` registers it the moment Python runs the ``class`` statement, so a form needs no URL entry, no view, and no decorator.
 This follows the same filesystem-as-source-of-truth rule the rest of the framework keeps.
 
-Every action posts to one endpoint, ``/_next/form/<uid>/``, where the ``uid`` is a stable short id derived from the action's scope and name.
-A per-view dispatch URL would couple each form to a route and re-introduce the URL wiring file scope exists to avoid.
-A single endpoint keyed by a derived uid keeps the invariant that moving a form between pages, or declaring two forms of the same name in different files, never changes the URL configuration.
+Every action posts to one endpoint, ``/_next/form/<uid>/``, where the ``uid`` is a stable short id derived from the action's scope and name, so moving a form between pages never changes the URL configuration.
 The dispatcher resolves the uid back to the registered action and runs the validation and re-render pipeline.
 
 Small Public Surfaces

--- a/docs/content/misc/glossary.rst
+++ b/docs/content/misc/glossary.rst
@@ -87,7 +87,7 @@ Terms used throughout the next.dj documentation.
       Wraps every descendant page.
 
    JS context policy
-      Algorithm class that resolves duplicate serialised keys for ``window.Next.context``.
+      Algorithm class that resolves duplicate serialised keys for ``window.Next.context``, distinct from the :term:`JS context serializer` that encodes the values.
       Selected through ``JS_CONTEXT_POLICY`` inside static backend ``OPTIONS``, see :doc:`/content/topics/static-assets/js-context`.
 
    NextScriptBuilder
@@ -100,7 +100,6 @@ Terms used throughout the next.dj documentation.
    manager
       The singleton orchestrator for one subsystem.
       Examples include ``page``, ``components_manager``, ``router_manager``, ``form_action_manager``.
-      ``page`` is the outlier without a ``_manager`` suffix because the rendering manager is exposed as a decorator-style facade rather than a named singleton.
 
    origin page
       The page that rendered a form.
@@ -150,7 +149,7 @@ Terms used throughout the next.dj documentation.
       Subscribers react without subclassing.
 
    JS context serializer
-      Implementations of ``next.static.JsContextSerializer`` that encode values for ``window.Next.context``.
+      Implementations of ``next.static.JsContextSerializer`` that encode values for ``window.Next.context``, distinct from the :term:`JS context policy` that resolves duplicate keys.
       Distinct from frozen form specs in ``next.forms.serializers``.
 
    slot

--- a/docs/content/ref/conf.rst
+++ b/docs/content/ref/conf.rst
@@ -37,7 +37,8 @@ Import Utilities
 
 .. autofunction:: next.conf.imports.perform_import
 
-.. autofunction:: next.conf.imports.clear_import_cache
+``next.conf.imports.clear_import_cache`` is framework-internal.
+The settings object invokes it from ``reload`` to drop cached imports when settings change.
 
 .. autodata:: next.conf.imports.IMPORT_STRINGS
 

--- a/docs/content/ref/forms.rst
+++ b/docs/content/ref/forms.rst
@@ -144,7 +144,8 @@ Fields and Widgets
 
 The framework re-exports a curated set of commonly used Django form fields and widgets through
 ``next.forms`` so a single import covers most form definitions.
-The package surface is a superset of ``django.forms`` by construction: any public ``django.forms``
+The package surface is a superset of ``django.forms`` by construction.
+Any public ``django.forms``
 name resolves through ``next.forms``, with the framework versions winning where next.dj overrides
 a name such as ``Form`` or ``ModelForm``, and every other name resolving to the Django original.
 The factories ``formset_factory``, ``modelformset_factory``, ``inlineformset_factory``, and
@@ -189,7 +190,8 @@ Dispatch
 ``FormActionDispatch``, ``ActionOutcome``, and ``ActionOutcomeKind`` are the public members of this module.
 ``ActionOutcome`` and ``ActionOutcomeKind`` are re-exported from ``next.forms``, while ``FormActionDispatch`` imports from ``next.forms.dispatch`` directly.
 ``ActionOutcome`` is the frozen keyword-only dataclass a backend's ``shape_response`` hook receives, with ``ActionOutcomeKind`` as its ``kind`` discriminator.
-On ``INVALID`` outcomes the ``page_path`` and ``origin`` fields carry the resolved identity of the origin page: the source location of its ``page.py`` and the validated origin URL path.
+On ``INVALID`` outcomes the ``page_path`` and ``origin`` fields carry the resolved identity of the origin page.
+The ``page_path`` field holds the source location of its ``page.py`` and the ``origin`` field holds the validated origin URL path.
 ``FormActionDispatch.shape_response`` builds the default envelope for one outcome, and the backend hook delegates to it unless overridden.
 ``ensure_http_response`` coerces a handler return value into an ``HttpResponse``, kept for custom backends that drive the pipeline by hand.
 The underscore-prefixed helpers are internal hooks per the ``Internal hooks`` tier described above.

--- a/docs/content/ref/index.rst
+++ b/docs/content/ref/index.rst
@@ -80,7 +80,7 @@ Each page lists the public surface plus configuration and signal entries that be
    testing
    apps
    utils
-   system-checks
    settings
+   system-checks
    template-tags
    decorators

--- a/docs/content/ref/partial.rst
+++ b/docs/content/ref/partial.rst
@@ -238,7 +238,7 @@ System Checks
 -------------
 
 See :doc:`system-checks` for the zone-placement and custom-verb checks
-(``next.E060`` through ``next.E066``, ``next.W067`` through ``next.W070``).
+(``next.E060`` through ``next.E066``, ``next.W067`` through ``next.W071``).
 
 See Also
 --------

--- a/docs/content/ref/settings.rst
+++ b/docs/content/ref/settings.rst
@@ -285,7 +285,15 @@ Use ``next.conf.extend_default_backend`` to patch one key of a default backend e
 The helper returns a deep copy of the default list with the entry at ``index`` (default ``0``) patched by the keyword overrides.
 Nested dicts such as ``OPTIONS`` are merged.
 
-The helper raises ``ImproperlyConfigured`` when ``key`` is not a known backend-list setting.
+The helper accepts five backend-list keys.
+
+- ``PAGE_BACKENDS``
+- ``COMPONENT_BACKENDS``
+- ``STATIC_BACKENDS``
+- ``FORM_ACTION_BACKENDS``
+- ``PARTIAL_BACKENDS``
+
+The helper raises ``ImproperlyConfigured`` when ``key`` is not one of these settings.
 It raises ``IndexError`` when ``index`` is out of range for the default list.
 
 See :doc:`conf` for the helper API and :doc:`/content/howto/extend-a-default-backend` for the recipe.

--- a/docs/content/ref/signals.rst
+++ b/docs/content/ref/signals.rst
@@ -78,8 +78,10 @@ not be retained past the receiver call.
      - After a context callable is attached to a page module.
    * - ``field_validated``
      - The active partial protocol backend class
-     - ``action_name``, ``uid``, ``request``, ``field_names``, ``error_count``
-     - After a validate-only blur pass runs, always behind the action guard so unauthenticated validate traffic never reaches telemetry. ``field_names`` is the validated subset, ``error_count`` the number of fields that failed.
+     - ``action_name``, ``uid``, ``request``, ``field_names``, ``error_count``.
+       ``field_names`` is the validated subset.
+       ``error_count`` is the number of fields that failed.
+     - After a validate-only blur pass runs, always behind the action guard so unauthenticated validate traffic never reaches telemetry.
    * - ``form_access_denied``
      - ``FormActionDispatch``
      - ``action_name``, ``uid``, ``request``, ``layer``, ``reason``
@@ -97,6 +99,7 @@ not be retained past the receiver call.
      - ``Page``
      - ``file_path``, ``duration_ms``, ``styles_count``, ``scripts_count``, ``context_keys``
      - After ``Page.render`` produces HTML and injects static assets. ``duration_ms`` times the render. ``context_keys`` is the tuple of context keys.
+       Fired only when a receiver is connected, and the ``duration_ms`` timer runs under the same gate.
    * - ``patch_op_registered``
      - ``PatchOpRegistry``
      - ``name``

--- a/docs/content/ref/static.rst
+++ b/docs/content/ref/static.rst
@@ -53,6 +53,7 @@ See :doc:`/content/topics/static-assets/js-context` for the runtime script optio
 
 .. automodule:: next.static.scripts
    :members:
+   :exclude-members: csrf_header_name, csrf_payload, csrf_payload_for, CSRF_PAYLOAD_KEY
 
 JS Context Serializer
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -356,6 +356,9 @@ Warnings
    * - ``next.W070``
      - A ``{% form %}`` renders directly inside a ``{% for %}`` of a composed page without a ``key=`` or a ``zone=``, so a partial morph cannot tell the repeated instances apart. The check does not descend into a component template, so a looped ``{% component %}`` that holds the form is not flagged. Thread a ``key=`` into the form to keep the repeated morph correct.
      - ``next.partial.checks``
+   * - ``next.W071``
+     - ``PARTIAL_BACKENDS`` has more than one entry. Partial rendering uses a single protocol backend, so only the first entry runs and the rest are ignored.
+     - ``next.partial.checks``
 
 .. note::
 

--- a/docs/content/ref/template-tags.rst
+++ b/docs/content/ref/template-tags.rst
@@ -16,13 +16,23 @@ Forms
 
    Renders a form bound to a registered action.
    The first argument is the action name, a quoted string or a context variable that resolves to a string.
-   Injects two hidden inputs: the ``csrfmiddlewaretoken`` CSRF field and the ``_next_form_origin`` field carrying the URL path of the rendering page.
+   Injects the ``csrfmiddlewaretoken`` CSRF field, and the ``_next_form_origin`` field carrying the URL path of the rendering page when an origin is available.
    The block body has access to the bound or unbound form through ``{{ form }}``.
 
    Optional ``attr="value"`` arguments after the action name render as HTML attributes on the ``<form>`` element, for example ``{% form "upload_form" class="stack" %}``.
    Attribute values are escaped, and an unquoted value resolves as a context variable.
 
-   The opening tag emits its attributes in a fixed order: ``action`` with the dispatch URL, ``method="post"``, ``data-next-action`` with the action UID when the registry meta is available, ``enctype="multipart/form-data"`` when the form is multipart, then the attributes passed to the tag.
+   The opening tag emits its attributes in a fixed order.
+
+   .. list-table::
+      :widths: 100
+
+      * - ``action`` with the dispatch URL.
+      * - ``method="post"``.
+      * - ``data-next-action`` with the action UID when the registry meta is available.
+      * - ``enctype="multipart/form-data"`` when the form is multipart.
+      * - The attributes passed to the tag.
+
    The ``enctype`` attribute is automatic for any form whose widgets need multipart encoding, so a file-upload form needs no extra argument.
    An explicit ``enctype="..."`` argument on the tag suppresses the automatic value and renders in the user-attribute position, for example ``{% form "upload_form" enctype="text/plain" %}``.
 
@@ -31,7 +41,8 @@ Forms
    ``data-next-*`` is the single framework namespace in rendered markup.
 
    The ``validate``, ``trigger``, ``debounce``, ``zone``, and ``key`` params compile to the matching ``data-next-*`` attributes, the authored seam for partial behaviour.
-   ``key`` distinguishes one instance of a repeated form, rendered in a loop, so a partial morph lands on the submitted instance rather than the first, see :doc:`/content/topics/partial-rendering/scenarios`.
+   ``key`` distinguishes one instance of a repeated form, rendered in a loop, so a partial morph lands on the submitted instance rather than the first.
+   See :doc:`/content/topics/partial-rendering/scenarios`.
 
    Captured URL parameters travel inside the origin path, the dispatcher recovers them by resolving ``_next_form_origin`` against the URLconf.
 
@@ -86,7 +97,7 @@ Components
    Block form.
    Marks a slot location inside a component template, with a fallback body used when the caller omits the slot.
 
-Multiline tag bodies
+Multiline Tag Bodies
 ~~~~~~~~~~~~~~~~~~~~
 
 The framework reinstalls Django's template tag pattern with the ``re.DOTALL`` flag so a single ``{% ... %}`` token may span several lines.

--- a/docs/content/ref/urls.rst
+++ b/docs/content/ref/urls.rst
@@ -30,6 +30,8 @@ Manager
 ``urlpatterns`` is a ``list`` subclass that recollects router and form-action patterns from the active backends on each access.
 The backends themselves are cached by ``router_manager`` and are only rebuilt when ``router_manager.reload()`` runs or when ``PAGE_BACKENDS`` changes.
 A route added after import is therefore visible without a process restart, but each access still iterates the cached backend list rather than walking the page tree again.
+The ``list`` subclass overrides ``__reversed__`` so Django's resolver observes the recollected patterns rather than the empty internal buffer of the ``list`` base.
+Django's resolver iterates ``reversed(urlpatterns)``, so the override feeds it the fresh patterns.
 ``RouterManager`` owns the active backend list, and the ``router_manager`` singleton exposes ``reload()`` to rebuild it.
 
 .. automodule:: next.urls.manager

--- a/docs/content/ref/utils.rst
+++ b/docs/content/ref/utils.rst
@@ -6,7 +6,7 @@ Utils Reference
 Module Summary
 --------------
 
-``next.utils`` exposes two helpers that project code can import: ``resolve_base_dir`` and ``classify_dirs_entries``.
+``next.utils`` exposes two helpers that project code can import, ``resolve_base_dir`` and ``classify_dirs_entries``.
 The module also defines a registration-internal frame helper that the framework uses to attribute decorated callables to their defining file.
 That helper is not part of the public surface and is excluded from the autodoc table below.
 

--- a/docs/content/security/overview.rst
+++ b/docs/content/security/overview.rst
@@ -129,7 +129,7 @@ The framework system checks cover configuration mistakes that affect security.
 
 - ``next.E041`` reports two actions registered under the same name from different handlers.
 - ``next.E045`` reports a form action backend that does not subclass ``FormActionBackend``.
-- ``next.E020`` reports a component name collision that could mask a third party component.
+- ``next.E020`` reports a component registered more than once within the same scope.
 
 Run them with ``uv run python manage.py check``.
 

--- a/docs/content/security/static-assets.rst
+++ b/docs/content/security/static-assets.rst
@@ -18,6 +18,8 @@ Random URLs that match the ``STATIC_URL`` prefix but do not match a registered a
 A custom backend can refuse to serve files that originate outside trusted directories.
 Add the directory whitelist to the backend and reject every path that falls outside.
 
+An empty ``STATIC_BACKENDS`` falls back to the bundled ``StaticFilesBackend``, and ``manage.py check`` reports ``next.W030`` so the missing chain stays visible.
+
 Content Hash
 ------------
 

--- a/docs/content/topics/components.rst
+++ b/docs/content/topics/components.rst
@@ -5,7 +5,6 @@ Components
 
 A component is a reusable template fragment with optional Python context.
 Components live in folders under a configured components root and the framework discovers them by name.
-This page covers the two component shapes, the rules for props and slots, how component context is resolved, how to ship co-located CSS and JS, and how to compose several components into a larger interface.
 
 .. contents::
    :local:
@@ -369,7 +368,7 @@ Module Loading
 By default the framework imports every ``component.py`` from each ``DIRS`` root during component backend setup.
 ``import_all_component_modules`` walks only the ``DIRS``-derived registry entries present at setup time.
 The bulk import runs the side effects of ``@component.context`` so they are visible from the first request.
-A ``component.py`` may also register a form action with ``@action``, which the same import makes visible.
+A ``component.py`` may also register a form action by importing ``action`` from ``next.forms`` and applying ``@action``, which the same import makes visible.
 See :doc:`/content/topics/forms/actions` for the action decorator.
 
 Page-tree ``component.py`` modules follow a different path.

--- a/docs/content/topics/context.rst
+++ b/docs/content/topics/context.rst
@@ -177,7 +177,7 @@ Resolution Order
 The framework computes the template scope in this order.
 
 1. URL kwargs from the matched route are seeded into the context dict.
-2. Inherited context functions from every ancestor ``page.py``, walked from the route root inward.
+2. Inherited context functions from every ancestor ``page.py``, walked from the current page upward toward the page root.
 3. Page level context functions declared in the current ``page.py``.
 4. Context processors run after every ``@context`` callable.
    The first source is ``OPTIONS.context_processors`` on each page backend entry inside ``PAGE_BACKENDS``.

--- a/docs/content/topics/dependency-injection.rst
+++ b/docs/content/topics/dependency-injection.rst
@@ -22,7 +22,7 @@ Custom providers and tests can import ``resolver`` from ``next.deps`` and call `
 Built In Providers
 ------------------
 
-The framework registers a fixed list of providers at startup.
+The framework discovers a fixed list of providers and instantiates them on first use.
 Each one carries an explicit ``priority`` value, the resolver consults them from lowest to highest, and the first match wins.
 
 1. Named dependency provider (priority 10).
@@ -51,6 +51,27 @@ The context-by-name provider sits ahead of the form, URL, and query providers be
 The form provider matches the parameter name ``form``, the marker ``DForm[FormClass]``, and any plain class annotation whose type the bound form is an instance of.
 The URL-kwargs provider is the last fallback that matches on the bare parameter name, after every marker provider has had a chance to claim the parameter.
 
+.. note::
+
+   This ordering is a publish-once, read-by-name escape hatch.
+   An ancestor that publishes a key under ``inherit_context=True`` lets a descendant page read it by bare parameter name in preference to a same-named URL kwarg.
+
+   .. code-block:: python
+      :caption: shadowing a same-named URL kwarg
+
+      # routes/shop/[category]/layout page.py
+      @context("category", inherit_context=True)
+      def category() -> str:
+          return "books"
+
+      # routes/shop/[category]/products/page.py
+      @context("listing")
+      def products(category: str) -> str:
+          return f"Listing for {category}."
+
+   The ``products`` callable receives the published ``category`` value, not the raw ``[category]`` segment.
+   See :doc:`/content/howto/share-context-across-pages` for the full pattern.
+
 DUrl
 ~~~~
 
@@ -70,7 +91,8 @@ The URL path provider coerces the captured segment to the requested type.
 In the simplest form ``DUrl[T]`` matches the captured segment whose name
 equals the parameter name, then coerces the captured value to ``T``.
 ``T`` may be ``str``, ``int``, ``bool``, ``float``, ``UUID``, ``Decimal``, ``date``, or ``datetime``.
-A value that already satisfies ``T`` passes through untouched, so a Django converter that pre-coerced the segment, such as ``[uuid:id]`` producing a :class:`~uuid.UUID`, reaches the handler in that shape.
+A value that already satisfies ``T`` passes through untouched.
+A Django converter that pre-coerced the segment, such as ``[uuid:id]`` producing a :class:`~uuid.UUID`, reaches the handler in that shape.
 A failed parse falls back to the raw captured value rather than raising.
 ``bool`` treats ``"1"``, ``"true"``, and ``"yes"`` as ``True`` and everything else as ``False``.
 ``date`` and ``datetime`` parse the ISO 8601 forms accepted by :meth:`date.fromisoformat <datetime.date.fromisoformat>` and :meth:`datetime.fromisoformat <datetime.datetime.fromisoformat>`.
@@ -186,11 +208,27 @@ Two markers fill parameters from distinct data sources.
 ``Context("key")``.
    Returns the value of the named context key produced by an ancestor layout or by a context function earlier in the chain.
    See :doc:`context` for the full set of ``Context`` shapes and how it relates to plain name matching.
+   ``Context`` takes four forms, namely no argument that reads the parameter name, a string key, a callable, and a constant, with a ``default=`` fallback when the key is absent.
+
+``Depends`` takes one of four forms, selected by its argument.
 
 ``Depends("name")``.
-   Returns the result of a callable registered through the ``resolver.dependency`` decorator.
-   ``Depends`` also accepts a callable factory, a constant value, and a bare ``Depends()`` that falls back to the parameter name.
-   See :doc:`/content/internals/di-resolver` for the four forms.
+   The argument is a string.
+   The resolver looks up the callable registered under that name through ``resolver.dependency`` and invokes it with its own parameters resolved.
+
+``Depends(callable)``.
+   The argument is a callable.
+   The resolver resolves the callable's own parameters and calls it as a factory.
+
+``Depends(value)``.
+   The argument is any other object.
+   That object is injected directly as a constant.
+
+``Depends()``.
+   No argument.
+   The marker falls back to the parameter name and resolves it as the named form.
+
+See :doc:`/content/internals/di-resolver` for the cycle and cache mechanics.
 
 .. code-block:: python
    :caption: consuming context and depends
@@ -340,11 +378,16 @@ Set ``priority`` on the subclass when the new provider has to claim a parameter 
 Resolution Cache
 ----------------
 
-The resolver creates a fresh ``DependencyCache`` for each resolution pass.
+Each resolution pass wraps a per-render dependency cache in a fresh ``DependencyCache``.
+The wrapper is new per call, but the backing store is shared across every ``@context`` callable in one page render, so a ``Depends("name")`` value resolved by one callable is reused by the next.
 The cache memoises ``Depends("name")`` callables only, keyed by the registered name.
-Parameter providers run once per parameter per resolution pass and their results are not stored, so a second context function that asks for the same ``DQuery`` or ``DUrl`` parameter triggers another provider call.
+Parameter providers run once per parameter per resolution pass and their results are not stored.
+A second context function that asks for the same ``DQuery`` or ``DUrl`` parameter triggers another provider call.
 
 A second context function in the same page render that asks for the same ``Depends("name")`` dependency receives the memoised value, not a fresh call.
+To share one value across several context functions in the same render, publish it through a named dependency such as ``Depends("active_tenant")``.
+The cache memoises named dependencies but not raw provider calls.
+See :doc:`/content/howto/share-context-across-pages` for a worked example.
 
 The same cache is shared between the initial render of a form page and the re-render on validation failure.
 ``FormActionDispatch`` attaches its dependency cache to the request, and ``get_request_dep_cache`` reads it back.
@@ -385,11 +428,8 @@ Keep DI types runtime importable.
 Resolver Lifecycle
 ------------------
 
-The resolver builds its provider registry on first use and reuses it, so register custom providers from ``AppConfig.ready`` and see :doc:`/content/internals/di-resolver` for the full lifecycle.
-
-A custom provider that wants to share one value across several context functions in the same render should publish it through ``Depends("name")``, because the per-resolution cache memoises named dependencies but not raw provider calls.
-Register a named callable through ``resolver.dependency("active_tenant")`` and have each ``@context`` function ask for ``Depends("active_tenant")``.
-See :doc:`/content/howto/share-context-across-pages` for a worked example.
+The resolver builds its provider registry on first use and reuses it, so register custom providers from ``AppConfig.ready``.
+See :doc:`/content/internals/di-resolver` for the full lifecycle.
 
 See Also
 --------

--- a/docs/content/topics/extending.rst
+++ b/docs/content/topics/extending.rst
@@ -34,8 +34,6 @@ Signal.
    Observe a lifecycle event without changing it.
    Used for audit, observability, cache invalidation, and cross-app coordination.
 
-Choosing a signal over a backend replacement keeps the framework defaults intact and the project surface small.
-
 Backends
 --------
 

--- a/docs/content/topics/file-router.rst
+++ b/docs/content/topics/file-router.rst
@@ -330,7 +330,7 @@ Hot Reload
 ----------
 
 A backend that reads from a database or other dynamic source needs to rebuild its pattern list when the data changes.
-``router_manager.reload()`` clears the resolver cache and rebuilds every backend, and the call is idempotent.
+``router_manager.reload()`` rebuilds every backend and clears the Django URL resolver cache, and the call is idempotent.
 Each invocation emits a ``router_reloaded`` signal with the manager class as sender, so long lived processes can listen for it to refresh cached URL references.
 Rebuilding drops the cached patterns, so the next request walks every page tree configured in ``PAGE_BACKENDS`` again.
 A burst of model writes that each triggers a reload can dominate that request.

--- a/docs/content/topics/forms/backends.rst
+++ b/docs/content/topics/forms/backends.rst
@@ -134,7 +134,7 @@ That success re-render carries no ``X-Next-*`` headers and never re-enters ``sha
 
 Customisation splits into two layers.
 Override ``render_invalid_page`` when only the page HTML changes.
-The default envelope calls it on the invalid branch with the bound failing form, and on the success re-render of a ``None`` handler result with ``form=None``.
+The default envelope calls it on the invalid branch with the bound failing form, and again on the ``None``-result success re-render described above with ``form=None``.
 Override ``shape_response`` when the envelope itself changes, such as a different status code, extra headers, or a response other than a redirect on a wizard advance.
 
 Building a Backend From Scratch
@@ -150,6 +150,7 @@ The four abstract methods must all be present.
    from typing import Any
    from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
    from django.urls import path
+   from django.views.decorators.http import require_http_methods
    from next.forms import ActionRegistration, FormActionBackend
    from next.forms.dispatch import FormActionDispatch
 
@@ -164,7 +165,8 @@ The four abstract methods must all be present.
            ...
 
        def generate_urls(self) -> list:
-           return [path("_next/custom/<str:uid>/", self.dispatch)]
+           view = require_http_methods(["GET", "POST"])(self.dispatch)
+           return [path("_next/custom/<str:uid>/", view)]
 
        def dispatch(self, request: HttpRequest, uid: str) -> HttpResponse:
            entry = self._entry_for_uid(uid)
@@ -172,6 +174,8 @@ The four abstract methods must all be present.
                return HttpResponseNotFound()
            action_name, meta = entry
            return FormActionDispatch.dispatch(self, request, action_name, meta)
+
+The bundled backend wraps its dispatch view in ``require_http_methods(["GET", "POST"])`` so the endpoint rejects other verbs, and a from-scratch backend should restrict its own view the same way.
 
 ``dispatch`` answers an unknown UID with a 404, either by returning ``HttpResponseNotFound`` or by raising :exc:`~django.http.Http404` with a message.
 The bundled backend raises ``Http404`` explaining that the page which rendered the form may be stale after a rename or restart.
@@ -249,7 +253,7 @@ A custom ``dispatch`` that drives the pipeline by hand reuses one static helper 
 ``ensure_http_response(response, request=None, action_name=None, backend=None)``.
    Coerces a handler return value into an ``HttpResponse``.
    A string becomes a body, an object with a ``url`` becomes a redirect, and ``None`` re-renders the origin page when ``request``, ``action_name``, and ``backend`` are passed, otherwise it returns a 204.
-   The ``None`` re-render goes through ``backend.render_invalid_page`` directly, without the ``X-Next-*`` headers and without re-entering ``shape_response``.
+   The ``None`` re-render follows the behaviour under `Shaping the Response`_, through ``backend.render_invalid_page`` and never re-entering ``shape_response``.
 
 Every outcome of the standard pipeline funnels into exactly one call to the backend hook ``shape_response(request, outcome)`` described under `Shaping the Response`_.
 A layer that must reshape responses globally overrides that one hook instead of patching each dispatch branch.

--- a/docs/content/topics/forms/field-components.rst
+++ b/docs/content/topics/forms/field-components.rst
@@ -194,7 +194,7 @@ A few field types are unsupported because their value semantics need behaviour t
 - A :class:`~django.forms.MultiValueField` such as a split date and time needs value decompression across several controls.
 - A :class:`~django.forms.SelectMultiple` and a checkbox or boolean field need multi-value or omitted-value handling the widget does not perform.
 
-The ``next.W055`` system check warns at startup when a ``ComponentWidget`` is attached to a ``FileField`` or a ``MultiValueField``, the cases where the mismatch silently loses data.
+The ``next.W055`` system check warns at startup for the first two cases, where the mismatch silently loses data.
 
 The widget renders through next.dj's component runtime and bypasses Django's form renderer, so the project's ``FORM_RENDERER`` theming does not apply, and widget introspection through ``subwidgets`` or a ``BoundWidget`` does not reflect the rendered output.
 This is the intended contract, since the component is itself the rendering and theming layer.

--- a/docs/content/topics/forms/overview.rst
+++ b/docs/content/topics/forms/overview.rst
@@ -46,20 +46,11 @@ The framework hashes the action's scope key and name into a single POST endpoint
 The URL is derived deterministically from the class, so a form needs no URL wiring and no per-page route.
 The same form can be embedded on any page that renders its tag and every copy submits to the same endpoint.
 
-File Scope (Anchor Files)
--------------------------
+Scope
+-----
 
-A single global registry would force every form name to be unique across the whole project, so two teams could not both ship a ``NoteForm`` without coordinating names.
-File scope removes that coupling.
-When a form class is declared in ``page.py`` or ``component.py``, its scope is ``page``.
-A page-scoped form is keyed to its definition file, so two different pages may each declare an ``ArticleEditForm`` without collision.
-The ``{% form "article_edit_form" %}`` tag on a given page resolves the form registered in that page's own file first.
-
-Shared Scope
-------------
-
-A form class declared in any other file (``forms.py``, ``models.py``, a module imported by ``AppConfig.ready``, etc.) receives ``shared`` scope.
-A shared form has a project-wide name and is reachable from any template.
+A form declared in ``page.py`` or ``component.py`` is page-scoped and keyed to its file, so two pages may each declare an ``ArticleEditForm`` without collision.
+A form declared in any other file is shared, carries a project-wide name, and is reachable from any template.
 
 .. code-block:: python
    :caption: app/forms.py — auto-registered as ``contact_form`` (shared)
@@ -74,30 +65,15 @@ A shared form has a project-wide name and is reachable from any template.
            send_email(self.cleaned_data["email"])
            return redirect_to_origin(request)
 
+Set ``Meta.scope`` to ``"page"`` or ``"shared"`` to pin the scope regardless of file name.
+See :doc:`actions` for the anchor-file rule, the ``Meta.scope`` override, and the ``next.E047`` check.
+
 Autodiscover
 ------------
 
 ``NextFrameworkConfig.ready`` calls ``autodiscover_forms()`` once on startup.
 It imports the ``forms`` submodule of every installed app so shared forms declared in ``app/forms.py`` register before the first request arrives.
 Set ``NEXT_FRAMEWORK["FORM_AUTODISCOVER"] = False`` to disable the automatic import.
-
-Override Scope
---------------
-
-Set ``Meta.scope`` to pin the form to a specific scope regardless of file name.
-
-.. code-block:: python
-   :caption: forcing page scope from forms.py
-
-   class LoginForm(next.forms.Form):
-       class Meta:
-           scope = "page"
-
-       username = next.forms.CharField()
-       password = next.forms.CharField(widget=next.forms.PasswordInput)
-
-Valid values are ``"page"`` and ``"shared"``.
-Any other value triggers the ``next.E047`` system check and the form is not registered.
 
 Handling Submissions
 --------------------

--- a/docs/content/topics/forms/serializers.rst
+++ b/docs/content/topics/forms/serializers.rst
@@ -4,7 +4,8 @@ Frozen Form Specs
 =================
 
 The forms subsystem ships frozen dataclass descriptors that describe a form, a formset, or a single field as immutable, comparable descriptors.
-This module (``next.forms.serializers``) is unrelated to JSON serializers for :doc:`the browser context object </content/topics/static-assets/js-context>`. Those live under ``next.static``.
+This module (``next.forms.serializers``) is unrelated to JSON serializers for :doc:`the browser context object </content/topics/static-assets/js-context>`.
+Those live under ``next.static``.
 
 Each descriptor is a frozen dataclass, so it is immutable and supports value equality.
 This makes a descriptor safe to cache or compare across renders.

--- a/docs/content/topics/forms/templates.rst
+++ b/docs/content/topics/forms/templates.rst
@@ -23,7 +23,7 @@ The Form Tag
 
 The first argument is the action name as a quoted string or a context variable that resolves to a string.
 An opening tag without the action name raises ``TemplateSyntaxError`` at parse time.
-Optional ``key="value"`` arguments after the name render as HTML attributes on the ``<form>`` element (see `HTML Attributes`_ below).
+Optional ``key="value"`` arguments after the name render as HTML attributes on the ``<form>`` element (see `HTML Attributes`_ below), except for the reserved partial param names (see `Partial Attributes`_ below).
 
 The tag does the following.
 
@@ -48,7 +48,7 @@ A name that is not in the registry raises ``FormActionNotFoundError`` at render 
 HTML Attributes
 ---------------
 
-Every ``key="value"`` argument after the action name lands on the ``<form>`` element, after the framework attributes.
+Every other ``key="value"`` argument after the action name lands on the ``<form>`` element, after the framework attributes.
 
 .. code-block:: jinja
    :caption: extra attributes
@@ -62,6 +62,44 @@ Attribute values are escaped, and an unquoted value resolves as a context variab
 An explicit ``enctype="..."`` argument suppresses the automatic multipart value, for the rare form that needs a different encoding.
 The ``action`` and ``method`` attributes belong to the tag, as does every attribute starting with ``data-next-``, and passing any of them raises ``TemplateSyntaxError`` at parse time.
 ``data-next-*`` is the single framework namespace in rendered markup, so user attributes never collide with framework ones.
+
+Partial Attributes
+------------------
+
+Five argument names are reserved for partial rendering and never land as raw HTML attributes.
+The tag compiles each one to a ``data-next-*`` attribute the client runtime reads.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 35 40
+
+   * - Tag argument
+     - Rendered attribute
+     - Carries
+   * - ``validate``
+     - ``data-next-validate``
+     - The client-side validation mode for the form.
+   * - ``trigger``
+     - ``data-next-trigger``
+     - The event that triggers a partial submission.
+   * - ``debounce``
+     - ``data-next-debounce``
+     - The debounce interval before a triggered submission fires.
+   * - ``zone``
+     - ``data-next-target``
+     - The zone the partial response replaces.
+   * - ``key``
+     - ``data-next-key``
+     - The stable key that pairs the form with its partial target.
+
+Pass each as a ``key="value"`` argument like any other, and the value resolves as a string literal or a context variable the same way an HTML attribute value does.
+
+.. code-block:: jinja
+   :caption: a form that posts a partial update
+
+   {% form "filter_form" trigger="change" debounce="200" zone="results" %}
+     {{ form.query }}
+   {% endform %}
 
 Scope Resolution
 ----------------

--- a/docs/content/topics/forms/wizard-backend.rst
+++ b/docs/content/topics/forms/wizard-backend.rst
@@ -219,11 +219,12 @@ Point ``FORM_WIZARD_BACKEND["BACKEND"]`` at the class to use it.
 
 The framework instantiates the backend lazily on first use and caches the instance, so the constructor runs once per process.
 A signed-cookie store or an external draft service follows the same shape, reading its own options from ``OPTIONS``.
+The framework reads ``FORM_WIZARD_BACKEND`` on first use, caches the result, and resets the cache when settings reload.
+The test isolation helper :func:`next.testing.reset_form_registration_state` resets it between cases.
 
-The lazy instance lives behind ``next.forms.wizard.wizard_backend_manager``, an instance of ``WizardBackendManager``.
-It reads ``FORM_WIZARD_BACKEND`` on first ``get()`` and caches the result.
-Application code never touches it directly.
-The framework resets it when settings reload, and the test isolation helper :func:`next.testing.reset_form_registration_state` resets it between cases.
+.. note::
+
+   The lazy instance is internal and application code never touches it directly.
 
 See Also
 --------

--- a/docs/content/topics/forms/wizard.rst
+++ b/docs/content/topics/forms/wizard.rst
@@ -105,7 +105,8 @@ The done Method
 It receives ``request`` and the merged ``cleaned_data`` of every stored step, so the keys from each step form are flattened into one mapping.
 For a wizard whose steps are ModelForms over a single model, the merged dict maps straight onto a model constructor.
 A field declared by two steps merges to the last stored value.
-Call ``self.get_cleaned_data_for_step(step)`` when the per-step value matters: it returns that step's stored dict, or ``None`` when the step has not been submitted.
+Call ``self.get_cleaned_data_for_step(step)`` when the per-step value matters.
+It returns that step's stored dict, or ``None`` when the step has not been submitted.
 
 .. code-block:: python
    :caption: finalising the wizard
@@ -119,7 +120,8 @@ The base implementation raises ``NotImplementedError``, so every wizard subclass
 Return any ``HttpResponse``, most often a redirect away from the wizard.
 
 A field declared by two steps is statically flagged by the ``next.W059`` check, since the merge silently keeps the last value.
-``Meta.success_message`` works on a wizard too: the message is flashed once, after ``done`` succeeds, interpolated over the merged step data, with ``get_success_message`` as the dynamic override.
+``Meta.success_message`` works on a wizard too.
+The message is flashed once, after ``done`` succeeds, interpolated over the merged step data, with ``get_success_message`` as the dynamic override.
 See :ref:`topics-forms-actions-success` for the message contract.
 
 Keep ``done`` idempotent.
@@ -159,6 +161,7 @@ The return value of ``done`` follows the same coercion as an action handler.
 
 - An ``HttpResponse`` subclass is sent as is. A redirect is the usual choice.
 - A string becomes an ``HttpResponse`` body with status 200.
+- A model instance with a ``get_absolute_url`` method redirects to that URL, the ``CreateView``-style idiom for a finaliser that saves and shows the result.
 - A value with a truthy ``url`` attribute becomes an ``HttpResponseRedirect`` to that URL.
 - ``None`` coerces to a success response that re-renders the origin page.
 
@@ -296,7 +299,8 @@ The captured kwarg name matches ``Meta.url_param``.
 On a valid non-final step the dispatcher saves the step data and redirects to the next step's URL.
 The redirect reuses the current page path and swaps the step segment, so ``request/identity/`` becomes ``request/scope/``.
 On a valid final step the dispatcher merges every stored step and calls ``done``.
-A direct POST to the final step does not finalise while an earlier step has no stored data: the dispatcher redirects to the first incomplete step instead, so a partial draft never reaches ``done``.
+A direct POST to the final step does not finalise while an earlier step has no stored data.
+The dispatcher redirects to the first incomplete step instead, so a partial draft never reaches ``done``.
 An invalid step re-renders the current step with its errors, and the draft already saved for earlier steps is left untouched.
 
 Back-navigation works through the same URL.

--- a/docs/content/topics/layouts.rst
+++ b/docs/content/topics/layouts.rst
@@ -80,7 +80,7 @@ The closing tag can be written either way.
      </body>
    </html>
 
-Without the placeholder the layout still renders, but the page body is dropped at render time without an error.
+Without the placeholder that layout emits its own markup and discards the wrapped content, so the page body and every inner layout below the broken layer vanish from the output without an error.
 The ``check_layout_templates`` system check emits ``next.W001`` for any ``layout.djx`` that lacks a ``{% block template %}`` block.
 Run ``uv run python manage.py check`` to catch layouts that miss the placeholder.
 

--- a/docs/content/topics/pages.rst
+++ b/docs/content/topics/pages.rst
@@ -58,6 +58,10 @@ This is the authoritative ordering for the page render path.
 
 A ``render`` function therefore cannot read a value that a ``@context`` callable would publish, because the callables have not run yet.
 
+A partial-zone request takes a different path.
+When the request targets named zones, the view returns a zone response before step 3, so the layout composition does not run.
+See :doc:`/content/topics/partial-rendering/zones` for the zone-morph request.
+
 The ``render`` Function
 -----------------------
 
@@ -151,8 +155,8 @@ Unkeyed dict.
    Useful when several values share a dependency you only want to resolve once.
    The unkeyed form must return a mapping, and a return annotation that is not a mapping type reports :ref:`next.E029 <ref-system-checks>`.
 
-The ``inherit_context=True`` flag on a keyed function publishes the value to
-every descendant page rather than to the declaring page alone.
+The ``inherit_context=True`` flag works on both the keyed and the unkeyed-dict shapes.
+It publishes the value to every descendant page rather than to the declaring page alone.
 See :doc:`context` for that flag and the other ways to vary the decorator.
 
 Including Values in the JS Context
@@ -344,7 +348,7 @@ Register a ``MarkdownTemplateLoader`` in ``NEXT_FRAMEWORK["TEMPLATE_LOADERS"]`` 
 The loader renders the Markdown to a body string, and that body flows through the ancestor layout chain like any other source.
 The page module still supplies context functions and action handlers as usual.
 
-The loader output passes through Django's template engine before the layout chain renders it.
+The loader output is substituted into the composed layout and rendered in one Django template pass.
 Any ``{{ ... }}`` or ``{% ... %}`` token inside the Markdown source is evaluated.
 Wrap untrusted prose in ``{% verbatim %}`` blocks inside the loader, or escape the braces before returning the body, when authors should not be able to invoke template tags.
 

--- a/docs/content/topics/partial-rendering/done-choreographies.rst
+++ b/docs/content/topics/partial-rendering/done-choreographies.rst
@@ -56,12 +56,14 @@ The runtime closes the layer, fires accept, and by ``data-next-accepted="request
    GET / HTTP/1.1
    X-Next-Request: 1
    X-Next-Zone: request-list
+   X-Next-Origin: /
 
 The list re-renders through its own page view, with its own guards and middleware, on a request that carries the caller's cookies.
-The wizard is portable: it sits on any page without a change, and ``data-next-accepted`` moves with the markup.
+The wizard is portable.
+It sits on any page without a change, and ``data-next-accepted`` moves with the markup.
 
 This is the cycle of a redirect with reloaded props.
-The cost is one extra GET after the modal closes, which the dialog animation hides.
+The cost is one extra GET after the modal closes, masked by the ``aria-busy`` busy gate the runtime sets on the target.
 
 Server OOB Through Page Addressing
 ----------------------------------

--- a/docs/content/topics/partial-rendering/how-it-works.rst
+++ b/docs/content/topics/partial-rendering/how-it-works.rst
@@ -67,5 +67,5 @@ See Also
 
 .. seealso::
 
-   :doc:`scenarios` for the same flow shown as six concrete tasks.
+   :doc:`scenarios` for the same flow shown as seven concrete tasks.
    :doc:`reference` for the verbs, headers, attributes, and client runtime surface in tables.

--- a/docs/content/topics/partial-rendering/index.rst
+++ b/docs/content/topics/partial-rendering/index.rst
@@ -13,14 +13,14 @@ The runtime is an enhancement layered on top of the same ``POST`` then ``303`` t
 A page that works without the runtime keeps working with it, and gains the partial behaviour for free.
 
 Read :doc:`scenarios` first.
-It walks six concrete tasks from markup to handler, and the rest of the section deepens one concern at a time.
+It walks seven concrete tasks from markup to handler, and the rest of the section deepens one concern at a time.
 
 .. rubric:: The tutorial
 
 :doc:`scenarios`
-   Six scenarios from task to markup to handler: neighbouring forms, inline validation,
-   an auto-submitting filter, pagination and infinite scroll, a live stream, and a modal
-   wizard that refreshes a list.
+   Seven scenarios from task to markup to handler: neighbouring forms, inline validation,
+   an auto-submitting filter, pagination and infinite scroll, a live stream, a modal
+   wizard that refreshes a list, and lazy zones.
 
 .. rubric:: Concepts
 

--- a/docs/content/topics/partial-rendering/reference.rst
+++ b/docs/content/topics/partial-rendering/reference.rst
@@ -32,11 +32,11 @@ The server is the only author of a target, the client never names one.
    * - ``replace``
      - ``replace()``
      - Replace the node wholesale, no morph.
-     - —
+     - none
    * - ``inner``
      - ``inner()``
      - Replace only the contents, no morph.
-     - —
+     - none
    * - ``append``
      - ``append()``
      - Add children at the end, dedup by ``data-next-key`` or ``id``.
@@ -48,15 +48,15 @@ The server is the only author of a target, the client never names one.
    * - ``remove``
      - ``remove()``
      - Remove the target.
-     - —
+     - none
    * - ``refresh``
      - ``refresh()``
      - Ask the client to re-fetch the zone with its own cookies. The safe default of an SSE fan-out.
-     - —
+     - none
    * - ``context``
      - ``context()``
      - Merge named serialize-provider values into ``Next.context`` and fire ``context-updated``.
-     - —
+     - none
    * - ``event``
      - ``event()``
      - Dispatch a ``CustomEvent`` on the document and the ``Next.on`` bus.
@@ -68,7 +68,7 @@ The server is the only author of a target, the client never names one.
    * - ``layer.open``
      - ``layer_open()``
      - Open a layer from the server, by zone or href.
-     - —
+     - none
    * - ``layer.close``
      - ``layer_close()``
      - Close the top layer with an accept result or a dismissal.
@@ -82,7 +82,7 @@ The server is the only author of a target, the client never names one.
    * - ``visit``
      - ``redirect()``
      - A full client navigation to a server-authored href. ``external=True`` skips same-host validation, see :ref:`security-overview`.
-     - —
+     - none
 
 A verb beyond this set is registered on both sides.
 ``register_patch_op("confetti")`` on the server clears the ``next.E066`` check and earns the generic ``op()`` channel on the builder.
@@ -185,7 +185,7 @@ Status Codes
    * - 404
      - An unknown form uid, the existing behaviour.
    * - 409
-     - A version mismatch on a safe method, with an empty body. The runtime fully visits the current URL. A mutation always runs and expresses a mismatch with a ``visit`` patch instead.
+     - A version mismatch on a safe method, with an empty body. The runtime fully visits the current URL. A mutation always runs, and a version mismatch surfaces in the envelope version, which the client reads to reload once into a full client visit.
    * - 5xx
      - No envelope. The runtime swaps nothing and fires ``partial:error``.
 

--- a/docs/content/topics/partial-rendering/scenarios.rst
+++ b/docs/content/topics/partial-rendering/scenarios.rst
@@ -14,7 +14,7 @@ Every scenario degrades to a full page cycle without the runtime.
 Three Neighbouring Forms
 ------------------------
 
-A board settings page carries three independent forms: rename the board, add a column, archive the board.
+A board settings page carries three independent forms, one to rename the board, one to add a column, one to archive the board.
 A validation error in one form must not touch the DOM of the other two, so text typed but not yet submitted in a neighbour survives.
 
 This works with no changes at all.
@@ -136,7 +136,7 @@ Without the runtime nothing happens on blur and validation runs on submit, the c
 An Auto-Submitting Filter
 -------------------------
 
-A product catalogue is filtered by a panel form: search, brands, price, sort.
+A product catalogue is filtered by a panel form over search, brands, price, and sort.
 Today an Apply button triggers a full reload.
 The results should update as the user types, the URL should stay shareable, and the providers should not change.
 
@@ -315,7 +315,8 @@ The vote page wraps its results in a zone and connects the stream with a ``data-
    <div data-next-sse="/polls/{{ poll.pk }}/stream/"></div>
 
 The vote form lives inside the chart component and does not change.
-The broker carries one extra field: each change event ships the request id of the mutation that produced it.
+The broker carries one extra field.
+Each change event ships the request id of the mutation that produced it.
 Threading that id is the application channel's job, the framework does not smuggle it.
 
 A vote from the initiating tab posts with a request id.
@@ -327,7 +328,7 @@ A vote from the initiating tab posts with a request id.
    X-Next-Request: 1
    X-Next-Request-Id: 1c9f…-r1
 
-The vote handler here returns ``None``, so the dispatcher funnels the POST into a morph of the initiator's zone and the tab stays in place.
+The vote handler here returns ``None`` and the vote form carries no ``zone=``, so the dispatcher funnels the POST into an extract-morph of the vote form by its uid and the tab stays in place.
 A handler that redirects on success would full-navigate the initiator instead.
 Then every subscriber receives the same envelope over the stream.
 
@@ -465,6 +466,7 @@ The runtime closes the layer, fires accept, and by ``data-next-accepted="request
    GET / HTTP/1.1
    X-Next-Request: 1
    X-Next-Zone: request-list
+   X-Next-Origin: /
 
 The wizard never knows about the list, the list never knows about the wizard, and the opening link binds them.
 Without the runtime the button navigates to the full step page, steps advance with a 302 between step pages, and the last step redirects to the ``fallback`` audit page.

--- a/docs/content/topics/partial-rendering/zones.rst
+++ b/docs/content/topics/partial-rendering/zones.rst
@@ -18,7 +18,8 @@ The default shape of an invalid form submission is an extract-morph.
 The server re-renders the whole origin page through the existing re-render path and sends it with ``extract: true``.
 The client parses the document, trims out the failed form by its ``data-next-action`` uid, and morphs only that form into the live page.
 
-The result on screen is correct: only the failed form changes, the neighbouring forms keep their typed input, the caret stays put.
+The result on screen is correct.
+Only the failed form changes, the neighbouring forms keep their typed input, the caret stays put.
 The cost is on the server, not the DOM.
 The whole page renders even though one form is kept.
 
@@ -34,9 +35,8 @@ The whole page renders even though one form is kept.
      "form": {"uid": "ab12cd34", "valid": false, "errors": {"title": ["…"]}}
    }
 
-This is the price today, not a regression.
-Before partial rendering an invalid submission always re-rendered the full page, so the extract default does exactly what the page did and adds nothing.
-The runtime turns that full render into a targeted DOM update for free.
+This is the price today, not a regression, because an invalid submission always re-rendered the full page before partial rendering.
+The runtime turns that same full render into a targeted DOM update for free.
 
 Adding a Zone
 -------------
@@ -138,7 +138,8 @@ A wrapping ``zone=`` is the alternative, and a looped form with neither raises `
 
 ``next.W070`` catches a ``{% form %}`` written directly inside a ``{% for %}`` of a composed page.
 It does not descend into a component template, so a form inside a ``{% component %}`` that a loop renders is not flagged.
-The remedy is the same either way: thread a ``key=`` with a stable per-row value into the form, and the repeated morph lands on the submitted instance even when the form lives inside a looped component.
+The remedy is the same either way.
+Thread a ``key=`` with a stable per-row value into the form, and the repeated morph lands on the submitted instance even when the form lives inside a looped component.
 
 Zone Rules the Checks Enforce
 -----------------------------

--- a/docs/content/topics/project-layout.rst
+++ b/docs/content/topics/project-layout.rst
@@ -123,6 +123,23 @@ Scalar and list overrides replace the existing value.
 Dict overrides such as ``OPTIONS`` are merged one level deep into the default dict.
 Use it for narrow overrides such as changing the page directory name.
 
+A dict override illustrates the one-level-deep merge.
+
+.. code-block:: python
+   :caption: config/settings.py
+
+   from next.conf import extend_default_backend
+
+   NEXT_FRAMEWORK = {
+       "PAGE_BACKENDS": extend_default_backend(
+           "PAGE_BACKENDS",
+           OPTIONS={"context_processors": ["myapp.context.site"]},
+       )
+   }
+
+The default backend ships ``OPTIONS`` carrying only the ``context_processors`` key.
+The override merges into that dict one level deep, so any key the override omits keeps its default value while the supplied ``context_processors`` list replaces the empty default.
+
 Per Project Page DIRS
 ---------------------
 

--- a/docs/content/topics/static-assets/asset-kinds.rst
+++ b/docs/content/topics/static-assets/asset-kinds.rst
@@ -43,7 +43,7 @@ The Registry
 ------------
 
 The kind registry is ``next.static.default_kinds``, an instance of ``KindRegistry``.
-A kind registration is keyed by the ``kind`` identifier and carries three pieces of metadata.
+A kind registration is keyed by the ``kind`` identifier and carries four pieces of metadata.
 
 ``kind``.
    The registry key, a non-empty Python identifier such as ``css`` or ``jsx``.
@@ -59,6 +59,10 @@ A kind registration is keyed by the ``kind`` identifier and carries three pieces
 ``renderer``.
    The method name that the active static backend exposes for rendering this kind.
    The manager looks the method up with ``getattr`` on the backend per asset.
+
+``inline_tag``.
+   The optional HTML wrapper element for an inline body, such as ``"style"`` or ``"script"``.
+   It defaults to verbatim, which wraps nothing and emits the inline body as written.
 
 Registering a Kind
 ------------------
@@ -83,6 +87,7 @@ Register kinds in ``AppConfig.ready`` so the kind exists before the first reques
            )
 
 The ``jsx`` kind now lands in the ``scripts`` slot and renders through ``render_module_tag``.
+The ``register`` call also accepts an optional ``inline_tag`` keyword, the HTML wrapper element such as ``"style"`` or ``"script"`` that wraps an inline body, defaulting to verbatim.
 A repeated call with identical parameters is idempotent.
 A repeated call with different parameters raises ``ValueError``.
 
@@ -161,10 +166,13 @@ Module Kind
 The ``module`` kind renders ``<script type="module" src="...">`` through ``render_module_tag``.
 Customise the rendered output through the ``module_tag`` key in the backend ``OPTIONS`` mapping, see :doc:`backends`.
 
+The ``module`` kind carries no ``inline_tag``, so it renders an inline body verbatim, as do custom kinds registered without an ``inline_tag``.
+
 System Checks
 -------------
 
-The static system checks validate the backend configuration and the ``JS_CONTEXT_SERIALIZER`` setting (``next.W042``).
+The static system checks ``next.W030`` and ``next.W031`` validate the backend configuration.
+The ``next.W042`` check validates the ``JS_CONTEXT_SERIALIZER`` setting.
 They do not validate kind registration.
 A bad call to ``default_kinds.register`` raises ``ValueError`` during ``AppConfig.ready``.
 Because Django runs ``ready`` for every management command and during ASGI or WSGI worker boot, the exception aborts whatever process is starting up, not only ``manage.py check``.

--- a/docs/content/topics/static-assets/index.rst
+++ b/docs/content/topics/static-assets/index.rst
@@ -4,9 +4,6 @@ Static Assets
 =============
 
 The static pipeline discovers co-located CSS, JS, and module files, deduplicates them across requests, and injects them into HTML.
-The default injection points are the ``collect_*`` template tags, which mark placeholder slots in the layout.
-Extra slots register through ``default_placeholders.register``, so projects can add their own injection points beyond ``styles`` and ``scripts``.
-The pipeline is fully pluggable through asset kinds, custom stems, and backends.
 
 .. rubric:: Concepts
 

--- a/docs/content/topics/static-assets/js-context.rst
+++ b/docs/content/topics/static-assets/js-context.rst
@@ -65,7 +65,14 @@ System Check
 ~~~~~~~~~~~~
 
 The ``next.W042`` system check validates ``JS_CONTEXT_SERIALIZER`` at startup.
-It warns when the value is not a string, when the dotted path cannot be imported, when the resolved attribute is not a class, when the class cannot be instantiated, or when the instance does not implement the ``JsContextSerializer`` protocol (a ``dumps(value) -> str`` method).
+It warns under any of five conditions.
+
+- The value is not a string.
+- The dotted path cannot be imported.
+- The resolved attribute is not a class.
+- The class cannot be instantiated.
+- The instance does not implement the ``JsContextSerializer`` protocol, a ``dumps(value) -> str`` method.
+
 The check is skipped when the key is absent or set to an empty string.
 
 Per-Key Serializer
@@ -279,7 +286,8 @@ An absent or empty ``NEXT_JS_OPTIONS`` uses the ``AUTO`` policy and the default 
 .. note::
 
    Under ``MANUAL`` the static manager skips both the preload hint and the ``Next._init`` wrap, exactly like ``DISABLED``.
-   To inject ``window.Next`` yourself, resolve the runtime URL with ``staticfiles_storage.url(NEXT_JS_STATIC_PATH)`` from ``next.static.scripts``, then build a ``NextScriptBuilder.from_options(url, NEXT_JS_OPTIONS)`` and emit ``preload_link()``, ``script_tag()``, and ``init_script(js_context)`` from a custom template tag or middleware.
+   To inject ``window.Next`` yourself, resolve the runtime URL with ``staticfiles_storage.url(NEXT_JS_STATIC_PATH)`` from ``next.static.scripts``, then bind one ``builder = NextScriptBuilder.from_options(url, NEXT_JS_OPTIONS)``.
+   Emit ``builder.preload_link()``, ``builder.script_tag()``, and ``builder.init_script(js_context)`` from a custom template tag or middleware.
 
 Set the policy through the ``NEXT_JS_OPTIONS`` dict.
 

--- a/docs/content/topics/static-assets/overview.rst
+++ b/docs/content/topics/static-assets/overview.rst
@@ -46,6 +46,7 @@ StaticAsset
 
 ``inline``.
    The pre-rendered inline body, or ``None`` for URL assets.
+   The manager wraps a ``css`` inline body in a ``<style>`` element and a ``js`` inline body in a ``<script>`` element on injection.
 
 ``url`` and ``inline`` are mutually exclusive.
 A URL asset carries a non-empty ``url`` and a ``None`` ``inline``.
@@ -130,7 +131,8 @@ Where Assets Live
 Hot Reload
 ----------
 
-The collector re-runs discovery on every request, so a saved or added co-located asset is picked up on the next page load without a process restart.
+The collector re-probes co-located files on every request, so a saved or added ``component.css`` or ``component.js`` is picked up on the next page load without a process restart.
+Module-level ``styles`` and ``scripts`` lists are read when the module imports, so an edit to one takes effect after a ``page.py`` change restarts the dev server.
 See the Hot Reload section of :doc:`/content/topics/components` for the full reload contract across ``page.py``, ``component.py``, and ``.djx`` changes.
 
 Production Build

--- a/docs/content/topics/static-assets/template-tags.rst
+++ b/docs/content/topics/static-assets/template-tags.rst
@@ -101,6 +101,9 @@ Prepend a hash sign to open the block and pair it with the matching close tag.
      console.log("hello");
    {% /use_script %}
 
+The framework wraps a ``{% #use_style %}`` body in a ``<style>`` element and a ``{% #use_script %}`` body in a ``<script>`` element on injection.
+The author writes only the inner CSS or JS, not the surrounding tag.
+
 The block body is rendered with the current template context, so inline blocks can interpolate page variables.
 Blank only blocks are dropped.
 The collector deduplicates inline entries by the rendered body, so two identical blocks collapse to one.
@@ -118,7 +121,8 @@ The recommended placement is the outermost layout.
 Customising the Tag Output
 --------------------------
 
-The ``collect`` tags accept no HTML attributes, and the rendered ``<link>``, ``<script>``, and ``<script type="module">`` markup comes from the active backend, see :doc:`backends` for the ``css_tag``, ``js_tag``, and ``module_tag`` ``OPTIONS`` keys.
+The ``collect`` tags accept no HTML attributes, and the rendered ``<link>``, ``<script>``, and ``<script type="module">`` markup comes from the active backend.
+See :doc:`backends` for the ``css_tag``, ``js_tag``, and ``module_tag`` ``OPTIONS`` keys.
 
 Tag Loading
 -----------

--- a/docs/content/topics/testing.rst
+++ b/docs/content/topics/testing.rst
@@ -30,6 +30,15 @@ The table below maps each testing goal to the helper and its import path.
    * - POST to a registered action by name
      - ``NextClient.post_action``
      - ``next.testing`` or ``next.testing.client``
+   * - GET a URL as a partial zone request
+     - ``NextClient.get_zones``
+     - ``next.testing`` or ``next.testing.client``
+   * - Decode a partial response for structural assertions
+     - ``envelope_of``
+     - ``next.testing`` or ``next.testing.client``
+   * - Inspect ops, targets, and assets of a patch envelope
+     - ``PartialEnvelope``
+     - ``next.testing`` or ``next.testing.client``
    * - Render a page body without HTTP
      - ``render_page``
      - ``next.testing`` or ``next.testing.rendering``
@@ -70,7 +79,8 @@ The table below maps each testing goal to the helper and its import path.
      - ``reset_form_registration_state``
      - ``next.testing`` or ``next.testing.isolation``
 
-You can import everything above from the ``next.testing`` package. Submodule imports stay valid when you prefer explicit paths.
+You can import everything above from the ``next.testing`` package.
+Submodule imports stay valid when you prefer explicit paths.
 See :doc:`/content/ref/testing` for generated signatures.
 
 Boot the Suite
@@ -164,7 +174,8 @@ Eager Page Loading
 ``eager_load_pages(base_dir)`` imports every ``page.py`` under a given directory.
 Use it when a test suite does not go through the full request cycle and must trigger ``@context`` and ``@action`` side-effects manually.
 ``clear_loaded_dirs()`` drops the per-directory memoisation so a later ``eager_load_pages`` call re-imports.
-It is needed only when a test rewrites ``page.py`` files on disk within a single session.
+It is intended for self-tests of the loader and for the rare case of rewritten ``page.py`` files within one session.
+A normal test suite does not call it, since each pytest session starts a fresh interpreter.
 
 NextClient
 ----------
@@ -214,6 +225,46 @@ A value already present in ``data`` under ``_next_form_origin`` wins over the ke
 Both methods resolve the name through ``resolve_action_url`` from ``next.testing.actions``.
 An unknown name raises ``FormActionNotFoundError`` from ``next.forms``.
 
+Partial Requests
+~~~~~~~~~~~~~~~~
+
+The client drives partial rendering without hand-built headers.
+Pass ``partial=True`` and ``zones=`` to ``post_action`` to turn the POST into a patch request scoped to a zone.
+``zones`` accepts one name or a tuple of names.
+
+.. code-block:: python
+   :caption: tests/test_partial_action.py
+
+   from next.testing.client import NextClient, envelope_of
+
+   def test_partial_morph(db) -> None:
+       response = NextClient().post_action(
+           "create_note",
+           {"title": "hi"},
+           partial=True,
+           zones="notes",
+       )
+       envelope = envelope_of(response)
+       assert "notes" in envelope.zone_targets()
+
+``NextClient.get_zones(url, zones)`` GETs a URL as a partial request for the named zones.
+``zones`` is one name or a tuple of names.
+Both ``post_action`` and ``get_zones`` accept a ``version=`` keyword that stamps the ``X-Next-Version`` header so tests can drive the version-sync branch.
+
+.. code-block:: python
+   :caption: tests/test_partial_get.py
+
+   from next.testing.client import NextClient, envelope_of
+
+   def test_zone_get() -> None:
+       response = NextClient().get_zones("/notes/", "notes")
+       envelope = envelope_of(response)
+       assert envelope.zone_targets() == ["notes"]
+
+``envelope_of(response)`` decodes a patch response into a ``PartialEnvelope``.
+It raises when the response is not a patch envelope, so a navigation fallback never passes a structural assertion.
+``PartialEnvelope`` exposes ``version``, ``ops``, and ``assets``, plus ``op_verbs``, ``targets``, ``zone_targets``, ``form_targets``, ``form_meta``, ``toasts``, and ``html_for_zone`` for asserting on the server contract without parsing HTML.
+
 Render a Page
 -------------
 
@@ -228,7 +279,7 @@ Use ``next.testing.rendering`` to render a page without an HTTP round trip.
        html = render_page("notes/pages/page.py")
        assert "Notes" in html
 
-``render_page`` reads the static body source, the ``template`` attribute or a ``template.djx`` file, then runs context functions and the static collector.
+``render_page`` reads the static body source, the ``template`` attribute or a registered file template such as ``template.djx``, then runs context functions and the static collector.
 It does not invoke a ``render()`` function declared in ``page.py``.
 Use ``NextClient`` for pages whose body is built by ``render()``.
 Use it for snapshot tests and template assertion tests that do not need URL routing.
@@ -274,10 +325,12 @@ The recorder holds a list of ``SignalEvent`` instances with ``signal``, ``sender
    The full list of captured ``SignalEvent`` instances in emission order.
 
 ``start()``.
-   Connects receivers for every tracked signal and returns the recorder. Called automatically on context entry.
+   Connects receivers for every tracked signal and returns the recorder.
+   Called automatically on context entry.
 
 ``stop()``.
-   Disconnects receivers for every tracked signal. Called automatically on context exit.
+   Disconnects receivers for every tracked signal.
+   Called automatically on context exit.
 
 ``events_for(signal)``.
    Returns the list of captured events emitted by that signal.
@@ -319,7 +372,8 @@ Action Helpers
 ``next.testing.actions`` exposes ``resolve_action_url`` and ``build_form_for``.
 ``resolve_action_url`` turns an action name into its dispatch URL.
 ``build_form_for`` builds a bound form for an action so a unit test can assert validation without HTTP.
-Both raise ``FormActionNotFoundError`` from ``next.forms`` for an unknown action name, with the closest registered names rendered into the message, and ``build_form_for`` raises ``LookupError`` for an action registered without a form class.
+Both raise ``FormActionNotFoundError`` from ``next.forms`` for an unknown action name, with the closest registered names rendered into the message.
+``build_form_for`` raises ``LookupError`` for an action registered without a form class.
 
 .. code-block:: python
    :caption: tests/test_action_helpers.py

--- a/docs/content/topics/url-reversing.rst
+++ b/docs/content/topics/url-reversing.rst
@@ -3,11 +3,8 @@
 URL Reversing
 =============
 
-next.dj generates URL names for every file-routed page.
-This page covers the two reverse helpers ``page_reverse`` and ``with_query`` exported from ``next.urls``.
-``page_reverse`` builds a URL from a directory-shaped template.
-``with_query`` adjusts the query string of an existing URL.
-These helpers cover every location where Python code needs a URL path, including action redirects, signal payloads, and tests.
+next.dj generates a URL name for every file-routed page.
+This page covers ``page_reverse`` and ``with_query``, the two reverse helpers exported from ``next.urls``.
 
 .. contents::
    :local:
@@ -134,6 +131,9 @@ The helper takes a URL string and adds, replaces, or removes query parameters.
    # An empty-valued parameter is preserved unless you pass that key.
    with_query("/search/?flag=", query="next.dj")
    # "/search/?flag=&query=next.dj"
+
+``with_query`` preserves blank-valued keys such as ``flag=`` because it parses the existing query with blank values kept.
+Pass the key explicitly to change or drop it.
 
 Multi Value Keys
 ~~~~~~~~~~~~~~~~

--- a/next/client/apply.test.ts
+++ b/next/client/apply.test.ts
@@ -103,6 +103,21 @@ describe("parseEnvelope", () => {
       { kind: "css", url: "/also-ok.css" },
     ]);
   });
+
+  it("keeps an inline asset carrying a body but no url", () => {
+    const parsed = parseEnvelope({
+      version: "v1",
+      assets: [
+        { kind: "css", url: "", inline: ".z{color:red}" },
+        { kind: "js", inline: "console.log(1)" },
+        { kind: "css" },
+      ],
+    });
+    expect(parsed.assets).toEqual([
+      { kind: "css", url: "", inline: ".z{color:red}" },
+      { kind: "js", inline: "console.log(1)" },
+    ]);
+  });
 });
 
 describe("Applier verbs", () => {

--- a/next/client/apply.ts
+++ b/next/client/apply.ts
@@ -159,17 +159,22 @@ function isBuiltin(patch: Patch): patch is BuiltinPatch {
 export interface Asset {
   kind: string;
   url: string;
+  // The body of a co-located inline asset, absent on a URL-form asset. The
+  // server collects a zone's inline styles and scripts that have no URL, so the
+  // loader inserts the body itself rather than a <link>/<script src>.
+  inline?: string;
 }
 
 // Narrow an unknown wire entry to an Asset. The manifest crosses the wire
 // boundary like the ops do, so a malformed entry is dropped here rather than
 // cast blind into envelope.assets and the event details. Only the two kinds the
-// loader acts on pass, so a junk kind never rides into the event details.
+// loader acts on pass, so a junk kind never rides into the event details. A
+// URL-form asset carries a url string, an inline asset carries an inline body.
 export function isAsset(value: unknown): value is Asset {
   return (
     isRecord(value) &&
     (value.kind === "css" || value.kind === "js") &&
-    typeof value.url === "string"
+    (typeof value.url === "string" || typeof value.inline === "string")
   );
 }
 

--- a/next/client/assets.test.ts
+++ b/next/client/assets.test.ts
@@ -133,6 +133,49 @@ describe("assets registry and delta", () => {
     expect(loaded).toEqual(["http://x/s.css"]);
   });
 
+  it("injects an inline style with the body and skips the link loader", () => {
+    const { assets, loaded } = makeAssets();
+    const done = vi.fn();
+    assets.loadCss([{ kind: "css", url: "", inline: ".z{color:red}" }], done);
+    const style = document.head.querySelector("style")!;
+    expect(style.textContent).toBe(".z{color:red}");
+    expect(loaded).toEqual([]);
+    expect(done).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes an inline style by body across applies", () => {
+    const { assets } = makeAssets();
+    const inline = { kind: "css", url: "", inline: ".z{color:red}" };
+    assets.loadCss([inline], () => undefined);
+    assets.loadCss([inline], () => undefined);
+    expect(document.head.querySelectorAll("style")).toHaveLength(1);
+  });
+
+  it("injects an inline script with its body as textContent", () => {
+    const { assets } = makeAssets();
+    assets.loadJs([{ kind: "js", url: "", inline: "globalThis.__x = 1" }]);
+    const script = document.head.querySelector("script:not([src])")!;
+    expect(script.textContent).toBe("globalThis.__x = 1");
+  });
+
+  it("dedupes an inline script by body across applies", () => {
+    const { assets } = makeAssets();
+    const inline = { kind: "js", url: "", inline: "globalThis.__x = 1" };
+    assets.loadJs([inline]);
+    assets.loadJs([inline]);
+    expect(document.head.querySelectorAll("script:not([src])")).toHaveLength(1);
+  });
+
+  it("keeps inline and url assets of the same kind apart", () => {
+    const { assets, loaded } = makeAssets();
+    assets.loadCss(
+      [{ kind: "css", url: "", inline: ".z{color:red}" }, css("http://x/u.css")],
+      () => undefined,
+    );
+    expect(document.head.querySelector("style")!.textContent).toBe(".z{color:red}");
+    expect(loaded).toEqual(["http://x/u.css"]);
+  });
+
   it("copies the bootstrap nonce onto inserted scripts", () => {
     const boot = document.createElement("script");
     boot.nonce = "nonce-7a3f";
@@ -150,6 +193,28 @@ describe("assets registry and delta", () => {
       'script[src="http://x/n.js"]',
     )!;
     expect(script.nonce).toBe("nonce-7a3f");
+  });
+
+  it("copies the bootstrap nonce onto inline assets", () => {
+    const boot = document.createElement("script");
+    boot.nonce = "nonce-7a3f";
+    Object.defineProperty(document, "currentScript", {
+      value: boot,
+      configurable: true,
+    });
+    const { assets } = makeAssets();
+    Object.defineProperty(document, "currentScript", {
+      value: null,
+      configurable: true,
+    });
+    assets.loadCss([{ kind: "css", url: "", inline: ".z{}" }], () => undefined);
+    assets.loadJs([{ kind: "js", url: "", inline: "void 0" }]);
+    expect(document.head.querySelector<HTMLStyleElement>("style")!.nonce).toBe(
+      "nonce-7a3f",
+    );
+    expect(
+      document.head.querySelector<HTMLScriptElement>("script:not([src])")!.nonce,
+    ).toBe("nonce-7a3f");
   });
 });
 

--- a/next/client/assets.test.ts
+++ b/next/client/assets.test.ts
@@ -67,6 +67,30 @@ describe("assets registry and delta", () => {
     ).toHaveLength(1);
   });
 
+  it("seeds an inline style so the inline css delta skips it", () => {
+    document.head.innerHTML = "<style>.z{}</style>";
+    const { assets } = makeAssets();
+    assets.seed();
+    assets.loadCss([{ kind: "css", url: "", inline: ".z{}" }], () => undefined);
+    expect(document.head.querySelectorAll("style")).toHaveLength(1);
+  });
+
+  it("seeds an inline script so the inline js delta does not re-execute it", () => {
+    document.head.innerHTML = "<script>void 0</script>";
+    const { assets } = makeAssets();
+    assets.seed();
+    assets.loadJs([{ kind: "js", url: "", inline: "void 0" }]);
+    expect(document.head.querySelectorAll("script:not([src])")).toHaveLength(1);
+  });
+
+  it("still inserts an inline body that differs from the seeded one", () => {
+    document.head.innerHTML = "<style>.z{}</style>";
+    const { assets } = makeAssets();
+    assets.seed();
+    assets.loadCss([{ kind: "css", url: "", inline: ".y{}" }], () => undefined);
+    expect(document.head.querySelectorAll("style")).toHaveLength(2);
+  });
+
   it("gates the done callback until the last of several sheets settles", () => {
     const settlers: ((ok: boolean) => void)[] = [];
     const loadLink: LinkLoader = (_url, _nonce, done) => settlers.push(done);

--- a/next/client/assets.test.ts
+++ b/next/client/assets.test.ts
@@ -83,6 +83,29 @@ describe("assets registry and delta", () => {
     expect(document.head.querySelectorAll("script:not([src])")).toHaveLength(1);
   });
 
+  it("seeds inline bodies from the body, not just the head", () => {
+    document.body.innerHTML = "<style>.b{}</style><script>void 1</script>";
+    const { assets } = makeAssets();
+    assets.seed();
+    assets.loadCss([{ kind: "css", url: "", inline: ".b{}" }], () => undefined);
+    assets.loadJs([{ kind: "js", url: "", inline: "void 1" }]);
+    expect(document.head.querySelectorAll("style")).toHaveLength(0);
+    expect(document.head.querySelectorAll("script:not([src])")).toHaveLength(0);
+  });
+
+  it("inserts an inline asset that omits url entirely", () => {
+    const { assets, loaded } = makeAssets();
+    const done = vi.fn();
+    assets.loadCss([{ kind: "css", inline: ".n{}" } as Asset], done);
+    assets.loadJs([{ kind: "js", inline: "void 2" } as Asset]);
+    expect(document.head.querySelector("style")!.textContent).toBe(".n{}");
+    expect(document.head.querySelector("script:not([src])")!.textContent).toBe(
+      "void 2",
+    );
+    expect(loaded).toEqual([]);
+    expect(done).toHaveBeenCalledTimes(1);
+  });
+
   it("still inserts an inline body that differs from the seeded one", () => {
     document.head.innerHTML = "<style>.z{}</style>";
     const { assets } = makeAssets();

--- a/next/client/assets.ts
+++ b/next/client/assets.ts
@@ -152,14 +152,19 @@ export function createAssets(deps: AssetsDeps): Assets {
     return bodies;
   }
 
+  // Insert an inline body with the page nonce so CSP still allows it.
+  function insertInline(tag: "style" | "script", body: string): void {
+    const el = doc.createElement(tag);
+    el.textContent = body;
+    if (nonce !== undefined) el.nonce = nonce;
+    doc.head.append(el);
+  }
+
   function loadCss(manifest: Asset[], done: () => void): void {
     // Inline styles insert synchronously and need no load gate, so they go in
     // before the URL delta whose loads the done callback waits on.
     for (const body of missingInline(manifest, "css")) {
-      const style = doc.createElement("style");
-      style.textContent = body;
-      if (nonce !== undefined) style.nonce = nonce;
-      doc.head.append(style);
+      insertInline("style", body);
     }
     const urls = missing(manifest, "css");
     if (urls.length === 0) {
@@ -191,10 +196,7 @@ export function createAssets(deps: AssetsDeps): Assets {
 
   function loadJs(manifest: Asset[]): void {
     for (const body of missingInline(manifest, "js")) {
-      const script = doc.createElement("script");
-      script.textContent = body;
-      if (nonce !== undefined) script.nonce = nonce;
-      doc.head.append(script);
+      insertInline("script", body);
     }
     for (const url of missing(manifest, "js")) {
       const script = doc.createElement("script");

--- a/next/client/assets.ts
+++ b/next/client/assets.ts
@@ -107,6 +107,18 @@ export function createAssets(deps: AssetsDeps): Assets {
     )) {
       loaded.add(script.src);
     }
+    // Seed the inline bodies the server already materialised into the head, so
+    // the first zone GET of a zone whose inline is up there does not re-insert
+    // the <style> or re-execute the <script>. textContent on an element node is
+    // a string, never null, so the body reads straight through.
+    for (const style of Array.from(doc.querySelectorAll<HTMLStyleElement>("style"))) {
+      loaded.add(inlineKey("css", textOf(style)));
+    }
+    for (const script of Array.from(
+      doc.querySelectorAll<HTMLScriptElement>("script:not([src])"),
+    )) {
+      loaded.add(inlineKey("js", textOf(script)));
+    }
   }
 
   function missing(manifest: Asset[], kind: string): string[] {
@@ -132,7 +144,7 @@ export function createAssets(deps: AssetsDeps): Assets {
     for (const asset of manifest) {
       if (!isAsset(asset) || asset.kind !== kind) continue;
       if (asset.inline === undefined) continue;
-      const key = `inline:${kind}:${asset.inline}`;
+      const key = inlineKey(kind, asset.inline);
       if (loaded.has(key)) continue;
       loaded.add(key);
       bodies.push(asset.inline);
@@ -247,6 +259,19 @@ export function createAssets(deps: AssetsDeps): Assets {
       knownVersion = "";
     },
   };
+}
+
+// The dedup key for an inline body, shared by seed and the inline delta so the
+// seeded head bodies and the manifest bodies match byte for byte.
+function inlineKey(kind: string, body: string): string {
+  return `inline:${kind}:${body}`;
+}
+
+// The text body of an element. textContent is typed string | null, but for an
+// element node the DOM always yields a string, so String() coerces with no
+// untestable null branch left for the coverage gate.
+function textOf(element: Element): string {
+  return String(element.textContent);
 }
 
 // The bootstrap script carries the page nonce. document.currentScript is null by

--- a/next/client/assets.ts
+++ b/next/client/assets.ts
@@ -113,6 +113,9 @@ export function createAssets(deps: AssetsDeps): Assets {
     const urls: string[] = [];
     for (const asset of manifest) {
       if (!isAsset(asset) || asset.kind !== kind) continue;
+      // An inline asset rides the inline path, never this URL delta: its empty
+      // url would otherwise collapse every inline body onto one "" key.
+      if (asset.inline !== undefined) continue;
       if (loaded.has(asset.url)) continue;
       // Mark loaded eagerly so a manifest that names the same URL twice, or a
       // re-entrant apply, inserts it exactly once.
@@ -122,7 +125,30 @@ export function createAssets(deps: AssetsDeps): Assets {
     return urls;
   }
 
+  // The inline bodies of a manifest, deduped by body under a kind-scoped key so
+  // the same inline asset inserts once per page and never clashes with a URL.
+  function missingInline(manifest: Asset[], kind: string): string[] {
+    const bodies: string[] = [];
+    for (const asset of manifest) {
+      if (!isAsset(asset) || asset.kind !== kind) continue;
+      if (asset.inline === undefined) continue;
+      const key = `inline:${kind}:${asset.inline}`;
+      if (loaded.has(key)) continue;
+      loaded.add(key);
+      bodies.push(asset.inline);
+    }
+    return bodies;
+  }
+
   function loadCss(manifest: Asset[], done: () => void): void {
+    // Inline styles insert synchronously and need no load gate, so they go in
+    // before the URL delta whose loads the done callback waits on.
+    for (const body of missingInline(manifest, "css")) {
+      const style = doc.createElement("style");
+      style.textContent = body;
+      if (nonce !== undefined) style.nonce = nonce;
+      doc.head.append(style);
+    }
     const urls = missing(manifest, "css");
     if (urls.length === 0) {
       done();
@@ -152,6 +178,12 @@ export function createAssets(deps: AssetsDeps): Assets {
   }
 
   function loadJs(manifest: Asset[]): void {
+    for (const body of missingInline(manifest, "js")) {
+      const script = doc.createElement("script");
+      script.textContent = body;
+      if (nonce !== undefined) script.nonce = nonce;
+      doc.head.append(script);
+    }
     for (const url of missing(manifest, "js")) {
       const script = doc.createElement("script");
       script.src = url;

--- a/next/partial/keys.py
+++ b/next/partial/keys.py
@@ -21,6 +21,7 @@ HTML: Final = "html"
 
 KIND: Final = "kind"
 URL: Final = "url"
+INLINE: Final = "inline"
 
 UID: Final = "uid"
 VALID: Final = "valid"
@@ -39,6 +40,7 @@ __all__ = [
     "FORM",
     "FORM_SELECTOR",
     "HTML",
+    "INLINE",
     "KIND",
     "OP",
     "OPS",

--- a/next/partial/patches.py
+++ b/next/partial/patches.py
@@ -456,7 +456,7 @@ class Patches:
     ) -> "Patches":
         """Render the named zone of the origin page and morph it in place."""
         result = self._render_zone(zone, overrides)
-        self.collect_zone_assets(result)
+        self._collect_zone_assets(result)
         return self._append_morph({keys.ZONE: zone}, result.html[zone], extract=False)
 
     def morph_foreign_zone(
@@ -487,7 +487,7 @@ class Patches:
         if dynamic:
             raise DynamicForeignPageError(foreign_path)
         result = self._render_foreign_zone(foreign_path, zone, request, kwargs)
-        self.collect_zone_assets(result)
+        self._collect_zone_assets(result)
         return self._append_morph({keys.ZONE: zone}, result.html[zone], extract=False)
 
     def _foreign_page_path(self, page: "Path | str") -> "Path":
@@ -608,7 +608,7 @@ class Patches:
         self._ops.append(Patch(op="context", extras={"data": data}))
         return self
 
-    def add_context(self, data: "Mapping[str, Any]") -> "Patches":
+    def _add_context(self, data: "Mapping[str, Any]") -> "Patches":
         """Record a context patch from already wire-ready provider values.
 
         The caller owns serialization, used by the zone-GET path where the
@@ -845,8 +845,12 @@ class Patches:
         js_context = self._origin_render_context().get("_next_js_context", {})
         return frozenset(js_context) if isinstance(js_context, dict) else frozenset()
 
-    def collect_zone_assets(self, result: "ZoneRenderResult") -> "Patches":
-        """Record the URL-form and inline-form assets a zone body collected."""
+    def _collect_zone_assets(self, result: "ZoneRenderResult") -> "Patches":
+        """Record the URL-form and inline-form assets a zone body collected.
+
+        This deliberately collects assets only. The js-context delta is emitted
+        by the view path, since the builder path owns context through context().
+        """
         for kind, body in result.inline_assets():
             self.add_asset(kind, "", inline=body)
         for kind, url in result.url_assets():

--- a/next/partial/patches.py
+++ b/next/partial/patches.py
@@ -253,14 +253,18 @@ class Patch:
 
 @dataclass(frozen=True, slots=True)
 class Asset:
-    """One co-located asset of a rendered target, by kind and URL."""
+    """One co-located asset of a rendered target by kind, URL, and inline body."""
 
     kind: str
     url: str
+    inline: str | None = None
 
     def as_dict(self) -> dict[str, str]:
-        """Return the wire form of the asset entry."""
-        return {keys.KIND: self.kind, keys.URL: self.url}
+        """Return the wire form of the asset, carrying its inline body when set."""
+        data = {keys.KIND: self.kind, keys.URL: self.url}
+        if self.inline is not None:
+            data[keys.INLINE] = self.inline
+        return data
 
 
 @dataclass(frozen=True, slots=True)
@@ -452,7 +456,7 @@ class Patches:
     ) -> "Patches":
         """Render the named zone of the origin page and morph it in place."""
         result = self._render_zone(zone, overrides)
-        self._collect_assets(result)
+        self.collect_zone_assets(result)
         return self._append_morph({keys.ZONE: zone}, result.html[zone], extract=False)
 
     def morph_foreign_zone(
@@ -483,7 +487,7 @@ class Patches:
         if dynamic:
             raise DynamicForeignPageError(foreign_path)
         result = self._render_foreign_zone(foreign_path, zone, request, kwargs)
-        self._collect_assets(result)
+        self.collect_zone_assets(result)
         return self._append_morph({keys.ZONE: zone}, result.html[zone], extract=False)
 
     def _foreign_page_path(self, page: "Path | str") -> "Path":
@@ -604,6 +608,15 @@ class Patches:
         self._ops.append(Patch(op="context", extras={"data": data}))
         return self
 
+    def add_context(self, data: "Mapping[str, Any]") -> "Patches":
+        """Record a context patch from already wire-ready provider values.
+
+        The caller owns serialization, used by the zone-GET path where the
+        collector already gathered and encoded the js-context.
+        """
+        self._ops.append(Patch(op="context", extras={"data": dict(data)}))
+        return self
+
     def layer_open(
         self,
         *,
@@ -703,9 +716,9 @@ class Patches:
         self._ops.append(Patch(op=name, extras=dict(payload)))
         return self
 
-    def add_asset(self, kind: str, url: str) -> "Patches":
+    def add_asset(self, kind: str, url: str, *, inline: str | None = None) -> "Patches":
         """Record a co-located asset in the envelope manifest."""
-        self._assets.append(Asset(kind=kind, url=url))
+        self._assets.append(Asset(kind=kind, url=url, inline=inline))
         return self
 
     def set_form(self, form: FormMeta) -> "Patches":
@@ -832,10 +845,13 @@ class Patches:
         js_context = self._origin_render_context().get("_next_js_context", {})
         return frozenset(js_context) if isinstance(js_context, dict) else frozenset()
 
-    def _collect_assets(self, result: "ZoneRenderResult") -> None:
-        """Record the assets a rendered zone body collected on the envelope."""
+    def collect_zone_assets(self, result: "ZoneRenderResult") -> "Patches":
+        """Record the URL-form and inline-form assets a zone body collected."""
+        for kind, body in result.inline_assets():
+            self.add_asset(kind, "", inline=body)
         for kind, url in result.url_assets():
             self.add_asset(kind, url)
+        return self
 
     def _is_same_site(self, href: str) -> bool:
         """Return True when `href` targets the bound request's host and scheme."""

--- a/next/partial/render.py
+++ b/next/partial/render.py
@@ -63,6 +63,17 @@ class ZoneRenderResult:
                 if static_asset.url:
                     yield static_asset.kind, static_asset.url
 
+    def inline_assets(self) -> "Iterator[tuple[str, str]]":
+        """Yield the (kind, inline body) of each collected inline asset."""
+        for slot in default_placeholders:
+            for static_asset in self.collector.assets_in_slot(slot.name):
+                if static_asset.inline is not None:
+                    yield static_asset.kind, static_asset.inline
+
+    def js_context_delta(self) -> dict[str, object]:
+        """Return the zone js-context as wire-ready values for a context patch."""
+        return self.collector.js_context_wire()
+
 
 def render_zone(
     page_path: "Path",

--- a/next/partial/view.py
+++ b/next/partial/view.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse
 from . import keys
 from .headers import MergeMode, set_partial_vary
 from .manager import partial_backend_manager
-from .patches import Asset, Envelope, Patches, PatchResponse
+from .patches import Envelope, Patches, PatchResponse
 from .render import UnknownZoneError, render_zone
 
 
@@ -82,8 +82,10 @@ def _build_envelope(
     patches = Patches(version)
     for name in intent.zones:
         _patch_zone(patches, name, result.html[name], intent.merge)
-    for asset in _collected_assets(result):
-        patches.add_asset(asset.kind, asset.url)
+    patches.collect_zone_assets(result)
+    delta = result.js_context_delta()
+    if delta:
+        patches.add_context(delta)
     return patches.envelope()
 
 
@@ -101,11 +103,6 @@ def _patch_zone(
         patches.prepend(target, html)
     else:
         patches.morph(target, html)
-
-
-def _collected_assets(result: "ZoneRenderResult") -> list[Asset]:
-    """Return the URL-form assets the rendered zone bodies collected."""
-    return [Asset(kind=kind, url=url) for kind, url in result.url_assets()]
 
 
 def _bad_request(reason: str) -> HttpResponse:

--- a/next/partial/view.py
+++ b/next/partial/view.py
@@ -82,10 +82,10 @@ def _build_envelope(
     patches = Patches(version)
     for name in intent.zones:
         _patch_zone(patches, name, result.html[name], intent.merge)
-    patches.collect_zone_assets(result)
+    patches._collect_zone_assets(result)
     delta = result.js_context_delta()
     if delta:
-        patches.add_context(delta)
+        patches._add_context(delta)
     return patches.envelope()
 
 

--- a/next/static/assets.py
+++ b/next/static/assets.py
@@ -90,6 +90,7 @@ class KindRegistry:
         self._extensions: dict[str, str] = {}
         self._slots: dict[str, str] = {}
         self._renderers: dict[str, str] = {}
+        self._inline_tags: dict[str, str] = {}
 
     def register(
         self,
@@ -98,15 +99,20 @@ class KindRegistry:
         extension: str,
         slot: str,
         renderer: str,
+        inline_tag: str | None = None,
     ) -> None:
         """Register an asset kind and its dispatch metadata.
 
         The `kind` argument must be a non-empty Python identifier. The
         `extension` argument must begin with a dot. The `slot` and
         `renderer` arguments must be non-empty strings. Any other input
-        raises `ValueError`. A repeated call with identical parameters
-        is idempotent. A repeated call with different parameters raises
-        `ValueError` so silent re-registrations cannot mask bugs.
+        raises `ValueError`. The optional `inline_tag` names the HTML
+        element that wraps a co-located inline body for this kind, for
+        example `"style"` or `"script"`. When omitted, inline bodies of
+        this kind render verbatim. A repeated call with identical
+        parameters is idempotent. A repeated call with different
+        parameters raises `ValueError` so silent re-registrations cannot
+        mask bugs.
         """
         if not kind or not kind.isidentifier():
             msg = f"Invalid kind {kind!r}: must be a non-empty identifier"
@@ -122,8 +128,13 @@ class KindRegistry:
             raise ValueError(msg)
         existing = self._extensions.get(kind)
         if existing is not None:
-            current = (existing, self._slots[kind], self._renderers[kind])
-            incoming = (extension, slot, renderer)
+            current = (
+                existing,
+                self._slots[kind],
+                self._renderers[kind],
+                self._inline_tags.get(kind),
+            )
+            incoming = (extension, slot, renderer, inline_tag)
             if current == incoming:
                 return
             msg = (
@@ -136,6 +147,8 @@ class KindRegistry:
         self._extensions[kind] = extension
         self._slots[kind] = slot
         self._renderers[kind] = renderer
+        if inline_tag is not None:
+            self._inline_tags[kind] = inline_tag
 
     def extension(self, kind: str) -> str:
         """Return the file extension registered for the given kind.
@@ -160,6 +173,15 @@ class KindRegistry:
             msg = f"Unsupported asset kind: {kind!r}"
             raise KeyError(msg)
         return self._renderers[kind]
+
+    def inline_tag(self, kind: str) -> str | None:
+        """Return the inline wrapper element for the kind or None.
+
+        A `None` result means inline bodies of this kind render
+        verbatim, preserving backward compatibility for custom kinds
+        registered without an inline wrapper.
+        """
+        return self._inline_tags.get(kind)
 
     def kind_for_extension(self, extension: str) -> str | None:
         """Return the kind registered for the given extension or None."""

--- a/next/static/collector.py
+++ b/next/static/collector.py
@@ -21,6 +21,7 @@ dictionary on the collector. There is no built-in knowledge of `css`,
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
@@ -319,6 +320,7 @@ class StaticCollector:
         self._prepend_idx: dict[str, int] = {}
         self._js_context: dict[str, Any] = {}
         self._js_context_serializers: dict[str, JsContextSerializer] = {}
+        self._js_context_encoded: dict[str, str] = {}
 
     def add(self, asset: StaticAsset, *, prepend: bool = False) -> None:
         """Add the asset unless its dedup key was already recorded.
@@ -379,11 +381,15 @@ class StaticCollector:
         """
         active = serializer if serializer is not None else self._get_js_serializer()
         try:
-            active.dumps(value)
+            encoded = active.dumps(value)
         except (TypeError, ValueError) as e:
             msg = f"JS context value for key {key!r} is not serialisable: {e}"
             raise TypeError(msg) from e
         self._js_context = self._js_policy.merge(self._js_context, key, value)
+        if self._js_context.get(key) is value:
+            self._js_context_encoded[key] = encoded
+        else:
+            self._js_context_encoded.pop(key, None)
         if serializer is not None:
             self._js_context_serializers[key] = serializer
 
@@ -401,3 +407,19 @@ class StaticCollector:
         serializer. Callers must not mutate it.
         """
         return self._js_context_serializers
+
+    def js_context_wire(self) -> dict[str, Any]:
+        """Return the merged js-context as wire-ready JSON values.
+
+        Reuses the fragment cached at registration when present so the context
+        patch does not re-encode what add_js_context already validated.
+        """
+        default = self._get_js_serializer()
+        wire: dict[str, Any] = {}
+        for key, value in self._js_context.items():
+            encoded = self._js_context_encoded.get(key)
+            if encoded is None:
+                serializer = self._js_context_serializers.get(key, default)
+                encoded = serializer.dumps(value)
+            wire[key] = json.loads(encoded)
+        return wire

--- a/next/static/collector.py
+++ b/next/static/collector.py
@@ -408,6 +408,37 @@ class StaticCollector:
         """
         return self._js_context_serializers
 
+    def _encoded_fragment(
+        self,
+        key: str,
+        value: object,
+        default: JsContextSerializer,
+    ) -> str:
+        """Return the cached JSON fragment for a key or re-encode on miss.
+
+        A miss happens when a merge policy overwrote the value after
+        add_js_context cached its fragment, so the value is re-encoded
+        through the same per-key serializer the collector recorded.
+        """
+        encoded = self._js_context_encoded.get(key)
+        if encoded is None:
+            serializer = self._js_context_serializers.get(key, default)
+            encoded = serializer.dumps(value)
+        return encoded
+
+    def js_context_encoded(self) -> dict[str, str]:
+        """Return the merged js-context as per-key encoded JSON fragments.
+
+        Each fragment is the exact byte output add_js_context validated,
+        so the init script assembles its payload without re-serialising.
+        Callers must not mutate the returned mapping.
+        """
+        default = self._get_js_serializer()
+        return {
+            key: self._encoded_fragment(key, value, default)
+            for key, value in self._js_context.items()
+        }
+
     def js_context_wire(self) -> dict[str, Any]:
         """Return the merged js-context as wire-ready JSON values.
 
@@ -415,11 +446,7 @@ class StaticCollector:
         patch does not re-encode what add_js_context already validated.
         """
         default = self._get_js_serializer()
-        wire: dict[str, Any] = {}
-        for key, value in self._js_context.items():
-            encoded = self._js_context_encoded.get(key)
-            if encoded is None:
-                serializer = self._js_context_serializers.get(key, default)
-                encoded = serializer.dumps(value)
-            wire[key] = json.loads(encoded)
-        return wire
+        return {
+            key: json.loads(self._encoded_fragment(key, value, default))
+            for key, value in self._js_context.items()
+        }

--- a/next/static/defaults.py
+++ b/next/static/defaults.py
@@ -30,12 +30,14 @@ def register_defaults() -> None:
         extension=".css",
         slot="styles",
         renderer="render_link_tag",
+        inline_tag="style",
     )
     default_kinds.register(
         "js",
         extension=".js",
         slot="scripts",
         renderer="render_script_tag",
+        inline_tag="script",
     )
     default_kinds.register(
         "module",

--- a/next/static/manager.py
+++ b/next/static/manager.py
@@ -236,7 +236,10 @@ class StaticManager:
         request: HttpRequest | None,
     ) -> str:
         if asset.inline is not None:
-            return asset.inline
+            tag = default_kinds.inline_tag(asset.kind)
+            if tag is None:
+                return asset.inline
+            return f"<{tag}>{asset.inline}</{tag}>"
         renderer_name = default_kinds.renderer(asset.kind)
         renderer = getattr(backend, renderer_name)
         return cast("str", renderer(asset.url, request=request))

--- a/next/static/manager.py
+++ b/next/static/manager.py
@@ -208,6 +208,7 @@ class StaticManager:
             init_payload = builder.init_script(
                 js_context,
                 key_serializers=collector.js_context_serializers(),
+                encoded=collector.js_context_encoded(),
             )
             next_scripts = f"{builder.script_tag()}\n{init_payload}\n"
             return next_scripts + user_tags if user_tags else next_scripts

--- a/next/static/scripts.py
+++ b/next/static/scripts.py
@@ -146,27 +146,27 @@ class NextScriptBuilder:
         js_context: Mapping[str, Any],
         *,
         key_serializers: Mapping[str, JsContextSerializer] | None = None,
+        encoded: Mapping[str, str] | None = None,
     ) -> str:
         """Return the inline script that passes the context to `Next._init`.
 
-        Delegates serialisation to the configured `JsContextSerializer`
-        so the init payload honours the same encoding rules as values
-        registered through `StaticCollector.add_js_context`. When
-        `key_serializers` is supplied, each top-level key listed there
-        is encoded with its dedicated serializer and the rest fall
-        back to the global default.
+        Assembles the payload from per-key fragments so a value
+        `StaticCollector.add_js_context` already encoded is reused through
+        `encoded` rather than serialised a second time. A key missing from
+        `encoded` falls back to its serializer. Compact top-level separators
+        keep the output byte-identical to a whole-dict dump for the compact
+        serializers the framework ships.
         """
-        if not key_serializers:
-            payload = resolve_serializer().dumps(dict(js_context))
-        else:
-            default = resolve_serializer()
-            fragments: list[str] = []
-            for k, v in js_context.items():
-                key_serializer = key_serializers.get(k, default)
-                encoded_key = json.dumps(k, separators=(",", ":"))
-                encoded_val = key_serializer.dumps(v)
-                fragments.append(f"{encoded_key}:{encoded_val}")
-            payload = "{" + ",".join(fragments) + "}"
+        default = resolve_serializer()
+        serializers = key_serializers or {}
+        fragments: list[str] = []
+        for k, v in js_context.items():
+            frag = encoded.get(k) if encoded is not None else None
+            if frag is None:
+                frag = serializers.get(k, default).dumps(v)
+            encoded_key = json.dumps(k, separators=(",", ":"))
+            fragments.append(f"{encoded_key}:{frag}")
+        payload = "{" + ",".join(fragments) + "}"
         return self._init_template.format(payload=payload)
 
     @classmethod

--- a/tests/partial/test_headers.py
+++ b/tests/partial/test_headers.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+import pytest
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory
 
@@ -12,6 +13,7 @@ from next.partial.headers import (
     PartialIntent,
     set_partial_vary,
 )
+from next.testing import NextClient
 
 
 def _request_with_headers(**headers: str) -> HttpRequest:
@@ -149,6 +151,18 @@ class TestVaryHeaders:
         set_partial_vary(response)
         assert "Cookie" in response["Vary"]
         assert "X-Next-Merge" in response["Vary"]
+
+
+class TestZoneResponseVary:
+    """A zone GET response stamps the protective partial Vary header."""
+
+    @pytest.mark.parametrize(
+        "header",
+        ["X-Next-Request", "X-Next-Zone", "X-Next-Merge", "X-Next-Version"],
+    )
+    def test_zone_response_varies_on_partial_header(self, header: str) -> None:
+        response = NextClient().get_zones("/zoned/", "alpha")
+        assert header in response.get("Vary", "")
 
 
 class TestProtocolConstants:

--- a/tests/partial/test_patches.py
+++ b/tests/partial/test_patches.py
@@ -199,7 +199,7 @@ class TestPatchesBuilder:
         assert envelope.assets[0] == Asset(kind="css", url="", inline=".x {}")
 
     def test_add_context_records_a_context_op(self) -> None:
-        envelope = Patches("v1").add_context({"unread": 3}).envelope()
+        envelope = Patches("v1")._add_context({"unread": 3}).envelope()
         assert envelope.ops[0].as_dict() == {
             "op": "context",
             "data": {"unread": 3},

--- a/tests/partial/test_patches.py
+++ b/tests/partial/test_patches.py
@@ -42,6 +42,24 @@ class TestPatchAsDict:
         }
 
 
+class TestAssetAsDict:
+    """An asset serialises with its inline body only when one is present."""
+
+    def test_url_form_asset_carries_no_inline_key(self) -> None:
+        assert Asset(kind="css", url="/a.css").as_dict() == {
+            "kind": "css",
+            "url": "/a.css",
+        }
+
+    def test_inline_form_asset_carries_its_body(self) -> None:
+        asset = Asset(kind="css", url="", inline=".x { color: red; }")
+        assert asset.as_dict() == {
+            "kind": "css",
+            "url": "",
+            "inline": ".x { color: red; }",
+        }
+
+
 class TestEnvelopeAsDict:
     """The envelope wire form carries ops and meta with stable keys."""
 
@@ -176,6 +194,17 @@ class TestPatchesBuilder:
         assert envelope.assets[0] == Asset(kind="css", url="/x.css")
         assert envelope.form is form
 
+    def test_add_asset_records_an_inline_body(self) -> None:
+        envelope = Patches("v1").add_asset("css", "", inline=".x {}").envelope()
+        assert envelope.assets[0] == Asset(kind="css", url="", inline=".x {}")
+
+    def test_add_context_records_a_context_op(self) -> None:
+        envelope = Patches("v1").add_context({"unread": 3}).envelope()
+        assert envelope.ops[0].as_dict() == {
+            "op": "context",
+            "data": {"unread": 3},
+        }
+
     def test_version_carried(self) -> None:
         assert Patches("9f3c").envelope().version == "9f3c"
 
@@ -260,6 +289,53 @@ class TestReservedPatchKey:
             Patch(op="x", extras={"target": 1, "op": 2, "html": 3})
         assert exc.value.keys == frozenset({"op", "target", "html"})
         assert "html, op, target" in str(exc.value)
+
+
+class TestBuilderZoneManifest:
+    """`morph_zone` ships the same inline and URL manifest as the view path."""
+
+    def test_inline_and_url_assets_travel_together(self) -> None:
+        envelope = (
+            Patches(partial_request(origin="/zoned_inline/"))
+            .morph(zone="styled")
+            .envelope()
+        )
+        wire = [asset.as_dict() for asset in envelope.assets]
+        assert {
+            "kind": "css",
+            "url": "",
+            "inline": ".zone-styled { color: crimson; }",
+        } in wire
+        assert {"kind": "css", "url": "/static/next/zoned_inline.css"} in wire
+
+    def test_inline_script_asset_travels(self) -> None:
+        envelope = (
+            Patches(partial_request(origin="/zoned_inline/"))
+            .morph(zone="scripted")
+            .envelope()
+        )
+        inline = [a.as_dict() for a in envelope.assets if a.url == ""]
+        assert inline == [
+            {"kind": "js", "url": "", "inline": 'console.log("zone scripted");'}
+        ]
+
+    def test_builder_path_emits_no_automatic_context_op(self) -> None:
+        envelope = (
+            Patches(partial_request(origin="/zoned_inline/"))
+            .morph(zone="styled")
+            .envelope()
+        )
+        assert [op.op for op in envelope.ops] == ["morph"]
+
+    def test_explicit_context_still_rides_on_the_builder_path(self) -> None:
+        envelope = (
+            Patches(partial_request(origin="/zoned_inline/"))
+            .morph(zone="styled")
+            .context(seen=7)
+            .envelope()
+        )
+        assert [op.op for op in envelope.ops] == ["morph", "context"]
+        assert envelope.ops[1].as_dict() == {"op": "context", "data": {"seen": 7}}
 
 
 class TestOriginRenderContextMemoised:

--- a/tests/partial/test_view_branch.py
+++ b/tests/partial/test_view_branch.py
@@ -12,7 +12,9 @@ class TestZoneGetEnvelope:
         assert response.status_code == 200
         assert response["Content-Type"] == CONTENT_TYPE
         envelope = envelope_of(response)
-        assert envelope.op_verbs() == ["morph", "morph"]
+        # The zoned page registers a serialize=True provider, so the batch
+        # ends with the context op carrying its js-context delta.
+        assert envelope.op_verbs() == ["morph", "morph", "context"]
         assert envelope.zone_targets() == ["alpha", "beta"]
 
     def test_zone_html_is_wrapped_body(self) -> None:
@@ -104,7 +106,7 @@ class TestZoneGetMergeIntent:
         )
         assert response.status_code == 200
         envelope = envelope_of(response)
-        assert envelope.op_verbs() == ["append"]
+        assert envelope.op_verbs() == ["append", "context"]
         assert envelope.zone_targets() == ["alpha"]
 
     def test_append_patch_carries_key_dedupe(self) -> None:
@@ -117,11 +119,11 @@ class TestZoneGetMergeIntent:
         response = NextClient().get_zones(
             "/zoned/", "alpha", HTTP_X_NEXT_MERGE="prepend"
         )
-        assert envelope_of(response).op_verbs() == ["prepend"]
+        assert envelope_of(response).op_verbs() == ["prepend", "context"]
 
     def test_unknown_merge_value_falls_back_to_morph(self) -> None:
         response = NextClient().get_zones("/zoned/", "alpha", HTTP_X_NEXT_MERGE="bogus")
-        assert envelope_of(response).op_verbs() == ["morph"]
+        assert envelope_of(response).op_verbs() == ["morph", "context"]
 
     def test_merge_response_varies_on_merge_header(self) -> None:
         response = NextClient().get_zones(

--- a/tests/partial/test_zone_assets.py
+++ b/tests/partial/test_zone_assets.py
@@ -1,0 +1,91 @@
+import pytest
+
+from next.testing import NextClient, envelope_of
+
+
+class TestZoneGetInlineAssets:
+    """A zone GET ships the inline assets its body collected."""
+
+    @pytest.mark.parametrize(
+        ("zone", "kind", "body"),
+        [
+            ("styled", "css", ".zone-styled { color: crimson; }"),
+            ("scripted", "js", 'console.log("zone scripted");'),
+        ],
+    )
+    def test_inline_asset_travels_with_its_body(
+        self, zone: str, kind: str, body: str
+    ) -> None:
+        response = NextClient().get_zones("/zoned_inline/", zone)
+        inline = [a for a in envelope_of(response).assets if a["url"] == ""]
+        assert inline == [{"kind": kind, "url": "", "inline": body}]
+
+    def test_inline_asset_manifest_is_not_empty(self) -> None:
+        response = NextClient().get_zones("/zoned_inline/", "styled")
+        assert envelope_of(response).assets
+
+
+class TestZoneGetUrlAssets:
+    """URL-form assets keep their byte-stable wire shape."""
+
+    def test_url_form_asset_travels(self) -> None:
+        response = NextClient().get_zones("/zoned/", "alpha")
+        assert envelope_of(response).assets == [
+            {"kind": "css", "url": "/static/next/zoned.css"}
+        ]
+
+    def test_url_form_asset_carries_no_inline_key(self) -> None:
+        response = NextClient().get_zones("/zoned/", "alpha")
+        assert "inline" not in envelope_of(response).assets[0]
+
+
+class TestZoneGetContextDelta:
+    """A serialize provider rides out as a context op with wire values."""
+
+    def test_serialize_provider_emits_context_op(self) -> None:
+        response = NextClient().get_zones("/zoned/", "alpha")
+        context_ops = [op for op in envelope_of(response).ops if op["op"] == "context"]
+        assert context_ops == [{"op": "context", "data": {"flag": True}}]
+
+    def test_context_op_is_last_after_the_morphs(self) -> None:
+        response = NextClient().get_zones("/zoned/", ("alpha", "beta"))
+        assert envelope_of(response).op_verbs() == ["morph", "morph", "context"]
+
+    def test_context_values_are_wire_ready(self) -> None:
+        response = NextClient().get_zones("/zoned_inline/", "styled")
+        ops = envelope_of(response).ops
+        data = next(op["data"] for op in ops if op["op"] == "context")
+        assert data == {"seen": 7}
+
+
+class TestZoneGetWithoutSerializeProvider:
+    """A page with no serialize provider never emits an empty context op."""
+
+    def test_no_context_op_when_delta_is_empty(self) -> None:
+        response = NextClient().get_zones("/counted/", "alpha")
+        assert "context" not in envelope_of(response).op_verbs()
+
+    def test_no_assets_and_only_a_morph(self) -> None:
+        response = NextClient().get_zones("/counted/", "alpha")
+        envelope = envelope_of(response)
+        assert envelope.op_verbs() == ["morph"]
+        assert envelope.assets == []
+
+
+class TestZoneGetMixedManifest:
+    """One zone GET carries inline, URL, and js-context together."""
+
+    def test_inline_url_and_context_in_one_envelope(self) -> None:
+        response = NextClient().get_zones("/zoned_inline/", "mixed")
+        envelope = envelope_of(response)
+        assert {
+            "kind": "css",
+            "url": "",
+            "inline": ".zone-mixed { color: navy; }",
+        } in envelope.assets
+        assert {
+            "kind": "css",
+            "url": "/static/next/zoned_inline.css",
+        } in envelope.assets
+        context_ops = [op for op in envelope.ops if op["op"] == "context"]
+        assert context_ops == [{"op": "context", "data": {"seen": 7}}]

--- a/tests/site_pages/zoned_inline/page.py
+++ b/tests/site_pages/zoned_inline/page.py
@@ -1,0 +1,13 @@
+from next.pages import context
+
+
+@context("greeting")
+def greeting() -> str:
+    """Provide a context value the inline zone bodies read."""
+    return "hi"
+
+
+@context("seen", serialize=True)
+def seen() -> int:
+    """Provide a serialised value so the collector hydrates its JS context."""
+    return 7

--- a/tests/site_pages/zoned_inline/template.css
+++ b/tests/site_pages/zoned_inline/template.css
@@ -1,0 +1,1 @@
+.zoned-inline { color: teal; }

--- a/tests/site_pages/zoned_inline/template.djx
+++ b/tests/site_pages/zoned_inline/template.djx
@@ -1,0 +1,4 @@
+<h1>zoned inline page</h1>
+{% zone "styled" %}{% #use_style %}.zone-styled { color: crimson; }{% /use_style %}<p>styled {{ greeting }}</p>{% endzone %}
+{% zone "scripted" %}{% #use_script %}console.log("zone scripted");{% /use_script %}<p>scripted {{ greeting }}</p>{% endzone %}
+{% zone "mixed" %}{% #use_style %}.zone-mixed { color: navy; }{% /use_style %}<p>mixed {{ greeting }}</p>{% endzone %}

--- a/tests/static/test_assets.py
+++ b/tests/static/test_assets.py
@@ -62,6 +62,62 @@ class TestKindRegistryRegister:
         reg.register("css", extension=".css", slot="styles", renderer="render_link_tag")
         assert reg.kinds() == ("css",)
 
+    def test_register_stores_inline_tag(self) -> None:
+        reg = KindRegistry()
+        reg.register(
+            "css",
+            extension=".css",
+            slot="styles",
+            renderer="render_link_tag",
+            inline_tag="style",
+        )
+        assert reg.inline_tag("css") == "style"
+
+    def test_inline_tag_defaults_to_none(self) -> None:
+        reg = KindRegistry()
+        reg.register("css", extension=".css", slot="styles", renderer="render_link_tag")
+        assert reg.inline_tag("css") is None
+
+    def test_inline_tag_none_for_unregistered_kind(self) -> None:
+        reg = KindRegistry()
+        assert reg.inline_tag("ghost") is None
+
+    def test_register_is_idempotent_with_matching_inline_tag(self) -> None:
+        reg = KindRegistry()
+        reg.register(
+            "css",
+            extension=".css",
+            slot="styles",
+            renderer="render_link_tag",
+            inline_tag="style",
+        )
+        reg.register(
+            "css",
+            extension=".css",
+            slot="styles",
+            renderer="render_link_tag",
+            inline_tag="style",
+        )
+        assert reg.kinds() == ("css",)
+
+    def test_register_rejects_conflicting_inline_tag(self) -> None:
+        reg = KindRegistry()
+        reg.register(
+            "css",
+            extension=".css",
+            slot="styles",
+            renderer="render_link_tag",
+            inline_tag="style",
+        )
+        with pytest.raises(ValueError, match="already registered"):
+            reg.register(
+                "css",
+                extension=".css",
+                slot="styles",
+                renderer="render_link_tag",
+                inline_tag="span",
+            )
+
     def test_register_rejects_conflicting_re_registration(self) -> None:
         reg = KindRegistry()
         reg.register("css", extension=".css", slot="styles", renderer="render_link_tag")
@@ -150,6 +206,8 @@ class TestDefaultKinds:
         assert default_kinds.slot("js") == "scripts"
         assert default_kinds.renderer("css") == "render_link_tag"
         assert default_kinds.renderer("js") == "render_script_tag"
+        assert default_kinds.inline_tag("css") == "style"
+        assert default_kinds.inline_tag("js") == "script"
 
 
 class TestStaticNamespace:

--- a/tests/static/test_collector.py
+++ b/tests/static/test_collector.py
@@ -411,6 +411,21 @@ class TestJsContextWire:
         assert collector.js_context_wire() == {}
 
 
+class TestJsContextEncoded:
+    """`js_context_encoded` serves per-key fragments from cache or re-encodes."""
+
+    def test_serves_fragment_from_cache(self, collector: StaticCollector) -> None:
+        collector.add_js_context("k", {"x": 1})
+        assert collector.js_context_encoded() == {"k": '{"x":1}'}
+
+    def test_reencodes_on_cache_miss(self) -> None:
+        collector = StaticCollector(js_context_policy=FirstWinsPolicy())
+        collector.add_js_context("k", {"a": 1})
+        collector.add_js_context("k", {"a": 2})
+        assert "k" not in collector._js_context_encoded
+        assert collector.js_context_encoded() == {"k": '{"a":1}'}
+
+
 class TestPlaceholderRegistry:
     """PlaceholderRegistry stores slot metadata keyed by slot name."""
 

--- a/tests/static/test_collector.py
+++ b/tests/static/test_collector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -342,6 +343,72 @@ class TestJsContextSerializerOverride:
         collector.add_js_context("a", 1)
         collector.add_js_context("b", 2)
         assert collector.js_context_serializers() == {}
+
+
+class TestJsContextWire:
+    """`js_context_wire` reuses the cached fragment and reflects the merge."""
+
+    def test_single_add_serves_wire_from_cache(
+        self, collector: StaticCollector
+    ) -> None:
+        collector.add_js_context("k", {"x": 1})
+        assert collector.js_context_wire() == {"k": {"x": 1}}
+
+    def test_wire_matches_direct_serialisation(
+        self, collector: StaticCollector
+    ) -> None:
+        serializer = collector._get_js_serializer()
+        collector.add_js_context("a", [1, 2, 3])
+        encoded = serializer.dumps([1, 2, 3])
+        assert collector.js_context_wire() == {"a": json.loads(encoded)}
+
+    def test_cache_holds_the_validated_fragment(
+        self, collector: StaticCollector
+    ) -> None:
+        collector.add_js_context("k", {"x": 1})
+        assert collector._js_context_encoded["k"] == '{"x":1}'
+
+    @pytest.mark.parametrize(
+        ("policy", "first", "second", "expected"),
+        [
+            (FirstWinsPolicy(), {"a": 1}, {"a": 2}, {"a": 1}),
+            (DeepMergePolicy(), {"a": 1}, {"b": 2}, {"a": 1, "b": 2}),
+        ],
+    )
+    def test_second_write_pops_cache_and_wire_reflects_merge(
+        self,
+        policy: object,
+        first: dict[str, int],
+        second: dict[str, int],
+        expected: dict[str, int],
+    ) -> None:
+        collector = StaticCollector(js_context_policy=policy)
+        collector.add_js_context("k", first)
+        collector.add_js_context("k", second)
+        assert "k" not in collector._js_context_encoded
+        assert collector.js_context_wire() == {"k": expected}
+
+    def test_wire_fallback_uses_recorded_override(self) -> None:
+        calls: list[object] = []
+
+        class Wrapper:
+            def dumps(self, value: object) -> str:
+                calls.append(value)
+                return f'{{"wrapped":{value}}}'
+
+        collector = StaticCollector(js_context_policy=FirstWinsPolicy())
+        override = Wrapper()
+        collector.add_js_context("k", 1, serializer=override)
+        collector.add_js_context("k", 2, serializer=override)
+        assert collector.js_context_wire() == {"k": {"wrapped": 1}}
+        assert calls == [1, 2, 1]
+
+    def test_non_serialisable_value_still_raises_at_add(
+        self, collector: StaticCollector
+    ) -> None:
+        with pytest.raises(TypeError, match="not serialisable"):
+            collector.add_js_context("k", object())
+        assert collector.js_context_wire() == {}
 
 
 class TestPlaceholderRegistry:

--- a/tests/static/test_integration.py
+++ b/tests/static/test_integration.py
@@ -92,6 +92,38 @@ class TestUseStyleBlocksThroughPipeline:
         assert 'href="https://cdn/shared.css"' in final
 
 
+class TestInlineBlocksThroughPipeline:
+    """`{% #use_style %}` / `{% #use_script %}` reach the head as working tags."""
+
+    def test_inline_style_block_lands_wrapped(self) -> None:
+        manager = StaticManager()
+        manager._backends = [StaticFilesBackend()]
+        collector = StaticCollector()
+        template = Template(
+            "{% load next_static %}"
+            "{% #use_style %}.card{margin:0}{% /use_style %}"
+            f"{STYLES_PLACEHOLDER}"
+        )
+        rendered = template.render(Context({"_static_collector": collector}))
+
+        final = manager.inject(rendered, collector)
+        assert "<style>.card{margin:0}</style>" in final
+
+    def test_inline_script_block_lands_wrapped(self) -> None:
+        manager = StaticManager()
+        manager._backends = [StaticFilesBackend()]
+        collector = StaticCollector()
+        template = Template(
+            "{% load next_static %}"
+            "{% #use_script %}window.x=1;{% /use_script %}"
+            f"{SCRIPTS_PLACEHOLDER}"
+        )
+        rendered = template.render(Context({"_static_collector": collector}))
+
+        final = manager.inject(rendered, collector)
+        assert "<script>window.x=1;</script>" in final
+
+
 class TestJsContextFlowsThroughInit:
     def test_context_values_reach_init_script(self) -> None:
 

--- a/tests/static/test_integration.py
+++ b/tests/static/test_integration.py
@@ -95,32 +95,20 @@ class TestUseStyleBlocksThroughPipeline:
 class TestInlineBlocksThroughPipeline:
     """`{% #use_style %}` / `{% #use_script %}` reach the head as working tags."""
 
-    def test_inline_style_block_lands_wrapped(self) -> None:
+    def test_inline_blocks_land_wrapped(self) -> None:
         manager = StaticManager()
         manager._backends = [StaticFilesBackend()]
         collector = StaticCollector()
         template = Template(
             "{% load next_static %}"
             "{% #use_style %}.card{margin:0}{% /use_style %}"
-            f"{STYLES_PLACEHOLDER}"
+            "{% #use_script %}window.x=1;{% /use_script %}"
+            f"{STYLES_PLACEHOLDER}{SCRIPTS_PLACEHOLDER}"
         )
         rendered = template.render(Context({"_static_collector": collector}))
 
         final = manager.inject(rendered, collector)
         assert "<style>.card{margin:0}</style>" in final
-
-    def test_inline_script_block_lands_wrapped(self) -> None:
-        manager = StaticManager()
-        manager._backends = [StaticFilesBackend()]
-        collector = StaticCollector()
-        template = Template(
-            "{% load next_static %}"
-            "{% #use_script %}window.x=1;{% /use_script %}"
-            f"{SCRIPTS_PLACEHOLDER}"
-        )
-        rendered = template.render(Context({"_static_collector": collector}))
-
-        final = manager.inject(rendered, collector)
         assert "<script>window.x=1;</script>" in final
 
 

--- a/tests/static/test_manager.py
+++ b/tests/static/test_manager.py
@@ -99,21 +99,17 @@ class TestInjectStyles:
         assert f'<link rel="stylesheet" href="{CSS_URL}">' in out
         assert STYLES_PLACEHOLDER not in out
 
-    def test_inline_css_body_wrapped_in_style_tag(
-        self, fresh_manager: StaticManager
-    ) -> None:
+    def test_inline_body_wrapped_by_kind(self, fresh_manager: StaticManager) -> None:
         fresh_manager._ensure_backends()
-        asset = StaticAsset(url="", kind="css", inline="body{color:red}")
-        rendered = fresh_manager._render_one(asset, fresh_manager.default_backend, None)
-        assert rendered == "<style>body{color:red}</style>"
-
-    def test_inline_js_body_wrapped_in_script_tag(
-        self, fresh_manager: StaticManager
-    ) -> None:
-        fresh_manager._ensure_backends()
-        asset = StaticAsset(url="", kind="js", inline="console.log(1)")
-        rendered = fresh_manager._render_one(asset, fresh_manager.default_backend, None)
-        assert rendered == "<script>console.log(1)</script>"
+        backend = fresh_manager.default_backend
+        css = StaticAsset(url="", kind="css", inline="body{color:red}")
+        js = StaticAsset(url="", kind="js", inline="console.log(1)")
+        assert fresh_manager._render_one(css, backend, None) == (
+            "<style>body{color:red}</style>"
+        )
+        assert fresh_manager._render_one(js, backend, None) == (
+            "<script>console.log(1)</script>"
+        )
 
     def test_inline_body_verbatim_when_kind_has_no_inline_tag(
         self, fresh_manager: StaticManager

--- a/tests/static/test_manager.py
+++ b/tests/static/test_manager.py
@@ -99,14 +99,34 @@ class TestInjectStyles:
         assert f'<link rel="stylesheet" href="{CSS_URL}">' in out
         assert STYLES_PLACEHOLDER not in out
 
-    def test_inline_style_emitted_verbatim(self, fresh_manager: StaticManager) -> None:
-        collector = StaticCollector()
-        collector.add(
-            StaticAsset(url="", kind="css", inline="<style>body{color:red}</style>")
-        )
-        html = f"<head>{STYLES_PLACEHOLDER}</head>"
-        out = fresh_manager.inject(html, collector)
-        assert "<style>body{color:red}</style>" in out
+    def test_inline_css_body_wrapped_in_style_tag(
+        self, fresh_manager: StaticManager
+    ) -> None:
+        fresh_manager._ensure_backends()
+        asset = StaticAsset(url="", kind="css", inline="body{color:red}")
+        rendered = fresh_manager._render_one(asset, fresh_manager.default_backend, None)
+        assert rendered == "<style>body{color:red}</style>"
+
+    def test_inline_js_body_wrapped_in_script_tag(
+        self, fresh_manager: StaticManager
+    ) -> None:
+        fresh_manager._ensure_backends()
+        asset = StaticAsset(url="", kind="js", inline="console.log(1)")
+        rendered = fresh_manager._render_one(asset, fresh_manager.default_backend, None)
+        assert rendered == "<script>console.log(1)</script>"
+
+    def test_inline_body_verbatim_when_kind_has_no_inline_tag(
+        self, fresh_manager: StaticManager
+    ) -> None:
+        fresh_manager._ensure_backends()
+        asset = StaticAsset(url="", kind="raw", inline="<custom>x</custom>")
+        with mock.patch(
+            "next.static.manager.default_kinds.inline_tag", return_value=None
+        ):
+            rendered = fresh_manager._render_one(
+                asset, fresh_manager.default_backend, None
+            )
+        assert rendered == "<custom>x</custom>"
 
     def test_empty_collector_empties_placeholder(
         self, fresh_manager: StaticManager

--- a/tests/static/test_scripts.py
+++ b/tests/static/test_scripts.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 from decimal import Decimal
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from django.test import RequestFactory, override_settings
 
 from next.static import NextScriptBuilder, ScriptInjectionPolicy
+from next.static.collector import StaticCollector
 from next.static.scripts import (
     CSRF_PAYLOAD_KEY,
     NEXT_JS_STATIC_PATH,
@@ -14,9 +16,40 @@ from next.static.scripts import (
     csrf_payload,
     csrf_payload_for,
 )
+from next.static.serializers import resolve_serializer
+
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from next.static.serializers import JsContextSerializer
 
 
 URL = "/static/next/next.min.js"
+
+
+def _legacy_init_payload(
+    js_context: Mapping[str, Any],
+    key_serializers: Mapping[str, JsContextSerializer] | None,
+) -> str:
+    """Reproduce the whole-dict or per-key init payload for byte-parity checks."""
+    if not key_serializers:
+        return resolve_serializer().dumps(dict(js_context))
+    default = resolve_serializer()
+    fragments: list[str] = []
+    for k, v in js_context.items():
+        serializer = key_serializers.get(k, default)
+        encoded_key = json.dumps(k, separators=(",", ":"))
+        fragments.append(f"{encoded_key}:{serializer.dumps(v)}")
+    return "{" + ",".join(fragments) + "}"
+
+
+class _MarkSerializer:
+    """Compact per-key serializer that wraps values under a marker."""
+
+    def dumps(self, value: object) -> str:
+        """Return the value wrapped in a marker object as compact JSON."""
+        return json.dumps({"mark": value}, separators=(",", ":"))
 
 
 class TestScriptInjectionPolicy:
@@ -138,6 +171,80 @@ class TestNextScriptBuilderFromOptions:
         assert "async" in builder.script_tag()
         payload = json.dumps({"a": 1}, separators=(",", ":"))
         assert builder.init_script({"a": 1}) == f"<script>boot({payload})</script>"
+
+
+class TestInitScriptGoldenParity:
+    """Fragment-assembled init payload stays byte-identical to the whole-dict dump.
+
+    Each case builds a collector the way the static manager does, then asserts
+    the new `encoded`-driven `init_script` output equals the legacy payload for
+    the compact serializers the framework ships.
+    """
+
+    def _assert_parity(
+        self,
+        js_context: Mapping[str, Any],
+        *,
+        key_serializers: Mapping[str, JsContextSerializer],
+        encoded: Mapping[str, str],
+    ) -> str:
+        builder = NextScriptBuilder(URL)
+        new = builder.init_script(
+            js_context, key_serializers=key_serializers, encoded=encoded
+        )
+        legacy = _legacy_init_payload(js_context, key_serializers)
+        assert new == f"<script>Next._init({legacy});</script>"
+        return new
+
+    def test_default_serializer_simple_value(self) -> None:
+        collector = StaticCollector()
+        collector.add_js_context("user", "alice")
+        self._assert_parity(
+            collector.js_context(),
+            key_serializers=collector.js_context_serializers(),
+            encoded=collector.js_context_encoded(),
+        )
+
+    def test_empty_js_context(self) -> None:
+        collector = StaticCollector()
+        out = self._assert_parity(
+            collector.js_context(),
+            key_serializers=collector.js_context_serializers(),
+            encoded=collector.js_context_encoded(),
+        )
+        assert out == "<script>Next._init({});</script>"
+
+    def test_per_key_serializer_override(self) -> None:
+        collector = StaticCollector()
+        collector.add_js_context("user", "alice")
+        collector.add_js_context("flags", [1, 2], serializer=_MarkSerializer())
+        out = self._assert_parity(
+            collector.js_context(),
+            key_serializers=collector.js_context_serializers(),
+            encoded=collector.js_context_encoded(),
+        )
+        assert '"flags":{"mark":[1,2]}' in out
+
+    def test_nested_structure_value(self) -> None:
+        collector = StaticCollector()
+        collector.add_js_context("data", {"a": [1, 2], "b": {"c": 3}})
+        self._assert_parity(
+            collector.js_context(),
+            key_serializers=collector.js_context_serializers(),
+            encoded=collector.js_context_encoded(),
+        )
+
+    def test_externally_added_csrf_key_falls_back(self) -> None:
+        collector = StaticCollector()
+        collector.add_js_context("user", "alice")
+        csrf = {"header": "X-CSRFToken", "token": "tok"}
+        js_context = {**collector.js_context(), CSRF_PAYLOAD_KEY: csrf}
+        out = self._assert_parity(
+            js_context,
+            key_serializers=collector.js_context_serializers(),
+            encoded=collector.js_context_encoded(),
+        )
+        assert '"$csrf":{"header":"X-CSRFToken","token":"tok"}' in out
 
 
 class TestNextJsStaticPath:

--- a/tests/testing/test_client.py
+++ b/tests/testing/test_client.py
@@ -128,8 +128,10 @@ class TestEnvelopeHelpers:
         envelope = envelope_of(NextClient().get_zones("/zoned/", ("alpha", "beta")))
         assert isinstance(envelope, PartialEnvelope)
         assert envelope.version == "0"
-        assert envelope.op_verbs() == ["morph", "morph"]
-        assert envelope.targets() == [{"zone": "alpha"}, {"zone": "beta"}]
+        # The zoned page registers a serialize=True provider, so the batch
+        # ends with the context op carrying its js-context delta.
+        assert envelope.op_verbs() == ["morph", "morph", "context"]
+        assert envelope.targets() == [{"zone": "alpha"}, {"zone": "beta"}, None]
 
     def test_assets_manifest_lists_co_located_css(self) -> None:
         envelope = envelope_of(NextClient().get_zones("/zoned/", "alpha"))


### PR DESCRIPTION
## Description

A zone GET collected its co-located inline styles, scripts, and the serialize=True js-context into the render collector but the envelope shipped only URL-form assets, so a zone with co-located inline CSS arrived unstyled and islands never saw fresh provider values.

ZoneRenderResult now exposes inline assets and the js-context delta, the view and the morph_zone builder ship assets through one manifest helper, Asset carries an optional inline body, and the client injects inline assets through the existing asset loop deduplicated by body. The collector caches the serialized js-context fragment so the zone-GET context patch reuses it instead of re-serializing.

## How to test

<!-- e.g. `make ci` before opening the PR. If you changed docs, run `make docs` or rely on the CI docs job. -->

## Related issues

<!-- e.g. Fixes #123 / Closes #456 -->

## Checklist

- [ ] `make ci` passes locally
- [ ] New or changed `next/` code covered by tests (100% for package)
- [ ] Example + tests when adding public API or behavior users copy from `examples/`
- [ ] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable

---

Full guidelines: [CONTRIBUTING.md](https://github.com/next-dj/next-dj/blob/main/CONTRIBUTING.md)
