### PR TITLE
feat(partial): declarative {% zone poll %} interval mode 

### DIFF
--- a/docs/content/ref/partial.rst
+++ b/docs/content/ref/partial.rst
@@ -237,8 +237,8 @@ See :doc:`signals` and :doc:`/content/topics/signals` for the partial signals
 System Checks
 -------------
 
-See :doc:`system-checks` for the zone-placement and custom-verb checks
-(``next.E060`` through ``next.E066``, ``next.W067`` through ``next.W071``).
+See :doc:`system-checks` for the zone-placement, template-compile, and custom-verb checks
+(``next.E060`` through ``next.E066``, ``next.E072``, ``next.W067`` through ``next.W071``).
 
 See Also
 --------

--- a/docs/content/ref/signals.rst
+++ b/docs/content/ref/signals.rst
@@ -148,8 +148,8 @@ not be retained past the receiver call.
      - After a ``FormWizard`` step validates during dispatch. ``cleaned_data`` is a copy of that step's validated data.
    * - ``zone_registered``
      - The compiled page template class
-     - ``template``, ``zone_name``, ``lazy``
-     - Once per compiled composed template, when its named zones are first read. ``lazy`` is the trigger string or ``None``.
+     - ``template``, ``zone_name``, ``lazy``, ``poll``
+     - Once per compiled composed template, when its named zones are first read. ``lazy`` is the trigger string or ``None``, ``poll`` the interval in milliseconds or ``None``.
    * - ``zone_rendered``
      - ``ZoneRenderResult``
      - ``zone_name``, ``page_path``, ``request``, ``duration_ms``

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -283,6 +283,9 @@ Errors
    * - ``next.E066``
      - A custom patch op shadows a built-in verb or uses a name that is not a valid verb token.
      - ``next.partial.checks``
+   * - ``next.E072``
+     - A composed page template does not compile, so the syntax error would otherwise surface only as a 500 on the first request to the page.
+     - ``next.partial.checks``
 
 A code emitted by ``next.checks.common`` is produced by a shared helper that the listed subsystem check modules call.
 

--- a/docs/content/ref/template-tags.rst
+++ b/docs/content/ref/template-tags.rst
@@ -144,7 +144,7 @@ Static Pipeline
 Partial Rendering
 -----------------
 
-.. describe:: {% zone "<name>" tag="<element>" lazy="<trigger>" %}...{% placeholder %}...{% endzone %}
+.. describe:: {% zone "<name>" tag="<element>" lazy="<trigger>" poll="<interval>" %}...{% placeholder %}...{% endzone %}
 
    Marks a named slice of a page template the server can re-render on its own.
    The first argument is the quoted zone name, an ASCII slug that must be unique across the composed template, the layout chain plus the page body.
@@ -158,10 +158,14 @@ Partial Rendering
    A lazy zone renders only its ``{% placeholder %}`` branch up front and fetches the body on ``ready`` for ``load`` or when it scrolls into view for ``revealed``.
    Any other ``lazy`` value raises ``TemplateSyntaxError`` at parse time.
 
+   ``poll="<interval>"`` re-GETs the body on the interval, read from a ``5s`` or ``1500ms`` literal or a bare number of milliseconds.
+   It is mutually exclusive with ``lazy=``, and an interval below one second, above the browser timer ceiling, or malformed raises ``TemplateSyntaxError`` at parse time.
+
 .. describe:: {% placeholder %}
 
    Opens the placeholder branch of a lazy ``{% zone %}``, shown until the deferred body arrives.
    It is valid only between a ``{% zone %}`` and its ``{% endzone %}``, and a lazy zone without it raises ``next.E064``.
+   The branch belongs to lazy zones only, so a zone without ``lazy=`` rejects it with ``TemplateSyntaxError`` when the template compiles.
 
 A zone belongs to a page or layout, not a component, and may not sit inside a ``{% for %}``, an ``{% if %}``, or directly inside a ``{% with %}``.
 The :doc:`zone placement checks </content/ref/system-checks>` enforce each rule at ``manage.py check`` time.

--- a/docs/content/ref/template-tags.rst
+++ b/docs/content/ref/template-tags.rst
@@ -158,8 +158,10 @@ Partial Rendering
    A lazy zone renders only its ``{% placeholder %}`` branch up front and fetches the body on ``ready`` for ``load`` or when it scrolls into view for ``revealed``.
    Any other ``lazy`` value raises ``TemplateSyntaxError`` at parse time.
 
-   ``poll="<interval>"`` re-GETs the body on the interval, read from a ``5s`` or ``1500ms`` literal or a bare number of milliseconds.
+   ``poll="<interval>"`` re-GETs the body on the interval, read from a quoted ``5s`` or ``1500ms`` literal or a bare number of milliseconds, never from a template variable.
    It is mutually exclusive with ``lazy=``, and an interval below one second, above the browser timer ceiling, or malformed raises ``TemplateSyntaxError`` at parse time.
+
+   An option without ``=`` and an unknown option key also raise ``TemplateSyntaxError`` at parse time, so a typo fails the compile rather than being silently dropped.
 
 .. describe:: {% placeholder %}
 

--- a/docs/content/topics/partial-rendering/done-choreographies.rst
+++ b/docs/content/topics/partial-rendering/done-choreographies.rst
@@ -72,7 +72,7 @@ The canonical server-driven done choreography.
 The wizard puts the morph of the list's zone into its own response, so one envelope closes the layer, refreshes the list, and shows the toast.
 
 This addresses a zone of a foreign page through ``morph(page=, url_kwargs=)``, the one path the server takes to refresh a host-page zone from a ``done`` step.
-The builder takes ``page=`` and ``url_kwargs=`` alongside ``zone=``, and the request carries ``X-Next-Origin`` with the path of the page that hosts the layer.
+The builder takes ``page=`` and ``url_kwargs=`` alongside ``zone=``, and the request carries ``X-Next-Origin`` with the path and query string of the page that hosts the layer.
 ``resolve_partial_origin`` is the thin helper that reads that header back into the ``page_path`` and ``url_kwargs`` the morph needs, nothing more.
 
 .. code-block:: python

--- a/docs/content/topics/partial-rendering/how-it-works.rst
+++ b/docs/content/topics/partial-rendering/how-it-works.rst
@@ -39,7 +39,9 @@ A selector or a swap strategy never crosses the wire, so the client cannot be as
 The Apply
 ---------
 
-The client narrows the envelope and runs each operation against the addressed zone, resolving a layer zone before the same-named page zone.
+The client narrows the envelope and runs each operation against the addressed zone.
+A patch answering a zone GET resolves inside the page that GET fetched, so a base-page refresh cannot morph a same-named zone in an open modal.
+A patch with no page attached resolves top-down, a layer zone before the same-named page zone.
 The built-in verbs are ``morph``, ``replace``, ``inner``, ``append``, ``prepend``, ``remove``, ``refresh``, ``event``, ``toast``, ``url``, ``visit``, ``layer.open``, ``layer.close``, and ``context``.
 ``morph`` is the default, reconciling the live subtree in place against the new markup so focus, the caret, and a field the user is editing survive the update.
 A reused node keeps its own state, scroll position included, because it never leaves the document.

--- a/docs/content/topics/partial-rendering/reference.rst
+++ b/docs/content/topics/partial-rendering/reference.rst
@@ -212,9 +212,11 @@ The form-behaviour attributes are written by the ``{% form %}`` tag from Python 
        ``revealed`` arms the observer that fires the merge GET.
    * - ``data-next-poll``
      - Zone wrapper
-     - The poll interval in milliseconds, written by the ``{% zone %}`` tag from a
-       ``poll=`` literal. The runtime re-GETs the zone on the interval while the
-       tab is visible.
+     - The poll interval in milliseconds, from the ``poll=`` literal, written on the
+       full render and on the partial response wrapper. The runtime re-GETs the zone
+       on the interval while the tab is visible. A hand-written value outside the
+       whole-millisecond grammar or the browser timer range is dropped, with a
+       console warning in dev.
    * - ``data-next-action``
      - ``<form>``
      - The action uid, written by ``{% form %}``, enables submit interception.

--- a/docs/content/topics/partial-rendering/reference.rst
+++ b/docs/content/topics/partial-rendering/reference.rst
@@ -128,7 +128,7 @@ All values are ASCII, and zone names are ASCII slugs.
      - The ring id used to suppress an SSE echo.
    * - ``X-Next-Origin``
      - Server OOB choreography only
-     - The path of the page that hosts a layer, for a server-side morph of its zones.
+     - The path and query string of the page that hosts a layer, for a server-side morph of its zones.
    * - CSRF header
      - Every unsafe method
      - The name comes from ``CSRF_HEADER_NAME``, the token from the runtime payload, the cookie is never read.
@@ -215,8 +215,9 @@ The form-behaviour attributes are written by the ``{% form %}`` tag from Python 
      - The poll interval in milliseconds, from the ``poll=`` literal, written on the
        full render and on the partial response wrapper. The runtime re-GETs the zone
        on the interval while the tab is visible. A hand-written value outside the
-       whole-millisecond grammar or the browser timer range is dropped, with a
-       console warning in dev.
+       whole-millisecond grammar, below the one-second floor, or above the browser
+       timer ceiling is dropped, as is the attribute on an element without
+       ``data-next-zone``, each with a console warning in dev.
    * - ``data-next-action``
      - ``<form>``
      - The action uid, written by ``{% form %}``, enables submit interception.

--- a/docs/content/topics/partial-rendering/reference.rst
+++ b/docs/content/topics/partial-rendering/reference.rst
@@ -210,6 +210,11 @@ The form-behaviour attributes are written by the ``{% form %}`` tag from Python 
      - ``load`` or ``revealed``, the materialisation trigger. ``load`` fetches on
        ``ready``, ``revealed`` waits for the viewport. On a pagination sentinel
        ``revealed`` arms the observer that fires the merge GET.
+   * - ``data-next-poll``
+     - Zone wrapper
+     - The poll interval in milliseconds, written by the ``{% zone %}`` tag from a
+       ``poll=`` literal. The runtime re-GETs the zone on the interval while the
+       tab is visible.
    * - ``data-next-action``
      - ``<form>``
      - The action uid, written by ``{% form %}``, enables submit interception.

--- a/docs/content/topics/partial-rendering/zones.rst
+++ b/docs/content/topics/partial-rendering/zones.rst
@@ -83,12 +83,13 @@ The body renders inline on the first paint, and the runtime re-GETs the zone on 
      {% component "stat_card" label="Pages" value=totals.pages %}
    {% endzone %}
 
-The interval reads ``5s``, ``500ms``, or a bare number of milliseconds.
-An interval below one second or a malformed literal fails when the template compiles, the same honest-fail as an unknown ``lazy=`` trigger.
+The interval reads ``5s``, ``1500ms``, or a bare number of milliseconds.
+An interval below one second or above the browser timer ceiling fails when the template compiles, the same honest-fail as a malformed literal or an unknown ``lazy=`` trigger.
 
 The wrapper carries ``data-next-poll`` with the resolved milliseconds on the full render.
-A partial response for the zone drops the hint, because the runtime reads the interval from the live element.
-A hidden tab does not poll, and the next tick after the tab returns to the foreground fetches the fresh body.
+A partial response for the zone keeps the interval on its wrapper and drops only the lazy hint, so the live element stays the source of truth across morphs.
+A hidden tab pauses the poll timers.
+A tab hidden long enough to have missed a tick refreshes every polling zone on its return to the foreground, while a brief flicker between tabs re-arms the timers without a fetch, so switching windows does not storm the server.
 A polling zone shows its body, so it cannot also be ``lazy=``, the two modes are exclusive and combining them is a compile error.
 
 The Wrapper Element

--- a/docs/content/topics/partial-rendering/zones.rst
+++ b/docs/content/topics/partial-rendering/zones.rst
@@ -88,8 +88,10 @@ An interval below one second or above the browser timer ceiling fails when the t
 
 The wrapper carries ``data-next-poll`` with the resolved milliseconds on the full render.
 A partial response for the zone keeps the interval on its wrapper and drops only the lazy hint, so the live element stays the source of truth across morphs.
-A hidden tab pauses the poll timers.
-A tab hidden long enough to have missed a tick refreshes every polling zone on its return to the foreground, while a brief flicker between tabs re-arms the timers without a fetch, so switching windows does not storm the server.
+Zones that share an interval batch into one zone request per owning page.
+A hidden tab holds no poll timers.
+On its return to the foreground each zone refetches only when its own interval elapsed while hidden, and otherwise the countdown resumes with the remaining time.
+A brief flicker between tabs therefore fetches nothing, and switching windows does not storm the server.
 A polling zone shows its body, so it cannot also be ``lazy=``, the two modes are exclusive and combining them is a compile error.
 
 The Wrapper Element

--- a/docs/content/topics/partial-rendering/zones.rst
+++ b/docs/content/topics/partial-rendering/zones.rst
@@ -70,6 +70,27 @@ The network payload shrinks from a page to a zone, and the server render shrinks
 Reach for a zone when a page is heavy, when a form sits among expensive siblings, or when the response size matters.
 Leave it off when the page is small and the extract default already does the job.
 
+Poll a Zone on an Interval
+--------------------------
+
+A zone polls itself when the tag carries a ``poll=`` interval.
+The body renders inline on the first paint, and the runtime re-GETs the zone on the interval through the same zone request a lazy load uses.
+
+.. code-block:: jinja
+   :caption: a polling zone
+
+   {% zone "overview-totals" poll="5s" %}
+     {% component "stat_card" label="Pages" value=totals.pages %}
+   {% endzone %}
+
+The interval reads ``5s``, ``500ms``, or a bare number of milliseconds.
+An interval below one second or a malformed literal fails when the template compiles, the same honest-fail as an unknown ``lazy=`` trigger.
+
+The wrapper carries ``data-next-poll`` with the resolved milliseconds on the full render.
+A partial response for the zone drops the hint, because the runtime reads the interval from the live element.
+A hidden tab does not poll, and the next tick after the tab returns to the foreground fetches the fresh body.
+A polling zone shows its body, so it cannot also be ``lazy=``, the two modes are exclusive and combining them is a compile error.
+
 The Wrapper Element
 -------------------
 

--- a/examples/kanban/kanban/boards/board/[int:id]/page.test.jsx
+++ b/examples/kanban/kanban/boards/board/[int:id]/page.test.jsx
@@ -48,7 +48,7 @@ describe("Board", () => {
     const col2 = document.querySelector("[data-kanban-column='2']");
     fireEvent.drop(col2, { dataTransfer: { getData: () => "10" } });
 
-    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
 
     const [url, opts] = mockFetch.mock.calls[0];
     expect(url).toBe("/actions/kanban/move_card");

--- a/examples/kanban/kanban/boards/board/[int:id]/page.test.jsx
+++ b/examples/kanban/kanban/boards/board/[int:id]/page.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Board } from "./page";
 
 const mockBoard = {
@@ -99,7 +99,7 @@ describe("Board", () => {
     const col2 = document.querySelector("[data-kanban-column='2']");
     fireEvent.drop(col2, { dataTransfer: { getData: () => "10" } });
 
-    await vi.waitFor(() =>
+    await waitFor(() =>
       expect(document.querySelector("[data-kanban-error]")).toBeTruthy(),
     );
 
@@ -119,7 +119,7 @@ describe("Board", () => {
     const col2 = document.querySelector("[data-kanban-column='2']");
     fireEvent.drop(col2, { dataTransfer: { getData: () => "10" } });
 
-    await vi.waitFor(() =>
+    await waitFor(() =>
       expect(document.querySelector("[data-kanban-error]")).toBeTruthy(),
     );
 
@@ -137,7 +137,7 @@ describe("Board", () => {
     const col2 = document.querySelector("[data-kanban-column='2']");
     fireEvent.drop(col2, { dataTransfer: { getData: () => "10" } });
 
-    await vi.waitFor(() =>
+    await waitFor(() =>
       expect(document.querySelector("[data-kanban-error]")).toBeTruthy(),
     );
 

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -19,7 +19,7 @@ The page tree is `dashboards/`. The components live next to the pages that use t
 
 The filter form uses the framework `{% form "window_filter_form" %}` tag. Submitting it fires `forms.action_dispatched` so the example exercises the full form path without adding a model write. From the live page the form targets the `live-totals` zone, so the apply rides the partial protocol and ships a project-defined verb beside the built-in morph.
 
-The overview shows the other two zone modes. The stat-tile grid sits in `{% zone "overview-totals" poll="5s" %}`, so the client re-GETs the zone every five seconds and the counters refresh without a reload. The busiest-pages widget below the sparkline is a `lazy="load"` zone: the first paint ships only its `{% placeholder %}` branch and the body arrives through one batched zone-GET as soon as the page loads.
+The overview shows the other two zone modes. The stat-tile grid sits in `{% zone "overview-totals" poll="5s" %}`, so the client re-GETs the zone every five seconds and the counters refresh without a reload. Each poll tick re-renders the four tiles, so the components counter also counts the poll's own renders — visible proof the polling works. The busiest-pages widget below the sparkline is a `lazy="load"` zone: the first paint ships only its `{% placeholder %}` branch and the body arrives through one batched zone-GET as soon as the page loads.
 
 ## How to run
 
@@ -56,11 +56,12 @@ obs/
 ├── management/commands/flush_metrics.py
 └── dashboards/
     ├── layout.djx            <- root html shell, Tailwind from CDN
-    ├── page.py               <- @context totals, busiest_pages
+    ├── page.py               <- @context totals
     ├── template.djx          <- poll zone with the overview grid, React sparkline, lazy busiest-pages widget
     ├── _widgets/
     │   ├── stat_card/        <- card composite reused on every page
     │   ├── counter_list/     <- list/table widget shared by every stats subpage
+    │   ├── busiest_pages/    <- lazy-zone body, component-level top_by_kind lookup
     │   ├── stats_nav/        <- nav tabs rendered from a Python list
     │   ├── filter_window/    <- window filter form (template-only component)
     │   ├── render_chart/     <- Chart.js bar chart, scripts=[chart.js cdn]

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -8,7 +8,7 @@ The page tree is `dashboards/`. The components live next to the pages that use t
 
 | URL | Description |
 | --- | --- |
-| `/` | Overview with four headline counters and a React sparkline. |
+| `/` | Overview with four headline counters in a polling zone, a React sparkline, and a lazy-loaded busiest-pages widget. |
 | `/stats/` | Live page with the Chart.js bar chart and a filter form. |
 | `/stats/?window=1h` | Same page, real time-bucketed aggregation across the last hour. |
 | `/stats/pages/` | Per-page render counts pulled from the cumulative `pages.rendered` kind. |
@@ -19,6 +19,8 @@ The page tree is `dashboards/`. The components live next to the pages that use t
 
 The filter form uses the framework `{% form "window_filter_form" %}` tag. Submitting it fires `forms.action_dispatched` so the example exercises the full form path without adding a model write. From the live page the form targets the `live-totals` zone, so the apply rides the partial protocol and ships a project-defined verb beside the built-in morph.
 
+The overview shows the other two zone modes. The stat-tile grid sits in `{% zone "overview-totals" poll="5s" %}`, so the client re-GETs the zone every five seconds and the counters refresh without a reload. The busiest-pages widget below the sparkline is a `lazy="load"` zone: the first paint ships only its `{% placeholder %}` branch and the body arrives through one batched zone-GET as soon as the page loads.
+
 ## How to run
 
 ```bash
@@ -27,7 +29,7 @@ uv run python manage.py migrate
 uv run python manage.py runserver        # http://127.0.0.1:8000/
 ```
 
-Click around `/`, `/stats/`, the four sub-pages. Apply different windows. Counters move on every render, and the windowed view actually narrows to the chosen aggregation slice.
+Click around `/`, `/stats/`, the four sub-pages. Apply different windows. Counters move on every render, the overview tiles re-poll on their own every five seconds, and the windowed view actually narrows to the chosen aggregation slice.
 
 ```bash
 uv run python manage.py flush_metrics
@@ -54,8 +56,8 @@ obs/
 ├── management/commands/flush_metrics.py
 └── dashboards/
     ├── layout.djx            <- root html shell, Tailwind from CDN
-    ├── page.py               <- @context totals
-    ├── template.djx          <- overview grid + React sparkline
+    ├── page.py               <- @context totals, busiest_pages
+    ├── template.djx          <- poll zone with the overview grid, React sparkline, lazy busiest-pages widget
     ├── _widgets/
     │   ├── stat_card/        <- card composite reused on every page
     │   ├── counter_list/     <- list/table widget shared by every stats subpage

--- a/examples/observability/obs/dashboards/_widgets/busiest_pages/component.djx
+++ b/examples/observability/obs/dashboards/_widgets/busiest_pages/component.djx
@@ -1,0 +1,4 @@
+<section class="rounded-md border border-border bg-card p-6 shadow-sm">
+  <h2 class="mb-4 text-sm font-semibold text-foreground">Busiest pages</h2>
+  {% component "counter_list" items=busiest_pages empty_message="No pages have been rendered yet." %}
+</section>

--- a/examples/observability/obs/dashboards/_widgets/busiest_pages/component.djx
+++ b/examples/observability/obs/dashboards/_widgets/busiest_pages/component.djx
@@ -1,4 +1,1 @@
-<section class="rounded-md border border-border bg-card p-6 shadow-sm">
-  <h2 class="mb-4 text-sm font-semibold text-foreground">Busiest pages</h2>
-  {% component "counter_list" items=busiest_pages empty_message="No pages have been rendered yet." %}
-</section>
+{% component "counter_list" items=busiest_pages empty_message="No pages have been rendered yet." %}

--- a/examples/observability/obs/dashboards/_widgets/busiest_pages/component.py
+++ b/examples/observability/obs/dashboards/_widgets/busiest_pages/component.py
@@ -1,0 +1,9 @@
+from obs import metrics
+
+from next.components import component
+
+
+@component.context("busiest_pages")
+def busiest_pages() -> list[tuple[str, int]]:
+    """Return the five most rendered page modules for the lazy widget."""
+    return metrics.top_by_kind("pages.rendered", limit=5)

--- a/examples/observability/obs/dashboards/page.py
+++ b/examples/observability/obs/dashboards/page.py
@@ -19,3 +19,9 @@ def totals() -> dict[str, int]:
         "actions_dispatched": metrics.total_for_kind("forms.action_dispatched"),
         "html_injections": metrics.read_kind("static").get("html_injected", 0),
     }
+
+
+@context("busiest_pages")
+def busiest_pages() -> list[tuple[str, int]]:
+    """Return the five most rendered page modules for the lazy widget."""
+    return metrics.top_by_kind("pages.rendered", limit=5)

--- a/examples/observability/obs/dashboards/page.py
+++ b/examples/observability/obs/dashboards/page.py
@@ -19,9 +19,3 @@ def totals() -> dict[str, int]:
         "actions_dispatched": metrics.total_for_kind("forms.action_dispatched"),
         "html_injections": metrics.read_kind("static").get("html_injected", 0),
     }
-
-
-@context("busiest_pages")
-def busiest_pages() -> list[tuple[str, int]]:
-    """Return the five most rendered page modules for the lazy widget."""
-    return metrics.top_by_kind("pages.rendered", limit=5)

--- a/examples/observability/obs/dashboards/template.djx
+++ b/examples/observability/obs/dashboards/template.djx
@@ -11,14 +11,14 @@
 
   {% component "sparkline" %}
 
-  {% zone "busiest-pages" lazy="load" %}
-    {% component "busiest_pages" %}
-  {% placeholder %}
-    <section class="rounded-md border border-border bg-card p-6 shadow-sm">
-      <h2 class="mb-4 text-sm font-semibold text-foreground">Busiest pages</h2>
+  <section class="rounded-md border border-border bg-card p-6 shadow-sm">
+    <h2 class="mb-4 text-sm font-semibold text-foreground">Busiest pages</h2>
+    {% zone "busiest-pages" lazy="load" %}
+      {% component "busiest_pages" %}
+    {% placeholder %}
       <p class="text-sm text-muted-foreground">Loading the busiest pages&hellip;</p>
-    </section>
-  {% endzone %}
+    {% endzone %}
+  </section>
 
   <p class="text-sm text-muted-foreground">
     Drill down on the

--- a/examples/observability/obs/dashboards/template.djx
+++ b/examples/observability/obs/dashboards/template.djx
@@ -12,10 +12,7 @@
   {% component "sparkline" %}
 
   {% zone "busiest-pages" lazy="load" %}
-    <section class="rounded-md border border-border bg-card p-6 shadow-sm">
-      <h2 class="mb-4 text-sm font-semibold text-foreground">Busiest pages</h2>
-      {% component "counter_list" items=busiest_pages empty_message="No pages have been rendered yet." %}
-    </section>
+    {% component "busiest_pages" %}
   {% placeholder %}
     <section class="rounded-md border border-border bg-card p-6 shadow-sm">
       <h2 class="mb-4 text-sm font-semibold text-foreground">Busiest pages</h2>

--- a/examples/observability/obs/dashboards/template.djx
+++ b/examples/observability/obs/dashboards/template.djx
@@ -1,13 +1,27 @@
 <div class="space-y-6">
-  {% component "page_header" title="Overview" description="In-process counters refresh on every page render." %}
-  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-    {% component "stat_card" label="Pages rendered" value=totals.pages_rendered %}
-    {% component "stat_card" label="Components rendered" value=totals.components_rendered %}
-    {% component "stat_card" label="Actions dispatched" value=totals.actions_dispatched %}
-    {% component "stat_card" label="HTML injections" value=totals.html_injections %}
-  </div>
+  {% component "page_header" title="Overview" description="In-process counters refresh on an interval without a reload." %}
+  {% zone "overview-totals" poll="5s" %}
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {% component "stat_card" label="Pages rendered" value=totals.pages_rendered %}
+      {% component "stat_card" label="Components rendered" value=totals.components_rendered %}
+      {% component "stat_card" label="Actions dispatched" value=totals.actions_dispatched %}
+      {% component "stat_card" label="HTML injections" value=totals.html_injections %}
+    </div>
+  {% endzone %}
 
   {% component "sparkline" %}
+
+  {% zone "busiest-pages" lazy="load" %}
+    <section class="rounded-md border border-border bg-card p-6 shadow-sm">
+      <h2 class="mb-4 text-sm font-semibold text-foreground">Busiest pages</h2>
+      {% component "counter_list" items=busiest_pages empty_message="No pages have been rendered yet." %}
+    </section>
+  {% placeholder %}
+    <section class="rounded-md border border-border bg-card p-6 shadow-sm">
+      <h2 class="mb-4 text-sm font-semibold text-foreground">Busiest pages</h2>
+      <p class="text-sm text-muted-foreground">Loading the busiest pages&hellip;</p>
+    </section>
+  {% endzone %}
 
   <p class="text-sm text-muted-foreground">
     Drill down on the

--- a/examples/observability/tests/test_e2e.py
+++ b/examples/observability/tests/test_e2e.py
@@ -220,6 +220,40 @@ class TestFilterFormDispatch:
         assert events[0].kwargs["response_status"] == 302
 
 
+class TestPollZone:
+    """The overview totals zone carries a poll interval and still morphs."""
+
+    def test_overview_zone_carries_poll_interval(self, client) -> None:
+        body = client.get("/").content.decode()
+        assert 'data-next-poll="5000"' in body
+        assert 'data-next-zone="overview-totals"' in body
+
+    def test_overview_zone_get_still_morphs(self, client) -> None:
+        response = client.get_zones("/", "overview-totals")
+        envelope = envelope_of(response)
+        assert envelope.zone_targets() == ["overview-totals"]
+        assert "Pages rendered" in envelope.html_for_zone("overview-totals")
+
+
+class TestLazyLoadZone:
+    """The busiest-pages widget ships a placeholder and loads its body lazily."""
+
+    def test_overview_lazy_load_widget_renders_hint(self, client) -> None:
+        body = client.get("/").content.decode()
+        assert 'data-next-lazy="load"' in body
+        assert 'data-next-zone="busiest-pages"' in body
+        assert "Loading the busiest pages" in body
+
+    def test_lazy_zone_get_delivers_the_body(self, client) -> None:
+        client.get("/stats/pages/")
+        response = client.get_zones("/", "busiest-pages")
+        envelope = envelope_of(response)
+        assert envelope.zone_targets() == ["busiest-pages"]
+        html = envelope.html_for_zone("busiest-pages")
+        assert "Busiest pages" in html
+        assert "Loading the busiest pages" not in html
+
+
 class TestMetricPulseVerb:
     """A partial apply morphs the totals zone and emits the custom verb."""
 

--- a/examples/observability/tests/test_e2e.py
+++ b/examples/observability/tests/test_e2e.py
@@ -242,6 +242,7 @@ class TestLazyLoadZone:
         body = client.get("/").content.decode()
         assert 'data-next-lazy="load"' in body
         assert 'data-next-zone="busiest-pages"' in body
+        assert "Busiest pages" in body
         assert "Loading the busiest pages" in body
 
     def test_lazy_zone_get_delivers_the_body(self, client) -> None:
@@ -250,7 +251,8 @@ class TestLazyLoadZone:
         envelope = envelope_of(response)
         assert envelope.zone_targets() == ["busiest-pages"]
         html = envelope.html_for_zone("busiest-pages")
-        assert "Busiest pages" in html
+        assert "stats/pages/page.py" in html
+        assert "No pages have been rendered yet." not in html
         assert "Loading the busiest pages" not in html
 
 

--- a/next/client/apply.test.ts
+++ b/next/client/apply.test.ts
@@ -1002,6 +1002,52 @@ describe("Applier layer, toast, and url verbs", () => {
   });
 });
 
+describe("Applier page-scoped zone resolve", () => {
+  function makeRecordingApplier() {
+    const pages: (string | undefined)[] = [];
+    const layers = {
+      resolveZone: (name: string, root: ParentNode, page?: string) => {
+        pages.push(page);
+        return root.querySelector(`[data-next-zone="${name}"]`);
+      },
+      open: () => undefined,
+      close: () => undefined,
+      toast: () => undefined,
+    };
+    const applier = new Applier({
+      dispatch: () => undefined,
+      mergeContext: () => undefined,
+      document,
+      layers,
+    });
+    return { applier, pages };
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("threads the fetched page of a zone GET into the layer resolve", () => {
+    document.body.innerHTML = '<div data-next-zone="z">old</div>';
+    const { applier, pages } = makeRecordingApplier();
+    applier.apply(
+      envelope([{ op: "inner", target: { zone: "z" }, html: "new" }]),
+      undefined,
+      undefined,
+      "/host/",
+    );
+    expect(pages).toEqual(["/host/"]);
+    expect(document.querySelector('[data-next-zone="z"]')!.textContent).toBe("new");
+  });
+
+  it("a direct apply resolves zones with no page", () => {
+    document.body.innerHTML = '<div data-next-zone="z">old</div>';
+    const { applier, pages } = makeRecordingApplier();
+    applier.apply(envelope([{ op: "inner", target: { zone: "z" }, html: "new" }]));
+    expect(pages).toEqual([undefined]);
+  });
+});
+
 describe("Applier visit verb", () => {
   beforeEach(() => {
     document.body.innerHTML = "";

--- a/next/client/apply.ts
+++ b/next/client/apply.ts
@@ -207,12 +207,13 @@ export interface ApplyContext {
   dev: boolean;
 }
 
-// The layer-aware bits the applier needs from the layer stack: a top-down zone
-// resolve, the open and close verbs, and the toast container. The LayerStack
-// satisfies this structurally, so partial.ts passes it directly. A
-// server-initiated open carries no opener element.
+// The layer-aware bits the applier needs from the layer stack: a zone resolve
+// (top-down, or scoped to the page a zone GET fetched), the open and close
+// verbs, and the toast container. The LayerStack satisfies this structurally,
+// so partial.ts passes it directly. A server-initiated open carries no opener
+// element.
 export interface LayerBridge {
-  resolveZone(name: string, root: ParentNode): Element | null;
+  resolveZone(name: string, root: ParentNode, page?: string): Element | null;
   open(opener: null, href: string, zone: string): unknown;
   close(detail: { result?: unknown; dismiss?: boolean; reason?: string }): void;
   toast(text: string, variant: string): void;
@@ -266,6 +267,8 @@ export type ZoneFetch = (request: {
 interface ApplyState {
   isDirty: (field: Element) => boolean;
   requestKey: string | undefined;
+  // The page a safe zone GET fetched, scoping its zone patches to that page.
+  page: string | undefined;
   touched: Element[];
 }
 
@@ -415,11 +418,12 @@ export class Applier {
 
   // The snapshot is the dirty counter wire.ts captured at fetch time. A direct
   // apply with no snapshot uses the highest mark, so no field reads as dirty.
-  // The pipeline is normative: version → before-apply → CSS delta → ops → JS
-  // delta → mount → applied. CSS is gated before the ops, so the body after the
-  // gate runs in a continuation. With no asset bridge the gate is a
-  // straight-through call and the whole apply stays synchronous.
-  apply(raw: unknown, snapshot?: number, key?: string): Envelope {
+  // The page scopes zone patches to the page a zone GET fetched. The pipeline
+  // is normative: version, before-apply, CSS delta, ops, JS delta, mount, then
+  // applied. CSS is gated before the ops, so the body after the gate runs in
+  // a continuation. With no asset bridge the gate is a straight-through call
+  // and the whole apply stays synchronous.
+  apply(raw: unknown, snapshot?: number, key?: string, page?: string): Envelope {
     const envelope = parseEnvelope(raw);
     // A version mismatch is a full visit instead of an apply, guarded against a
     // reload loop inside the bridge. true means the bridge took over.
@@ -434,6 +438,7 @@ export class Applier {
     const state: ApplyState = {
       isDirty: snapshot === undefined ? () => false : this.#dirtySince(snapshot),
       requestKey: key,
+      page,
       touched: [],
     };
     const runOps = (): void => this.#runOps(envelope, state);
@@ -751,12 +756,11 @@ export class Applier {
     if (zone !== undefined) this.#applied.set(zone, this.generation(zone) + 1);
   }
 
-  // Resolve against the live document. A zone is asked of the layer stack
-  // first, top layer down, so a zone inside the upper modal wins over the
-  // same-named page zone beneath it.
+  // Resolve against the live document. A zone goes to the layer stack with the
+  // envelope's page, so a base-page poll cannot morph a same-named modal zone.
   #resolve(target: Target | undefined, state: ApplyState): Element | null {
     if (target?.zone !== undefined && this.#layers !== undefined) {
-      return this.#layers.resolveZone(target.zone, this.#document);
+      return this.#layers.resolveZone(target.zone, this.#document, state.page);
     }
     return this.#resolveIn(this.#document, target, state);
   }

--- a/next/client/layers.test.ts
+++ b/next/client/layers.test.ts
@@ -90,6 +90,14 @@ describe("layer stack", () => {
     expect((found as Element).textContent).toBe("page");
   });
 
+  it("the top-down walk continues past a layer that lacks the zone", async () => {
+    document.body.innerHTML = '<div data-next-zone="only">page</div>';
+    await layers.open(null, "/w/", "m");
+    const found = layers.resolveZone("only", document);
+    expect((found as Element).textContent).toBe("page");
+    layers._reset();
+  });
+
   it("accept fires layer-accepted with the result and re-GETs the host zone", async () => {
     const opener = document.createElement("a");
     opener.setAttribute("href", "/wizard/");
@@ -435,6 +443,144 @@ describe("urlFor resolves the page that owns an element", () => {
     document.body.append(el);
     await layers.open(null, "/photos/1/", "photo");
     expect(layers.urlFor(el)).toBe("/feed/?page=2");
+    layers._reset();
+  });
+});
+
+describe("page-scoped zone resolution", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    window.history.replaceState(null, "", "/host/");
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("a host-page patch resolves the base zone, not the layer twin", async () => {
+    document.body.innerHTML = '<div data-next-zone="dup" id="page">page</div>';
+    const { layers } = makeStack();
+    await layers.open(null, "/modal/", "dup");
+    const found = layers.resolveZone("dup", document, "/host/");
+    expect((found as Element).id).toBe("page");
+    layers._reset();
+  });
+
+  it("the base-page lookup skips a same-named zone inside a dialog", async () => {
+    const { layers } = makeStack();
+    await layers.open(null, "/modal/", "dup");
+    const late = document.createElement("div");
+    late.setAttribute("data-next-zone", "dup");
+    late.id = "late";
+    document.body.append(late);
+    const found = layers.resolveZone("dup", document, "/host/");
+    expect((found as Element).id).toBe("late");
+    layers._reset();
+  });
+
+  it("a base-page lookup answers null when the zone lives only in the layer", async () => {
+    const { layers } = makeStack();
+    await layers.open(null, "/modal/", "dup");
+    expect(layers.resolveZone("dup", document, "/host/")).toBeNull();
+    layers._reset();
+  });
+
+  it("a layer-page patch resolves the layer's own container", async () => {
+    document.body.innerHTML = '<div data-next-zone="dup" id="page">page</div>';
+    const { layers } = makeStack();
+    await layers.open(null, "/modal/", "dup");
+    const found = layers.resolveZone("dup", document, "/modal/");
+    expect((found as Element).closest("dialog")).not.toBeNull();
+    layers._reset();
+  });
+
+  it("a layer-page lookup stays inside its layer when the zone is missing", async () => {
+    document.body.innerHTML = '<div data-next-zone="dup" id="page">page</div>';
+    const { layers } = makeStack();
+    await layers.open(null, "/modal/", "m");
+    expect(layers.resolveZone("dup", document, "/modal/")).toBeNull();
+    layers._reset();
+  });
+
+  it("a page matching no open scope degrades to the top-down walk", async () => {
+    document.body.innerHTML = '<div data-next-zone="dup" id="page">page</div>';
+    const { layers } = makeStack();
+    await layers.open(null, "/modal/", "dup");
+    const found = layers.resolveZone("dup", document, "/elsewhere/");
+    expect((found as Element).closest("dialog")).not.toBeNull();
+    layers._reset();
+  });
+
+  it("a base-page lookup with no layers open answers the page zone", () => {
+    document.body.innerHTML = '<div data-next-zone="solo" id="s">x</div>';
+    const { layers } = makeStack();
+    const found = layers.resolveZone("solo", document, "/host/");
+    expect((found as Element).id).toBe("s");
+  });
+});
+
+describe("open unwinds when history.push throws", () => {
+  function makeThrowingStack(history: {
+    push(href: string): void;
+    replace(href: string): void;
+  }) {
+    const dispatched: Dispatched[] = [];
+    const fetched: string[] = [];
+    const layers = createLayers({
+      dispatch: (event, detail) => dispatched.push({ event, detail }),
+      fetch: async (request) => {
+        fetched.push(request.url);
+      },
+      document,
+      dialog: mockDialog().adapter,
+      history,
+    });
+    return { layers, dispatched, fetched };
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("a throwing pushState tears the half-open layer down and rejects", async () => {
+    const replaced: string[] = [];
+    const { layers, dispatched, fetched } = makeThrowingStack({
+      push: () => {
+        throw new Error("pushState rate limited");
+      },
+      replace: (href) => replaced.push(href),
+    });
+    const opener = document.createElement("a");
+    document.body.append(opener);
+    await expect(layers.open(opener, "/photos/1/", "photo")).rejects.toThrow(
+      "pushState rate limited",
+    );
+    expect(layers.size()).toBe(0);
+    expect(document.querySelector("[data-next-dialog]")).toBeNull();
+    expect(opener.hasAttribute("data-next-busy")).toBe(false);
+    expect(opener.hasAttribute("aria-busy")).toBe(false);
+    // The URL never moved and the body GET never left, so nothing rolls back.
+    expect(replaced).toEqual([]);
+    expect(fetched).toEqual([]);
+    expect(dispatched.some((d) => d.event === "partial:layer-opened")).toBe(false);
+  });
+
+  it("a fresh open succeeds after a failed push released the opener", async () => {
+    let fail = true;
+    const { layers } = makeThrowingStack({
+      push: () => {
+        if (fail) {
+          fail = false;
+          throw new Error("boom");
+        }
+      },
+      replace: () => undefined,
+    });
+    const opener = document.createElement("a");
+    document.body.append(opener);
+    await expect(layers.open(opener, "/photos/1/", "photo")).rejects.toThrow("boom");
+    await layers.open(opener, "/photos/1/", "photo");
+    expect(layers.size()).toBe(1);
     layers._reset();
   });
 });

--- a/next/client/layers.test.ts
+++ b/next/client/layers.test.ts
@@ -374,6 +374,69 @@ describe("layer requests carry the host origin", () => {
     expect(requests[0]!.headers?.[HEADER_ORIGIN]).toBe("/host/page/");
     layers._reset();
   });
+
+  it("keeps the host query string in the origin and the accept re-GET", async () => {
+    window.history.replaceState(null, "", "/host/page/?window=1h");
+    const { layers, requests } = makeOriginStack();
+    const opener = document.createElement("a");
+    opener.setAttribute("href", "/wizard/identity/");
+    opener.setAttribute("data-next-accepted", "request-list");
+    document.body.append(opener);
+    await layers.open(opener, "/wizard/identity/", "access-wizard");
+    expect(requests[0]!.headers?.[HEADER_ORIGIN]).toBe("/host/page/?window=1h");
+    requests.length = 0;
+    layers.close({ result: { id: 7 } });
+    expect(requests[0]!.url).toBe("/host/page/?window=1h");
+    expect(requests[0]!.headers?.[HEADER_ORIGIN]).toBe("/host/page/?window=1h");
+    layers._reset();
+  });
+});
+
+describe("urlFor resolves the page that owns an element", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    window.history.replaceState(null, "", "/feed/");
+  });
+
+  afterEach(() => {
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("answers the current URL when no layer is open", () => {
+    const { layers } = makeStack();
+    const el = document.createElement("div");
+    document.body.append(el);
+    expect(layers.urlFor(el)).toBe("/feed/");
+  });
+
+  it("answers the pushed URL for an element inside an open layer", async () => {
+    const { layers } = makeStack();
+    await layers.open(null, "/photos/1/", "photo");
+    const root = document.querySelector('dialog [data-next-zone="photo"]')!;
+    root.innerHTML = "<span>inside</span>";
+    expect(layers.urlFor(root.querySelector("span")!)).toBe("/photos/1/");
+    layers._reset();
+  });
+
+  it("answers the bottom layer's host for an element outside every layer", async () => {
+    const { layers } = makeStack();
+    const el = document.createElement("div");
+    document.body.append(el);
+    await layers.open(null, "/photos/1/", "photo");
+    expect(window.location.pathname).toBe("/photos/1/");
+    expect(layers.urlFor(el)).toBe("/feed/");
+    layers._reset();
+  });
+
+  it("keeps the host query string for a base-page element under a layer", async () => {
+    window.history.replaceState(null, "", "/feed/?page=2");
+    const { layers } = makeStack();
+    const el = document.createElement("div");
+    document.body.append(el);
+    await layers.open(null, "/photos/1/", "photo");
+    expect(layers.urlFor(el)).toBe("/feed/?page=2");
+    layers._reset();
+  });
 });
 
 describe("layer intercepting URL lifecycle", () => {
@@ -439,6 +502,13 @@ describe("layer intercepting URL lifecycle", () => {
     layers.close({ dismiss: true, reason: "escape" });
     expect(layers.size()).toBe(0);
     expect(window.location.pathname).toBe("/feed/");
+  });
+
+  it("restores the host query string on a programmatic close", async () => {
+    window.history.replaceState(null, "", "/feed/?page=2");
+    await layers.open(null, "/photos/1/", "photo");
+    layers.close({ result: undefined });
+    expect(window.location.pathname + window.location.search).toBe("/feed/?page=2");
   });
 
   it("Back closes only the top of a nested stack", async () => {

--- a/next/client/layers.ts
+++ b/next/client/layers.ts
@@ -59,10 +59,10 @@ interface Layer {
   close: DialogControl;
   // The element to return focus to once the layer closes.
   returnFocus: Element | null;
-  // The path of the page that opened the layer, captured at open time. It rides
-  // X-Next-Origin on the layer's requests so the server resolves the host for a
-  // page-addressed out-of-band render of its zones, rather than falling back to
-  // the step page the form lives on.
+  // The URL of the page that opened the layer, path plus query, captured at
+  // open time. It rides X-Next-Origin on the layer's requests so the server
+  // resolves the host for a page-addressed out-of-band render of its zones,
+  // rather than falling back to the step page the form lives on.
   host: string;
   // The honest URL pushed when the layer opened, so the modal is shareable and
   // refresh-resolves to the standalone page. Absent for a layer that never
@@ -94,6 +94,11 @@ export interface LayerStack {
   // Resolve a zone from the top layer down, then the page root. The applier
   // calls this for every zone-addressed patch so a layer target wins.
   resolveZone(name: string, root: ParentNode): Element | null;
+  // The URL of the page that owns an element: a layer's pushed URL for an
+  // element inside its subtree, the host page for the base document even while
+  // layers are open, the current URL when none are. A poll tick GETs this
+  // rather than the address bar, which reads the modal route while one is up.
+  urlFor(el: Element): string;
   // Open a layer. Builds the dialog and the zone container before the request,
   // then GETs the body into it. The opener link, when present, carries
   // data-next-accepted and takes focus back on close. A server-initiated open
@@ -148,6 +153,23 @@ export function createLayers(deps: LayerDeps): LayerStack {
     return root.querySelector(selector);
   }
 
+  // Top layer down, the same walk as resolveZone: an element inside a layer's
+  // subtree belongs to that layer's pushed URL. An element in no layer belongs
+  // to the base page, which is the bottom layer's host while any layer is open
+  // (the address bar reads the modal route then) and the current URL otherwise.
+  function urlFor(el: Element): string {
+    for (const layer of Array.from(stack).reverse()) {
+      if (layer.root.contains(el)) {
+        // pushedUrl is assigned right after the push in open, so a layer on
+        // the stack always carries it and the fallback is never taken.
+        /* v8 ignore next */
+        return layer.pushedUrl ?? currentUrl();
+      }
+    }
+    const bottom = stack[0];
+    return bottom === undefined ? currentUrl() : bottom.host;
+  }
+
   function busy(initiator: Element | null, target: Element | null): () => void {
     const marked: Element[] = [];
     for (const el of [initiator, target]) {
@@ -188,8 +210,9 @@ export function createLayers(deps: LayerDeps): LayerStack {
     doc.body.append(dialog);
     const returnFocus = doc.activeElement;
     // The host page is the one that opened the layer, captured before the
-    // request so a later navigation cannot move it. It rides X-Next-Origin.
-    const host = doc.location.pathname;
+    // request so a later navigation cannot move it. The canon keeps the
+    // query, so a filtered host page comes back with its filters intact.
+    const host = currentUrl();
     // A browser dismiss gesture (Esc, backdrop, dialog form) reaches the same
     // close path as a server dismiss, so the reason flows through one channel.
     const close = dialogAdapter.open(dialog, (reason) => dismissFrom(dialog, reason));
@@ -344,6 +367,7 @@ export function createLayers(deps: LayerDeps): LayerStack {
 
   return {
     resolveZone,
+    urlFor,
     open,
     close,
     toast,

--- a/next/client/layers.ts
+++ b/next/client/layers.ts
@@ -91,9 +91,9 @@ export interface LayerDeps {
 }
 
 export interface LayerStack {
-  // Resolve a zone from the top layer down, then the page root. The applier
-  // calls this for every zone-addressed patch so a layer target wins.
-  resolveZone(name: string, root: ParentNode): Element | null;
+  // Resolve a zone for a patch: scoped to the page a zone GET fetched, or the
+  // top-down walk (layer target wins) when no page is known.
+  resolveZone(name: string, root: ParentNode, page?: string): Element | null;
   // The URL of the page that owns an element: a layer's pushed URL for an
   // element inside its subtree, the host page for the base document even while
   // layers are open, the current URL when none are. A poll tick GETs this
@@ -139,18 +139,40 @@ export function createLayers(deps: LayerDeps): LayerStack {
     return pageUrl(doc);
   }
 
-  function resolveZone(name: string, root: ParentNode): Element | null {
+  // A page-scoped lookup searches only the fetched page's subtree: the layer
+  // whose pushed URL matches, or the base document outside every dialog. An
+  // unmatched page (its layer closed mid-flight) degrades to the top-down walk.
+  function resolveZone(name: string, root: ParentNode, page?: string): Element | null {
     const selector = `[data-next-zone="${cssEscape(name)}"]`;
-    // Top layer down: a zone inside the upper modal is found before the
-    // same-named page zone beneath it. The layer's own container carries the
-    // zone, so it is matched directly, not only its descendants.
+    if (page !== undefined) {
+      for (const layer of Array.from(stack).reverse()) {
+        if (layer.pushedUrl === page) return findIn(layer.root, selector);
+      }
+      const bottom = stack[0];
+      const base = bottom === undefined ? currentUrl() : bottom.host;
+      if (page === base) return findOutsideLayers(selector, root);
+    }
     for (const layer of Array.from(stack).reverse()) {
-      const container = layer.root;
-      if (container.matches(selector)) return container;
-      const found = container.querySelector(selector);
+      const found = findIn(layer.root, selector);
       if (found !== null) return found;
     }
     return root.querySelector(selector);
+  }
+
+  // The layer's own container carries the zone, so it is matched directly, not
+  // only its descendants.
+  function findIn(container: HTMLElement, selector: string): Element | null {
+    if (container.matches(selector)) return container;
+    return container.querySelector(selector);
+  }
+
+  // Dialogs live in the body, so a bare querySelector would still reach a
+  // layer's zone: skip matches inside any dialog subtree.
+  function findOutsideLayers(selector: string, root: ParentNode): Element | null {
+    for (const el of Array.from(root.querySelectorAll(selector))) {
+      if (!stack.some((layer) => layer.dialog.contains(el))) return el;
+    }
+    return null;
   }
 
   // Top layer down, the same walk as resolveZone: an element inside a layer's
@@ -160,8 +182,9 @@ export function createLayers(deps: LayerDeps): LayerStack {
   function urlFor(el: Element): string {
     for (const layer of Array.from(stack).reverse()) {
       if (layer.root.contains(el)) {
-        // pushedUrl is assigned right after the push in open, so a layer on
-        // the stack always carries it and the fallback is never taken.
+        // open stacks the layer and assigns pushedUrl in one synchronous
+        // stretch (a failed push unwinds within it), so the fallback is
+        // never taken.
         /* v8 ignore next */
         return layer.pushedUrl ?? currentUrl();
       }
@@ -218,24 +241,23 @@ export function createLayers(deps: LayerDeps): LayerStack {
     const close = dialogAdapter.open(dialog, (reason) => dismissFrom(dialog, reason));
     const layer: Layer = { dialog, root, opener, close, returnFocus, host };
     stack.push(layer);
-    // Push the honest URL of the layer body so the modal is shareable and a
-    // refresh resolves it as the standalone page, while Back closes it.
-    history.push(href);
-    layer.pushedUrl = currentUrl();
-    emit("partial:layer-opened", { opener });
     // The opener already carries busy, so only the target zone is marked here.
     const release = busy(null, root);
     try {
+      // Push the honest URL of the layer body so the modal is shareable and
+      // Back closes it. Inside the try: pushState can throw (Safari's rate
+      // limit) and the half-open layer must unwind, not strand on the stack.
+      history.push(href);
+      layer.pushedUrl = currentUrl();
+      emit("partial:layer-opened", { opener });
       await deps.fetch({
         url: href,
         zone,
         headers: { [HEADER_ZONE]: zone, [HEADER_ORIGIN]: host },
       });
     } catch (e) {
-      // The request died after the URL was pushed and the dialog opened. Tear
-      // down the orphaned layer: remove already rolls the URL back through
-      // history.replace(host) while the current URL still equals pushedUrl, so
-      // Back does not land on a dead modal URL.
+      // remove rolls the URL back to the host only when the push actually
+      // moved it (pushedUrl set), so a failed push rolls back nothing.
       remove(layer);
       throw e;
     } finally {

--- a/next/client/morph.ts
+++ b/next/client/morph.ts
@@ -326,7 +326,7 @@ function morphNode(
 }
 
 // Walk new children left to right with an insertion pointer into old children.
-// hard match -> soft match -> create. A match at the pointer is morphed in place
+// hard match, then soft match, then create. A match at the pointer is morphed in place
 // and the pointer advances. A match found further on is moved before the pointer
 // and morphed, the pointer stays so the skipped old nodes are revisited by later
 // new children or swept at the end. The trailing old children are discarded once

--- a/next/client/partial.test.ts
+++ b/next/client/partial.test.ts
@@ -2,8 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPartial } from "./partial";
 import type { PartialAdapters, PartialSurface } from "./partial";
 import type { DialogAdapter } from "./layers";
-import type { EventSourceAdapter, SourceControl, VisibilityAdapter } from "./sse";
-import type { Clock } from "./wire";
+import type { EventSourceAdapter, SourceControl } from "./sse";
+import { manualPollClock, manualVisibility } from "./test-doubles";
 
 // A patches response the configured fetch returns so the wire resolves without a
 // real server.
@@ -32,49 +32,6 @@ function mockSource(): {
     },
   };
   return { adapter, opened };
-}
-
-// A visibility adapter the harness flips by hand. It holds every onChange
-// subscriber, since the SSE bridge and the trigger pollers share the seam.
-function mockVisibility(): { adapter: VisibilityAdapter; set(hidden: boolean): void } {
-  let hidden = false;
-  const listeners = new Set<() => void>();
-  const adapter: VisibilityAdapter = {
-    hidden: () => hidden,
-    onChange(l) {
-      listeners.add(l);
-      return () => {
-        listeners.delete(l);
-      };
-    },
-  };
-  return {
-    adapter,
-    set(value) {
-      hidden = value;
-      for (const l of listeners) l();
-    },
-  };
-}
-
-// A single-slot clock whose tick() drives one self-rescheduling poll cycle.
-function mockPollClock(): Clock & { tick(): void } {
-  let pending: (() => void) | null = null;
-  return {
-    now: () => 0,
-    setTimeout: (handler) => {
-      pending = handler;
-      return 1;
-    },
-    clearTimeout: () => {
-      pending = null;
-    },
-    tick() {
-      const h = pending;
-      pending = null;
-      h?.();
-    },
-  };
 }
 
 function makeSurface() {
@@ -347,7 +304,7 @@ describe("createPartial surface", () => {
 
   it("_configure stops the pollers the previous configuration armed", async () => {
     document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
-    const clock = mockPollClock();
+    const clock = manualPollClock();
     const calls: string[] = [];
     const fetch = async (url: string) => {
       calls.push(url);
@@ -367,7 +324,7 @@ describe("createPartial surface", () => {
   it("a poll tick GETs the host page while a layer holds the address bar", async () => {
     window.history.replaceState(null, "", "/host/");
     document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
-    const clock = mockPollClock();
+    const clock = manualPollClock();
     const calls: string[] = [];
     partial._configure({
       document,
@@ -386,6 +343,38 @@ describe("createPartial surface", () => {
     clock.tick();
     await Promise.resolve();
     expect(calls).toEqual(["/host/"]);
+    partial.layers._reset();
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("a host-page zone GET morphs the base zone, not an open layer's twin", async () => {
+    window.history.replaceState(null, "", "/host/");
+    document.body.innerHTML = '<div data-next-zone="dup" id="base">stale</div>';
+    partial._configure({
+      document,
+      dialog: mockDialog(),
+      fetch: async (url) => {
+        const html =
+          url === "/host/"
+            ? '<div data-next-zone="dup" id="base">host</div>'
+            : '<div data-next-zone="dup">modal</div>';
+        return patchesResponse(
+          JSON.stringify({
+            version: "v1",
+            ops: [{ op: "morph", target: { zone: "dup" }, html }],
+            assets: [],
+            form: null,
+          }),
+        );
+      },
+      navigate: () => {},
+    });
+    await partial.layers.open(null, "/modal/", "dup");
+    const layerZone = document.querySelector('dialog [data-next-zone="dup"]')!;
+    expect(layerZone.textContent).toBe("modal");
+    await partial.fetch({ url: "/host/", zone: "dup" });
+    expect(document.querySelector("#base")!.textContent).toBe("host");
+    expect(layerZone.textContent).toBe("modal");
     partial.layers._reset();
     window.history.replaceState(null, "", "/");
   });
@@ -456,7 +445,7 @@ describe("createPartial surface", () => {
     partial._configure({
       document,
       source: source.adapter,
-      visibility: mockVisibility().adapter,
+      visibility: manualVisibility(),
     });
     partial.sse.scan(document);
     expect(source.opened).toHaveLength(1);
@@ -474,13 +463,13 @@ describe("createPartial surface", () => {
   it("an SSE resume re-GETs the bound zones through the wire", async () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const source = mockSource();
-    const visibility = mockVisibility();
+    const visibility = manualVisibility();
     const calls: { url: string; init: RequestInit }[] = [];
     let clock = 0;
     partial._configure({
       document,
       source: source.adapter,
-      visibility: visibility.adapter,
+      visibility,
       fetch: async (url, init) => {
         calls.push({ url, init });
         return patchesResponse();
@@ -501,9 +490,9 @@ describe("createPartial surface", () => {
     // The refresh op itself fetched once. Dropping that call proves the next
     // one comes from the resume revalidation, not the stream event.
     calls.length = 0;
-    visibility.set(true);
+    visibility.setHidden(true);
     clock = 5000;
-    visibility.set(false);
+    visibility.setHidden(false);
     await Promise.resolve();
     nowSpy.mockRestore();
     expect(

--- a/next/client/partial.test.ts
+++ b/next/client/partial.test.ts
@@ -3,6 +3,7 @@ import { createPartial } from "./partial";
 import type { PartialAdapters, PartialSurface } from "./partial";
 import type { DialogAdapter } from "./layers";
 import type { EventSourceAdapter, SourceControl, VisibilityAdapter } from "./sse";
+import type { Clock } from "./wire";
 
 // A patches response the configured fetch returns so the wire resolves without a
 // real server.
@@ -33,16 +34,17 @@ function mockSource(): {
   return { adapter, opened };
 }
 
-// A visibility adapter the harness flips by hand.
+// A visibility adapter the harness flips by hand. It holds every onChange
+// subscriber, since the SSE bridge and the trigger pollers share the seam.
 function mockVisibility(): { adapter: VisibilityAdapter; set(hidden: boolean): void } {
   let hidden = false;
-  let listener: (() => void) | null = null;
+  const listeners = new Set<() => void>();
   const adapter: VisibilityAdapter = {
     hidden: () => hidden,
     onChange(l) {
-      listener = l;
+      listeners.add(l);
       return () => {
-        listener = null;
+        listeners.delete(l);
       };
     },
   };
@@ -50,7 +52,27 @@ function mockVisibility(): { adapter: VisibilityAdapter; set(hidden: boolean): v
     adapter,
     set(value) {
       hidden = value;
-      listener?.();
+      for (const l of listeners) l();
+    },
+  };
+}
+
+// A single-slot clock whose tick() drives one self-rescheduling poll cycle.
+function mockPollClock(): Clock & { tick(): void } {
+  let pending: (() => void) | null = null;
+  return {
+    now: () => 0,
+    setTimeout: (handler) => {
+      pending = handler;
+      return 1;
+    },
+    clearTimeout: () => {
+      pending = null;
+    },
+    tick() {
+      const h = pending;
+      pending = null;
+      h?.();
     },
   };
 }
@@ -323,6 +345,51 @@ describe("createPartial surface", () => {
     );
   });
 
+  it("_configure stops the pollers the previous configuration armed", async () => {
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const clock = mockPollClock();
+    const calls: string[] = [];
+    const fetch = async (url: string) => {
+      calls.push(url);
+      return patchesResponse();
+    };
+    partial._configure({ document, clock, fetch, navigate: () => {} });
+    partial.ready();
+    clock.tick();
+    await Promise.resolve();
+    expect(calls).toHaveLength(1);
+    partial._configure({ document, clock, fetch, navigate: () => {} });
+    clock.tick();
+    await Promise.resolve();
+    expect(calls).toHaveLength(1);
+  });
+
+  it("a poll tick GETs the host page while a layer holds the address bar", async () => {
+    window.history.replaceState(null, "", "/host/");
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const clock = mockPollClock();
+    const calls: string[] = [];
+    partial._configure({
+      document,
+      clock,
+      dialog: mockDialog(),
+      fetch: async (url) => {
+        calls.push(url);
+        return patchesResponse();
+      },
+      navigate: () => {},
+    });
+    partial.ready();
+    await partial.layers.open(null, "/modal/", "m");
+    expect(window.location.pathname).toBe("/modal/");
+    calls.length = 0;
+    clock.tick();
+    await Promise.resolve();
+    expect(calls).toEqual(["/host/"]);
+    partial.layers._reset();
+    window.history.replaceState(null, "", "/");
+  });
+
   it("opening a layer GETs its body through the wire", async () => {
     const calls: string[] = [];
     partial._configure({
@@ -430,12 +497,15 @@ describe("createPartial surface", () => {
         form: null,
       }),
     );
+    await Promise.resolve();
+    // The refresh op itself fetched once. Dropping that call proves the next
+    // one comes from the resume revalidation, not the stream event.
+    calls.length = 0;
     visibility.set(true);
     clock = 5000;
     visibility.set(false);
     await Promise.resolve();
     nowSpy.mockRestore();
-    expect(calls.some((c) => c.url.includes("?") || c.init.headers)).toBe(true);
     expect(
       calls.some(
         (c) => (c.init.headers as Record<string, string>)["X-Next-Zone"] === "poll",

--- a/next/client/partial.ts
+++ b/next/client/partial.ts
@@ -194,7 +194,12 @@ export function createPartial(deps: PartialDeps): PartialSurface {
     return {
       fetch: (request: WireRequest) => void wire.fetch(request),
       abort: (zone: string) => wire.abort(zone),
-      version: () => assets.version(),
+      // A poll tick or lazy activation asks the layer stack for the page that
+      // owns its element, so a base-page zone keeps GETting the host URL while
+      // a modal layer holds the address bar. The arrow reads the `layers`
+      // variable, and _configure rebuilds the stack before the triggers, so
+      // the binding stays live the same way applyDeps holds it.
+      pageUrl: (el: Element) => layers.urlFor(el),
       ...opt("document", adapters?.document),
       ...opt("clock", adapters?.clock),
       ...opt("observer", adapters?.observer),
@@ -294,6 +299,10 @@ export function createPartial(deps: PartialDeps): PartialSurface {
       assets = createAssets(assetsDeps(adapters));
       detachLayers();
       detachTriggers();
+      // Stop the old instance's pollers and observers before the rebuild, or
+      // they would keep fetching through the live wire as orphans, the same
+      // reason the SSE bridge resets here.
+      triggers._reset();
       sse._reset();
       layers = createLayers(layerDeps(adapters));
       triggers = createTriggers(triggerDeps(adapters));

--- a/next/client/partial.ts
+++ b/next/client/partial.ts
@@ -198,6 +198,7 @@ export function createPartial(deps: PartialDeps): PartialSurface {
       ...opt("document", adapters?.document),
       ...opt("clock", adapters?.clock),
       ...opt("observer", adapters?.observer),
+      ...opt("visibility", adapters?.visibility),
       ...opt("confirm", adapters?.confirm),
       ...opt("dev", adapters?.dev),
     };

--- a/next/client/partial.ts
+++ b/next/client/partial.ts
@@ -30,7 +30,7 @@ import type { ConfirmAdapter, IntersectionAdapter } from "./triggers";
 import { createSse } from "./sse";
 import type { EventSourceAdapter, Sse, VisibilityAdapter } from "./sse";
 import { defaultHistory, defaultNavigate } from "./adapters";
-import { currentUrl } from "./protocol";
+import { currentUrl, matching } from "./protocol";
 
 export interface PartialDeps {
   dispatch: (event: string, detail: Record<string, unknown>) => void;
@@ -61,8 +61,9 @@ export interface PartialAdapters {
   session?: SessionStore;
   confirm?: ConfirmAdapter;
   cssTimeoutMs?: number;
-  // The EventSource and visibility seams of the SSE bridge, both absent in
-  // jsdom: tests drive message, error, and the visibility flip through mocks.
+  // The EventSource seam of the SSE bridge and the visibility seam the bridge
+  // shares with the poll triggers, both absent in jsdom: tests drive message,
+  // error, and the visibility flip through mocks.
   source?: EventSourceAdapter;
   visibility?: VisibilityAdapter;
 }
@@ -119,13 +120,7 @@ export function createPartial(deps: PartialDeps): PartialSurface {
   let mounted = false;
   const runMount: MountCallback = (root) => {
     for (const entry of mounts) {
-      for (const el of Array.from(root.querySelectorAll(entry.selector))) {
-        entry.callback(el);
-      }
-      // A subtree root that matches the selector itself is mounted too.
-      if (root instanceof Element && root.matches(entry.selector)) {
-        entry.callback(root);
-      }
+      for (const el of matching(root, entry.selector)) entry.callback(el);
     }
     triggers.scan(root);
     sse.scan(root);
@@ -216,6 +211,10 @@ export function createPartial(deps: PartialDeps): PartialSurface {
       apply: (raw: unknown) => void applier.apply(raw),
       fetch: (request: WireRequest) => void wire.fetch(request),
       dispatch: deps.dispatch,
+      // A stream subscription captures the page that owns its container from
+      // the layer stack, the same live binding as triggerDeps: _configure
+      // rebuilds the stack before the bridge, so the arrow stays current.
+      pageUrl: (el: Element) => layers.urlFor(el),
       ...opt("document", adapters?.document),
       ...opt("source", adapters?.source),
       ...opt("visibility", adapters?.visibility),
@@ -232,8 +231,9 @@ export function createPartial(deps: PartialDeps): PartialSurface {
         _response: Response,
         snapshot: number,
         key: string | undefined,
+        page: string | undefined,
       ) => {
-        const envelope = applier.apply(raw, snapshot, key);
+        const envelope = applier.apply(raw, snapshot, key, page);
         // The csrf meta rotates the payload token too, so the next mutation
         // submits the fresh token, not just the forms already in the document.
         if (envelope.csrf) csrf = envelope.csrf;

--- a/next/client/protocol.ts
+++ b/next/client/protocol.ts
@@ -23,6 +23,13 @@ export const HEADER_VERSION = "X-Next-Version";
 export const HEADER_REQUEST_ID = "X-Next-Request-Id";
 export const HEADER_ORIGIN = "X-Next-Origin";
 
+// A visibility flip shorter than this revalidates nothing: a momentary alt-tab
+// reconnects the SSE stream and re-arms the poll timers but skips the zone
+// re-GETs, so flicking between tabs does not storm the server. The SSE bridge
+// and the poll triggers gate the same resume seam, so the threshold is part of
+// the shared vocabulary.
+export const RESUME_REVALIDATE_MS = 3000;
+
 // The data-next-* attributes the runtime resolves across module boundaries: a
 // zone container, a form keyed by its action uid, and a list-row dedup key. The
 // applier, the layer stack, the triggers, and the morph engine must spell these

--- a/next/client/protocol.ts
+++ b/next/client/protocol.ts
@@ -23,12 +23,11 @@ export const HEADER_VERSION = "X-Next-Version";
 export const HEADER_REQUEST_ID = "X-Next-Request-Id";
 export const HEADER_ORIGIN = "X-Next-Origin";
 
-// A visibility flip shorter than this revalidates nothing: a momentary alt-tab
-// reconnects the SSE stream and re-arms the poll timers but skips the zone
-// re-GETs, so flicking between tabs does not storm the server. The SSE bridge
-// and the poll triggers gate the same resume seam, so the threshold is part of
-// the shared vocabulary.
-export const RESUME_REVALIDATE_MS = 3000;
+// The data-next-poll bounds. Both must match _MIN_POLL_MS and _MAX_POLL_MS in
+// next/partial/zone.py exactly. The ceiling is the browser's signed-32-bit
+// setTimeout coercion, above which a timer fires immediately.
+export const MIN_POLL_MS = 1000;
+export const MAX_POLL_MS = 2147483647;
 
 // The data-next-* attributes the runtime resolves across module boundaries: a
 // zone container, a form keyed by its action uid, and a list-row dedup key. The
@@ -66,4 +65,12 @@ export function cssEscape(value: string): string {
 // so a query filter survives a re-GET instead of collapsing to the bare path.
 export function currentUrl(doc: Document): string {
   return doc.location.pathname + doc.location.search;
+}
+
+// querySelectorAll never matches its own root, but a replace patch scans the
+// new wrapper element itself, so scans fold a matching root into the result.
+export function matching(root: ParentNode, selector: string): Element[] {
+  const found = Array.from(root.querySelectorAll(selector));
+  if (root instanceof Element && root.matches(selector)) found.push(root);
+  return found;
 }

--- a/next/client/sse.test.ts
+++ b/next/client/sse.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSse } from "./sse";
 import type { EventSourceAdapter, SourceControl, VisibilityAdapter } from "./sse";
+import { manualVisibility } from "./test-doubles";
 import { Wire } from "./wire";
 import { CONTENT_TYPE, HEADER_REQUEST_ID } from "./protocol";
 
@@ -34,31 +35,6 @@ function mockSource(): { adapter: EventSourceAdapter; opened: MockSource[] } {
   return { adapter, opened };
 }
 
-// A mock visibility adapter the test flips and fires by hand.
-function mockVisibility(): {
-  adapter: VisibilityAdapter;
-  set(hidden: boolean): void;
-} {
-  let hidden = false;
-  let listener: (() => void) | null = null;
-  const adapter: VisibilityAdapter = {
-    hidden: () => hidden,
-    onChange(l) {
-      listener = l;
-      return () => {
-        listener = null;
-      };
-    },
-  };
-  return {
-    adapter,
-    set(value) {
-      hidden = value;
-      listener?.();
-    },
-  };
-}
-
 function envelope(ops: unknown[], requestId?: string): string {
   const body: Record<string, unknown> = {
     version: "v1",
@@ -85,23 +61,26 @@ describe("createSse", () => {
   function makeSse(
     source: EventSourceAdapter,
     visibility: VisibilityAdapter,
-    now?: () => number,
+    over: { now?: () => number; pageUrl?: (el: Element) => string } = {},
   ) {
     return createSse({
       apply: (raw) => applied.push(raw),
-      fetch: (request) => fetched.push({ url: request.url, zone: request.zone }),
+      // The request object is recorded as handed over, so an assertion on its
+      // exact shape proves the bridge passes intent and stamps no headers.
+      fetch: (request) => fetched.push(request),
       dispatch: (event, detail) => dispatched.push({ event, detail }),
       document,
       source,
       visibility,
-      ...(now !== undefined ? { now } : {}),
+      ...(over.now !== undefined ? { now: over.now } : {}),
+      ...(over.pageUrl !== undefined ? { pageUrl: over.pageUrl } : {}),
     });
   }
 
   it("scan opens one stream per data-next-sse container and applies events", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const sse = makeSse(adapter, mockVisibility().adapter);
+    const sse = makeSse(adapter, manualVisibility());
     sse.scan(document);
     expect(opened).toHaveLength(1);
     expect(opened[0]!.url).toBe("/stream/");
@@ -112,7 +91,7 @@ describe("createSse", () => {
   it("scan opens a stream only once per url", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const sse = makeSse(adapter, mockVisibility().adapter);
+    const sse = makeSse(adapter, manualVisibility());
     sse.scan(document);
     sse.scan(document);
     expect(opened).toHaveLength(1);
@@ -122,7 +101,7 @@ describe("createSse", () => {
   it("drops an event whose request_id is the client's own echo", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const sse = makeSse(adapter, mockVisibility().adapter);
+    const sse = makeSse(adapter, manualVisibility());
     sse.scan(document);
     sse.remember("r1");
     opened[0]!.message(envelope([{ op: "refresh", zone: "poll" }], "r1"));
@@ -134,7 +113,7 @@ describe("createSse", () => {
   it("keeps only the last 25 request ids in the echo ring", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const sse = makeSse(adapter, mockVisibility().adapter);
+    const sse = makeSse(adapter, manualVisibility());
     sse.scan(document);
     for (let i = 0; i < 26; i += 1) sse.remember(`r${i}`);
     opened[0]!.message(envelope([], "r0"));
@@ -146,7 +125,7 @@ describe("createSse", () => {
   it("drops the echo of a mutation whose id the wire fed into the ring", async () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const sse = makeSse(adapter, mockVisibility().adapter);
+    const sse = makeSse(adapter, manualVisibility());
     sse.scan(document);
     const envelopeBody = '{"version":"v1","ops":[],"assets":[],"form":null}';
     const sent: { headers: Record<string, string> }[] = [];
@@ -174,7 +153,7 @@ describe("createSse", () => {
   it("fires partial:error on a malformed event and keeps the stream alive", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const sse = makeSse(adapter, mockVisibility().adapter);
+    const sse = makeSse(adapter, manualVisibility());
     sse.scan(document);
     opened[0]!.message("{not json");
     const err = dispatched.find((d) => d.event === "partial:error");
@@ -186,7 +165,7 @@ describe("createSse", () => {
   it("evicts the connection and fires partial:error on a fatal error", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const sse = makeSse(adapter, mockVisibility().adapter);
+    const sse = makeSse(adapter, manualVisibility());
     sse.scan(document);
     opened[0]!.error(true);
     expect(opened[0]!.closed).toBe(true);
@@ -198,7 +177,7 @@ describe("createSse", () => {
   it("leaves a transient error to the native reconnect without a toast", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const sse = makeSse(adapter, mockVisibility().adapter);
+    const sse = makeSse(adapter, manualVisibility());
     sse.scan(document);
     opened[0]!.error(false);
     expect(opened[0]!.closed).toBe(false);
@@ -209,13 +188,13 @@ describe("createSse", () => {
   it("does not reopen a fatally evicted url on resume", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const visibility = mockVisibility();
-    const sse = makeSse(adapter, visibility.adapter);
+    const visibility = manualVisibility();
+    const sse = makeSse(adapter, visibility);
     sse.scan(document);
     opened[0]!.error(true);
     expect(sse.size()).toBe(0);
-    visibility.set(true);
-    visibility.set(false);
+    visibility.setHidden(true);
+    visibility.setHidden(false);
     expect(opened).toHaveLength(1);
     expect(sse.size()).toBe(0);
   });
@@ -223,9 +202,9 @@ describe("createSse", () => {
   it("pauses in a background tab and reconnects with a re-GET of bound zones", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const visibility = mockVisibility();
+    const visibility = manualVisibility();
     let clock = 0;
-    const sse = makeSse(adapter, visibility.adapter, () => clock);
+    const sse = makeSse(adapter, visibility, { now: () => clock });
     sse.scan(document);
     opened[0]!.message(
       envelope([
@@ -233,12 +212,12 @@ describe("createSse", () => {
         { op: "morph", target: { zone: "list" } },
       ]),
     );
-    visibility.set(true);
+    visibility.setHidden(true);
     expect(opened[0]!.closed).toBe(true);
     // A pause longer than the revalidate threshold may have missed events, so
     // resume re-GETs every bound zone.
     clock = 5000;
-    visibility.set(false);
+    visibility.setHidden(false);
     expect(opened).toHaveLength(2);
     expect(opened[1]!.closed).toBe(false);
     expect(sse.size()).toBe(1);
@@ -249,27 +228,76 @@ describe("createSse", () => {
     window.history.replaceState(null, "", "/catalog/?q=novel");
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const visibility = mockVisibility();
+    const visibility = manualVisibility();
     let clock = 0;
-    const sse = makeSse(adapter, visibility.adapter, () => clock);
+    const sse = makeSse(adapter, visibility, { now: () => clock });
     sse.scan(document);
     opened[0]!.message(envelope([{ op: "refresh", zone: "poll" }]));
-    visibility.set(true);
+    visibility.setHidden(true);
     // The address bar moved while the tab was hidden, so resume must still
     // target the page the stream subscribed from, query filters and all.
     window.history.replaceState(null, "", "/catalog/?q=other");
     clock = 5000;
-    visibility.set(false);
+    visibility.setHidden(false);
     expect(fetched.find((f) => f.zone === "poll")?.url).toBe("/catalog/?q=novel");
     window.history.replaceState(null, "", "/");
+  });
+
+  it("captures the owning page through the pageUrl seam, not the address bar", () => {
+    window.history.replaceState(null, "", "/modal/");
+    document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
+    const { adapter, opened } = mockSource();
+    const visibility = manualVisibility();
+    let clock = 0;
+    const sse = makeSse(adapter, visibility, {
+      now: () => clock,
+      // The layer stack answers the host page while a modal holds the address
+      // bar, so the stream subscribes for the page that owns its container.
+      pageUrl: () => "/host/",
+    });
+    sse.scan(document);
+    opened[0]!.message(envelope([{ op: "refresh", zone: "poll" }]));
+    visibility.setHidden(true);
+    clock = 5000;
+    visibility.setHidden(false);
+    expect(fetched.find((f) => f.zone === "poll")?.url).toBe("/host/");
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("a resume re-GET passes zone intent and stamps no headers of its own", () => {
+    document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
+    const { adapter, opened } = mockSource();
+    const visibility = manualVisibility();
+    let clock = 0;
+    const sse = makeSse(adapter, visibility, { now: () => clock });
+    sse.scan(document);
+    opened[0]!.message(envelope([{ op: "refresh", zone: "poll" }]));
+    visibility.setHidden(true);
+    clock = 5000;
+    visibility.setHidden(false);
+    // The wire stamps X-Next-Zone from the zone intent, so the exact request
+    // shape carries url and zone and nothing else.
+    expect(fetched).toEqual([{ url: "/", zone: "poll" }]);
+  });
+
+  it("opens a stream when the scan root itself carries data-next-sse", () => {
+    document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
+    const el = document.querySelector("div")!;
+    const { adapter, opened } = mockSource();
+    const sse = makeSse(adapter, manualVisibility());
+    // A replace patch scans the new wrapper element itself, so the container
+    // binds even when it is the subtree root and not a descendant.
+    sse.scan(el);
+    expect(opened).toHaveLength(1);
+    expect(opened[0]!.url).toBe("/stream/");
   });
 
   it("reconnects without a re-GET when the tab flickers briefly", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const visibility = mockVisibility();
+    const visibility = manualVisibility();
     let clock = 0;
-    const sse = makeSse(adapter, visibility.adapter, () => clock);
+    const sse = makeSse(adapter, visibility, { now: () => clock });
     sse.scan(document);
     opened[0]!.message(
       envelope([
@@ -277,11 +305,11 @@ describe("createSse", () => {
         { op: "morph", target: { zone: "list" } },
       ]),
     );
-    visibility.set(true);
+    visibility.setHidden(true);
     // A momentary alt-tab reconnects the stream but skips the zone re-GET, so
     // flicking between tabs does not storm the server.
     clock = 500;
-    visibility.set(false);
+    visibility.setHidden(false);
     expect(opened).toHaveLength(2);
     expect(opened[1]!.closed).toBe(false);
     expect(sse.size()).toBe(1);
@@ -291,7 +319,7 @@ describe("createSse", () => {
   it("applies a non-record event body without binding any zone", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const sse = makeSse(adapter, mockVisibility().adapter);
+    const sse = makeSse(adapter, manualVisibility());
     sse.scan(document);
     opened[0]!.message("[1,2,3]");
     expect(applied).toEqual([[1, 2, 3]]);
@@ -300,23 +328,23 @@ describe("createSse", () => {
   it("binds no zone when the event ops field is not an array", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const visibility = mockVisibility();
+    const visibility = manualVisibility();
     let clock = 0;
-    const sse = makeSse(adapter, visibility.adapter, () => clock);
+    const sse = makeSse(adapter, visibility, { now: () => clock });
     sse.scan(document);
     opened[0]!.message('{"ops":"nope"}');
-    visibility.set(true);
+    visibility.setHidden(true);
     clock = 5000;
-    visibility.set(false);
+    visibility.setHidden(false);
     expect(fetched).toHaveLength(0);
   });
 
   it("skips a non-record op and an op without a zone when binding", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const visibility = mockVisibility();
+    const visibility = manualVisibility();
     let clock = 0;
-    const sse = makeSse(adapter, visibility.adapter, () => clock);
+    const sse = makeSse(adapter, visibility, { now: () => clock });
     sse.scan(document);
     opened[0]!.message(
       JSON.stringify({
@@ -326,56 +354,56 @@ describe("createSse", () => {
         form: null,
       }),
     );
-    visibility.set(true);
+    visibility.setHidden(true);
     clock = 5000;
-    visibility.set(false);
+    visibility.setHidden(false);
     expect(fetched.map((f) => f.zone)).toEqual(["poll"]);
   });
 
   it("resume copies bound zones so a late event on the paused stream does not leak", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const visibility = mockVisibility();
+    const visibility = manualVisibility();
     let clock = 0;
-    const sse = makeSse(adapter, visibility.adapter, () => clock);
+    const sse = makeSse(adapter, visibility, { now: () => clock });
     sse.scan(document);
     opened[0]!.message(envelope([{ op: "refresh", zone: "poll" }]));
-    visibility.set(true);
+    visibility.setHidden(true);
     clock = 5000;
-    visibility.set(false);
+    visibility.setHidden(false);
     fetched.length = 0;
     // The paused predecessor still holds its message closure. A stray event on
     // it must not bind into the resumed connection, which carries its own copy.
     opened[0]!.message(envelope([{ op: "refresh", zone: "stale" }]));
     clock = 10000;
-    visibility.set(true);
+    visibility.setHidden(true);
     clock = 15000;
-    visibility.set(false);
+    visibility.setHidden(false);
     expect(fetched.map((f) => f.zone)).toEqual(["poll"]);
   });
 
   it("caps the bound registry so a long sleep does not re-GET an unbounded set", () => {
     document.body.innerHTML = '<div data-next-sse="/stream/"></div>';
     const { adapter, opened } = mockSource();
-    const visibility = mockVisibility();
+    const visibility = manualVisibility();
     let clock = 0;
-    const sse = makeSse(adapter, visibility.adapter, () => clock);
+    const sse = makeSse(adapter, visibility, { now: () => clock });
     sse.scan(document);
     const ops = Array.from({ length: 100 }, (_, i) => ({
       op: "refresh",
       zone: `zone-${i}`,
     }));
     opened[0]!.message(envelope(ops));
-    visibility.set(true);
+    visibility.setHidden(true);
     clock = 5000;
-    visibility.set(false);
+    visibility.setHidden(false);
     expect(fetched).toHaveLength(64);
   });
 
   it("ignores a data-next-sse container with an empty url", () => {
     document.body.innerHTML = '<div data-next-sse=""></div>';
     const { adapter, opened } = mockSource();
-    const sse = makeSse(adapter, mockVisibility().adapter);
+    const sse = makeSse(adapter, manualVisibility());
     sse.scan(document);
     expect(opened).toHaveLength(0);
     expect(sse.size()).toBe(0);

--- a/next/client/sse.ts
+++ b/next/client/sse.ts
@@ -11,15 +11,13 @@
 // the stream lives on.
 
 import { defaultEventSource, defaultVisibility } from "./adapters";
-import {
-  HEADER_ZONE,
-  RESUME_REVALIDATE_MS,
-  asString,
-  currentUrl,
-  isRecord,
-} from "./protocol";
+import { asString, currentUrl, isRecord, matching } from "./protocol";
 
 const SSE_ATTR = "data-next-sse";
+// A visibility flip shorter than this revalidates nothing: a momentary alt-tab
+// reconnects the stream but skips the zone re-GETs, so flicking between tabs
+// does not storm the server.
+const RESUME_REVALIDATE_MS = 3000;
 // The ring holds the last 25 own request ids, matching the server-side echo
 // window. Overflow is safe: a dropped id yields an extra refresh, not a break.
 const ECHO_LIMIT = 25;
@@ -68,16 +66,16 @@ export interface SseDeps {
   // fires partial:error without poisoning the connection.
   apply: (raw: unknown) => void;
   // The zone re-GET used to revalidate bound zones on resume, the same shape
-  // the refresh verb already uses.
-  fetch: (request: {
-    url: string;
-    zone: string;
-    headers?: Record<string, string>;
-  }) => void;
+  // the refresh verb already uses. The wire stamps X-Next-Zone from the zone
+  // intent, so the bridge passes intent, never headers.
+  fetch: (request: { url: string; zone: string }) => void;
   dispatch: (event: string, detail: Record<string, unknown>) => void;
   document?: Document;
   source?: EventSourceAdapter;
   visibility?: VisibilityAdapter;
+  // The URL of the page that owns a data-next-sse container, answered by the
+  // layer stack. Absent, the capture reads the address bar.
+  pageUrl?: (el: Element) => string;
   // The monotonic clock the resume gate reads to measure how long the tab was
   // hidden. Injectable so tests drive the anti-storm threshold deterministically.
   now?: () => number;
@@ -98,10 +96,8 @@ export interface Sse {
 interface Connection {
   url: string;
   control: SourceControl;
-  // The page path and query the stream subscribed from, captured at open and
-  // carried across a pause so resume re-GETs the bound zones against the page
-  // they were rendered for, query filters and all, not whatever the location
-  // reads at resume time.
+  // The page the stream subscribed from, captured at open so resume re-GETs
+  // the bound zones against it rather than the location at resume time.
   pageUrl: string;
   // The zones this stream addressed with operations since subscribing, the
   // registry re-GET on resume so events missed while hidden converge.
@@ -113,6 +109,7 @@ export function createSse(deps: SseDeps): Sse {
   const source = deps.source ?? defaultEventSource();
   const visibility = deps.visibility ?? defaultVisibility();
   const now = deps.now ?? (() => Date.now());
+  const pageUrl = deps.pageUrl ?? (() => currentUrl(doc));
   // The connections keyed by url so a re-scan of a re-inserted container does
   // not open a second stream to the same endpoint.
   const connections = new Map<string, Connection>();
@@ -179,14 +176,15 @@ export function createSse(deps: SseDeps): Sse {
     deps.dispatch("partial:error", { kind: "network", error: null });
   }
 
-  // Open a stream to a url, carrying over the bound zones and page URL of a
-  // paused predecessor so resume knows what to revalidate and where.
-  function openConnection(url: string, previous?: Connection): void {
+  // Open a stream to a url against the resolved owning page, carrying over
+  // the bound zones of a paused predecessor so resume knows what to
+  // revalidate and where.
+  function openConnection(url: string, page: string, previous?: Connection): void {
     if (connections.has(url) || paused) return;
     const connection: Connection = {
       url,
       control: NOOP,
-      pageUrl: previous?.pageUrl ?? currentUrl(doc),
+      pageUrl: page,
       // An independent copy per connection, never the predecessor's Set by
       // reference, so a mutation on the resumed stream cannot leak back into a
       // paused one that was never re-GET.
@@ -201,9 +199,9 @@ export function createSse(deps: SseDeps): Sse {
   }
 
   function scan(root: ParentNode): void {
-    for (const el of Array.from(root.querySelectorAll(`[${SSE_ATTR}]`))) {
+    for (const el of matching(root, `[${SSE_ATTR}]`)) {
       const url = el.getAttribute(SSE_ATTR);
-      if (url !== null && url !== "") openConnection(url);
+      if (url !== null && url !== "") openConnection(url, pageUrl(el));
     }
   }
 
@@ -215,24 +213,20 @@ export function createSse(deps: SseDeps): Sse {
     for (const connection of connections.values()) connection.control.close();
   }
 
-  // On returning visibility every paused connection reopens. Its bound zones are
-  // re-GET only when the tab was hidden long enough to have missed events, so a
-  // flicker between tabs reconnects without storming the server. A longer pause
-  // revalidates with the zone's own cookies so missed events converge.
+  // On returning visibility every paused connection reopens, and bound zones
+  // re-GET only when the tab was hidden past the threshold, so a flicker
+  // reconnects without storming the server. A polled zone may also refetch on
+  // the same flip once its own interval elapsed — the morphs are idempotent.
   function resume(): void {
     paused = false;
     const revalidate = now() - pausedAt >= RESUME_REVALIDATE_MS;
     const pending = [...connections.values()];
     connections.clear();
     for (const previous of pending) {
-      openConnection(previous.url, previous);
+      openConnection(previous.url, previous.pageUrl, previous);
       if (!revalidate) continue;
       for (const zone of previous.bound) {
-        deps.fetch({
-          url: previous.pageUrl,
-          zone,
-          headers: { [HEADER_ZONE]: zone },
-        });
+        deps.fetch({ url: previous.pageUrl, zone });
       }
     }
   }

--- a/next/client/sse.ts
+++ b/next/client/sse.ts
@@ -11,16 +11,18 @@
 // the stream lives on.
 
 import { defaultEventSource, defaultVisibility } from "./adapters";
-import { HEADER_ZONE, asString, currentUrl, isRecord } from "./protocol";
+import {
+  HEADER_ZONE,
+  RESUME_REVALIDATE_MS,
+  asString,
+  currentUrl,
+  isRecord,
+} from "./protocol";
 
 const SSE_ATTR = "data-next-sse";
 // The ring holds the last 25 own request ids, matching the server-side echo
 // window. Overflow is safe: a dropped id yields an extra refresh, not a break.
 const ECHO_LIMIT = 25;
-// A visibility flip shorter than this revalidates nothing: a momentary alt-tab
-// reconnects the stream but skips the zone re-GET, so flicking between tabs does
-// not storm the server. A longer pause may have missed events, so it converges.
-const RESUME_REVALIDATE_MS = 3000;
 // The cap on bound zones a connection tracks. Without it a long background sleep
 // lets the registry grow unbounded, and resume would re-GET every accumulated
 // zone at once, a thundering herd on the server. Past the cap a new zone is

--- a/next/client/test-doubles.ts
+++ b/next/client/test-doubles.ts
@@ -1,0 +1,64 @@
+// Shared test doubles for the seams more than one suite drives. Imported only
+// from *.test.ts files, so the bundle built from next.ts never ships them.
+
+import type { VisibilityAdapter } from "./sse";
+import type { Clock } from "./wire";
+
+// Holds every pending timer with a working clearTimeout, so a duplicate chain
+// shows up as pending() above one. tick() drains the due set first, so a
+// re-arm from inside a handler lands in the next cycle.
+export function manualPollClock(): Clock & {
+  tick(): void;
+  pending(): number;
+  setNow(ms: number): void;
+  intervals: number[];
+} {
+  let now = 0;
+  let handles = 0;
+  const timers = new Map<number, () => void>();
+  const intervals: number[] = [];
+  return {
+    now: () => now,
+    setTimeout: (handler, ms) => {
+      handles += 1;
+      timers.set(handles, handler);
+      intervals.push(ms);
+      return handles;
+    },
+    clearTimeout: (handle) => {
+      timers.delete(handle);
+    },
+    tick() {
+      const due = Array.from(timers.values());
+      timers.clear();
+      for (const handler of due) handler();
+    },
+    pending: () => timers.size,
+    setNow(ms) {
+      now = ms;
+    },
+    intervals,
+  };
+}
+
+// Holds every onChange subscriber, since the SSE bridge and the poll triggers
+// share the seam.
+export function manualVisibility(): VisibilityAdapter & {
+  setHidden(v: boolean): void;
+} {
+  let hidden = false;
+  const listeners = new Set<() => void>();
+  return {
+    hidden: () => hidden,
+    onChange(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    setHidden(v) {
+      hidden = v;
+      for (const listener of listeners) listener();
+    },
+  };
+}

--- a/next/client/triggers.test.ts
+++ b/next/client/triggers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { VisibilityAdapter } from "./sse";
 import { createTriggers } from "./triggers";
 import type { IntersectionAdapter, TriggerDeps, Triggers } from "./triggers";
 import type { Clock } from "./wire";
@@ -22,6 +23,38 @@ function manualClock(): Clock & { run(): void } {
       const h = pending;
       pending = null;
       h?.();
+    },
+  };
+}
+
+// The poll timer re-arms itself from inside its own handler, so this clock
+// clears the pending slot before running it and each tick() drives one cycle.
+function manualPollClock(): Clock & { tick(): void } {
+  let pending: (() => void) | null = null;
+  return {
+    now: () => 0,
+    setTimeout: (handler) => {
+      pending = handler;
+      return 1;
+    },
+    clearTimeout: () => {
+      pending = null;
+    },
+    tick() {
+      const h = pending;
+      pending = null;
+      h?.();
+    },
+  };
+}
+
+function manualVisibility(): VisibilityAdapter & { setHidden(v: boolean): void } {
+  let hidden = false;
+  return {
+    hidden: () => hidden,
+    onChange: () => () => undefined,
+    setHidden(v) {
+      hidden = v;
     },
   };
 }
@@ -559,6 +592,115 @@ describe("trigger delegation", () => {
     triggers.scan(document.body);
     triggers._reset();
     observer.reveal();
+    expect(requests).toHaveLength(0);
+  });
+});
+
+describe("zone polling", () => {
+  let detach: () => void;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    detach?.();
+  });
+
+  it("re-GETs a polling zone on each tick", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    expect(requests).toHaveLength(0);
+    clock.tick();
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.zone).toBe("t");
+    expect(requests[0]!.headers?.["X-Next-Zone"]).toBe("t");
+    expect(requests[0]!.headers?.["X-Next-Version"]).toBe("v1");
+    clock.tick();
+    expect(requests).toHaveLength(2);
+  });
+
+  it("skips the fetch on a hidden tab and reschedules", () => {
+    const clock = manualPollClock();
+    const visibility = manualVisibility();
+    visibility.setHidden(true);
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock, visibility });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    clock.tick();
+    expect(requests).toHaveLength(0);
+    visibility.setHidden(false);
+    clock.tick();
+    expect(requests).toHaveLength(1);
+  });
+
+  it("stops the timer when the zone leaves the DOM", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const el = document.querySelector("div")!;
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    el.remove();
+    clock.tick();
+    expect(requests).toHaveLength(0);
+    clock.tick();
+    expect(requests).toHaveLength(0);
+  });
+
+  it("does not arm a second timer on re-scan", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    triggers.scan(document.body);
+    clock.tick();
+    expect(requests).toHaveLength(1);
+  });
+
+  it("_reset stops outstanding pollers", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    triggers._reset();
+    clock.tick();
+    expect(requests).toHaveLength(0);
+  });
+
+  it("ignores a zone with a non-positive interval", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="0"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    clock.tick();
+    expect(requests).toHaveLength(0);
+  });
+
+  it("ignores a non-numeric interval", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="soon"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    clock.tick();
+    expect(requests).toHaveLength(0);
+  });
+
+  it("ignores a polling element without a zone name", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    clock.tick();
     expect(requests).toHaveLength(0);
   });
 });

--- a/next/client/triggers.test.ts
+++ b/next/client/triggers.test.ts
@@ -28,33 +28,62 @@ function manualClock(): Clock & { run(): void } {
 }
 
 // The poll timer re-arms itself from inside its own handler, so this clock
-// clears the pending slot before running it and each tick() drives one cycle.
-function manualPollClock(): Clock & { tick(): void } {
-  let pending: (() => void) | null = null;
+// holds every pending timer by handle with a working clearTimeout: a duplicate
+// timer chain is observable as pending() above one and doubled fetches per
+// tick(), which drains the due set before running it so a re-arm lands in the
+// next cycle. The intervals record every setTimeout delay, so a reschedule that
+// re-read a changed data-next-poll is observable, and setNow drives the
+// hidden-span gate of the visibility resume.
+function manualPollClock(): Clock & {
+  tick(): void;
+  pending(): number;
+  setNow(ms: number): void;
+  intervals: number[];
+} {
+  let now = 0;
+  let handles = 0;
+  const timers = new Map<number, () => void>();
+  const intervals: number[] = [];
   return {
-    now: () => 0,
-    setTimeout: (handler) => {
-      pending = handler;
-      return 1;
+    now: () => now,
+    setTimeout: (handler, ms) => {
+      handles += 1;
+      timers.set(handles, handler);
+      intervals.push(ms);
+      return handles;
     },
-    clearTimeout: () => {
-      pending = null;
+    clearTimeout: (handle) => {
+      timers.delete(handle);
     },
     tick() {
-      const h = pending;
-      pending = null;
-      h?.();
+      const due = Array.from(timers.values());
+      timers.clear();
+      for (const handler of due) handler();
     },
+    pending: () => timers.size,
+    setNow(ms) {
+      now = ms;
+    },
+    intervals,
   };
 }
 
+// The visibility seam holds every onChange subscriber, so the pause/resume
+// choreography fires alongside any other listener the runtime registers.
 function manualVisibility(): VisibilityAdapter & { setHidden(v: boolean): void } {
   let hidden = false;
+  const listeners = new Set<() => void>();
   return {
     hidden: () => hidden,
-    onChange: () => () => undefined,
+    onChange(listener) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
     setHidden(v) {
       hidden = v;
+      for (const listener of listeners) listener();
     },
   };
 }
@@ -84,7 +113,6 @@ function makeTriggers(over: Partial<Parameters<typeof createTriggers>[0]> = {}):
   const triggers = createTriggers({
     fetch: (request) => requests.push(request),
     abort: (zone) => aborted.push(zone),
-    version: () => "v1",
     document,
     clock: manualClock(),
     observer: manualObserver(),
@@ -114,7 +142,23 @@ describe("trigger delegation", () => {
     detach = triggers.install(document);
     triggers.ready();
     expect(requests).toHaveLength(1);
-    expect(requests[0]!.headers?.["X-Next-Zone"]).toBe("a,b");
+    expect(requests[0]!.zone).toBe("a,b");
+    expect(requests[0]!.headers).toBeUndefined();
+  });
+
+  it("groups a load batch by the owning page URL, one GET per page", () => {
+    document.body.innerHTML =
+      '<div id="a" data-next-zone="a" data-next-lazy="load"></div>' +
+      '<div id="b" data-next-zone="b" data-next-lazy="load"></div>' +
+      '<div id="c" data-next-zone="c" data-next-lazy="load"></div>';
+    const { triggers, requests } = makeTriggers({
+      pageUrl: (el) => (el.id === "c" ? "/layer/" : "/host/"),
+    });
+    detach = triggers.install(document);
+    triggers.ready();
+    expect(requests).toHaveLength(2);
+    expect(requests[0]).toMatchObject({ url: "/host/", zone: "a,b" });
+    expect(requests[1]).toMatchObject({ url: "/layer/", zone: "c" });
   });
 
   it("does not re-fire a load zone re-scanned by a parent morph", () => {
@@ -153,6 +197,20 @@ describe("trigger delegation", () => {
     observer.reveal();
     expect(requests).toHaveLength(1);
     expect(requests[0]!.zone).toBe("late");
+  });
+
+  it("a revealed zone GETs the page answered by the pageUrl dep", () => {
+    const observer = manualObserver();
+    document.body.innerHTML =
+      '<div data-next-zone="late" data-next-lazy="revealed"></div>';
+    const { triggers, requests } = makeTriggers({
+      observer,
+      pageUrl: () => "/host/",
+    });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    observer.reveal();
+    expect(requests[0]!.url).toBe("/host/");
   });
 
   it("blocks a request when confirm is cancelled", () => {
@@ -617,13 +675,49 @@ describe("zone polling", () => {
     clock.tick();
     expect(requests).toHaveLength(1);
     expect(requests[0]!.zone).toBe("t");
-    expect(requests[0]!.headers?.["X-Next-Zone"]).toBe("t");
-    expect(requests[0]!.headers?.["X-Next-Version"]).toBe("v1");
+    expect(requests[0]!.headers).toBeUndefined();
     clock.tick();
     expect(requests).toHaveLength(2);
   });
 
-  it("skips the fetch on a hidden tab and reschedules", () => {
+  it("a poller armed on a hidden tab sleeps and resumes as a single chain", () => {
+    const clock = manualPollClock();
+    const visibility = manualVisibility();
+    // Hidden before install, so no visibilitychange ever clears a pending timer.
+    visibility.setHidden(true);
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock, visibility });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    // Hidden arming registers the entry with no live timer, so a background
+    // tab never wakes.
+    expect(clock.pending()).toBe(0);
+    clock.tick();
+    expect(requests).toHaveLength(0);
+    clock.setNow(3000);
+    visibility.setHidden(false);
+    expect(requests).toHaveLength(1);
+    expect(clock.pending()).toBe(1);
+    clock.tick();
+    expect(requests).toHaveLength(2);
+    expect(clock.pending()).toBe(1);
+  });
+
+  it("a tick landing on a hidden tab puts the poller to sleep", () => {
+    const clock = manualPollClock();
+    const visibility = manualVisibility();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock, visibility });
+    // No install: the hidden flip delivers no visibilitychange, so the armed
+    // timer fires into the in-tick safety net and stops rescheduling.
+    triggers.scan(document.body);
+    visibility.setHidden(true);
+    clock.tick();
+    expect(requests).toHaveLength(0);
+    expect(clock.pending()).toBe(0);
+  });
+
+  it("a repeated hidden flip tolerates a poller already sleeping", () => {
     const clock = manualPollClock();
     const visibility = manualVisibility();
     visibility.setHidden(true);
@@ -631,11 +725,80 @@ describe("zone polling", () => {
     const { triggers, requests } = makeTriggers({ clock, visibility });
     detach = triggers.install(document);
     triggers.scan(document.body);
+    visibility.setHidden(true);
+    expect(clock.pending()).toBe(0);
+    clock.setNow(3000);
+    visibility.setHidden(false);
+    expect(requests).toHaveLength(1);
+    expect(clock.pending()).toBe(1);
+  });
+
+  it("a hidden flip silences the pending poll timer", () => {
+    const clock = manualPollClock();
+    const visibility = manualVisibility();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock, visibility });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    visibility.setHidden(true);
     clock.tick();
     expect(requests).toHaveLength(0);
-    visibility.setHidden(false);
+    clock.tick();
+    expect(requests).toHaveLength(0);
+  });
+
+  it("a long hide runs the poller tick immediately on the visible flip", () => {
+    const clock = manualPollClock();
+    const visibility = manualVisibility();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock, visibility });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
     clock.tick();
     expect(requests).toHaveLength(1);
+    visibility.setHidden(true);
+    clock.setNow(3000);
+    visibility.setHidden(false);
+    expect(requests).toHaveLength(2);
+    expect(clock.pending()).toBe(1);
+    clock.tick();
+    expect(requests).toHaveLength(3);
+  });
+
+  it("a brief flicker re-arms the timers without an immediate fetch", () => {
+    const clock = manualPollClock();
+    const visibility = manualVisibility();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock, visibility });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    clock.tick();
+    expect(requests).toHaveLength(1);
+    visibility.setHidden(true);
+    clock.setNow(1000);
+    visibility.setHidden(false);
+    // Under the resume threshold nothing fetches: each poller re-arms with its
+    // own interval, the same anti-storm gate as the SSE resume.
+    expect(requests).toHaveLength(1);
+    expect(clock.pending()).toBe(1);
+    expect(clock.intervals).toEqual([5000, 5000, 5000]);
+    clock.tick();
+    expect(requests).toHaveLength(2);
+  });
+
+  it("resume tears down a poller whose zone vanished while hidden", () => {
+    const clock = manualPollClock();
+    const visibility = manualVisibility();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock, visibility });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    visibility.setHidden(true);
+    document.querySelector("div")!.removeAttribute("data-next-poll");
+    visibility.setHidden(false);
+    expect(requests).toHaveLength(0);
+    clock.tick();
+    expect(requests).toHaveLength(0);
   });
 
   it("stops the timer when the zone leaves the DOM", () => {
@@ -648,6 +811,90 @@ describe("zone polling", () => {
     el.remove();
     clock.tick();
     expect(requests).toHaveLength(0);
+    clock.tick();
+    expect(requests).toHaveLength(0);
+  });
+
+  it("stops the poller when the poll attribute is removed between ticks", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    document.querySelector("div")!.removeAttribute("data-next-poll");
+    clock.tick();
+    expect(requests).toHaveLength(0);
+    clock.tick();
+    expect(requests).toHaveLength(0);
+  });
+
+  it("stops the poller when the zone attribute is removed between ticks", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    document.querySelector("div")!.removeAttribute("data-next-zone");
+    clock.tick();
+    expect(requests).toHaveLength(0);
+    clock.tick();
+    expect(requests).toHaveLength(0);
+  });
+
+  it("a tick reschedules with the interval re-read from the live element", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    expect(clock.intervals).toEqual([5000]);
+    document.querySelector("div")!.setAttribute("data-next-poll", "9000");
+    clock.tick();
+    expect(requests).toHaveLength(1);
+    expect(clock.intervals).toEqual([5000, 9000]);
+    clock.tick();
+    expect(requests).toHaveLength(2);
+  });
+
+  it("arms a poller when the scan root itself is the poll wrapper", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const el = document.querySelector("div")!;
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    // A replace patch scans the new wrapper element itself, not a parent.
+    triggers.scan(el);
+    clock.tick();
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.zone).toBe("t");
+  });
+
+  it("fires the load batch when the scan root itself is the load wrapper", () => {
+    document.body.innerHTML = '<div data-next-zone="a" data-next-lazy="load"></div>';
+    const el = document.querySelector("div")!;
+    const { triggers, requests } = makeTriggers();
+    detach = triggers.install(document);
+    triggers.scan(el);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.zone).toBe("a");
+  });
+
+  it("polls the URL answered by the pageUrl dep, not the address bar", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock, pageUrl: () => "/host/" });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    clock.tick();
+    expect(requests[0]!.url).toBe("/host/");
+  });
+
+  it("ignores a hand-written duration literal under the strict grammar", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5s"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
     clock.tick();
     expect(requests).toHaveLength(0);
   });
@@ -690,6 +937,18 @@ describe("zone polling", () => {
     const { triggers, requests } = makeTriggers({ clock });
     detach = triggers.install(document);
     triggers.scan(document.body);
+    clock.tick();
+    expect(requests).toHaveLength(0);
+  });
+
+  it("ignores an interval above the browser's signed-32-bit timer bound", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML =
+      '<div data-next-zone="t" data-next-poll="2147483648"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    expect(clock.pending()).toBe(0);
     clock.tick();
     expect(requests).toHaveLength(0);
   });
@@ -741,10 +1000,50 @@ describe("dev attribute validation", () => {
     warn.mockRestore();
   });
 
+  it("warns on a malformed data-next-poll value in dev", () => {
+    document.body.innerHTML = '<div data-next-zone="z" data-next-poll="5s"></div>';
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { triggers } = makeTriggers({ dev: true });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]![0]).toContain('data-next-poll="5s"');
+    expect(warn.mock.calls[0]![0]).toContain("whole number of milliseconds");
+    warn.mockRestore();
+  });
+
+  it("warns on a poll interval above the timer bound in dev", () => {
+    document.body.innerHTML =
+      '<div data-next-zone="z" data-next-poll="2147483648"></div>';
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { triggers } = makeTriggers({ dev: true });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]![0]).toContain('data-next-poll="2147483648"');
+    expect(warn.mock.calls[0]![0]).toContain("between 1 and 2147483647");
+    warn.mockRestore();
+  });
+
+  it("warns when the scan root itself carries the malformed attribute", () => {
+    document.body.innerHTML = '<div data-next-zone="z" data-next-lazy="loaded"></div>';
+    const el = document.querySelector("div")!;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { triggers } = makeTriggers({ dev: true });
+    detach = triggers.install(document);
+    // A replace patch scans the new wrapper element itself, so the dev warning
+    // must cover the root and not only its descendants.
+    triggers.scan(el);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]![0]).toContain('data-next-lazy="loaded"');
+    warn.mockRestore();
+  });
+
   it("stays silent on recognised values in dev", () => {
     document.body.innerHTML =
       '<div data-next-zone="z" data-next-lazy="load"></div>' +
-      '<a href="/p2/" data-next-merge="append" data-next-target="list">more</a>';
+      '<a href="/p2/" data-next-merge="append" data-next-target="list">more</a>' +
+      '<div data-next-zone="p" data-next-poll="5000"></div>';
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { triggers } = makeTriggers({ dev: true });
     detach = triggers.install(document);
@@ -756,7 +1055,8 @@ describe("dev attribute validation", () => {
   it("stays silent on an out-of-set value when dev is off", () => {
     document.body.innerHTML =
       '<div data-next-zone="z" data-next-lazy="loaded"></div>' +
-      '<a href="/p2/" data-next-merge="add" data-next-target="list">more</a>';
+      '<a href="/p2/" data-next-merge="add" data-next-target="list">more</a>' +
+      '<div data-next-zone="p" data-next-poll="5s"></div>';
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { triggers } = makeTriggers();
     detach = triggers.install(document);

--- a/next/client/triggers.test.ts
+++ b/next/client/triggers.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { VisibilityAdapter } from "./sse";
+import { manualPollClock, manualVisibility } from "./test-doubles";
 import { createTriggers } from "./triggers";
 import type { IntersectionAdapter, TriggerDeps, Triggers } from "./triggers";
 import type { Clock } from "./wire";
@@ -23,67 +23,6 @@ function manualClock(): Clock & { run(): void } {
       const h = pending;
       pending = null;
       h?.();
-    },
-  };
-}
-
-// The poll timer re-arms itself from inside its own handler, so this clock
-// holds every pending timer by handle with a working clearTimeout: a duplicate
-// timer chain is observable as pending() above one and doubled fetches per
-// tick(), which drains the due set before running it so a re-arm lands in the
-// next cycle. The intervals record every setTimeout delay, so a reschedule that
-// re-read a changed data-next-poll is observable, and setNow drives the
-// hidden-span gate of the visibility resume.
-function manualPollClock(): Clock & {
-  tick(): void;
-  pending(): number;
-  setNow(ms: number): void;
-  intervals: number[];
-} {
-  let now = 0;
-  let handles = 0;
-  const timers = new Map<number, () => void>();
-  const intervals: number[] = [];
-  return {
-    now: () => now,
-    setTimeout: (handler, ms) => {
-      handles += 1;
-      timers.set(handles, handler);
-      intervals.push(ms);
-      return handles;
-    },
-    clearTimeout: (handle) => {
-      timers.delete(handle);
-    },
-    tick() {
-      const due = Array.from(timers.values());
-      timers.clear();
-      for (const handler of due) handler();
-    },
-    pending: () => timers.size,
-    setNow(ms) {
-      now = ms;
-    },
-    intervals,
-  };
-}
-
-// The visibility seam holds every onChange subscriber, so the pause/resume
-// choreography fires alongside any other listener the runtime registers.
-function manualVisibility(): VisibilityAdapter & { setHidden(v: boolean): void } {
-  let hidden = false;
-  const listeners = new Set<() => void>();
-  return {
-    hidden: () => hidden,
-    onChange(listener) {
-      listeners.add(listener);
-      return () => {
-        listeners.delete(listener);
-      };
-    },
-    setHidden(v) {
-      hidden = v;
-      for (const listener of listeners) listener();
     },
   };
 }
@@ -680,6 +619,40 @@ describe("zone polling", () => {
     expect(requests).toHaveLength(2);
   });
 
+  it("batches same-interval zones into one comma-joined GET per tick", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML =
+      '<div data-next-zone="a" data-next-poll="5000"></div>' +
+      '<div data-next-zone="b" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    // One cadence, one timer chain: the second zone joins the first's group.
+    expect(clock.pending()).toBe(1);
+    clock.tick();
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.zone).toBe("a,b");
+    clock.tick();
+    expect(requests).toHaveLength(2);
+  });
+
+  it("a same-interval batch still GETs one request per owning page", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML =
+      '<div id="a" data-next-zone="a" data-next-poll="5000"></div>' +
+      '<div id="b" data-next-zone="b" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({
+      clock,
+      pageUrl: (el) => (el.id === "b" ? "/layer/" : "/host/"),
+    });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    clock.tick();
+    expect(requests).toHaveLength(2);
+    expect(requests[0]).toMatchObject({ url: "/host/", zone: "a" });
+    expect(requests[1]).toMatchObject({ url: "/layer/", zone: "b" });
+  });
+
   it("a poller armed on a hidden tab sleeps and resumes as a single chain", () => {
     const clock = manualPollClock();
     const visibility = manualVisibility();
@@ -689,18 +662,39 @@ describe("zone polling", () => {
     const { triggers, requests } = makeTriggers({ clock, visibility });
     detach = triggers.install(document);
     triggers.scan(document.body);
-    // Hidden arming registers the entry with no live timer, so a background
+    // Hidden arming registers the group with no live timer, so a background
     // tab never wakes.
     expect(clock.pending()).toBe(0);
     clock.tick();
     expect(requests).toHaveLength(0);
-    clock.setNow(3000);
+    // The reveal lands past the group's own interval, so its tick runs at once
+    // and exactly one chain re-arms.
+    clock.setNow(6000);
     visibility.setHidden(false);
     expect(requests).toHaveLength(1);
     expect(clock.pending()).toBe(1);
     clock.tick();
     expect(requests).toHaveLength(2);
     expect(clock.pending()).toBe(1);
+  });
+
+  it("a poller armed hidden and revealed early re-arms with the remaining time", () => {
+    const clock = manualPollClock();
+    const visibility = manualVisibility();
+    visibility.setHidden(true);
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock, visibility });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    clock.setNow(3000);
+    visibility.setHidden(false);
+    // The interval never elapsed, so nothing fetches: the countdown resumes
+    // where the hidden span left it.
+    expect(requests).toHaveLength(0);
+    expect(clock.pending()).toBe(1);
+    expect(clock.intervals).toEqual([2000]);
+    clock.tick();
+    expect(requests).toHaveLength(1);
   });
 
   it("a tick landing on a hidden tab puts the poller to sleep", () => {
@@ -727,7 +721,7 @@ describe("zone polling", () => {
     triggers.scan(document.body);
     visibility.setHidden(true);
     expect(clock.pending()).toBe(0);
-    clock.setNow(3000);
+    clock.setNow(6000);
     visibility.setHidden(false);
     expect(requests).toHaveLength(1);
     expect(clock.pending()).toBe(1);
@@ -757,7 +751,9 @@ describe("zone polling", () => {
     clock.tick();
     expect(requests).toHaveLength(1);
     visibility.setHidden(true);
-    clock.setNow(3000);
+    // The hide spans the poller's own interval, so a tick was missed and the
+    // reveal runs it at once.
+    clock.setNow(6000);
     visibility.setHidden(false);
     expect(requests).toHaveLength(2);
     expect(clock.pending()).toBe(1);
@@ -777,13 +773,31 @@ describe("zone polling", () => {
     visibility.setHidden(true);
     clock.setNow(1000);
     visibility.setHidden(false);
-    // Under the resume threshold nothing fetches: each poller re-arms with its
-    // own interval, the same anti-storm gate as the SSE resume.
+    // The interval never elapsed, so nothing fetches and the countdown resumes
+    // with the remaining time instead of restarting: rapid switching can never
+    // postpone a due tick.
     expect(requests).toHaveLength(1);
     expect(clock.pending()).toBe(1);
-    expect(clock.intervals).toEqual([5000, 5000, 5000]);
+    expect(clock.intervals).toEqual([5000, 5000, 4000]);
     clock.tick();
     expect(requests).toHaveLength(2);
+  });
+
+  it("a repeated visible event does not fork a second timer chain", () => {
+    const clock = manualPollClock();
+    const visibility = manualVisibility();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock, visibility });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    // A visible event with no intervening hidden (delivered twice here) clears
+    // the live handle before re-arming, so exactly one chain survives.
+    visibility.setHidden(false);
+    visibility.setHidden(false);
+    expect(clock.pending()).toBe(1);
+    clock.tick();
+    expect(requests).toHaveLength(1);
+    expect(clock.pending()).toBe(1);
   });
 
   it("resume tears down a poller whose zone vanished while hidden", () => {
@@ -921,12 +935,59 @@ describe("zone polling", () => {
     expect(requests).toHaveLength(0);
   });
 
+  it("_reset drops a sleeping poller that holds no timer to clear", () => {
+    const clock = manualPollClock();
+    const visibility = manualVisibility();
+    visibility.setHidden(true);
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock, visibility });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    expect(clock.pending()).toBe(0);
+    triggers._reset();
+    clock.setNow(6000);
+    visibility.setHidden(false);
+    expect(requests).toHaveLength(0);
+    expect(clock.pending()).toBe(0);
+  });
+
+  it("a tick that outlived _reset returns without re-inserting its group", () => {
+    // A clock whose clearTimeout is a no-op models the callback the browser
+    // already dequeued when the clear arrived: the orphan tick must find its
+    // group gone and die silently instead of fetching or re-arming.
+    const handlers: (() => void)[] = [];
+    const clock: Clock = {
+      now: () => 0,
+      setTimeout: (handler) => handlers.push(handler),
+      clearTimeout: () => undefined,
+    };
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="5000"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    triggers._reset();
+    handlers[0]!();
+    expect(requests).toHaveLength(0);
+    expect(handlers).toHaveLength(1);
+  });
+
   it("ignores a zone with a non-positive interval", () => {
     const clock = manualPollClock();
     document.body.innerHTML = '<div data-next-zone="t" data-next-poll="0"></div>';
     const { triggers, requests } = makeTriggers({ clock });
     detach = triggers.install(document);
     triggers.scan(document.body);
+    clock.tick();
+    expect(requests).toHaveLength(0);
+  });
+
+  it("ignores a sub-second interval under the tag's floor", () => {
+    const clock = manualPollClock();
+    document.body.innerHTML = '<div data-next-zone="t" data-next-poll="500"></div>';
+    const { triggers, requests } = makeTriggers({ clock });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    expect(clock.pending()).toBe(0);
     clock.tick();
     expect(requests).toHaveLength(0);
   });
@@ -1021,7 +1082,31 @@ describe("dev attribute validation", () => {
     triggers.scan(document.body);
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0]![0]).toContain('data-next-poll="2147483648"');
-    expect(warn.mock.calls[0]![0]).toContain("between 1 and 2147483647");
+    expect(warn.mock.calls[0]![0]).toContain("between 1000 and 2147483647");
+    warn.mockRestore();
+  });
+
+  it("warns on a sub-second poll interval in dev, naming the floor", () => {
+    document.body.innerHTML = '<div data-next-zone="z" data-next-poll="500"></div>';
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { triggers } = makeTriggers({ dev: true });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]![0]).toContain('data-next-poll="500"');
+    expect(warn.mock.calls[0]![0]).toContain("between 1000 and 2147483647");
+    warn.mockRestore();
+  });
+
+  it("warns on a valid poll interval whose element names no zone in dev", () => {
+    document.body.innerHTML = '<div data-next-poll="5000"></div>';
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { triggers } = makeTriggers({ dev: true });
+    detach = triggers.install(document);
+    triggers.scan(document.body);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]![0]).toContain('data-next-poll="5000"');
+    expect(warn.mock.calls[0]![0]).toContain("without data-next-zone");
     warn.mockRestore();
   });
 
@@ -1056,7 +1141,8 @@ describe("dev attribute validation", () => {
     document.body.innerHTML =
       '<div data-next-zone="z" data-next-lazy="loaded"></div>' +
       '<a href="/p2/" data-next-merge="add" data-next-target="list">more</a>' +
-      '<div data-next-zone="p" data-next-poll="5s"></div>';
+      '<div data-next-zone="p" data-next-poll="5s"></div>' +
+      '<div data-next-poll="5000"></div>';
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { triggers } = makeTriggers();
     detach = triggers.install(document);

--- a/next/client/triggers.ts
+++ b/next/client/triggers.ts
@@ -23,8 +23,7 @@ import {
   ATTR_KEY,
   ATTR_ZONE,
   HEADER_MERGE,
-  HEADER_VERSION,
-  HEADER_ZONE,
+  RESUME_REVALIDATE_MS,
   currentUrl,
 } from "./protocol";
 import type { VisibilityAdapter } from "./sse";
@@ -48,6 +47,11 @@ const HEADER_VALIDATE = "X-Next-Validate";
 // is caught at authoring time rather than failing quietly downstream.
 const LAZY_VALUES = new Set(["load", "revealed"]);
 const MERGE_VALUES = new Set(["append", "prepend"]);
+
+// The upper bound the {% zone %} tag enforces server-side. Above 2^31-1 the
+// browser's signed-32-bit setTimeout coercion fires the timer immediately, so
+// a larger hand-written value would poll in a tight loop instead of slowly.
+const MAX_POLL_MS = 2147483647;
 
 // The geometry seam: real IntersectionObserver behind a mock the harness drives
 // by calling the callback, since jsdom reports no intersections.
@@ -75,15 +79,19 @@ export interface TriggerDeps {
   // Abort the in-flight request on a zone queue, called when a form submit must
   // cancel its own inline validation.
   abort: (zone: string) => void;
-  // The version known to the client, sent on the lazy-zone and validate GETs so
-  // the safeguard sees a stale page.
-  version: () => string;
   document?: Document;
   clock?: Clock;
   observer?: IntersectionAdapter;
-  // The tab-visibility seam, shared with the SSE bridge: a poll tick on a
-  // hidden tab skips the fetch and reschedules.
+  // The tab-visibility seam, shared with the SSE bridge: a hidden tab arms no
+  // poll timers at all, a tab returning after a real absence runs every tick
+  // immediately, and a brief flicker only re-arms the timers, the same
+  // anti-storm gate as the SSE resume.
   visibility?: VisibilityAdapter;
+  // The URL of the page that owns an element, answered by the layer stack: a
+  // zone in the base document belongs to the host page even while a modal
+  // layer sits on top of history. Absent, lazy and poll GETs read the address
+  // bar.
+  pageUrl?: (el: Element) => string;
   // The confirm gate. Absent, the default calls window.confirm. Injectable so
   // tests drive accept and cancel without a real dialog.
   confirm?: ConfirmAdapter;
@@ -119,12 +127,28 @@ export function createTriggers(deps: TriggerDeps): Triggers {
   // Observer teardowns, dropped on reset so vitest files do not leak observers.
   const observed: (() => void)[] = [];
   // Active pollers keyed by element, so a re-scan of a re-inserted zone does
-  // not arm a second timer and _reset can stop every one.
-  const polling = new Map<Element, number>();
+  // not arm a second timer and _reset can stop every one. The tick rides along
+  // so the visibility resume can run or re-arm every poller. A null handle is
+  // a sleeping entry: the tab was hidden, so no timer is live.
+  const polling = new Map<Element, { handle: number | null; tick: () => void }>();
+  // The clock reading at the last hidden flip, so the visible flip measures
+  // the hidden span and skips the immediate refresh for a flicker.
+  let hiddenAt = 0;
   let detach: (() => void) | null = null;
 
   function here(): string {
     return currentUrl(doc);
+  }
+
+  const pageUrl = deps.pageUrl ?? (() => here());
+
+  // querySelectorAll never matches its own root, but a replace patch scans the
+  // new wrapper element itself, so every activation pass folds a matching root
+  // into the result.
+  function matching(root: ParentNode, selector: string): Element[] {
+    const found = Array.from(root.querySelectorAll(selector));
+    if (root instanceof Element && root.matches(selector)) found.push(root);
+    return found;
   }
 
   // The abortable zone key of a form's inline validation, shared by the sender
@@ -170,7 +194,14 @@ export function createTriggers(deps: TriggerDeps): Triggers {
     const action = form.getAttribute("action") || here().replace(/\?.*$/, "");
     const url = query === "" ? action : `${action}?${query}`;
     doc.defaultView?.history.replaceState(null, "", url);
-    deps.fetch({ url, zone, headers: versionHeaders({ [HEADER_ZONE]: zone }) });
+    zoneGet(url, zone);
+  }
+
+  // The one shape of a zone GET. The wire stamps X-Next-Zone from request.zone
+  // and asserts the asset version once one is learned, so the triggers pass
+  // intent, never headers.
+  function zoneGet(url: string, zone: string): void {
+    deps.fetch({ url, zone });
   }
 
   // A pagination link or sentinel GETs the next page with a merge intent, the
@@ -183,15 +214,7 @@ export function createTriggers(deps: TriggerDeps): Triggers {
     // "append" fallback is never taken.
     /* v8 ignore next */
     const merge = el.getAttribute(MERGE_ATTR) ?? "append";
-    deps.fetch({
-      url: href,
-      zone,
-      headers: versionHeaders({ [HEADER_ZONE]: zone, [HEADER_MERGE]: merge }),
-    });
-  }
-
-  function versionHeaders(extra: Record<string, string>): Record<string, string> {
-    return { ...extra, [HEADER_VERSION]: deps.version() };
+    deps.fetch({ url: href, zone, headers: { [HEADER_MERGE]: merge } });
   }
 
   // Inline validation on blur. The FormData drops file fields so a multipart
@@ -212,7 +235,7 @@ export function createTriggers(deps: TriggerDeps): Triggers {
       // fresh blur or a submit of the same form aborts it through the queue.
       zone: validateZone(uid),
       abortable: true,
-      headers: versionHeaders({ [HEADER_VALIDATE]: field }),
+      headers: { [HEADER_VALIDATE]: field },
       body: data,
     });
   }
@@ -315,13 +338,7 @@ export function createTriggers(deps: TriggerDeps): Triggers {
     const merge = el.getAttribute(MERGE_ATTR);
     if (zone !== null && lazy === "revealed") {
       activated.add(el);
-      const stop = observer.observe(el, () => {
-        deps.fetch({
-          url: here(),
-          zone,
-          headers: versionHeaders({ [HEADER_ZONE]: zone }),
-        });
-      });
+      const stop = observer.observe(el, () => zoneGet(pageUrl(el), zone));
       observed.push(stop);
       return;
     }
@@ -334,75 +351,123 @@ export function createTriggers(deps: TriggerDeps): Triggers {
     }
   }
 
+  // The poll interval under a strict decimal grammar: parseInt("5s") is 5 and
+  // would poll at 5ms, so only an all-digit positive value up to the server
+  // tag's own bound is an interval.
+  function pollMs(el: Element): number | null {
+    const raw = el.getAttribute(POLL_ATTR);
+    if (raw === null || !/^\d+$/.test(raw)) return null;
+    const ms = Number(raw);
+    return ms > 0 && ms <= MAX_POLL_MS ? ms : null;
+  }
+
   // Arm the self-rescheduling poll timer of one zone. A single Clock seam and
   // chained setTimeout, no setInterval, so tests drive ticks one by one. Each
-  // tick checks isConnected for an honest teardown after a morph removed the
-  // zone, and a hidden tab skips the fetch but keeps the schedule.
+  // tick re-reads the live element rather than trusting the arm-time capture:
+  // a morph may have removed it, reused it for unrelated content, or changed
+  // the interval, and the server keeps data-next-poll on partial responses, so
+  // a healthy zone always carries both attributes. Anything else is an honest
+  // teardown. A hidden tab arms no timer at all: the entry registers sleeping
+  // and the visible flip wakes it, so a background tab never forks a second
+  // timer chain on resume.
   function startPoll(el: Element): void {
     if (polling.has(el)) return;
-    const zone = el.getAttribute(ATTR_ZONE);
-    // scan reaches startPoll only via a [data-next-poll] match, so the
-    // attribute is always present.
-    const ms = Number.parseInt(el.getAttribute(POLL_ATTR)!, 10);
-    if (zone === null || !Number.isFinite(ms) || ms <= 0) return;
+    if (el.getAttribute(ATTR_ZONE) === null) return;
+    const ms = pollMs(el);
+    if (ms === null) return;
     const tick = (): void => {
-      if (!el.isConnected) {
+      const zone = el.getAttribute(ATTR_ZONE);
+      const interval = pollMs(el);
+      if (!el.isConnected || zone === null || interval === null) {
         stopPoll(el);
         return;
       }
-      if (!visibility.hidden()) {
-        deps.fetch({
-          url: here(),
-          zone,
-          headers: versionHeaders({ [HEADER_ZONE]: zone }),
-        });
+      if (visibility.hidden()) {
+        // The safety net for a hidden flip whose visibilitychange event was
+        // not delivered: the entry goes to sleep instead of rescheduling, and
+        // the visible flip wakes it like any paused poller.
+        polling.set(el, { handle: null, tick });
+        return;
       }
-      polling.set(el, clock.setTimeout(tick, ms));
+      zoneGet(pageUrl(el), zone);
+      polling.set(el, { handle: clock.setTimeout(tick, interval), tick });
     };
-    polling.set(el, clock.setTimeout(tick, ms));
+    polling.set(el, {
+      handle: visibility.hidden() ? null : clock.setTimeout(tick, ms),
+      tick,
+    });
   }
 
   // A tick's element is always in the map and _reset walks the map's own keys,
-  // so the handle is always present.
+  // so the entry is always present. A sleeping entry holds no live timer.
   function stopPoll(el: Element): void {
-    clock.clearTimeout(polling.get(el)!);
+    const entry = polling.get(el)!;
+    if (entry.handle !== null) clock.clearTimeout(entry.handle);
     polling.delete(el);
   }
 
-  // Batch the document's load zones into a single GET with a comma-joined
-  // X-Next-Zone, one round trip for every load zone on the page.
+  // On hidden, silence every pending timer but keep the entries sleeping, so a
+  // background tab stops waking entirely. On visible after a real absence, run
+  // every tick at once: each re-reads the live attributes, fetches, and re-arms
+  // itself. A flicker between tabs instead re-arms each timer with its own
+  // interval and no immediate fetch, the anti-storm gate the SSE resume applies
+  // at the same seam. A poller whose interval died while hidden still ticks so
+  // it tears itself down. A tick may stopPoll and delete its entry mid-walk,
+  // hence the copied entries.
+  function onVisibility(): void {
+    if (visibility.hidden()) {
+      hiddenAt = clock.now();
+      for (const entry of polling.values()) {
+        if (entry.handle !== null) clock.clearTimeout(entry.handle);
+        entry.handle = null;
+      }
+      return;
+    }
+    const stale = clock.now() - hiddenAt >= RESUME_REVALIDATE_MS;
+    for (const [el, entry] of Array.from(polling.entries())) {
+      const interval = pollMs(el);
+      if (stale || interval === null) entry.tick();
+      else entry.handle = clock.setTimeout(entry.tick, interval);
+    }
+  }
+
+  // Batch the load zones into one comma-joined GET per owning page, one round
+  // trip for every load zone the page contributed. The batch groups by the
+  // layer-resolved page URL: a base-page zone and a layer zone activated by
+  // the same apply GET their own pages, not whatever the address bar reads.
   function loadBatch(root: ParentNode): void {
-    const zones: string[] = [];
-    for (const el of Array.from(root.querySelectorAll(`[${LAZY_ATTR}="load"]`))) {
+    const batches = new Map<string, string[]>();
+    for (const el of matching(root, `[${LAZY_ATTR}="load"]`)) {
       if (activated.has(el)) continue;
       const zone = el.getAttribute(ATTR_ZONE);
       if (zone === null) continue;
       activated.add(el);
-      zones.push(zone);
+      const url = pageUrl(el);
+      const zones = batches.get(url);
+      if (zones === undefined) batches.set(url, [zone]);
+      else zones.push(zone);
     }
-    if (zones.length === 0) return;
-    const header = zones.join(",");
-    deps.fetch({
-      url: here(),
-      // The queue key is the batch header so a re-fired batch supersedes the
-      // old one cleanly.
-      zone: header,
-      headers: versionHeaders({ [HEADER_ZONE]: header }),
-    });
+    // The queue key is the zone batch so a re-fired batch supersedes the old
+    // one cleanly.
+    for (const [url, zones] of batches) zoneGet(url, zones.join(","));
   }
 
-  // Warn on a hand-written attribute value outside its closed set, which the
-  // runtime drops without acting on it. Dev-only, by the same shape as the
-  // script-neutralisation warning: prefix, attribute, value, and allowed set.
+  // Warn on a hand-written attribute value outside its closed set, and on a
+  // poll interval failing the strict grammar, both of which the runtime drops
+  // without acting on. Dev-only, by the same shape as the script-neutralisation
+  // warning: prefix, attribute, value, and allowed set.
   function validateAttrs(root: ParentNode): void {
     if (!dev) return;
-    for (const el of Array.from(root.querySelectorAll(`[${LAZY_ATTR}]`))) {
+    for (const el of matching(root, `[${LAZY_ATTR}]`)) {
       const value = el.getAttribute(LAZY_ATTR)!;
       if (!LAZY_VALUES.has(value)) warnAttr(LAZY_ATTR, value, LAZY_VALUES);
     }
-    for (const el of Array.from(root.querySelectorAll(`[${MERGE_ATTR}]`))) {
+    for (const el of matching(root, `[${MERGE_ATTR}]`)) {
       const value = el.getAttribute(MERGE_ATTR)!;
       if (!MERGE_VALUES.has(value)) warnAttr(MERGE_ATTR, value, MERGE_VALUES);
+    }
+    for (const el of matching(root, `[${POLL_ATTR}]`)) {
+      if (pollMs(el) === null) warnPoll(el.getAttribute(POLL_ATTR)!);
     }
   }
 
@@ -413,19 +478,25 @@ export function createTriggers(deps: TriggerDeps): Triggers {
     );
   }
 
+  // The numeric sibling of warnAttr: the poll interval has no closed set to
+  // list, so the message points at the tag that writes a valid one.
+  function warnPoll(value: string): void {
+    console.warn(
+      `[next.partial] ${POLL_ATTR}="${value}" is not a whole number of milliseconds between 1 and ${MAX_POLL_MS} and is ignored. The {% zone %} tag writes the resolved interval.`,
+    );
+  }
+
   function scan(root: ParentNode): void {
     validateAttrs(root);
-    for (const el of Array.from(root.querySelectorAll(`[${LAZY_ATTR}="revealed"]`))) {
+    for (const el of matching(root, `[${LAZY_ATTR}="revealed"]`)) {
       activate(el);
     }
-    for (const el of Array.from(
-      root.querySelectorAll(`a[${MERGE_ATTR}][${TARGET_ATTR}]`),
-    )) {
+    for (const el of matching(root, `a[${MERGE_ATTR}][${TARGET_ATTR}]`)) {
       // Only sentinels (non-anchor or marked) arm an observer, plain pagination
       // links stay click-driven and are skipped here.
       if (el.hasAttribute(LAZY_ATTR)) activate(el);
     }
-    for (const el of Array.from(root.querySelectorAll(`[${POLL_ATTR}]`))) {
+    for (const el of matching(root, `[${POLL_ATTR}]`)) {
       startPoll(el);
     }
   }
@@ -438,12 +509,16 @@ export function createTriggers(deps: TriggerDeps): Triggers {
     target.addEventListener("blur", onBlur, true);
     target.addEventListener("submit", onSubmit, true);
     target.addEventListener("click", onClick, true);
+    // The visibility subscription pauses and resumes the poll timers, torn
+    // down with the event listeners, the same choreography as the SSE bridge.
+    const stopVisibility = visibility.onChange(onVisibility);
     detach = () => {
       target.removeEventListener("input", onInput);
       target.removeEventListener("change", onInput);
       target.removeEventListener("blur", onBlur, true);
       target.removeEventListener("submit", onSubmit, true);
       target.removeEventListener("click", onClick, true);
+      stopVisibility();
     };
     return detach;
   }

--- a/next/client/triggers.ts
+++ b/next/client/triggers.ts
@@ -12,7 +12,12 @@
 // cancels its own in-flight validation so a late validation answer cannot
 // overwrite a response the server already accepted.
 
-import { defaultClock, defaultConfirm, defaultObserver } from "./adapters";
+import {
+  defaultClock,
+  defaultConfirm,
+  defaultObserver,
+  defaultVisibility,
+} from "./adapters";
 import {
   ATTR_ACTION,
   ATTR_KEY,
@@ -22,6 +27,7 @@ import {
   HEADER_ZONE,
   currentUrl,
 } from "./protocol";
+import type { VisibilityAdapter } from "./sse";
 import type { Clock } from "./wire";
 
 const TRIGGER_ATTR = "data-next-trigger";
@@ -30,6 +36,7 @@ const DEBOUNCE_ATTR = "data-next-debounce";
 const MERGE_ATTR = "data-next-merge";
 const CONFIRM_ATTR = "data-next-confirm";
 const LAZY_ATTR = "data-next-lazy";
+const POLL_ATTR = "data-next-poll";
 const VALIDATE_ATTR = "data-next-validate";
 // X-Next-Validate is local to inline validation, so it stays here rather than in
 // the shared protocol vocabulary.
@@ -74,6 +81,9 @@ export interface TriggerDeps {
   document?: Document;
   clock?: Clock;
   observer?: IntersectionAdapter;
+  // The tab-visibility seam, shared with the SSE bridge: a poll tick on a
+  // hidden tab skips the fetch and reschedules.
+  visibility?: VisibilityAdapter;
   // The confirm gate. Absent, the default calls window.confirm. Injectable so
   // tests drive accept and cancel without a real dialog.
   confirm?: ConfirmAdapter;
@@ -99,6 +109,7 @@ export function createTriggers(deps: TriggerDeps): Triggers {
   const clock = deps.clock ?? defaultClock();
   const observer = deps.observer ?? defaultObserver();
   const confirm = deps.confirm ?? defaultConfirm();
+  const visibility = deps.visibility ?? defaultVisibility();
   const dev = deps.dev ?? false;
   // Per-element debounce handles, keyed by the element itself.
   const timers = new WeakMap<Element, number>();
@@ -107,6 +118,9 @@ export function createTriggers(deps: TriggerDeps): Triggers {
   const activated = new WeakSet<Element>();
   // Observer teardowns, dropped on reset so vitest files do not leak observers.
   const observed: (() => void)[] = [];
+  // Active pollers keyed by element, so a re-scan of a re-inserted zone does
+  // not arm a second timer and _reset can stop every one.
+  const polling = new Map<Element, number>();
   let detach: (() => void) | null = null;
 
   function here(): string {
@@ -320,6 +334,41 @@ export function createTriggers(deps: TriggerDeps): Triggers {
     }
   }
 
+  // Arm the self-rescheduling poll timer of one zone. A single Clock seam and
+  // chained setTimeout, no setInterval, so tests drive ticks one by one. Each
+  // tick checks isConnected for an honest teardown after a morph removed the
+  // zone, and a hidden tab skips the fetch but keeps the schedule.
+  function startPoll(el: Element): void {
+    if (polling.has(el)) return;
+    const zone = el.getAttribute(ATTR_ZONE);
+    // scan reaches startPoll only via a [data-next-poll] match, so the
+    // attribute is always present.
+    const ms = Number.parseInt(el.getAttribute(POLL_ATTR)!, 10);
+    if (zone === null || !Number.isFinite(ms) || ms <= 0) return;
+    const tick = (): void => {
+      if (!el.isConnected) {
+        stopPoll(el);
+        return;
+      }
+      if (!visibility.hidden()) {
+        deps.fetch({
+          url: here(),
+          zone,
+          headers: versionHeaders({ [HEADER_ZONE]: zone }),
+        });
+      }
+      polling.set(el, clock.setTimeout(tick, ms));
+    };
+    polling.set(el, clock.setTimeout(tick, ms));
+  }
+
+  // A tick's element is always in the map and _reset walks the map's own keys,
+  // so the handle is always present.
+  function stopPoll(el: Element): void {
+    clock.clearTimeout(polling.get(el)!);
+    polling.delete(el);
+  }
+
   // Batch the document's load zones into a single GET with a comma-joined
   // X-Next-Zone, one round trip for every load zone on the page.
   function loadBatch(root: ParentNode): void {
@@ -376,6 +425,9 @@ export function createTriggers(deps: TriggerDeps): Triggers {
       // links stay click-driven and are skipped here.
       if (el.hasAttribute(LAZY_ATTR)) activate(el);
     }
+    for (const el of Array.from(root.querySelectorAll(`[${POLL_ATTR}]`))) {
+      startPoll(el);
+    }
   }
 
   function install(target: Document): () => void {
@@ -408,6 +460,7 @@ export function createTriggers(deps: TriggerDeps): Triggers {
     _reset() {
       for (const stop of observed) stop();
       observed.length = 0;
+      for (const el of Array.from(polling.keys())) stopPoll(el);
     },
   };
 }

--- a/next/client/triggers.ts
+++ b/next/client/triggers.ts
@@ -23,8 +23,10 @@ import {
   ATTR_KEY,
   ATTR_ZONE,
   HEADER_MERGE,
-  RESUME_REVALIDATE_MS,
+  MAX_POLL_MS,
+  MIN_POLL_MS,
   currentUrl,
+  matching,
 } from "./protocol";
 import type { VisibilityAdapter } from "./sse";
 import type { Clock } from "./wire";
@@ -48,10 +50,16 @@ const HEADER_VALIDATE = "X-Next-Validate";
 const LAZY_VALUES = new Set(["load", "revealed"]);
 const MERGE_VALUES = new Set(["append", "prepend"]);
 
-// The upper bound the {% zone %} tag enforces server-side. Above 2^31-1 the
-// browser's signed-32-bit setTimeout coercion fires the timer immediately, so
-// a larger hand-written value would poll in a tight loop instead of slowly.
-const MAX_POLL_MS = 2147483647;
+// One interval group of the poller engine: every zone on the same cadence
+// rides one timer chain and one batched GET. lastFire anchors the visibility
+// resume, so only a group whose own interval elapsed while hidden runs at
+// once. A null handle is a sleeping group: the tab is hidden, no timer is
+// live.
+interface PollGroup {
+  handle: number | null;
+  lastFire: number;
+  elements: Set<Element>;
+}
 
 // The geometry seam: real IntersectionObserver behind a mock the harness drives
 // by calling the callback, since jsdom reports no intersections.
@@ -82,15 +90,12 @@ export interface TriggerDeps {
   document?: Document;
   clock?: Clock;
   observer?: IntersectionAdapter;
-  // The tab-visibility seam, shared with the SSE bridge: a hidden tab arms no
-  // poll timers at all, a tab returning after a real absence runs every tick
-  // immediately, and a brief flicker only re-arms the timers, the same
-  // anti-storm gate as the SSE resume.
+  // The tab-visibility seam, shared with the SSE bridge: a hidden tab holds no
+  // poll timers, a returning tab runs each group only once its own interval
+  // elapsed while hidden.
   visibility?: VisibilityAdapter;
-  // The URL of the page that owns an element, answered by the layer stack: a
-  // zone in the base document belongs to the host page even while a modal
-  // layer sits on top of history. Absent, lazy and poll GETs read the address
-  // bar.
+  // The URL of the page that owns an element, answered by the layer stack.
+  // Absent, lazy and poll GETs read the address bar.
   pageUrl?: (el: Element) => string;
   // The confirm gate. Absent, the default calls window.confirm. Injectable so
   // tests drive accept and cancel without a real dialog.
@@ -126,14 +131,10 @@ export function createTriggers(deps: TriggerDeps): Triggers {
   const activated = new WeakSet<Element>();
   // Observer teardowns, dropped on reset so vitest files do not leak observers.
   const observed: (() => void)[] = [];
-  // Active pollers keyed by element, so a re-scan of a re-inserted zone does
-  // not arm a second timer and _reset can stop every one. The tick rides along
-  // so the visibility resume can run or re-arm every poller. A null handle is
-  // a sleeping entry: the tab was hidden, so no timer is live.
-  const polling = new Map<Element, { handle: number | null; tick: () => void }>();
-  // The clock reading at the last hidden flip, so the visible flip measures
-  // the hidden span and skips the immediate refresh for a flicker.
-  let hiddenAt = 0;
+  // Poller groups keyed by interval, plus each element's group index so a
+  // re-scan never arms a second timer and _reset can stop every chain.
+  const groups = new Map<number, PollGroup>();
+  const membership = new Map<Element, number>();
   let detach: (() => void) | null = null;
 
   function here(): string {
@@ -141,15 +142,6 @@ export function createTriggers(deps: TriggerDeps): Triggers {
   }
 
   const pageUrl = deps.pageUrl ?? (() => here());
-
-  // querySelectorAll never matches its own root, but a replace patch scans the
-  // new wrapper element itself, so every activation pass folds a matching root
-  // into the result.
-  function matching(root: ParentNode, selector: string): Element[] {
-    const found = Array.from(root.querySelectorAll(selector));
-    if (root instanceof Element && root.matches(selector)) found.push(root);
-    return found;
-  }
 
   // The abortable zone key of a form's inline validation, shared by the sender
   // and the submit canceller so they address the same queue.
@@ -352,82 +344,106 @@ export function createTriggers(deps: TriggerDeps): Triggers {
   }
 
   // The poll interval under a strict decimal grammar: parseInt("5s") is 5 and
-  // would poll at 5ms, so only an all-digit positive value up to the server
-  // tag's own bound is an interval.
+  // would poll at 5ms, so only an all-digit value within the server tag's own
+  // bounds is an interval.
   function pollMs(el: Element): number | null {
     const raw = el.getAttribute(POLL_ATTR);
     if (raw === null || !/^\d+$/.test(raw)) return null;
     const ms = Number(raw);
-    return ms > 0 && ms <= MAX_POLL_MS ? ms : null;
+    return ms >= MIN_POLL_MS && ms <= MAX_POLL_MS ? ms : null;
   }
 
-  // Arm the self-rescheduling poll timer of one zone. A single Clock seam and
-  // chained setTimeout, no setInterval, so tests drive ticks one by one. Each
-  // tick re-reads the live element rather than trusting the arm-time capture:
-  // a morph may have removed it, reused it for unrelated content, or changed
-  // the interval, and the server keeps data-next-poll on partial responses, so
-  // a healthy zone always carries both attributes. Anything else is an honest
-  // teardown. A hidden tab arms no timer at all: the entry registers sleeping
-  // and the visible flip wakes it, so a background tab never forks a second
-  // timer chain on resume.
-  function startPoll(el: Element): void {
-    if (polling.has(el)) return;
-    if (el.getAttribute(ATTR_ZONE) === null) return;
-    const ms = pollMs(el);
-    if (ms === null) return;
-    const tick = (): void => {
-      const zone = el.getAttribute(ATTR_ZONE);
-      const interval = pollMs(el);
-      if (!el.isConnected || zone === null || interval === null) {
-        stopPoll(el);
-        return;
-      }
-      if (visibility.hidden()) {
-        // The safety net for a hidden flip whose visibilitychange event was
-        // not delivered: the entry goes to sleep instead of rescheduling, and
-        // the visible flip wakes it like any paused poller.
-        polling.set(el, { handle: null, tick });
-        return;
-      }
-      zoneGet(pageUrl(el), zone);
-      polling.set(el, { handle: clock.setTimeout(tick, interval), tick });
-    };
-    polling.set(el, {
-      handle: visibility.hidden() ? null : clock.setTimeout(tick, ms),
-      tick,
+  // Chained setTimeout, no setInterval, so tests drive ticks one by one. On a
+  // hidden tab the group registers sleeping and the visible flip wakes it.
+  function joinPoll(el: Element, interval: number): void {
+    membership.set(el, interval);
+    const group = groups.get(interval);
+    if (group !== undefined) {
+      group.elements.add(el);
+      return;
+    }
+    groups.set(interval, {
+      handle: visibility.hidden()
+        ? null
+        : clock.setTimeout(() => pollTick(interval), interval),
+      lastFire: clock.now(),
+      elements: new Set([el]),
     });
   }
 
-  // A tick's element is always in the map and _reset walks the map's own keys,
-  // so the entry is always present. A sleeping entry holds no live timer.
-  function stopPoll(el: Element): void {
-    const entry = polling.get(el)!;
-    if (entry.handle !== null) clock.clearTimeout(entry.handle);
-    polling.delete(el);
+  function startPoll(el: Element): void {
+    if (membership.has(el)) return;
+    if (el.getAttribute(ATTR_ZONE) === null) return;
+    const ms = pollMs(el);
+    if (ms === null) return;
+    joinPoll(el, ms);
   }
 
-  // On hidden, silence every pending timer but keep the entries sleeping, so a
-  // background tab stops waking entirely. On visible after a real absence, run
-  // every tick at once: each re-reads the live attributes, fetches, and re-arms
-  // itself. A flicker between tabs instead re-arms each timer with its own
-  // interval and no immediate fetch, the anti-storm gate the SSE resume applies
-  // at the same seam. A poller whose interval died while hidden still ticks so
-  // it tears itself down. A tick may stopPoll and delete its entry mid-walk,
-  // hence the copied entries.
+  // Each element is re-read live: the server keeps data-next-poll on partial
+  // responses, so a wrapper missing either attribute was morphed away and
+  // tears down, and a changed interval migrates after this fetch. A group
+  // already gone (_reset won the race) returns silently.
+  function pollTick(interval: number): void {
+    const group = groups.get(interval);
+    if (group === undefined) return;
+    if (visibility.hidden()) {
+      // Safety net for an undelivered hidden visibilitychange: sleep instead
+      // of rescheduling, the visible flip wakes the group.
+      group.handle = null;
+      return;
+    }
+    const batches = new Map<string, string[]>();
+    for (const el of Array.from(group.elements)) {
+      const zone = el.getAttribute(ATTR_ZONE);
+      const ms = pollMs(el);
+      if (!el.isConnected || zone === null || ms === null) {
+        group.elements.delete(el);
+        membership.delete(el);
+        continue;
+      }
+      const url = pageUrl(el);
+      const zones = batches.get(url);
+      if (zones === undefined) batches.set(url, [zone]);
+      else zones.push(zone);
+      if (ms !== interval) {
+        group.elements.delete(el);
+        membership.delete(el);
+        joinPoll(el, ms);
+      }
+    }
+    for (const [url, zones] of batches) zoneGet(url, zones.join(","));
+    group.lastFire = clock.now();
+    if (group.elements.size === 0) {
+      groups.delete(interval);
+      return;
+    }
+    group.handle = clock.setTimeout(() => pollTick(interval), interval);
+  }
+
+  // On hidden, silence every live timer but keep the groups sleeping. On
+  // visible, each group measures elapsed against its own lastFire: due ticks
+  // run at once, the rest resume with the remaining time. Live handles are
+  // cleared first so a repeated visible event cannot stack a second chain.
+  // Entries are copied since a tick may delete its group mid-walk.
   function onVisibility(): void {
     if (visibility.hidden()) {
-      hiddenAt = clock.now();
-      for (const entry of polling.values()) {
-        if (entry.handle !== null) clock.clearTimeout(entry.handle);
-        entry.handle = null;
+      for (const group of groups.values()) {
+        if (group.handle !== null) clock.clearTimeout(group.handle);
+        group.handle = null;
       }
       return;
     }
-    const stale = clock.now() - hiddenAt >= RESUME_REVALIDATE_MS;
-    for (const [el, entry] of Array.from(polling.entries())) {
-      const interval = pollMs(el);
-      if (stale || interval === null) entry.tick();
-      else entry.handle = clock.setTimeout(entry.tick, interval);
+    for (const [interval, group] of Array.from(groups.entries())) {
+      if (group.handle !== null) {
+        clock.clearTimeout(group.handle);
+        group.handle = null;
+      }
+      const elapsed = clock.now() - group.lastFire;
+      if (elapsed >= interval) {
+        pollTick(interval);
+      } else {
+        group.handle = clock.setTimeout(() => pollTick(interval), interval - elapsed);
+      }
     }
   }
 
@@ -447,15 +463,14 @@ export function createTriggers(deps: TriggerDeps): Triggers {
       if (zones === undefined) batches.set(url, [zone]);
       else zones.push(zone);
     }
-    // The queue key is the zone batch so a re-fired batch supersedes the old
-    // one cleanly.
+    // The wire queues per path and zone batch, so a re-fired batch supersedes
+    // its own page's predecessor and never another page's.
     for (const [url, zones] of batches) zoneGet(url, zones.join(","));
   }
 
-  // Warn on a hand-written attribute value outside its closed set, and on a
-  // poll interval failing the strict grammar, both of which the runtime drops
-  // without acting on. Dev-only, by the same shape as the script-neutralisation
-  // warning: prefix, attribute, value, and allowed set.
+  // Warn on hand-written values the runtime drops in silence: an attribute
+  // outside its closed set, a poll interval failing the grammar or bounds, a
+  // poll element naming no zone. Dev-only.
   function validateAttrs(root: ParentNode): void {
     if (!dev) return;
     for (const el of matching(root, `[${LAZY_ATTR}]`)) {
@@ -467,7 +482,9 @@ export function createTriggers(deps: TriggerDeps): Triggers {
       if (!MERGE_VALUES.has(value)) warnAttr(MERGE_ATTR, value, MERGE_VALUES);
     }
     for (const el of matching(root, `[${POLL_ATTR}]`)) {
-      if (pollMs(el) === null) warnPoll(el.getAttribute(POLL_ATTR)!);
+      const value = el.getAttribute(POLL_ATTR)!;
+      if (pollMs(el) === null) warnPoll(value);
+      else if (el.getAttribute(ATTR_ZONE) === null) warnPollZone(value);
     }
   }
 
@@ -478,11 +495,16 @@ export function createTriggers(deps: TriggerDeps): Triggers {
     );
   }
 
-  // The numeric sibling of warnAttr: the poll interval has no closed set to
-  // list, so the message points at the tag that writes a valid one.
+  // The interval has no closed set to list, so the message spells the bounds.
   function warnPoll(value: string): void {
     console.warn(
-      `[next.partial] ${POLL_ATTR}="${value}" is not a whole number of milliseconds between 1 and ${MAX_POLL_MS} and is ignored. The {% zone %} tag writes the resolved interval.`,
+      `[next.partial] ${POLL_ATTR}="${value}" is not a whole number of milliseconds between ${MIN_POLL_MS} and ${MAX_POLL_MS} and is ignored. The {% zone %} tag writes the resolved interval.`,
+    );
+  }
+
+  function warnPollZone(value: string): void {
+    console.warn(
+      `[next.partial] ${POLL_ATTR}="${value}" sits on an element without ${ATTR_ZONE} and is ignored. Polling re-GETs the zone by name, so the container must carry both attributes.`,
     );
   }
 
@@ -535,7 +557,11 @@ export function createTriggers(deps: TriggerDeps): Triggers {
     _reset() {
       for (const stop of observed) stop();
       observed.length = 0;
-      for (const el of Array.from(polling.keys())) stopPoll(el);
+      for (const group of groups.values()) {
+        if (group.handle !== null) clock.clearTimeout(group.handle);
+      }
+      groups.clear();
+      membership.clear();
     },
   };
 }

--- a/next/client/wire.test.ts
+++ b/next/client/wire.test.ts
@@ -26,6 +26,7 @@ function makeWire(
   const dispatched: { event: string; detail: Record<string, unknown> }[] = [];
   const navigated: string[] = [];
   const envelopes: unknown[] = [];
+  const pages: (string | undefined)[] = [];
   const calls: { url: string; init: RequestInit }[] = [];
   const wire = new Wire({
     fetch: (url, init) => {
@@ -34,11 +35,14 @@ function makeWire(
     },
     navigate: (url) => navigated.push(url),
     dispatch: (event, detail) => dispatched.push({ event, detail }),
-    onEnvelope: (raw) => envelopes.push(raw),
+    onEnvelope: (raw, _response, _snapshot, _key, page) => {
+      envelopes.push(raw);
+      pages.push(page);
+    },
     version: () => opts.version ?? "v1",
     csrf: () => opts.csrf,
   });
-  return { wire, dispatched, navigated, envelopes, calls };
+  return { wire, dispatched, navigated, envelopes, pages, calls };
 }
 
 const ENVELOPE = '{"version":"v1","ops":[],"assets":[],"form":null}';
@@ -238,7 +242,7 @@ describe("Wire mutation lock", () => {
 });
 
 describe("Wire safe-GET queue", () => {
-  it("aborts the in-flight GET of the same zone (latest-wins)", async () => {
+  it("aborts the in-flight GET of the same page and zone (latest-wins)", async () => {
     const signals: AbortSignal[] = [];
     let resolveFirst!: (r: Response) => void;
     let n = 0;
@@ -248,12 +252,49 @@ describe("Wire safe-GET queue", () => {
       if (n === 1) return new Promise<Response>((r) => (resolveFirst = r));
       return Promise.resolve(envelopeResponse(ENVELOPE));
     });
-    const first = h.wire.fetch({ url: "/p1/", zone: "list" });
-    const second = h.wire.fetch({ url: "/p2/", zone: "list" });
+    const first = h.wire.fetch({ url: "/p/", zone: "list" });
+    const second = h.wire.fetch({ url: "/p/", zone: "list" });
     expect(signals[0]!.aborted).toBe(true);
     resolveFirst(envelopeResponse(ENVELOPE));
     await Promise.all([first, second]);
     // Only the latest response is applied, the stale one is dropped.
+    expect(h.envelopes).toHaveLength(1);
+  });
+
+  it("runs same-zone GETs for different pages independently", async () => {
+    const signals: AbortSignal[] = [];
+    let resolveFirst!: (r: Response) => void;
+    let n = 0;
+    const h = makeWire((_url, init) => {
+      signals.push(init.signal!);
+      n += 1;
+      if (n === 1) return new Promise<Response>((r) => (resolveFirst = r));
+      return Promise.resolve(envelopeResponse(ENVELOPE));
+    });
+    // Two pages sharing a zone name must not abort each other.
+    const first = h.wire.fetch({ url: "/host/", zone: "list" });
+    const second = h.wire.fetch({ url: "/modal/", zone: "list" });
+    expect(signals[0]!.aborted).toBe(false);
+    resolveFirst(envelopeResponse(ENVELOPE));
+    await Promise.all([first, second]);
+    expect(h.envelopes).toHaveLength(2);
+  });
+
+  it("a re-filtered GET of the same page supersedes across query strings", async () => {
+    const signals: AbortSignal[] = [];
+    let resolveFirst!: (r: Response) => void;
+    let n = 0;
+    const h = makeWire((_url, init) => {
+      signals.push(init.signal!);
+      n += 1;
+      if (n === 1) return new Promise<Response>((r) => (resolveFirst = r));
+      return Promise.resolve(envelopeResponse(ENVELOPE));
+    });
+    const first = h.wire.fetch({ url: "/p/?window=1h", zone: "totals" });
+    const second = h.wire.fetch({ url: "/p/?window=6h", zone: "totals" });
+    expect(signals[0]!.aborted).toBe(true);
+    resolveFirst(envelopeResponse(ENVELOPE));
+    await Promise.all([first, second]);
     expect(h.envelopes).toHaveLength(1);
   });
 
@@ -263,6 +304,24 @@ describe("Wire safe-GET queue", () => {
       h.wire.fetch({ url: "/a/", zone: "a" }),
       h.wire.fetch({ url: "/b/", zone: "b" }),
     ]);
+    expect(h.envelopes).toHaveLength(2);
+  });
+
+  it("a mutating POST with a zone intent never joins the GET queue", async () => {
+    const signals: (AbortSignal | undefined)[] = [];
+    let resolveFirst!: (r: Response) => void;
+    let n = 0;
+    const h = makeWire((_url, init) => {
+      signals.push(init.signal ?? undefined);
+      n += 1;
+      if (n === 1) return new Promise<Response>((r) => (resolveFirst = r));
+      return Promise.resolve(envelopeResponse(ENVELOPE));
+    });
+    const inflight = h.wire.fetch({ url: "/p/", zone: "z" });
+    await h.wire.fetch({ url: "/p/", method: "POST", uid: "u1", zone: "z" });
+    expect(signals[0]!.aborted).toBe(false);
+    resolveFirst(envelopeResponse(ENVELOPE));
+    await inflight;
     expect(h.envelopes).toHaveLength(2);
   });
 
@@ -281,10 +340,55 @@ describe("Wire safe-GET queue", () => {
       }
       return Promise.resolve(envelopeResponse(ENVELOPE));
     });
-    const first = h.wire.fetch({ url: "/p1/", zone: "list" });
-    const second = h.wire.fetch({ url: "/p2/", zone: "list" });
+    const first = h.wire.fetch({ url: "/p/", zone: "list" });
+    const second = h.wire.fetch({ url: "/p/", zone: "list" });
     await Promise.all([first, second]);
     expect(h.dispatched.some((d) => d.event === "partial:error")).toBe(false);
+  });
+});
+
+describe("Wire page threading", () => {
+  it("threads the fetched url as the page of a safe zone GET", async () => {
+    const h = makeWire(async () => envelopeResponse(ENVELOPE));
+    await h.wire.fetch({ url: "/host/?q=1", zone: "list" });
+    expect(h.pages).toEqual(["/host/?q=1"]);
+  });
+
+  it("a mutation applies with no page, keeping the top-down resolve", async () => {
+    const h = makeWire(async () => envelopeResponse(ENVELOPE));
+    await h.wire.fetch({
+      url: "/_next/form/u1/",
+      method: "POST",
+      uid: "u1",
+      zone: "z",
+    });
+    expect(h.pages).toEqual([undefined]);
+  });
+
+  it("an abortable validate POST applies with no page", async () => {
+    const h = makeWire(async () => envelopeResponse(ENVELOPE));
+    await h.wire.fetch({
+      url: "/f/",
+      method: "POST",
+      zone: "validate:u",
+      abortable: true,
+    });
+    expect(h.pages).toEqual([undefined]);
+  });
+
+  it("a zone-less GET applies with no page", async () => {
+    const h = makeWire(async () => envelopeResponse(ENVELOPE));
+    await h.wire.fetch({ url: "/list/" });
+    expect(h.pages).toEqual([undefined]);
+  });
+
+  it("the parse-hook path threads the page alongside the foreign envelope", async () => {
+    const h = makeWire(async () =>
+      envelopeResponse("raw", { type: "text/vnd.next.stream+html" }),
+    );
+    h.wire.parseHook("text/vnd.next.stream+html", () => ({ version: "v1", ops: [] }));
+    await h.wire.fetch({ url: "/list/", zone: "z" });
+    expect(h.pages).toEqual(["/list/"]);
   });
 });
 

--- a/next/client/wire.ts
+++ b/next/client/wire.ts
@@ -36,7 +36,8 @@ export interface WireRequest {
   url: string;
   method?: string;
   // The lock key for mutations is the form uid, the queue key for safe GETs is
-  // the target zone. Absent, the request runs unqueued and unlocked.
+  // the url and target zone pair. Absent both, the request runs unqueued and
+  // unlocked.
   uid?: string;
   zone?: string;
   headers?: Record<string, string>;
@@ -50,12 +51,14 @@ export interface WireRequest {
 }
 
 // The snapshot is the dirty counter captured at fetch time, threaded to apply so
-// a field touched after this request is protected from its own response.
+// a field touched after this request is protected from its own response. The
+// page is the URL a safe zone GET fetched, absent on mutations.
 export type EnvelopeHandler = (
   raw: unknown,
   response: Response,
   snapshot: number,
   key: string | undefined,
+  page: string | undefined,
 ) => void;
 
 // A parse-hook turns a non-default content-type body into a JSON-ish envelope.
@@ -164,15 +167,26 @@ export class Wire {
       if (this.#busy.has(request.uid!)) return;
       this.#busy.add(request.uid!);
     }
-    const queueKey = safe || request.abortable === true ? request.zone : undefined;
+    const queueKey = this.#queueKey(request, safe);
     const entry = queueKey !== undefined ? this.#enqueue(queueKey) : undefined;
     try {
-      await this.#run(request, method, entry);
+      await this.#run(request, method, queueKey, entry);
     } finally {
       if (locked) {
         this.#busy.delete(request.uid!);
       }
     }
+  }
+
+  // A safe GET queues per path+zone: two pages may legally GET the same zone
+  // name at once, while a re-filtered GET of the same page differs only in
+  // query and must supersede its predecessor. The space separator cannot
+  // appear in either part. An abortable POST keeps the bare zone key that
+  // abort() addresses.
+  #queueKey(request: WireRequest, safe: boolean): string | undefined {
+    if (request.zone === undefined) return undefined;
+    if (safe) return `${request.url.split("?")[0]} ${request.zone}`;
+    return request.abortable === true ? request.zone : undefined;
   }
 
   // A new safe GET to a target aborts the in-flight one (latest-wins). The
@@ -193,6 +207,7 @@ export class Wire {
   async #run(
     request: WireRequest,
     method: string,
+    queueKey: string | undefined,
     entry: QueueEntry | undefined,
   ): Promise<void> {
     const headers = this.#headers(request, method);
@@ -217,7 +232,7 @@ export class Wire {
       return;
     }
     // A stale safe-GET response that lost its race is dropped silently.
-    if (entry !== undefined && this.#queues.get(request.zone!)?.seq !== entry.seq) {
+    if (entry !== undefined && this.#queues.get(queueKey!)?.seq !== entry.seq) {
       return;
     }
     await this.#classify(request, method, response, snapshot);
@@ -244,12 +259,15 @@ export class Wire {
       });
       return;
     }
+    // Only a safe zone GET names a page: mutations keep the unscoped resolve.
+    const page =
+      SAFE_METHODS.has(method) && request.zone !== undefined ? request.url : undefined;
     const contentType = response.headers.get("content-type") ?? "";
     const baseType = contentType.replace(/;.*$/, "").trim();
     const hook = this.#parseHooks.get(baseType);
     if (hook !== undefined) {
       const body = await this.#text(response);
-      this.#onEnvelope(hook(response, body), response, snapshot, request.key);
+      this.#onEnvelope(hook(response, body), response, snapshot, request.key, page);
       return;
     }
     // Any non-envelope content-type, or a redirected response, is a full
@@ -279,7 +297,7 @@ export class Wire {
       this.#dispatch("partial:error", { kind: "parse", body, error });
       return;
     }
-    this.#onEnvelope(raw, response, snapshot, request.key);
+    this.#onEnvelope(raw, response, snapshot, request.key, page);
   }
 
   #text(response: Response): Promise<string> {

--- a/next/pages/manager.py
+++ b/next/pages/manager.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast, overload
 
 from django.http import HttpRequest, HttpResponse
 from django.http.response import HttpResponseBase
-from django.template import Context as DjangoTemplateContext, Template
+from django.template import Context as DjangoTemplateContext, Origin, Template
 from django.urls import URLPattern, path
 
 from next.conf import next_framework_settings
@@ -410,7 +410,12 @@ class Page:
             self._record_template_source_mtimes(file_path)
         compiled = self._compiled_registry.get(file_path)
         if compiled is None:
-            compiled = Template(self._template_registry[file_path])
+            # The origin makes compile errors name the page path.
+            compiled = Template(
+                self._template_registry[file_path],
+                origin=Origin(str(file_path)),
+                name=str(file_path),
+            )
             self._compiled_registry[file_path] = compiled
         return compiled
 

--- a/next/partial/checks.py
+++ b/next/partial/checks.py
@@ -51,6 +51,7 @@ E_ZONE_IN_IF: Final = "next.E063"
 E_LAZY_WITHOUT_PLACEHOLDER: Final = "next.E064"
 E_ZONE_IN_COMPONENT: Final = "next.E065"
 E_UNREGISTERED_OP: Final = "next.E066"
+E_COMPOSED_TEMPLATE_SYNTAX: Final = "next.E072"
 
 W_WITH_OVER_ZONE: Final = "next.W067"
 W_FORM_BACKEND_NOT_AWARE: Final = "next.W068"
@@ -71,6 +72,7 @@ CHECK_IDS: Final = (
     E_LAZY_WITHOUT_PLACEHOLDER,
     E_ZONE_IN_COMPONENT,
     E_UNREGISTERED_OP,
+    E_COMPOSED_TEMPLATE_SYNTAX,
     W_WITH_OVER_ZONE,
     W_FORM_BACKEND_NOT_AWARE,
     W_MANIFEST_VERSION_NO_STORAGE,
@@ -87,7 +89,8 @@ def _iter_composed_pages() -> "Iterator[tuple[Path, Template]]":
 
     Pages whose body is produced dynamically by `render()` have no
     static composed template and are skipped. A page that fails to
-    compile is left to the page checks that own that failure.
+    compile is skipped here and reported by
+    `check_composed_templates_compile`.
     """
     router_manager, _errors = get_router_manager()
     if router_manager is None:
@@ -137,6 +140,46 @@ def _significant(nodelist: NodeList) -> list[Node]:
             continue
         out.append(node)
     return out
+
+
+@register(Tags.templates)
+def check_composed_templates_compile(
+    *_args: object,
+    **_kwargs: object,
+) -> list[CheckMessage]:
+    """Error when a composed page template fails to compile (`next.E072`).
+
+    The zone checks skip a page whose composed template does not
+    compile, so without this check the syntax error would surface only
+    as a 500 on the first request to the page.
+    """
+    messages: list[CheckMessage] = []
+    router_manager, _errors = get_router_manager()
+    if router_manager is None:
+        return messages
+    seen: set[Path] = set()
+    for router in router_manager._backends:
+        for _url_path, page_path in iter_scanned_page_pairs(router):
+            resolved = page_path.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            if not page.has_template(page_path):
+                continue
+            try:
+                page.composed_template_for(page_path)
+            except TemplateSyntaxError as error:
+                messages.append(
+                    Error(
+                        f"The composed page template for {page_path} does not "
+                        f"compile. {error}",
+                        obj=str(page_path),
+                        id=E_COMPOSED_TEMPLATE_SYNTAX,
+                    )
+                )
+            except (TemplateDoesNotExist, OSError, ValueError):
+                continue
+    return messages
 
 
 @register(Tags.templates)
@@ -611,6 +654,7 @@ def _staticfiles_storage_path() -> str | None:
 
 __all__ = [
     "CHECK_IDS",
+    "E_COMPOSED_TEMPLATE_SYNTAX",
     "E_DUPLICATE_ZONE",
     "E_LAZY_WITHOUT_PLACEHOLDER",
     "E_NON_ASCII_ZONE",
@@ -623,6 +667,7 @@ __all__ = [
     "W_MANIFEST_VERSION_NO_STORAGE",
     "W_TOO_MANY_BACKENDS",
     "W_WITH_OVER_ZONE",
+    "check_composed_templates_compile",
     "check_custom_patch_ops_well_formed",
     "check_duplicate_zone_names",
     "check_form_backend_partial_aware",

--- a/next/partial/checks.py
+++ b/next/partial/checks.py
@@ -322,7 +322,7 @@ def check_lazy_zone_has_placeholder(
     messages: list[CheckMessage] = []
     for page_path, template in _iter_composed_pages():
         for node in _zone_nodes(template):
-            if node.lazy is None or _significant(node.placeholder):
+            if node.options.lazy is None or _significant(node.placeholder):
                 continue
             messages.append(
                 Error(

--- a/next/partial/registry.py
+++ b/next/partial/registry.py
@@ -80,17 +80,28 @@ def register_patch_op(name: str) -> None:
 class ZoneInfo:
     """One compiled zone of a composed page template.
 
-    `lazy`, `poll`, and `tag` mirror the structured `options` for the
-    read model, while the standalone render path consumes `options`
-    whole so no mode is lost between the two render paths.
+    The render paths consume `options` whole, and the scalar read
+    surface delegates to it so no mode can drift between the two.
     """
 
     name: str
-    lazy: str | None
-    poll: int | None
-    tag: str
     partial: "ZonePartial"
     options: "ZoneOptions"
+
+    @property
+    def lazy(self) -> str | None:
+        """Lazy trigger of the zone, read from its options."""
+        return self.options.lazy
+
+    @property
+    def poll(self) -> int | None:
+        """Poll interval of the zone in milliseconds, read from its options."""
+        return self.options.poll
+
+    @property
+    def tag(self) -> str:
+        """Wrapper tag name of the zone, read from its options."""
+        return self.options.tag
 
 
 _zone_cache: "WeakKeyDictionary[Template, Mapping[str, ZoneInfo]]" = WeakKeyDictionary()
@@ -103,9 +114,6 @@ def _zones_from_template(template: "Template") -> dict[str, ZoneInfo]:
     for node in nodes:
         zones[node.name] = ZoneInfo(
             name=node.name,
-            lazy=node.options.lazy,
-            poll=node.options.poll,
-            tag=node.options.tag,
             partial=node.partial,
             options=node.options,
         )
@@ -131,8 +139,8 @@ def zones_of(template: "Template") -> "Mapping[str, ZoneInfo]":
                 sender=type(template),
                 template=template,
                 zone_name=info.name,
-                lazy=info.lazy,
-                poll=info.poll,
+                lazy=info.options.lazy,
+                poll=info.options.poll,
             )
     return zones
 

--- a/next/partial/registry.py
+++ b/next/partial/registry.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from django.http import HttpRequest
     from django.template.base import Template
 
-    from .zone import ZonePartial
+    from .zone import ZoneOptions, ZonePartial
 
 
 BUILTIN_OPS: frozenset[str] = frozenset(
@@ -78,13 +78,19 @@ def register_patch_op(name: str) -> None:
 
 @dataclass(frozen=True, slots=True)
 class ZoneInfo:
-    """One compiled zone of a composed page template."""
+    """One compiled zone of a composed page template.
+
+    `lazy`, `poll`, and `tag` mirror the structured `options` for the
+    read model, while the standalone render path consumes `options`
+    whole so no mode is lost between the two render paths.
+    """
 
     name: str
     lazy: str | None
     poll: int | None
     tag: str
     partial: "ZonePartial"
+    options: "ZoneOptions"
 
 
 _zone_cache: "WeakKeyDictionary[Template, Mapping[str, ZoneInfo]]" = WeakKeyDictionary()
@@ -97,10 +103,11 @@ def _zones_from_template(template: "Template") -> dict[str, ZoneInfo]:
     for node in nodes:
         zones[node.name] = ZoneInfo(
             name=node.name,
-            lazy=node.lazy,
-            poll=node.poll,
-            tag=node.tag,
+            lazy=node.options.lazy,
+            poll=node.options.poll,
+            tag=node.options.tag,
             partial=node.partial,
+            options=node.options,
         )
     return zones
 

--- a/next/partial/registry.py
+++ b/next/partial/registry.py
@@ -82,6 +82,7 @@ class ZoneInfo:
 
     name: str
     lazy: str | None
+    poll: int | None
     tag: str
     partial: "ZonePartial"
 
@@ -97,6 +98,7 @@ def _zones_from_template(template: "Template") -> dict[str, ZoneInfo]:
         zones[node.name] = ZoneInfo(
             name=node.name,
             lazy=node.lazy,
+            poll=node.poll,
             tag=node.tag,
             partial=node.partial,
         )
@@ -123,6 +125,7 @@ def zones_of(template: "Template") -> "Mapping[str, ZoneInfo]":
                 template=template,
                 zone_name=info.name,
                 lazy=info.lazy,
+                poll=info.poll,
             )
     return zones
 

--- a/next/partial/render.py
+++ b/next/partial/render.py
@@ -114,9 +114,10 @@ def render_zone(
     html: dict[str, str] = {}
     for name in zone_names:
         info = zones[name]
-        html[name] = str(
-            render_zone_standalone(info.partial, info.name, info.tag, django_context)
+        rendered = render_zone_standalone(
+            info.partial, info.name, info.options, django_context
         )
+        html[name] = str(rendered)
 
     _emit_rendered(page_path, zone_names, request, start)
     return ZoneRenderResult(html=html, collector=collector)

--- a/next/partial/signals.py
+++ b/next/partial/signals.py
@@ -6,8 +6,8 @@ quiet deployment pays nothing.
 
 The `zone_registered` signal fires once per compiled composed template
 when its named zones are first read. The sender is the compiled
-template class. The keyword arguments are `template`, `zone_name`, and
-`lazy`.
+template class. The keyword arguments are `template`, `zone_name`,
+`lazy`, and `poll`.
 
 The `zone_rendered` signal fires after a zone body renders for a
 partial request. The sender is the `ZoneRenderResult` class. The keyword

--- a/next/partial/zone.py
+++ b/next/partial/zone.py
@@ -1,5 +1,7 @@
 """Zone template tag, its node, and the standalone zone-body renderable."""
 
+import re
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast, override
 
 from django.template import Library, TemplateSyntaxError
@@ -28,7 +30,9 @@ _TAG_KWARG = "tag"
 _LAZY_KWARG = "lazy"
 _POLL_KWARG = "poll"
 _MIN_POLL_MS = 1000
+_MAX_POLL_MS = 2_147_483_647
 _MS_PER_SECOND = 1000
+_POLL_DIGITS = re.compile(r"[0-9]+")
 
 
 def _strip_quotes(raw: str) -> str:
@@ -36,24 +40,51 @@ def _strip_quotes(raw: str) -> str:
     return raw.strip("'\"").strip()
 
 
-def _wrap_zone(tag: str, name: str, body: str) -> SafeString:
-    """Return the addressable wrapper element around a rendered zone body."""
-    return SafeString(f'<{tag} {ZONE_ATTR}="{name}">{body}</{tag}>')
+def _wrap_zone(tag: str, name: str, body: str, *, extra: str = "") -> SafeString:
+    """Return the addressable wrapper element around a rendered zone body.
+
+    A non-empty `extra` carries its own leading space, so the plain
+    wrapper stays byte-for-byte free of trailing whitespace.
+    """
+    return SafeString(f'<{tag} {ZONE_ATTR}="{name}"{extra}>{body}</{tag}>')
+
+
+@dataclass(frozen=True, slots=True)
+class ZoneOptions:
+    """Compile-time rendering options of one zone.
+
+    The wrapper attribute strings are assembled here once at parse time,
+    so the two render paths read the same precomputed values and a new
+    mode cannot diverge the full render from the standalone delivery.
+    """
+
+    tag: str = _DEFAULT_TAG
+    lazy: str | None = None
+    poll: int | None = None
+    full_attrs: str = field(init=False)
+    delivery_attrs: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Precompute the wrapper attribute strings from the mode options."""
+        delivery = "" if self.poll is None else f' {POLL_ATTR}="{self.poll}"'
+        full = delivery if self.lazy is None else f' {LAZY_ATTR}="{self.lazy}"'
+        object.__setattr__(self, "full_attrs", full)
+        object.__setattr__(self, "delivery_attrs", delivery)
 
 
 def render_zone_standalone(
     partial: "ZonePartial",
     name: str,
-    tag: str,
+    options: ZoneOptions,
     context: "Context",
 ) -> SafeString:
     """Render one zone body wrapped in its addressable element.
 
-    The wrapper drops the lazy hint because a partial request asks for
-    the body by name and the body has already arrived. Both the inline
-    full render and the partial path share this single wrapper string.
+    The wrapper carries the delivery attributes of the zone options,
+    which drop the lazy hint because the body has already arrived.
     """
-    return _wrap_zone(tag, name, partial.render(context))
+    body = partial.render(context)
+    return _wrap_zone(options.tag, name, body, extra=options.delivery_attrs)
 
 
 class ZonePartial:
@@ -116,39 +147,32 @@ class ZoneNode(Node):
         name: str,
         partial: ZonePartial,
         *,
-        tag: str = _DEFAULT_TAG,
-        lazy: str | None = None,
-        poll: int | None = None,
+        options: ZoneOptions,
         placeholder: NodeList | None = None,
     ) -> None:
         """Store the zone name, its body partial, and its rendering options."""
         self.name = name
         self.partial = partial
         self.nodelist = partial.nodelist
-        self.tag = tag
-        self.lazy = lazy
-        self.poll = poll
+        self.options = options
         self.placeholder = placeholder if placeholder is not None else NodeList()
 
     @override
     def render(self, context: "Context") -> SafeString:
         """Render the zone inline on a full page render."""
-        if self.lazy is not None:
-            open_tag = (
-                f'<{self.tag} {ZONE_ATTR}="{self.name}" {LAZY_ATTR}="{self.lazy}">'
+        options = self.options
+        if options.lazy is not None:
+            return _wrap_zone(
+                options.tag,
+                self.name,
+                self.placeholder.render(context),
+                extra=options.full_attrs,
             )
-            return SafeString(
-                f"{open_tag}{self.placeholder.render(context)}</{self.tag}>"
-            )
-        body = self.partial.render(context)
-        if self.poll is None:
-            return _wrap_zone(self.tag, self.name, body)
-        open_tag = f'<{self.tag} {ZONE_ATTR}="{self.name}" {POLL_ATTR}="{self.poll}">'
-        return SafeString(f"{open_tag}{body}</{self.tag}>")
+        return render_zone_standalone(self.partial, self.name, options, context)
 
 
-def _parse_options(token: "Token") -> tuple[str, str, str | None, int | None]:
-    """Return the zone name, wrapper tag, lazy trigger, and poll interval."""
+def _parse_options(token: "Token") -> tuple[str, ZoneOptions]:
+    """Return the zone name and its parsed rendering options."""
     bits = token.split_contents()
     if len(bits) < _ZONE_NAME_INDEX + 1:
         msg = '{% zone %} tag requires a quoted zone name, e.g. {% zone "name" %}.'
@@ -174,7 +198,7 @@ def _parse_options(token: "Token") -> tuple[str, str, str | None, int | None]:
     if lazy is not None and poll is not None:
         msg = "{% zone %} cannot combine poll= with lazy=, the modes are exclusive."
         raise TemplateSyntaxError(msg)
-    return name, tag, lazy, poll
+    return name, ZoneOptions(tag=tag, lazy=lazy, poll=poll)
 
 
 def _validate_lazy(value: str) -> str:
@@ -187,24 +211,28 @@ def _validate_lazy(value: str) -> str:
 
 
 def _validate_poll(value: str) -> int:
-    """Return the poll interval in ms parsed from a 5s or 500ms literal.
+    """Return the poll interval in ms parsed from a 5s or 1500ms literal.
 
-    A bare number is read as milliseconds. An interval below the floor or a
-    malformed literal fails at compile time, the same honest-fail as lazy.
+    A bare number is read as milliseconds and the digits must be plain
+    ASCII. An interval outside the floor-to-ceiling range or a malformed
+    literal fails at compile time, the same honest-fail as lazy.
     """
     text = value.strip()
-    try:
-        if text.endswith("ms"):
-            ms = int(text[:-2])
-        elif text.endswith("s"):
-            ms = int(text[:-1]) * _MS_PER_SECOND
-        else:
-            ms = int(text)
-    except ValueError:
-        msg = f"{{% zone %}} poll must be a duration like 5s or 500ms, got {value!r}."
-        raise TemplateSyntaxError(msg) from None
+    if text.endswith("ms"):
+        digits, scale = text[:-2], 1
+    elif text.endswith("s"):
+        digits, scale = text[:-1], _MS_PER_SECOND
+    else:
+        digits, scale = text, 1
+    if _POLL_DIGITS.fullmatch(digits) is None:
+        msg = f"{{% zone %}} poll must be a duration like 5s or 1500ms, got {value!r}."
+        raise TemplateSyntaxError(msg)
+    ms = int(digits) * scale
     if ms < _MIN_POLL_MS:
         msg = f"{{% zone %}} poll must be at least {_MIN_POLL_MS}ms, got {ms}ms."
+        raise TemplateSyntaxError(msg)
+    if ms > _MAX_POLL_MS:
+        msg = f"{{% zone %}} poll must be at most {_MAX_POLL_MS}ms, got {ms}ms."
         raise TemplateSyntaxError(msg)
     return ms
 
@@ -218,12 +246,18 @@ def do_zone(parser: "Parser", token: "Token") -> ZoneNode:
     arrives. This hook registers nothing with the zone registry, the
     registry is derived from the compiled page template on demand.
     """
-    name, tag, lazy, poll = _parse_options(token)
+    name, options = _parse_options(token)
     body = parser.parse(_PLACEHOLDER_THEN_END)
     placeholder: NodeList | None = None
     if parser.next_token().contents.split()[0] == "placeholder":
         placeholder = parser.parse(_END_ZONE)
         parser.delete_first_token()
+    if placeholder is not None and options.lazy is None:
+        msg = (
+            "{% zone %} placeholder requires lazy=, a zone that shows "
+            "its body never renders the placeholder branch."
+        )
+        raise TemplateSyntaxError(msg)
     partial = ZonePartial(
         nodelist=body,
         name=name,
@@ -233,9 +267,7 @@ def do_zone(parser: "Parser", token: "Token") -> ZoneNode:
     return ZoneNode(
         name=name,
         partial=partial,
-        tag=tag,
-        lazy=lazy,
-        poll=poll,
+        options=options,
         placeholder=placeholder,
     )
 
@@ -245,6 +277,7 @@ __all__ = [
     "POLL_ATTR",
     "ZONE_ATTR",
     "ZoneNode",
+    "ZoneOptions",
     "ZonePartial",
     "do_zone",
     "register",

--- a/next/partial/zone.py
+++ b/next/partial/zone.py
@@ -17,6 +17,7 @@ register = Library()
 
 ZONE_ATTR = "data-next-zone"
 LAZY_ATTR = "data-next-lazy"
+POLL_ATTR = "data-next-poll"
 
 _DEFAULT_TAG = "div"
 _ZONE_NAME_INDEX = 1
@@ -25,6 +26,9 @@ _PLACEHOLDER_THEN_END = ("placeholder", "endzone")
 _LAZY_TRIGGERS = frozenset({"load", "revealed"})
 _TAG_KWARG = "tag"
 _LAZY_KWARG = "lazy"
+_POLL_KWARG = "poll"
+_MIN_POLL_MS = 1000
+_MS_PER_SECOND = 1000
 
 
 def _strip_quotes(raw: str) -> str:
@@ -114,6 +118,7 @@ class ZoneNode(Node):
         *,
         tag: str = _DEFAULT_TAG,
         lazy: str | None = None,
+        poll: int | None = None,
         placeholder: NodeList | None = None,
     ) -> None:
         """Store the zone name, its body partial, and its rendering options."""
@@ -122,19 +127,28 @@ class ZoneNode(Node):
         self.nodelist = partial.nodelist
         self.tag = tag
         self.lazy = lazy
+        self.poll = poll
         self.placeholder = placeholder if placeholder is not None else NodeList()
 
     @override
     def render(self, context: "Context") -> SafeString:
         """Render the zone inline on a full page render."""
-        if self.lazy is None:
-            return render_zone_standalone(self.partial, self.name, self.tag, context)
-        open_tag = f'<{self.tag} {ZONE_ATTR}="{self.name}" {LAZY_ATTR}="{self.lazy}">'
-        return SafeString(f"{open_tag}{self.placeholder.render(context)}</{self.tag}>")
+        if self.lazy is not None:
+            open_tag = (
+                f'<{self.tag} {ZONE_ATTR}="{self.name}" {LAZY_ATTR}="{self.lazy}">'
+            )
+            return SafeString(
+                f"{open_tag}{self.placeholder.render(context)}</{self.tag}>"
+            )
+        body = self.partial.render(context)
+        if self.poll is None:
+            return _wrap_zone(self.tag, self.name, body)
+        open_tag = f'<{self.tag} {ZONE_ATTR}="{self.name}" {POLL_ATTR}="{self.poll}">'
+        return SafeString(f"{open_tag}{body}</{self.tag}>")
 
 
-def _parse_options(token: "Token") -> tuple[str, str, str | None]:
-    """Return the zone name, wrapper tag, and lazy trigger from a zone token."""
+def _parse_options(token: "Token") -> tuple[str, str, str | None, int | None]:
+    """Return the zone name, wrapper tag, lazy trigger, and poll interval."""
     bits = token.split_contents()
     if len(bits) < _ZONE_NAME_INDEX + 1:
         msg = '{% zone %} tag requires a quoted zone name, e.g. {% zone "name" %}.'
@@ -145,6 +159,7 @@ def _parse_options(token: "Token") -> tuple[str, str, str | None]:
         raise TemplateSyntaxError(msg)
     tag = _DEFAULT_TAG
     lazy: str | None = None
+    poll: int | None = None
     for part in bits[_ZONE_NAME_INDEX + 1 :]:
         key, sep, raw = part.partition("=")
         if not sep:
@@ -154,7 +169,12 @@ def _parse_options(token: "Token") -> tuple[str, str, str | None]:
             tag = value or _DEFAULT_TAG
         elif key == _LAZY_KWARG:
             lazy = _validate_lazy(value)
-    return name, tag, lazy
+        elif key == _POLL_KWARG:
+            poll = _validate_poll(value)
+    if lazy is not None and poll is not None:
+        msg = "{% zone %} cannot combine poll= with lazy=, the modes are exclusive."
+        raise TemplateSyntaxError(msg)
+    return name, tag, lazy, poll
 
 
 def _validate_lazy(value: str) -> str:
@@ -166,16 +186,39 @@ def _validate_lazy(value: str) -> str:
     return value
 
 
+def _validate_poll(value: str) -> int:
+    """Return the poll interval in ms parsed from a 5s or 500ms literal.
+
+    A bare number is read as milliseconds. An interval below the floor or a
+    malformed literal fails at compile time, the same honest-fail as lazy.
+    """
+    text = value.strip()
+    try:
+        if text.endswith("ms"):
+            ms = int(text[:-2])
+        elif text.endswith("s"):
+            ms = int(text[:-1]) * _MS_PER_SECOND
+        else:
+            ms = int(text)
+    except ValueError:
+        msg = f"{{% zone %}} poll must be a duration like 5s or 500ms, got {value!r}."
+        raise TemplateSyntaxError(msg) from None
+    if ms < _MIN_POLL_MS:
+        msg = f"{{% zone %}} poll must be at least {_MIN_POLL_MS}ms, got {ms}ms."
+        raise TemplateSyntaxError(msg)
+    return ms
+
+
 @register.tag(name="zone")
 def do_zone(parser: "Parser", token: "Token") -> ZoneNode:
-    """Compile `{% zone "name" tag=... lazy=... %}` … `{% endzone %}`.
+    """Compile `{% zone "name" tag=... lazy=... poll=... %}` … `{% endzone %}`.
 
     The body compiles into a standalone `ZonePartial`. An optional
     `{% placeholder %}` branch holds the markup shown until a lazy body
     arrives. This hook registers nothing with the zone registry, the
     registry is derived from the compiled page template on demand.
     """
-    name, tag, lazy = _parse_options(token)
+    name, tag, lazy, poll = _parse_options(token)
     body = parser.parse(_PLACEHOLDER_THEN_END)
     placeholder: NodeList | None = None
     if parser.next_token().contents.split()[0] == "placeholder":
@@ -192,12 +235,14 @@ def do_zone(parser: "Parser", token: "Token") -> ZoneNode:
         partial=partial,
         tag=tag,
         lazy=lazy,
+        poll=poll,
         placeholder=placeholder,
     )
 
 
 __all__ = [
     "LAZY_ATTR",
+    "POLL_ATTR",
     "ZONE_ATTR",
     "ZoneNode",
     "ZonePartial",

--- a/next/partial/zone.py
+++ b/next/partial/zone.py
@@ -1,7 +1,7 @@
 """Zone template tag, its node, and the standalone zone-body renderable."""
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast, override
 
 from django.template import Library, TemplateSyntaxError
@@ -53,23 +53,32 @@ def _wrap_zone(tag: str, name: str, body: str, *, extra: str = "") -> SafeString
 class ZoneOptions:
     """Compile-time rendering options of one zone.
 
-    The wrapper attribute strings are assembled here once at parse time,
-    so the two render paths read the same precomputed values and a new
-    mode cannot diverge the full render from the standalone delivery.
+    Both render paths derive their wrapper attributes from these options,
+    so a new mode cannot diverge the full render from the standalone
+    delivery.
     """
 
     tag: str = _DEFAULT_TAG
     lazy: str | None = None
     poll: int | None = None
-    full_attrs: str = field(init=False)
-    delivery_attrs: str = field(init=False)
 
     def __post_init__(self) -> None:
-        """Precompute the wrapper attribute strings from the mode options."""
-        delivery = "" if self.poll is None else f' {POLL_ATTR}="{self.poll}"'
-        full = delivery if self.lazy is None else f' {LAZY_ATTR}="{self.lazy}"'
-        object.__setattr__(self, "full_attrs", full)
-        object.__setattr__(self, "delivery_attrs", delivery)
+        """Reject the exclusive lazy and poll modes appearing together."""
+        if self.lazy is not None and self.poll is not None:
+            msg = "ZoneOptions cannot combine poll with lazy, the modes are exclusive."
+            raise ValueError(msg)
+
+    @property
+    def delivery_attrs(self) -> str:
+        """Wrapper attributes of a delivered zone body, without the lazy hint."""
+        return "" if self.poll is None else f' {POLL_ATTR}="{self.poll}"'
+
+    @property
+    def full_attrs(self) -> str:
+        """Wrapper attributes of the zone on a full page render."""
+        if self.lazy is None:
+            return self.delivery_attrs
+        return f' {LAZY_ATTR}="{self.lazy}"'
 
 
 def render_zone_standalone(
@@ -187,7 +196,11 @@ def _parse_options(token: "Token") -> tuple[str, ZoneOptions]:
     for part in bits[_ZONE_NAME_INDEX + 1 :]:
         key, sep, raw = part.partition("=")
         if not sep:
-            continue
+            msg = (
+                f"{{% zone %}} option {part!r} is missing '='. Write options "
+                'as key="value" with no spaces around =.'
+            )
+            raise TemplateSyntaxError(msg)
         value = _strip_quotes(raw)
         if key == _TAG_KWARG:
             tag = value or _DEFAULT_TAG
@@ -195,10 +208,18 @@ def _parse_options(token: "Token") -> tuple[str, ZoneOptions]:
             lazy = _validate_lazy(value)
         elif key == _POLL_KWARG:
             poll = _validate_poll(value)
-    if lazy is not None and poll is not None:
+        else:
+            msg = (
+                f"{{% zone %}} got an unknown option {key!r}. The valid "
+                "options are tag, lazy, and poll."
+            )
+            raise TemplateSyntaxError(msg)
+    try:
+        options = ZoneOptions(tag=tag, lazy=lazy, poll=poll)
+    except ValueError as error:
         msg = "{% zone %} cannot combine poll= with lazy=, the modes are exclusive."
-        raise TemplateSyntaxError(msg)
-    return name, ZoneOptions(tag=tag, lazy=lazy, poll=poll)
+        raise TemplateSyntaxError(msg) from error
+    return name, options
 
 
 def _validate_lazy(value: str) -> str:
@@ -217,15 +238,17 @@ def _validate_poll(value: str) -> int:
     ASCII. An interval outside the floor-to-ceiling range or a malformed
     literal fails at compile time, the same honest-fail as lazy.
     """
-    text = value.strip()
-    if text.endswith("ms"):
-        digits, scale = text[:-2], 1
-    elif text.endswith("s"):
-        digits, scale = text[:-1], _MS_PER_SECOND
+    if value.endswith("ms"):
+        digits, scale = value[:-2], 1
+    elif value.endswith("s"):
+        digits, scale = value[:-1], _MS_PER_SECOND
     else:
-        digits, scale = text, 1
+        digits, scale = value, 1
     if _POLL_DIGITS.fullmatch(digits) is None:
-        msg = f"{{% zone %}} poll must be a duration like 5s or 1500ms, got {value!r}."
+        msg = (
+            "{% zone %} poll must be a quoted literal duration like 5s or "
+            f"1500ms, got {value!r}. Template variables are not read."
+        )
         raise TemplateSyntaxError(msg)
     ms = int(digits) * scale
     if ms < _MIN_POLL_MS:
@@ -254,8 +277,8 @@ def do_zone(parser: "Parser", token: "Token") -> ZoneNode:
         parser.delete_first_token()
     if placeholder is not None and options.lazy is None:
         msg = (
-            "{% zone %} placeholder requires lazy=, a zone that shows "
-            "its body never renders the placeholder branch."
+            f'{{% zone "{name}" %}} placeholder requires lazy=, a zone that '
+            "shows its body never renders the placeholder branch."
         )
         raise TemplateSyntaxError(msg)
     partial = ZonePartial(

--- a/next/testing/patching.py
+++ b/next/testing/patching.py
@@ -38,7 +38,7 @@ def override_next_settings(**overrides: object) -> Iterator[None]:
 
     The merge is shallow: top-level keys supplied as kwargs replace any
     values present in the current `NEXT_FRAMEWORK`. Relies on Django's
-    `override_settings` underneath, so the `setting_changed` →
+    `override_settings` underneath, so the `setting_changed` then
     `settings_reloaded` signal chain fires automatically and framework
     managers pick up the new values.
     """

--- a/tests/pages/test_manager.py
+++ b/tests/pages/test_manager.py
@@ -542,6 +542,17 @@ class TestComposedTemplateCache:
         template = page_instance.composed_template_for(page_file)
         assert template.source == "<p>replaced</p>"
 
+    def test_composed_template_carries_page_origin(
+        self, page_instance, tmp_path
+    ) -> None:
+        """The compiled composed template names the page path as its origin."""
+        page_file = tmp_path / "page.py"
+        page_file.write_text("x = 1")
+        (tmp_path / "template.djx").write_text("<p>ok</p>")
+        template = page_instance.composed_template_for(page_file)
+        assert template.origin.name == str(page_file)
+        assert template.name == str(page_file)
+
     def test_render_function_pages_bypass_compiled_cache(
         self, page_instance, tmp_path
     ) -> None:

--- a/tests/partial/test_checks.py
+++ b/tests/partial/test_checks.py
@@ -155,6 +155,36 @@ class TestLazyPlaceholderCheck:
             assert checks.check_lazy_zone_has_placeholder() == []
 
 
+class TestComposedTemplateCompileCheck:
+    """`next.E072` fires when a composed page template fails to compile."""
+
+    def test_placeholder_without_lazy_errors(self, tmp_path: Path) -> None:
+        page_file = _page_dir(tmp_path, "broken")
+        body = '{% zone "z" %}<p>{{ a }}</p>{% placeholder %}<p>p</p>{% endzone %}'
+        with _composed_pages((page_file, body)):
+            messages = checks.check_composed_templates_compile()
+        assert [m.id for m in messages] == [checks.E_COMPOSED_TEMPLATE_SYNTAX]
+        assert str(page_file) in messages[0].msg
+        assert "placeholder requires lazy=" in messages[0].msg
+
+    def test_healthy_page_is_silent(self, tmp_path: Path) -> None:
+        page_file = _page_dir(tmp_path, "compiles")
+        body = '{% zone "z" %}<p>{{ a }}</p>{% endzone %}'
+        with _composed_pages((page_file, body)):
+            assert checks.check_composed_templates_compile() == []
+
+    def test_only_the_broken_page_is_reported(self, tmp_path: Path) -> None:
+        healthy = _page_dir(tmp_path, "fine")
+        broken = _page_dir(tmp_path, "torn")
+        with _composed_pages(
+            (healthy, '{% zone "ok" %}<p>{{ a }}</p>{% endzone %}'),
+            (broken, '{% zone "z" %}b{% placeholder %}p{% endzone %}'),
+        ):
+            messages = checks.check_composed_templates_compile()
+        assert [m.id for m in messages] == [checks.E_COMPOSED_TEMPLATE_SYNTAX]
+        assert messages[0].obj == str(broken)
+
+
 class TestWithOverZoneCheck:
     """`next.W067` warns when a `{% with %}` wraps a zone directly."""
 

--- a/tests/partial/test_registry.py
+++ b/tests/partial/test_registry.py
@@ -11,6 +11,7 @@ from next.partial.registry import (
     zones_of,
 )
 from next.partial.signals import patch_op_registered, zone_registered
+from next.partial.zone import ZoneOptions
 
 
 class TestBuiltinOps:
@@ -102,6 +103,17 @@ class TestZonesOf:
         template = Template('{% zone "z" poll="5s" %}b{% endzone %}')
         info = zones_of(template)["z"]
         assert info.poll == 5000
+
+    def test_zone_info_options_mirror_the_scalar_fields(self) -> None:
+        zones = zones_of(_zoned_template())
+        assert zones["first"].options == ZoneOptions()
+        assert zones["second"].options == ZoneOptions(tag="tbody", lazy="load")
+
+    def test_zone_info_options_carry_the_delivery_attrs(self) -> None:
+        template = Template('{% zone "z" poll="5s" %}b{% endzone %}')
+        info = zones_of(template)["z"]
+        assert info.options == ZoneOptions(poll=5000)
+        assert info.options.delivery_attrs == ' data-next-poll="5000"'
 
     def test_empty_template_has_no_zones(self) -> None:
         assert zones_of(Template("plain {{ x }}")) == {}

--- a/tests/partial/test_registry.py
+++ b/tests/partial/test_registry.py
@@ -93,6 +93,16 @@ class TestZonesOf:
         assert zones["second"].tag == "tbody"
         assert zones["second"].lazy == "load"
 
+    def test_carries_no_poll_without_the_kwarg(self) -> None:
+        zones = zones_of(_zoned_template())
+        assert zones["first"].poll is None
+        assert zones["second"].poll is None
+
+    def test_zone_info_carries_poll(self) -> None:
+        template = Template('{% zone "z" poll="5s" %}b{% endzone %}')
+        info = zones_of(template)["z"]
+        assert info.poll == 5000
+
     def test_empty_template_has_no_zones(self) -> None:
         assert zones_of(Template("plain {{ x }}")) == {}
 
@@ -131,6 +141,23 @@ class TestZoneRegisteredSignal:
 
         names = sorted(str(entry["zone_name"]) for entry in seen)
         assert names == ["first", "second"]
+
+    def test_sends_lazy_and_poll_kwargs(self) -> None:
+        seen: list[dict[str, object]] = []
+
+        def receiver(sender: object, **kwargs: object) -> None:
+            seen.append({"sender": sender, **kwargs})
+
+        zone_registered.connect(receiver)
+        try:
+            zones_of(Template('{% zone "z" poll="5s" %}b{% endzone %}'))
+        finally:
+            zone_registered.disconnect(receiver)
+
+        assert len(seen) == 1
+        assert seen[0]["zone_name"] == "z"
+        assert seen[0]["lazy"] is None
+        assert seen[0]["poll"] == 5000
 
     def test_quiet_without_receivers(self) -> None:
         assert zones_of(_zoned_template())

--- a/tests/partial/test_registry.py
+++ b/tests/partial/test_registry.py
@@ -104,10 +104,17 @@ class TestZonesOf:
         info = zones_of(template)["z"]
         assert info.poll == 5000
 
-    def test_zone_info_options_mirror_the_scalar_fields(self) -> None:
+    def test_zone_info_carries_structured_options(self) -> None:
         zones = zones_of(_zoned_template())
         assert zones["first"].options == ZoneOptions()
         assert zones["second"].options == ZoneOptions(tag="tbody", lazy="load")
+
+    def test_zone_info_scalars_delegate_to_options(self) -> None:
+        zones = zones_of(_zoned_template())
+        info = zones["second"]
+        assert info.lazy == info.options.lazy
+        assert info.poll == info.options.poll
+        assert info.tag == info.options.tag
 
     def test_zone_info_options_carry_the_delivery_attrs(self) -> None:
         template = Template('{% zone "z" poll="5s" %}b{% endzone %}')

--- a/tests/partial/test_render.py
+++ b/tests/partial/test_render.py
@@ -6,7 +6,7 @@ import pytest
 import next.partial.render as render_module
 from next.partial import UnknownZoneError, ZoneRenderResult, render_zone
 from next.partial.signals import zone_rendered
-from next.partial.zone import ZONE_ATTR
+from next.partial.zone import POLL_ATTR, ZONE_ATTR
 from tests.support import plain_get
 
 
@@ -43,6 +43,12 @@ class TestRenderZoneBatch:
         result = render_zone(ZONED_PAGE, ("later",), _request())
         assert result.html["later"] == f'<div {ZONE_ATTR}="later"><p>later hi</p></div>'
         assert "data-next-lazy" not in result.html["later"]
+
+    def test_poll_zone_delivery_keeps_the_poll_interval(self) -> None:
+        result = render_zone(ZONED_PAGE, ("ticker",), _request())
+        assert result.html["ticker"] == (
+            f'<div {ZONE_ATTR}="ticker" {POLL_ATTR}="5000"><p>tick hi</p></div>'
+        )
 
     def test_context_collected_once_for_the_batch(self) -> None:
         original = render_module.page.build_render_context

--- a/tests/partial/test_view_branch.py
+++ b/tests/partial/test_view_branch.py
@@ -24,6 +24,13 @@ class TestZoneGetEnvelope:
             '<div data-next-zone="alpha"><p>alpha hi</p></div>'
         )
 
+    def test_poll_zone_html_keeps_the_poll_interval(self) -> None:
+        response = NextClient().get_zones("/zoned/", "ticker")
+        envelope = envelope_of(response)
+        assert envelope.html_for_zone("ticker") == (
+            '<div data-next-zone="ticker" data-next-poll="5000"><p>tick hi</p></div>'
+        )
+
     def test_envelope_stamps_version(self) -> None:
         response = NextClient().get_zones("/zoned/", "alpha")
         assert response["X-Next-Version"] == envelope_of(response).version

--- a/tests/partial/test_zone.py
+++ b/tests/partial/test_zone.py
@@ -5,6 +5,7 @@ from django.test import RequestFactory
 
 from next.partial.zone import (
     LAZY_ATTR,
+    POLL_ATTR,
     ZONE_ATTR,
     ZoneNode,
     ZonePartial,
@@ -44,6 +45,18 @@ class TestZoneTagFullRender:
         out = _render(source)
         assert f'{LAZY_ATTR}="load"' in out
 
+    def test_poll_seconds_renders_interval_inline(self) -> None:
+        out = _render('{% zone "t" poll="5s" %}<p>{{ n }}</p>{% endzone %}', n=7)
+        assert out == f'<div {ZONE_ATTR}="t" {POLL_ATTR}="5000"><p>7</p></div>'
+
+    def test_poll_milliseconds_literal(self) -> None:
+        out = _render('{% zone "t" poll="1500ms" %}body{% endzone %}')
+        assert out == f'<div {ZONE_ATTR}="t" {POLL_ATTR}="1500">body</div>'
+
+    def test_poll_bare_number_reads_as_milliseconds(self) -> None:
+        out = _render('{% zone "t" poll="3000" %}body{% endzone %}')
+        assert out == f'<div {ZONE_ATTR}="t" {POLL_ATTR}="3000">body</div>'
+
     def test_full_render_is_byte_for_byte_outside_wrapper(self) -> None:
         plain = _render("before <p>{{ msg }}</p> after", msg="hi")
         zoned = _render(
@@ -67,6 +80,22 @@ class TestZoneTagSyntax:
     def test_unknown_lazy_trigger(self) -> None:
         with pytest.raises(TemplateSyntaxError):
             Template('{% zone "z" lazy="whenever" %}b{% placeholder %}p{% endzone %}')
+
+    def test_invalid_poll_literal_raises(self) -> None:
+        with pytest.raises(TemplateSyntaxError):
+            Template('{% zone "z" poll="soon" %}b{% endzone %}')
+
+    def test_poll_below_floor_raises(self) -> None:
+        with pytest.raises(TemplateSyntaxError):
+            Template('{% zone "z" poll="100ms" %}b{% endzone %}')
+
+    def test_poll_and_lazy_are_exclusive(self) -> None:
+        with pytest.raises(TemplateSyntaxError):
+            Template('{% zone "z" lazy="load" poll="5s" %}b{% endzone %}')
+
+    def test_empty_poll_raises(self) -> None:
+        with pytest.raises(TemplateSyntaxError):
+            Template('{% zone "z" poll="" %}b{% endzone %}')
 
     def test_stray_bits_ignored(self) -> None:
         out = _render('{% zone "z" garbage %}body{% endzone %}')
@@ -107,6 +136,15 @@ class TestRenderZoneStandalone:
         )
         assert out == f'<section {ZONE_ATTR}="lz"><b>x</b></section>'
         assert LAZY_ATTR not in out
+
+    def test_standalone_render_drops_poll_hint(self) -> None:
+        template = Template('{% zone "p" poll="5s" %}<b>{{ v }}</b>{% endzone %}')
+        node = template.nodelist.get_nodes_by_type(ZoneNode)[0]
+        out = render_zone_standalone(
+            node.partial, node.name, node.tag, Context({"v": "x"})
+        )
+        assert out == f'<div {ZONE_ATTR}="p"><b>x</b></div>'
+        assert POLL_ATTR not in out
 
 
 class TestZoneDebugContract:

--- a/tests/partial/test_zone.py
+++ b/tests/partial/test_zone.py
@@ -8,6 +8,7 @@ from next.partial.zone import (
     POLL_ATTR,
     ZONE_ATTR,
     ZoneNode,
+    ZoneOptions,
     ZonePartial,
     render_zone_standalone,
 )
@@ -57,6 +58,14 @@ class TestZoneTagFullRender:
         out = _render('{% zone "t" poll="3000" %}body{% endzone %}')
         assert out == f'<div {ZONE_ATTR}="t" {POLL_ATTR}="3000">body</div>'
 
+    def test_poll_at_the_ceiling_renders(self) -> None:
+        out = _render('{% zone "t" poll="2147483647" %}body{% endzone %}')
+        assert out == f'<div {ZONE_ATTR}="t" {POLL_ATTR}="2147483647">body</div>'
+
+    def test_poll_literal_outer_whitespace_is_stripped(self) -> None:
+        out = _render('{% zone "t" poll=" 5s " %}body{% endzone %}')
+        assert out == f'<div {ZONE_ATTR}="t" {POLL_ATTR}="5000">body</div>'
+
     def test_full_render_is_byte_for_byte_outside_wrapper(self) -> None:
         plain = _render("before <p>{{ msg }}</p> after", msg="hi")
         zoned = _render(
@@ -85,9 +94,30 @@ class TestZoneTagSyntax:
         with pytest.raises(TemplateSyntaxError):
             Template('{% zone "z" poll="soon" %}b{% endzone %}')
 
+    # U+0665 is the Arabic-Indic digit five, which int() accepts but the
+    # strict ASCII-digit grammar must not.
+    @pytest.mark.parametrize("literal", ["1_000", "+5s", "5 s", "\u0665s"])
+    def test_malformed_poll_literal_raises_with_the_grammar_hint(
+        self, literal: str
+    ) -> None:
+        with pytest.raises(TemplateSyntaxError, match="5s or 1500ms"):
+            Template('{% zone "z" poll="' + literal + '" %}b{% endzone %}')
+
     def test_poll_below_floor_raises(self) -> None:
         with pytest.raises(TemplateSyntaxError):
             Template('{% zone "z" poll="100ms" %}b{% endzone %}')
+
+    def test_poll_above_ceiling_raises(self) -> None:
+        with pytest.raises(TemplateSyntaxError):
+            Template('{% zone "z" poll="2592000s" %}b{% endzone %}')
+
+    def test_placeholder_without_lazy_raises(self) -> None:
+        with pytest.raises(TemplateSyntaxError):
+            Template('{% zone "z" %}b{% placeholder %}p{% endzone %}')
+
+    def test_placeholder_with_poll_raises(self) -> None:
+        with pytest.raises(TemplateSyntaxError):
+            Template('{% zone "z" poll="5s" %}b{% placeholder %}p{% endzone %}')
 
     def test_poll_and_lazy_are_exclusive(self) -> None:
         with pytest.raises(TemplateSyntaxError):
@@ -122,6 +152,30 @@ class TestZonePartialStandalone:
         assert node.partial.engine is not None
 
 
+class TestZoneOptions:
+    """`ZoneOptions` precomputes the wrapper attributes at parse time."""
+
+    def test_plain_options_have_no_attrs(self) -> None:
+        options = ZoneOptions()
+        assert options.full_attrs == ""
+        assert options.delivery_attrs == ""
+
+    def test_poll_attr_appears_on_both_render_paths(self) -> None:
+        options = ZoneOptions(poll=5000)
+        assert options.full_attrs == f' {POLL_ATTR}="5000"'
+        assert options.delivery_attrs == options.full_attrs
+
+    def test_lazy_attr_is_dropped_from_delivery(self) -> None:
+        options = ZoneOptions(lazy="load")
+        assert options.full_attrs == f' {LAZY_ATTR}="load"'
+        assert options.delivery_attrs == ""
+
+    def test_parsed_node_carries_options(self) -> None:
+        template = Template('{% zone "p" tag="ul" poll="5s" %}b{% endzone %}')
+        node = template.nodelist.get_nodes_by_type(ZoneNode)[0]
+        assert node.options == ZoneOptions(tag="ul", poll=5000)
+
+
 class TestRenderZoneStandalone:
     """`render_zone_standalone` wraps the body for a delivered partial."""
 
@@ -132,16 +186,26 @@ class TestRenderZoneStandalone:
         )
         node = template.nodelist.get_nodes_by_type(ZoneNode)[0]
         out = render_zone_standalone(
-            node.partial, node.name, node.tag, Context({"v": "x"})
+            node.partial, node.name, node.options, Context({"v": "x"})
         )
         assert out == f'<section {ZONE_ATTR}="lz"><b>x</b></section>'
         assert LAZY_ATTR not in out
 
-    def test_standalone_render_drops_poll_hint(self) -> None:
+    def test_standalone_render_carries_poll_interval(self) -> None:
+        # The client re-reads the interval from the live element after every
+        # morph, so a delivered poll zone must keep the hint on its wrapper.
         template = Template('{% zone "p" poll="5s" %}<b>{{ v }}</b>{% endzone %}')
         node = template.nodelist.get_nodes_by_type(ZoneNode)[0]
         out = render_zone_standalone(
-            node.partial, node.name, node.tag, Context({"v": "x"})
+            node.partial, node.name, node.options, Context({"v": "x"})
+        )
+        assert out == f'<div {ZONE_ATTR}="p" {POLL_ATTR}="5000"><b>x</b></div>'
+
+    def test_standalone_render_without_poll_stays_plain(self) -> None:
+        template = Template('{% zone "p" %}<b>{{ v }}</b>{% endzone %}')
+        node = template.nodelist.get_nodes_by_type(ZoneNode)[0]
+        out = render_zone_standalone(
+            node.partial, node.name, node.options, Context({"v": "x"})
         )
         assert out == f'<div {ZONE_ATTR}="p"><b>x</b></div>'
         assert POLL_ATTR not in out

--- a/tests/partial/test_zone.py
+++ b/tests/partial/test_zone.py
@@ -127,9 +127,31 @@ class TestZoneTagSyntax:
         with pytest.raises(TemplateSyntaxError):
             Template('{% zone "z" poll="" %}b{% endzone %}')
 
-    def test_stray_bits_ignored(self) -> None:
-        out = _render('{% zone "z" garbage %}body{% endzone %}')
-        assert out == f'<div {ZONE_ATTR}="z">body</div>'
+    def test_stray_bit_without_equals_raises(self) -> None:
+        with pytest.raises(TemplateSyntaxError, match="'garbage' is missing '='"):
+            Template('{% zone "z" garbage %}body{% endzone %}')
+
+    def test_spaces_around_equals_raise(self) -> None:
+        # token splitting turns poll = "5s" into three bits, the first of
+        # which carries no '=' and must fail loudly instead of dropping poll
+        with pytest.raises(TemplateSyntaxError, match='key="value"'):
+            Template('{% zone "z" poll = "5s" %}body{% endzone %}')
+
+    def test_unknown_option_key_raises(self) -> None:
+        with pytest.raises(TemplateSyntaxError, match="unknown option 'pol'"):
+            Template('{% zone "z" pol="5s" %}body{% endzone %}')
+
+    def test_unknown_option_error_lists_the_valid_keys(self) -> None:
+        with pytest.raises(TemplateSyntaxError, match="tag, lazy, and poll"):
+            Template('{% zone "z" lzay="load" %}body{% endzone %}')
+
+    def test_placeholder_error_names_the_zone(self) -> None:
+        with pytest.raises(TemplateSyntaxError, match='zone "z"'):
+            Template('{% zone "z" %}b{% placeholder %}p{% endzone %}')
+
+    def test_poll_grammar_error_says_literals_only(self) -> None:
+        with pytest.raises(TemplateSyntaxError, match="Template variables"):
+            Template('{% zone "z" poll=interval %}b{% endzone %}')
 
 
 class TestZonePartialStandalone:
@@ -153,7 +175,7 @@ class TestZonePartialStandalone:
 
 
 class TestZoneOptions:
-    """`ZoneOptions` precomputes the wrapper attributes at parse time."""
+    """`ZoneOptions` derives the wrapper attributes from the mode options."""
 
     def test_plain_options_have_no_attrs(self) -> None:
         options = ZoneOptions()
@@ -169,6 +191,10 @@ class TestZoneOptions:
         options = ZoneOptions(lazy="load")
         assert options.full_attrs == f' {LAZY_ATTR}="load"'
         assert options.delivery_attrs == ""
+
+    def test_lazy_and_poll_together_raise(self) -> None:
+        with pytest.raises(ValueError, match="the modes are exclusive"):
+            ZoneOptions(lazy="load", poll=5000)
 
     def test_parsed_node_carries_options(self) -> None:
         template = Template('{% zone "p" tag="ul" poll="5s" %}b{% endzone %}')

--- a/tests/site_pages/zoned/template.djx
+++ b/tests/site_pages/zoned/template.djx
@@ -2,3 +2,4 @@
 {% zone "alpha" %}<p>alpha {{ greeting }}</p>{% endzone %}
 {% zone "beta" tag="section" %}<p>beta {{ greeting }}</p>{% endzone %}
 {% zone "later" lazy="load" %}<p>later {{ greeting }}</p>{% placeholder %}<p>loading</p>{% endzone %}
+{% zone "ticker" poll="5s" %}<p>tick {{ greeting }}</p>{% endzone %}


### PR DESCRIPTION
## Description

Zones can now poll themselves declaratively: `{% zone "name" poll="5s" %}` re-GETs the zone body on an interval through the same zone request a lazy load uses.

**Template tag.** `poll=` accepts `5s`, `1500ms`, or a bare number of milliseconds under a strict ASCII grammar. The interval is validated at template compile time (floor 1000ms, ceiling 2147483647ms — the browser timer bound) and is exclusive with `lazy=`, combining them is a compile error. The resolved milliseconds ride the wrapper as `data-next-poll` on the full render and on the partial delivery, so the live element stays the source of truth across morphs.

**Core.** Wrapper attributes for both render paths assemble once in a new frozen `ZoneOptions` dataclass at parse time — the full render and the standalone delivery read the same precomputed strings, so a future zone mode cannot silently diverge the two. `ZoneInfo` carries the options, `zone_registered` gains the `poll` kwarg, `render_zone_standalone` consumes the options object.

**Client runtime.** Each polling zone runs a self-rescheduling `setTimeout` chain behind the injected clock seam. Every tick re-reads the live attributes, so a morph that removed the zone or changed the interval tears the poller down honestly. Hand-written `data-next-poll` values outside `1..2147483647` are dropped with a dev console warning, mirroring the server bound (an overflowing value would otherwise wrap the browser's signed-32-bit timer and poll in a tight loop).

**Visibility.** A hidden tab arms no timers at all — pollers register as sleeping entries, so a background tab never wakes and a resume can never fork a duplicate timer chain. The visible flip refreshes every polling zone after a real absence and only re-arms the timers on a brief flicker, gated by the same `RESUME_REVALIDATE_MS` threshold as the SSE resume (the constant moved to the shared protocol vocabulary).

**Layers.** Lazy and poll zone GETs resolve the page that owns their element through the layer stack (`layers.urlFor`), so a base-page zone keeps fetching the host page while a modal layer holds the address bar, and load batches group into one GET per owning page. The captured host URL now keeps its query string, so a filtered page survives polling under a layer, the accept-time refresh, and the close-time address restore.

**Misc.** Trigger requests carry zone intent via `request.zone` instead of hand-stamped headers (the wire owns protocol stamping), the dev attribute validation covers a replace-patch scan root, and the observability example gains a polling busiest-pages widget with poll and lazy e2e coverage.

## How to test

`make ci` — the full gate set. Individually: `make test` (2804 passed, 100% coverage), `make test-js` (477 passed, 100% coverage), `make lint`, `make type-check`, `make docs`, `make bench`, and the observability example suite at its own 100% gate.

## Related issues

—

## Checklist

- [x] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [x] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable
