### PR TITLE
docs(partial): sync docs with core and fix the bugs the review surfaced

### DIFF
--- a/docs/content/contributing/writing-documentation.rst
+++ b/docs/content/contributing/writing-documentation.rst
@@ -116,7 +116,7 @@ They duplicate the same problem under a different syntax.
 Runtime matrices
 ~~~~~~~~~~~~~~~~
 
-Document supported Python and Django releases in one place: :doc:`/content/intro/install` under *Requirements*.
+The *Requirements* section of :doc:`/content/intro/install` documents supported Python and Django releases in one place.
 On other pages link back with a short sentence such as "Use a supported Python and Django release (see :doc:`/content/intro/install`)" instead of copying the bullet list.
 Fragmented matrices drift out of sync with ``pyproject.toml`` and CI.
 

--- a/docs/content/deployment/checklist.rst
+++ b/docs/content/deployment/checklist.rst
@@ -77,6 +77,7 @@ Monitoring
 - Forward ``page_rendered`` and ``action_dispatched`` to your metrics pipeline.
 - Forward ``form_validation_failed`` to alerting when failure rate exceeds the baseline.
 - Track ``router_reloaded`` if the project mounts a dynamic router.
+- Forward ``sse_stream_opened``, ``sse_stream_closed``, and ``zone_rendered`` when the project uses partial rendering.
 
 System Checks
 -------------

--- a/docs/content/deployment/settings.rst
+++ b/docs/content/deployment/settings.rst
@@ -21,7 +21,7 @@ Strict Context
    NEXT_FRAMEWORK["STRICT_CONTEXT"] = True
 
 Use ``STRICT_CONTEXT: True`` in production so a misconfigured context processor fails loudly.
-Reference for behaviour and exception types: :ref:`ref-settings`.
+See :ref:`ref-settings` for behaviour and exception types.
 
 Eager Component Loading
 -----------------------
@@ -36,7 +36,7 @@ The framework discovers the component tree eagerly in both modes, so the registr
 The flag controls only when each ``component.py`` module is imported.
 With the default ``False``, every ``component.py`` is imported during startup, so any import-time error surfaces before the first request.
 With ``True``, a ``component.py`` is imported on the first render that resolves the component rather than during startup.
-Reference for lazy behaviour and testing helpers: :ref:`ref-settings` and :doc:`/content/topics/testing`.
+See :ref:`ref-settings` and :doc:`/content/topics/testing` for lazy behaviour and testing helpers.
 
 Static Backend
 --------------

--- a/docs/content/deployment/static-files.rst
+++ b/docs/content/deployment/static-files.rst
@@ -13,7 +13,8 @@ It covers the build step, the staticfiles finder integration, content hashing, a
 Overview
 --------
 
-next.dj contributes ``NextStaticFilesFinder`` (dotted path ``next.static.NextStaticFilesFinder``) that exposes every co-located asset to Django's :doc:`standard staticfiles pipeline <django:howto/static-files/index>`.
+next.dj contributes ``NextStaticFilesFinder``, exported as ``next.static.NextStaticFilesFinder``.
+The finder exposes every co-located asset to Django's :doc:`standard staticfiles pipeline <django:howto/static-files/index>`.
 ``NextFrameworkConfig.ready`` appends it to ``STATICFILES_FINDERS`` automatically, so no manual configuration is required.
 Production deployments use :doc:`collectstatic <django:ref/contrib/staticfiles>` exactly as they would for any other Django project.
 
@@ -48,7 +49,8 @@ Hashed URLs
 -----------
 
 The default ``StaticFilesBackend`` resolves every asset URL through Django staticfiles.
-Pair it with Django's :doc:`ManifestStaticFilesStorage <django:ref/contrib/staticfiles>` so each URL carries a content hash that changes only when the file content changes, which makes long lived browser cache lifetimes safe.
+Pair it with Django's :doc:`ManifestStaticFilesStorage <django:ref/contrib/staticfiles>` so each URL carries a content hash that changes only when the file content changes.
+Stable hashes make long lived browser cache lifetimes safe.
 
 .. code-block:: text
    :caption: rendered output example

--- a/docs/content/deployment/wsgi-asgi.rst
+++ b/docs/content/deployment/wsgi-asgi.rst
@@ -17,7 +17,7 @@ Pick WSGI when every response is synchronous and short lived.
 
 ASGI is the right choice when the project uses any of these features.
 
-- Server Sent Events for real time updates.
+- Server Sent Events for real time updates, including the patch streams described in :doc:`/content/topics/partial-rendering/sse`.
 - Websockets for bidirectional communication.
 - Async view handlers that await I/O.
 - Streaming responses that hold the connection open.
@@ -51,10 +51,7 @@ Run with a production WSGI server such as ``gunicorn`` or ``uwsgi``.
    uv run gunicorn config.wsgi:application --workers 4 --bind 0.0.0.0:8000
 
 The example passes ``--workers 4``.
-Effective worker counts depend on Gunicorn CLI flags and environment variables (for example ``WEB_CONCURRENCY``).
-Verify the upstream Gunicorn docs for your installed version instead of trusting second-hand shortcuts.
-Teams often iterate from rough heuristics such as ``(2 * num_cores) + 1`` once they profile real traffic and saturation.
-Tune based on the expected concurrency and the average request duration.
+Start from a heuristic such as ``(2 * num_cores) + 1`` and tune against the measured concurrency and request duration.
 
 ASGI Configuration
 ------------------
@@ -90,6 +87,8 @@ Size the worker count proportional to the request rate and the average response 
 
 ASGI workers can multiplex many connections through an event loop.
 A single worker handles many concurrent SSE or websocket connections.
+A patch stream (see :doc:`/content/topics/partial-rendering/sse`) holds its connection open until the source ends or the client disconnects, which outlives any reasonable sync worker timeout.
+Serve those streams from ASGI workers rather than raising the WSGI worker timeout.
 
 Reverse Proxy
 -------------

--- a/docs/content/faq/general.rst
+++ b/docs/content/faq/general.rst
@@ -13,7 +13,7 @@ What Is next.dj and Is It a Django Replacement
 ----------------------------------------------
 
 next.dj is a framework built on Django, not a replacement for it.
-It adds file-based routing, a layout system, reusable components, and form dispatch on top of a regular Django project.
+It adds file-based routing, a layout system, reusable components, form dispatch, and partial rendering on top of a regular Django project.
 See :doc:`/content/intro/overview`, especially :ref:`intro-overview-django-unchanged`, for what stays stock Django versus what the framework adds.
 
 Which Django and Python Versions Are Supported

--- a/docs/content/faq/troubleshooting.rst
+++ b/docs/content/faq/troubleshooting.rst
@@ -25,7 +25,8 @@ Page Renders Without Layout
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A layout must contain the placeholder block ``{% block template %}{% endblock template %}`` or its short form ``{% block template %}{% endblock %}``.
-Without the placeholder the framework drops the body at render time without an error, and ``manage.py check`` reports :ref:`next.W001 <ref-system-checks>`.
+Without the placeholder the framework skips that layout during composition, so its markup disappears from the rendered page while the body still renders through the remaining ancestor layouts.
+``manage.py check`` reports :ref:`next.W001 <ref-system-checks>`.
 
 Confirm that ``layout.djx`` sits in the same directory as ``page.py`` or in an ancestor directory.
 
@@ -146,7 +147,7 @@ Hashed URL Does Not Change
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Restart the development server.
-The watcher picks up file content changes but a hash computed at startup can stale during long sessions.
+The watcher picks up file content changes but a URL memoised at startup can go stale during long sessions.
 
 next.W030 Empty Static Backends
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -165,6 +166,37 @@ next.W042 Unusable JS_CONTEXT_SERIALIZER
 
 ``JS_CONTEXT_SERIALIZER`` is set but does not resolve to a class that implements the ``JsContextSerializer`` protocol (a ``dumps`` method).
 Fix the dotted path or install optional dependencies such as ``pydantic`` when using ``PydanticJsContextSerializer``.
+
+Partial Rendering
+-----------------
+
+Zone GET Returns HTTP 400
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A response body of ``unknown zone`` means the requested name matches no ``{% zone %}`` in the composed page.
+Check that ``data-next-target`` names the same string as the zone tag on the page that serves the request.
+A response body of ``zone in dynamic body`` means the page body comes from a ``render`` function returning a string, so there is no compiled template source to render the slice standalone.
+Move the zone to a page whose body comes from a template source.
+
+Zone GET Returns HTTP 409
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The client asserted an asset version that no longer matches the server's, which usually happens right after a deploy.
+The empty-bodied 409 tells the runtime to perform a full visit of the current URL, so the page reloads once with fresh assets.
+No action is needed beyond the reload the runtime already performs.
+
+Inline Script in a Patch Does Not Run
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The applier strips every ``<script>`` element from patch HTML before the markup reaches the document.
+A development build prints a ``console.warn`` for each neutralised script, so the removal is visible rather than silent.
+Move the behaviour into a co-located module, see :doc:`/content/topics/partial-rendering/co-located-js`.
+
+next.W071 Extra PARTIAL_BACKENDS Entries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``PARTIAL_BACKENDS`` lists more than one entry.
+Partial rendering activates only the first entry and ignores the rest, so remove the extra entries or merge their options into one.
 
 Dependency Injection
 --------------------

--- a/docs/content/faq/usage.rst
+++ b/docs/content/faq/usage.rst
@@ -42,6 +42,13 @@ Subclass ``next.forms.Form`` or ``next.forms.ModelForm`` and render the form wit
 The action name is derived automatically from the class name in ``snake_case``.
 See :doc:`/content/intro/tutorial04`.
 
+How Do I Update Part of a Page Without a Reload
+-----------------------------------------------
+
+Wrap the slice in ``{% zone "name" %}`` and point a form or a link at it with ``data-next-target="name"``.
+The server re-renders only that zone and the client runtime swaps it in place.
+See :doc:`/content/intro/tutorial06` for the walkthrough and :doc:`/content/topics/partial-rendering/index` for the full model.
+
 How Do I Customise the Static Output
 ------------------------------------
 
@@ -105,14 +112,14 @@ Reconstruct the query string from the validated fields instead.
 
    from django.http import HttpRequest, HttpResponseRedirect
    from django.urls import reverse
-   from next.forms import Form, CharField, redirect_to_origin
+   from next.forms import Form, CharField
 
    class SearchForm(Form):
        q = CharField(required=False)
 
        def on_valid(self, request: HttpRequest) -> HttpResponseRedirect:
            q = self.cleaned_data.get("q", "")
-           base = reverse("next:page_notes")
+           base = reverse("next:page_")
            return HttpResponseRedirect(f"{base}?q={q}" if q else base)
 
 The form registers as ``search_form`` automatically.

--- a/docs/content/howto/add-a-new-asset-kind.rst
+++ b/docs/content/howto/add-a-new-asset-kind.rst
@@ -41,7 +41,7 @@ The ``module`` style ``render_module_tag`` is reused here because pre compiled J
 Ship the file.
 
 .. code-block:: text
-   :caption: notes/_components/note_card/component.jsx
+   :caption: notes/pages/_components/note_card/component.jsx
 
    export const NoteCard = ({ title }) => title;
 
@@ -68,6 +68,8 @@ When the new kind needs a tag shape that the bundled methods do not produce, add
            return f'<script type="text/babel" src="{url}"></script>'
 
 Register the kind against the new method and register the backend.
+This registration replaces the one from the walkthrough.
+Registering the same kind twice with different parameters raises ``ValueError``.
 
 .. code-block:: python
    :caption: notes/apps.py

--- a/docs/content/howto/build-a-composite-component.rst
+++ b/docs/content/howto/build-a-composite-component.rst
@@ -19,10 +19,10 @@ Create a component folder under the components root with three files.
 Walkthrough
 -----------
 
-Create the folder ``notes/_components/info_card/`` with three files.
+Create the folder ``notes/pages/_components/info_card/`` with three files.
 
 .. code-block:: jinja
-   :caption: notes/_components/info_card/component.djx
+   :caption: notes/pages/_components/info_card/component.djx
 
    <article class="info-card">
      <header class="info-card__head">
@@ -35,7 +35,7 @@ Create the folder ``notes/_components/info_card/`` with three files.
    </article>
 
 .. code-block:: python
-   :caption: notes/_components/info_card/component.py
+   :caption: notes/pages/_components/info_card/component.py
 
    from next.components import component
 
@@ -47,7 +47,7 @@ The parameter and the published key share the name ``subtitle`` on purpose.
 The function reads its own ``subtitle`` prop through dependency injection and republishes the cleaned value under the same key, so the trimmed value replaces the raw prop and the template sees the trimmed string.
 
 .. code-block:: css
-   :caption: notes/_components/info_card/component.css
+   :caption: notes/pages/_components/info_card/component.css
 
    .info-card {
      border: 1px solid #ddd;

--- a/docs/content/howto/build-a-custom-asset-backend.rst
+++ b/docs/content/howto/build-a-custom-asset-backend.rst
@@ -48,7 +48,7 @@ A custom backend can intercept one kind and resolve it elsewhere, then delegate 
    class ViteManifestBackend(StaticFilesBackend):
        def __init__(self, config: Mapping[str, Any] | None = None) -> None:
            super().__init__(config)
-           opts = dict(self._config.get("OPTIONS") or {})
+           opts = dict(self.config.get("OPTIONS") or {})
            self._dev_origin: str = opts.get("DEV_ORIGIN", "")
            self._vite_root: str = opts.get("VITE_ROOT", "")
            self._manifest_path: str = opts.get("MANIFEST_PATH", "")
@@ -98,6 +98,14 @@ A missing manifest logs one warning and falls back to staticfiles so the dev wor
            return str(staticfiles_storage.url(f"kanban/dist/{built}"))
        return super().register_file(source_path, logical_name, "jsx")
 
+   def _manifest_key(self, source_path: Path) -> str:
+       if self._vite_root:
+           try:
+               return str(source_path.relative_to(Path(self._vite_root)))
+           except ValueError:
+               pass
+       return source_path.name
+
    def _load_manifest(self) -> dict[str, Any] | None:
        if self._manifest_data is not None:
            return self._manifest_data
@@ -115,6 +123,7 @@ A missing manifest logs one warning and falls back to staticfiles so the dev wor
            self._manifest_data = json.load(f)
        return self._manifest_data
 
+``_manifest_key`` builds the lookup key relative to ``VITE_ROOT`` and falls back to the bare filename.
 URL resolution delegates to ``staticfiles_storage`` so manifest storage, S3 storage, and CDN settings still apply to the hashed output.
 
 Register the Kind
@@ -153,7 +162,7 @@ Register the Backend
 ~~~~~~~~~~~~~~~~~~~~
 
 List the subclass in ``STATIC_BACKENDS``.
-Every key under ``OPTIONS`` reaches the constructor through ``self._config``.
+Every key under ``OPTIONS`` reaches the backend through the ``config`` property.
 
 .. code-block:: python
    :caption: config/settings.py

--- a/docs/content/howto/build-a-multi-step-wizard.rst
+++ b/docs/content/howto/build-a-multi-step-wizard.rst
@@ -27,11 +27,13 @@ The wizard lists them in order.
 .. code-block:: python
    :caption: access/views/request/[step]/page.py
 
+   from typing import Any
+
+   from django import forms
+   from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+
    import next.forms
    from access.models import AccessRequest
-   from django import forms
-   from django.http import HttpRequest
-   from next.forms import redirect_to_origin
 
    class IdentityStep(forms.ModelForm):
        class Meta:
@@ -54,9 +56,9 @@ The wizard lists them in order.
                ("approval", ApprovalStep),
            ]
 
-       def done(self, request: HttpRequest, cleaned_data):
-           AccessRequest.objects.create(**cleaned_data)
-           return redirect_to_origin(request)
+       def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> HttpResponse:
+           obj = AccessRequest.objects.create(**cleaned_data)
+           return HttpResponseRedirect(f"/request/{obj.pk}/audit/")
 
 The captions mirror the repository's ``audit-forms`` example, which configures ``PAGES_DIR`` as ``views``.
 Under the default settings the same files live in ``access/pages/request/[step]/``, see :doc:`/content/ref/settings`.
@@ -89,12 +91,15 @@ The ``{% form %}`` tag publishes ``form`` for the current step and ``wizard`` fo
 
 A valid step saves its draft and advances, the final step calls ``done``, and an invalid step re-renders with errors.
 Per-step drafts persist through the configured wizard backend (see :doc:`/content/topics/forms/wizard-backend`).
+A back link or a progress indicator builds on ``wizard.goto`` and ``wizard.step_names``, see the wizard template API in :doc:`/content/topics/forms/wizard`.
 
 Finalise the Wizard
 ~~~~~~~~~~~~~~~~~~~~
 
 ``done`` receives the merged cleaned data of every step, so for ModelForm steps over one model the dict maps straight onto the constructor.
 The ``create`` call in the wizard above is the whole finaliser.
+``done`` redirects to a result page rather than back to the wizard, because a successful finish clears the stored drafts and the wizard route would render an emptied final step.
+The result page here is the per-request audit page of the ``audit-forms`` example, and any routed page outside the ``[step]`` segment works.
 :doc:`/content/topics/forms/wizard` documents the ``done`` contract, its return-value coercion, and the idempotency requirement.
 
 Verification
@@ -105,7 +110,8 @@ Fill the first step, advance through the rest, and confirm the final submission 
 Use the browser back button on an earlier step and confirm the values you entered reappear.
 
 A test asserts the same flow with ``NextClient``.
-The whole wire protocol of a wizard step is the ``origin`` path: the dispatcher resolves it against the URLconf, the ``[step]`` segment yields the current step, and the next-step redirect derives from the same path.
+The whole wire protocol of a wizard step is the ``origin`` path.
+The dispatcher resolves it against the URLconf, the ``[step]`` segment yields the current step, and the next-step redirect derives from the same path.
 ``post_action(..., origin=...)`` fills the ``_next_form_origin`` field the ``{% form %}`` tag would emit.
 
 .. code-block:: python

--- a/docs/content/howto/customize-error-pages.rst
+++ b/docs/content/howto/customize-error-pages.rst
@@ -120,9 +120,9 @@ The exception propagates out of the page to Django's URL resolver, which then in
    :caption: notes/pages/notes/[int:note_id]/page.py
 
    from django.http import Http404
-   from notes.models import Note
    from next.pages import context
    from next.urls import DUrl
+   from notes.models import Note
 
    @context("note")
    def note(note_id: DUrl[int]) -> Note:

--- a/docs/content/howto/drive-form-actions-with-htmx.rst
+++ b/docs/content/howto/drive-form-actions-with-htmx.rst
@@ -12,7 +12,8 @@ Solution
 --------
 
 Pass ``hx-*`` attributes through the ``{% form %}`` tag.
-The tag reserves only ``action``, ``method``, and the ``data-next-*`` prefix, so every htmx attribute lands on the ``<form>`` element unchanged.
+The tag reserves ``action``, ``method``, the ``data-next-*`` prefix, and the partial parameters ``validate``, ``trigger``, ``debounce``, ``zone``, and ``key``.
+Every ``hx-*`` attribute lands on the ``<form>`` element unchanged.
 Boost the form with ``hx-boost`` and carve its region out of the response with ``hx-select``.
 Verified with django-htmx 1.19 and later on Django 5.2 through 6.0.
 

--- a/docs/content/howto/enforce-object-level-permissions.rst
+++ b/docs/content/howto/enforce-object-level-permissions.rst
@@ -21,7 +21,7 @@ A ``False`` return denies with HTTP 403 and the row is never saved.
 Walkthrough
 -----------
 
-Load the row from the URL
+Load the Row From the URL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The edit form loads its instance from a captured URL segment through ``Meta.instance_from_url``.
@@ -30,8 +30,9 @@ The route segment ``[slug]`` captures the lookup value.
 .. code-block:: python
    :caption: notes/pages/notes/edit/[slug]/page.py
 
-   import next.forms
    from django.http import HttpRequest
+
+   import next.forms
    from notes.models import Note
 
    class NoteEditForm(next.forms.ModelForm):
@@ -40,14 +41,14 @@ The route segment ``[slug]`` captures the lookup value.
            fields = ["title", "body"]
            instance_from_url = "slug"
 
-       def has_object_permission(self, request: HttpRequest):
+       def has_object_permission(self, request: HttpRequest) -> bool:
            return self.instance.owner_id == request.user.id
 
 The default ``get_initial`` loads ``Note.objects.get(slug=<captured slug>)`` through :func:`~django.shortcuts.get_object_or_404`.
 The dispatcher binds the form against that instance, then resolves ``has_object_permission``.
 At that point ``self.instance`` is the loaded ``Note``, so the hook compares its owner against the current user.
 
-Combine it with a login requirement
+Combine It With a Login Requirement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The object-level hook compares ``request.user``, so the request needs an authenticated user.
@@ -63,13 +64,13 @@ Pair the hook with the static ``Meta.login_required`` so an anonymous POST is re
            instance_from_url = "slug"
            login_required = True
 
-       def has_object_permission(self, request: HttpRequest):
+       def has_object_permission(self, request: HttpRequest) -> bool:
            return self.instance.owner_id == request.user.id
 
 The static guard runs first and pre-database.
 An anonymous visitor is redirected before any application code runs, and the object-level hook only ever sees an authenticated user.
 
-Render the form
+Render the Form
 ~~~~~~~~~~~~~~~
 
 The template renders the form by name.
@@ -121,7 +122,8 @@ A test signs in as the owner, edits the row, then signs in as another user and c
        assert Note.objects.get(pk=note.pk).title == "Intro v2"
 
 The owner's POST binds the form, passes ``has_object_permission``, and saves.
-The stranger's POST binds the same row, the hook returns ``False``, and the dispatcher raises :exc:`~django.core.exceptions.PermissionDenied` which Django renders as a bare HTTP 403 without re-rendering the origin, so the row is unchanged.
+The stranger's POST binds the same row, the hook returns ``False``, and the dispatcher raises :exc:`~django.core.exceptions.PermissionDenied`.
+Django renders the denial as a bare HTTP 403 without re-rendering the origin, so the row is unchanged.
 
 A ``form_access_denied`` signal fires on the denial with ``layer="object"`` and ``reason="denied"``.
 Connect a receiver to audit refused edits, see :ref:`topics-forms-signals-form-access-denied`.

--- a/docs/content/howto/handle-file-uploads.rst
+++ b/docs/content/howto/handle-file-uploads.rst
@@ -46,7 +46,8 @@ Define the form.
 
 ``AttachmentForm`` registers automatically as ``attachment_form`` via autodiscovery on startup.
 No manual import is needed in the page module.
-No ``on_valid`` override is needed either: the default ``ModelForm`` implementation saves the instance and redirects to ``Meta.success_url``.
+No ``on_valid`` override is needed either.
+The default ``ModelForm`` implementation saves the instance and redirects to ``Meta.success_url``.
 Without ``success_url`` the submission redirects back to the origin page.
 See :ref:`topics-forms-actions-success` for the redirect contract.
 

--- a/docs/content/howto/integrate-django-allauth-forms.rst
+++ b/docs/content/howto/integrate-django-allauth-forms.rst
@@ -175,7 +175,8 @@ Both metaclasses are ``DeclarativeFieldsMetaclass``, so the bases compose.
            return self.login(request, redirect_url=None)
 
 The request recovery in ``__init__`` is mandatory for request-aware forms such as ``LoginForm``.
-The dispatcher builds a registered form from the POST data without a ``request`` kwarg, so the allauth constructor stores ``self.request = None``, and ``clean()`` then crashes inside the login rate limiter, which calls ``get_current_site(self.request)``.
+The dispatcher builds a registered form from the POST data without a ``request`` kwarg, so the allauth constructor stores ``self.request = None``.
+``clean()`` then crashes inside the login rate limiter, which calls ``get_current_site(self.request)``.
 The GET render works without the line, the crash fires only on submit.
 ``AccountMiddleware`` publishes the live request through ``allauth.core.context``, and the constructor falls back to it.
 
@@ -207,7 +208,16 @@ Verification
 .. code-block:: python
    :caption: tests/test_login.py
 
+   import pytest
+   from django.contrib.auth import get_user_model
+
    from next.testing.client import NextClient
+
+   @pytest.fixture
+   def user(db):
+       return get_user_model().objects.create_user(
+           username="ada", password="correct-horse-staple"
+       )
 
    def test_wrong_password_rerenders(db, user) -> None:
        client = NextClient()

--- a/docs/content/howto/move-from-django-formtools.rst
+++ b/docs/content/howto/move-from-django-formtools.rst
@@ -98,8 +98,10 @@ Run the system checks after the port.
 
    uv run python manage.py check
 
-``next.E050`` catches an empty step list, ``next.W057`` a step class doubling as a standalone action, ``next.W058`` a file field in a step, and ``next.W059`` a field declared by two steps.
-Then walk the flow once: fill the first step, use the browser back button to confirm the draft reappears, and finish to confirm ``done`` runs exactly once.
+``next.E050`` catches an empty step list, and ``next.E054`` a page-scoped wizard whose page path lacks the ``[step]`` segment.
+``next.W057`` flags a step class doubling as a standalone action, ``next.W058`` a file field in a step, and ``next.W059`` a field declared by two steps.
+Then walk the flow once.
+Fill the first step, use the browser back button to confirm the draft reappears, and finish to confirm ``done`` runs exactly once.
 
 See Also
 --------

--- a/docs/content/howto/override-the-js-context-serializer.rst
+++ b/docs/content/howto/override-the-js-context-serializer.rst
@@ -54,8 +54,9 @@ See :doc:`/content/topics/static-assets/js-context` for the protocol and a minim
 Per Key Override
 ~~~~~~~~~~~~~~~~
 
-Pass ``serializer=`` on a single ``@context`` so only that key uses a different encoder. Everything else keeps the project default.
-See the **Per Key Serializer** section in :doc:`/content/topics/static-assets/js-context` for a concrete snippet.
+Pass ``serializer=`` on a single ``@context`` so only that key uses a different encoder.
+Everything else keeps the project default.
+See the Per-Key Serializer section in :doc:`/content/topics/static-assets/js-context` for a concrete snippet.
 
 Verification
 ------------

--- a/docs/content/howto/read-query-parameters.rst
+++ b/docs/content/howto/read-query-parameters.rst
@@ -168,7 +168,9 @@ Share the Snapshot Across a Layout Chain
 
 Register a resolved value with ``inherit_context=True`` so nested pages receive the same instance through DI.
 The ``[category]`` bracket segment becomes a URL kwarg.
-The callable reads it with ``DUrl[str]`` through a parameter named ``category`` to match the segment, then resolves it once.
+The callable reads it through a parameter named ``category`` to match the segment, then resolves it once.
+On the declaring page's own request the callable runs twice, first with the raw slug and then with the object the first run produced.
+The parameter therefore stays untyped and the callable returns early when the value is already resolved.
 Child callables then ask for ``category`` by parameter name and never re-query.
 
 .. code-block:: python
@@ -177,10 +179,11 @@ Child callables then ask for ``category`` by parameter name and never re-query.
    from catalog.models import Category
    from django.http import Http404
    from next.pages import context
-   from next.urls import DUrl
 
    @context("category", inherit_context=True)
-   def category(category: DUrl[str]) -> Category:
+   def category(category: object) -> Category:
+       if isinstance(category, Category):
+           return category
        try:
            return Category.objects.get(slug=category)
        except Category.DoesNotExist as exc:

--- a/docs/content/howto/reload-routes-from-code.rst
+++ b/docs/content/howto/reload-routes-from-code.rst
@@ -47,7 +47,7 @@ Import the receivers module from ``AppConfig.ready`` so the decorators run at st
        name = "notes"
 
        def ready(self) -> None:
-           from notes import receivers  # noqa: F401, PLC0415
+           from notes import receivers  # imported for its receiver registrations
 
 Each call rebuilds the backend list from the current ``NEXT_FRAMEWORK`` configuration, clears Django's URL caches, and emits ``router_reloaded``.
 Receivers should tolerate being invoked more than once when several writes batch into one task.

--- a/docs/content/howto/require-login-on-pages.rst
+++ b/docs/content/howto/require-login-on-pages.rst
@@ -45,7 +45,7 @@ The middleware lets the login page and static assets through, and redirects ever
 
 Place the middleware after :class:`~django.contrib.auth.middleware.AuthenticationMiddleware` so ``request.user`` is populated when the guard runs.
 
-Use :func:`next.urls.page_reverse` instead of a hard-coded path when redirecting to a file-routed login page.
+Use :func:`~next.urls.reverse.page_reverse` instead of a hard-coded path when redirecting to a file-routed login page.
 See :doc:`/content/topics/url-reversing` for the full reversing surface.
 
 .. code-block:: python
@@ -141,9 +141,11 @@ Use ``Meta.login_required`` and ``Meta.permission_required`` on the form class, 
            permission_required = "notes.change_note"
 
 An anonymous POST redirects to ``LOGIN_URL`` with ``next`` set to the origin page, and an authenticated user missing the permission gets HTTP 403.
-The guard protects the mutation, not the markup: a GET still renders the page and its form, so hide the form in the template when anonymous visitors should not see it.
+The guard protects the mutation, not the markup.
+A GET still renders the page and its form, so hide the form in the template when anonymous visitors should not see it.
 See :ref:`topics-forms-actions-guards` for the full semantics, including guard inheritance.
-For a per-request decision that the static keys cannot express, such as owner-only edits, override ``check_permissions`` or ``has_object_permission`` on the form class, see :ref:`topics-forms-actions-dynamic-guards`.
+For a per-request decision that the static keys cannot express, such as owner-only edits, override ``check_permissions`` or ``has_object_permission`` on the form class.
+See :ref:`topics-forms-actions-dynamic-guards` for those hooks.
 
 Verification
 ------------

--- a/docs/content/howto/resolve-feature-flags-with-di.rst
+++ b/docs/content/howto/resolve-feature-flags-with-di.rst
@@ -128,23 +128,24 @@ The next ``get_cached_flag`` call refetches from the database.
 Wire the provider and receivers at app ready
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``flags.providers`` registers ``FlagProvider`` with the resolver as a side effect of import, so a top-level import of the module is enough.
-``flags.receivers`` exposes a ``connect`` helper that ``AppConfig.ready`` calls, which keeps the actual signal wiring out of import time.
+``flags.providers`` registers ``FlagProvider`` with the resolver as a side effect of import.
+Both ``flags.providers`` and ``flags.receivers`` reach ``flags.models`` through their import chains, so ``AppConfig.ready`` defers the imports until the app registry is populated.
+A top-level import in ``apps.py`` would run while Django is still loading app configs, and defining the ``Flag`` model at that point raises :exc:`~django.core.exceptions.AppRegistryNotReady`.
 
 .. code-block:: python
    :caption: flags/apps.py
 
    from django.apps import AppConfig
-   from flags import providers, receivers
-
-   _ = providers
 
    class FlagsConfig(AppConfig):
        default_auto_field = "django.db.models.BigAutoField"
        name = "flags"
 
        def ready(self) -> None:
-           """Connect receivers once the app registry is populated."""
+           """Import providers and connect receivers once the app registry is populated."""
+           from flags import providers, receivers
+
+           _ = providers
            receivers.connect()
 
 The ``_ = providers`` line documents the intentional side-effect import.

--- a/docs/content/howto/reverse-urls.rst
+++ b/docs/content/howto/reverse-urls.rst
@@ -67,9 +67,9 @@ Use Inside an Action Handler
    :caption: notes/pages/page.py
 
    from django.http import HttpRequest, HttpResponseRedirect
-   from notes.models import Note
    from next.forms import ModelForm
    from next.urls import page_reverse
+   from notes.models import Note
 
    class CreateNoteForm(ModelForm):
        class Meta:

--- a/docs/content/howto/share-components-across-projects.rst
+++ b/docs/content/howto/share-components-across-projects.rst
@@ -84,10 +84,10 @@ A project can override a shared component by placing a component with the same n
 .. code-block:: text
    :caption: project override
 
-   projects/admin/admin_app/_components/button/component.djx
+   projects/admin/admin_app/pages/_components/button/component.djx
 
-The project local version wins because the visibility resolver scores the project's page-tree root and a global ``DIRS`` root equally and breaks the tie by registration order.
-The page-tree backend registers first during the URL router walk, so its components shadow same-name entries contributed through ``DIRS``.
+The project-local version wins because the visibility resolver scores the project's page-tree root and a global ``DIRS`` root equally, then breaks the tie in favour of the page-tree component.
+A page-tree component shadows a same-name ``DIRS`` component at equal score, so the project's own copy overrides the shared one regardless of which root was registered first.
 
 Static Files
 ~~~~~~~~~~~~

--- a/docs/content/howto/share-context-across-pages.rst
+++ b/docs/content/howto/share-context-across-pages.rst
@@ -21,8 +21,8 @@ Add the context function to the segment's ``page.py``.
 .. code-block:: python
    :caption: notes/pages/page.py
 
-   from notes.models import Note
    from next.pages import context
+   from notes.models import Note
 
    @context("note_count", inherit_context=True)
    def note_count() -> int:

--- a/docs/content/howto/split-settings-per-environment.rst
+++ b/docs/content/howto/split-settings-per-environment.rst
@@ -94,20 +94,9 @@ Override for Development
        },
    }
 
-Override a single ``NEXT_FRAMEWORK`` key without rewriting the whole block by copying it from ``base`` and patching the copy.
-
-.. code-block:: python
-   :caption: config/settings/dev.py
-
-   NEXT_FRAMEWORK = {**NEXT_FRAMEWORK}  # noqa: F405
-   NEXT_FRAMEWORK["STRICT_CONTEXT"] = True
-
-Because ``{**NEXT_FRAMEWORK}`` is a shallow copy, mutate only flat keys this way.
-For nested backend lists use ``extend_default_backend`` or ``copy.deepcopy``.
-
-``extend_default_backend`` patches the backend-list keys.
-A flat key such as ``STRICT_CONTEXT`` is copied and reassigned as shown here.
-See :doc:`extend-a-default-backend` for the backend-list case.
+Development keeps the framework defaults, so ``dev.py`` leaves ``NEXT_FRAMEWORK`` untouched.
+The default ``STRICT_CONTEXT`` value ``False`` keeps local rendering alive when a context processor fails.
+The copy-and-patch pattern for a per-environment key is shown in the production module below.
 
 Override for Production
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -129,6 +118,12 @@ Override for Production
 
    NEXT_FRAMEWORK = {**NEXT_FRAMEWORK}  # noqa: F405
    NEXT_FRAMEWORK["STRICT_CONTEXT"] = True
+
+Override a single ``NEXT_FRAMEWORK`` key without rewriting the whole block by copying it from ``base`` and patching the copy.
+Because ``{**NEXT_FRAMEWORK}`` is a shallow copy, mutate only flat keys this way.
+A flat key such as ``STRICT_CONTEXT`` is copied and reassigned as shown here.
+For nested backend lists use ``extend_default_backend`` or ``copy.deepcopy``.
+See :doc:`extend-a-default-backend` for the backend-list case.
 
 Select a Module per Process
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -163,7 +158,8 @@ Run the framework system checks under each module.
    DJANGO_SETTINGS_MODULE=config.settings.prod uv run python manage.py check
 
 Both runs report no errors.
-The development run has ``DEBUG`` on, the production run has it off, and ``NEXT_FRAMEWORK`` carries the per-environment override in each.
+The development run has ``DEBUG`` on and the production run has it off.
+The production run carries the ``STRICT_CONTEXT`` override, the development run keeps the default.
 
 See Also
 --------

--- a/docs/content/howto/style-forms-with-crispy-and-widget-tweaks.rst
+++ b/docs/content/howto/style-forms-with-crispy-and-widget-tweaks.rst
@@ -11,7 +11,7 @@ You want Bootstrap-grade form markup inside ``{% form %}`` without hand-writing 
 Solution
 --------
 
-The ``{% form %}`` tag publishes an ordinary bound form under the ``form`` variable, so every renderer that consumes a Django form works unchanged.
+The ``{% form %}`` tag publishes an ordinary Django form instance under the ``form`` variable, so every renderer that consumes a Django form works unchanged.
 Render the whole form through the ``|crispy`` filter, or restyle single fields with django-widget-tweaks filters.
 No compatibility code is involved on either side.
 Verified with django-crispy-forms 2.5 and later plus the crispy-bootstrap5 template pack, and django-widget-tweaks 1.5 and later, on Django 5.2 through 6.0.
@@ -76,9 +76,12 @@ The ``{% crispy %}`` tag drives the layout from a ``FormHelper``, and a helper d
 Inside ``{% form %}`` both must be switched off.
 
 .. code-block:: python
-   :caption: contact/pages/contact/page.py
+   :caption: contact/pages/contact/page.py — replaces the earlier ``ContactForm``
 
    from crispy_forms.helper import FormHelper
+   from django import forms
+
+   import next.forms
 
    class ContactForm(next.forms.Form):
        name = forms.CharField(max_length=100)
@@ -134,7 +137,8 @@ Validation Re-Render
 
 An invalid submission re-renders the origin page with the bound failing form in place of ``form``, see :doc:`/content/topics/forms/validation-rerender`.
 The styled markup survives that round trip.
-Crispy renders the bound errors with the pack's error markup (``is-invalid`` and ``invalid-feedback`` under Bootstrap 5), and the widget-tweaks classes and attributes stay on the field next to its error list.
+Crispy renders the bound errors with the pack's error markup, ``is-invalid`` and ``invalid-feedback`` under Bootstrap 5.
+The widget-tweaks classes and attributes stay on the field next to its error list.
 
 Verification
 ------------

--- a/docs/content/howto/test-a-component-in-isolation.rst
+++ b/docs/content/howto/test-a-component-in-isolation.rst
@@ -21,20 +21,22 @@ Load the Components
 ~~~~~~~~~~~~~~~~~~~
 
 Component discovery is a side effect, so import the components before a test resolves one.
-A pytest fixture calls ``eager_load_components`` once and resets the registries around each test.
+A session-scoped pytest fixture calls ``eager_load_components`` once.
 
 .. code-block:: python
    :caption: conftest.py
 
    import pytest
-   from next.testing import eager_load_components, reset_registries
+   from next.testing import eager_load_components
 
-   @pytest.fixture(autouse=True)
-   def _next_components():
-       reset_registries()
+   @pytest.fixture(autouse=True, scope="session")
+   def _load_components() -> None:
        eager_load_components()
-       yield
-       reset_registries()
+
+``eager_load_components`` covers the roots configured through ``COMPONENT_BACKENDS``.
+Component folders inside a page tree register during the URL router walk instead, which runs when the URLconf first loads.
+A suite whose other tests issue ``NextClient`` requests has already triggered the walk.
+A suite that renders components without any HTTP triggers it by reversing one route in the same fixture, for example with ``page_reverse()`` from ``next.urls``.
 
 Render the Component
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/content/howto/test-a-page-with-actions.rst
+++ b/docs/content/howto/test-a-page-with-actions.rst
@@ -16,19 +16,21 @@ Use ``NextClient.post_action`` for the HTTP round trip and ``SignalRecorder`` to
 Walkthrough
 -----------
 
-Set up pytest plus pytest-django and an isolation fixture (see :doc:`/content/topics/testing`).
+Set up pytest plus pytest-django and a session fixture that imports every ``page.py``, so the ``@action`` registrations are in place before the first request (see :doc:`/content/topics/testing`).
 
 .. code-block:: python
    :caption: conftest.py
 
-   import pytest
-   from next.testing import reset_registries
+   from pathlib import Path
 
-   @pytest.fixture(autouse=True)
-   def _next_isolation():
-       reset_registries()
-       yield
-       reset_registries()
+   import pytest
+   from next.testing import eager_load_pages
+
+   PROJECT_ROOT = Path(__file__).resolve().parent
+
+   @pytest.fixture(autouse=True, scope="session")
+   def _load_pages() -> None:
+       eager_load_pages(PROJECT_ROOT / "notes" / "pages")
 
 Write the test.
 
@@ -78,7 +80,8 @@ The ``origin`` keyword fills the ``_next_form_origin`` field the ``{% form %}`` 
 
 The status code is ``200`` because the dispatcher resolves the origin path and re-renders that page with the bound form in scope.
 
-A protocol-level test asserts the rejection instead: without a resolvable origin the invalid branch cannot re-render and answers HTTP 400.
+A protocol-level test asserts the rejection instead.
+Without a resolvable origin the invalid branch cannot re-render and answers HTTP 400.
 
 .. code-block:: python
    :caption: tests/test_validation_failure.py

--- a/docs/content/howto/use-formsets.rst
+++ b/docs/content/howto/use-formsets.rst
@@ -45,27 +45,28 @@ Register the action.
    :caption: notes/pages/notes/bulk/page.py
 
    from django.forms.formsets import BaseFormSet
-   from django.http import HttpResponseRedirect
-   from django.urls import reverse
-   from next.forms import action
+   from django.http import HttpRequest, HttpResponseRedirect
+
+   from next.forms import action, redirect_to_origin
    from notes.forms import NoteFormSet
 
    def build_bulk_formset() -> tuple[type[BaseFormSet], dict]:
        return NoteFormSet, {"prefix": "notes"}
 
    @action("bulk_create", form_class=build_bulk_formset)
-   def bulk_create(form: NoteFormSet) -> HttpResponseRedirect:
+   def bulk_create(request: HttpRequest, form: NoteFormSet) -> HttpResponseRedirect:
        for row in form:
            if row.cleaned_data and not row.cleaned_data.get("DELETE"):
                row.save()
-       return HttpResponseRedirect(reverse("next:page_"))
+       return redirect_to_origin(request)
 
-Passing a formset class directly to ``@action``'s ``form_class`` is accepted at decoration time but fails at request time, because the dispatcher calls ``get_initial`` on a directly passed class and Django formset classes have none.
+Passing a formset class directly to ``@action``'s ``form_class`` is accepted at decoration time but fails at request time.
+The dispatcher calls ``get_initial`` on a directly passed class, and Django formset classes have none.
 Register a factory callable that returns a ``(FormSetClass, init_kwargs)`` tuple instead.
 The ``init_kwargs`` reach the formset constructor, and a non-empty dict makes the dispatcher skip the ``get_initial`` step.
 A formset has no ``get_initial``, so the ``init_kwargs`` must be non-empty even if they only set the ``prefix``.
 
-The ``page_{path}`` URL name follows the file-router naming convention, see :doc:`/content/topics/file-router`.
+``redirect_to_origin`` reads the posted origin path, so a successful submission lands back on the bulk page.
 
 Render the formset.
 
@@ -79,19 +80,21 @@ Render the formset.
          <legend>Row {{ forloop.counter }}</legend>
          {{ row.title }}
          {{ row.body }}
+         {{ row.DELETE }}
        </fieldset>
      {% endfor %}
      <button type="submit">Save all</button>
    {% endform %}
 
 Always render ``{{ form.management_form }}`` before the row loop.
+``can_delete=True`` adds the ``DELETE`` checkbox to every row, and the handler skips the rows the user marked, so the template renders it alongside the fields.
 
 Clean Up Empty Rows
 -------------------
 
 A formset with ``extra=3`` ships three blank rows.
-When ``initial`` data is provided alongside those extra rows, Django pre-populates the blank rows with the initial values.
-A user who leaves those rows untouched submits data that appears empty but carries hidden values, triggering validation errors.
+Field-level initials, declared on the row form or inherited from model field defaults, pre-populate those blank rows.
+An untouched pre-filled row no longer looks empty to Django, so it validates as a partial submission and triggers errors.
 Use ``cleanup_extra_initial`` to clear initial values from blank extra rows before the formset is rendered.
 
 .. code-block:: python
@@ -103,19 +106,16 @@ Use ``cleanup_extra_initial`` to clear initial values from blank extra rows befo
    from next.pages import context
    from notes.forms import NoteFormSet
 
-   def build_formset(initial: list[dict]) -> NoteFormSet:
-       formset = NoteFormSet(initial=initial)
-       cleanup_extra_initial(formset)
-       return formset
-
    @context("bulk_create")
    def bulk_create_form() -> SimpleNamespace:
-       return SimpleNamespace(form=build_formset([{"title": "Draft"}]))
+       formset = NoteFormSet(prefix="notes")
+       cleanup_extra_initial(formset)
+       return SimpleNamespace(form=formset)
 
-The ``{% form %}`` tag looks up a context variable named after the action and reads its ``.form`` attribute.
-A regular form action satisfies this through its own ``get_initial``, but a formset has no ``get_initial``, so the ``@context`` callable must publish the value itself.
-The callable name must match the action name, and the returned object must expose ``.form``, hence the ``SimpleNamespace(form=...)`` wrapper.
-Returning the bare formset, or publishing it under a different key, leaves ``form`` as ``None`` in the template.
+The ``{% form %}`` tag first looks up a context variable named after the action and reads its ``.form`` attribute.
+When the variable is absent the tag builds the namespace itself from the registered factory, so a plain render needs no ``@context`` at all.
+Publish the namespace only to customise construction, here to clean the field-level initials off the blank extra rows.
+The context key passed to ``@context`` must match the action name, and the returned object must expose ``.form``, hence the ``SimpleNamespace(form=...)`` wrapper.
 
 Verification
 ------------

--- a/docs/content/howto/use-modelform-for-crud.rst
+++ b/docs/content/howto/use-modelform-for-crud.rst
@@ -18,10 +18,11 @@ The same class drives the create page, where the kwarg is absent and the form re
 Walkthrough
 -----------
 
-Declare the form once
+Declare the Form Once
 ~~~~~~~~~~~~~~~~~~~~~
 
-The class lives outside ``page.py``, so it registers with shared scope: one action name and one action URL serve both pages.
+The class lives outside ``page.py``, so it registers with shared scope.
+One action name and one action URL serve both pages.
 Autodiscovery imports ``notes/forms.py`` on startup, so neither page module imports it.
 
 .. code-block:: python
@@ -39,7 +40,7 @@ Autodiscovery imports ``notes/forms.py`` on startup, so neither page module impo
 A copy declared in each ``page.py`` would be page-scoped instead, keeping the shared action name but giving every per-file registration its own action URL.
 See :doc:`/content/topics/forms/modelforms` for that distinction and :doc:`/content/topics/forms/actions` for the scope rules.
 
-Edit page
+Edit Page
 ~~~~~~~~~
 
 The edit page lives under a route that captures the lookup field.
@@ -58,11 +59,14 @@ Here the route segment is ``[slug]``, so the captured kwarg is ``slug``.
 The default ``get_initial`` loads ``Note.objects.get(slug=<captured slug>)`` through :func:`~django.shortcuts.get_object_or_404`.
 The default ``on_valid`` calls ``self.save()`` and redirects to the origin page.
 No handler, no hidden lookup field, and no second lookup are needed.
+``Meta.success_url`` redirects the successful submission to another page instead, and ``next.urls.page_reverse_lazy`` builds that value from a page path.
+``Meta.success_message`` flashes a message through Django's :doc:`messages framework <django:ref/contrib/messages>`, interpolated over the cleaned data.
+See :ref:`topics-forms-actions-success` for both options.
 
 The ``{% form %}`` tag resolves the action by name, opens the ``<form>`` element, injects the CSRF token, and publishes ``form`` inside the block.
 It also emits a hidden ``_next_form_origin`` field with the page URL, so the dispatcher recovers the captured ``slug`` by resolving that path and the submission re-attaches to the same row.
 
-Create page
+Create Page
 ~~~~~~~~~~~
 
 The create page renders the same form on a route with no captured kwarg.
@@ -108,8 +112,10 @@ A test asserts the same flow with ``NextClient``.
        )
        assert Note.objects.get(pk=note.pk).title == "Intro v2"
 
-The first ``post_action`` mimics the create page: with no ``origin`` there is no captured kwarg, so the form is unbound and inserts a row.
-The second passes ``origin``, which fills the ``_next_form_origin`` field the ``{% form %}`` tag emits, so resolving the edit-page path yields the ``slug`` kwarg, ``instance_from_url`` loads the existing row, and the save updates it.
+The first ``post_action`` mimics the create page.
+With no ``origin`` there is no captured kwarg, ``get_initial`` returns an empty dict, and the bound form inserts a new row.
+The second passes ``origin``, which fills the ``_next_form_origin`` field the ``{% form %}`` tag emits.
+Resolving the edit-page path yields the ``slug`` kwarg, ``instance_from_url`` loads the existing row, and the save updates it.
 
 The recovered kwargs come through the URL converters of the resolved route, so a ``[int:id]`` kwarg arrives as an integer on both the initial render and the re-render, while a slug stays a string.
 

--- a/docs/content/howto/write-a-form-action-backend.rst
+++ b/docs/content/howto/write-a-form-action-backend.rst
@@ -6,7 +6,7 @@ Write a Form Action Backend
 Problem
 -------
 
-You want every form dispatch to run an extra step such as audit logging or rate limiting, transactional with the dispatch itself.
+You want every form dispatch to run an extra step such as audit logging or rate limiting, wired into the dispatch pipeline itself.
 
 Solution
 --------
@@ -132,9 +132,15 @@ Override ``shape_response`` to change the envelope without touching the HTML, fo
 
 ``outcome.kind`` discriminates the pipeline outcomes, so the handler-result and wizard-advance envelopes stay default.
 ``ActionOutcomeKind.INVALID`` only ever represents a failed validation.
-A valid submission whose handler returns ``None`` leaves the pipeline as a ``RESULT`` outcome whose default envelope re-renders the origin without re-entering ``shape_response``, so the 422 override never touches successful submissions.
+A valid submission whose handler returns ``None`` leaves the pipeline as a ``RESULT`` outcome.
+Its default envelope re-renders the origin without re-entering ``shape_response``, so the 422 override never touches successful submissions.
 Override ``render_invalid_page`` instead when only the error HTML changes and the envelope stays as shipped.
 See :doc:`/content/topics/forms/backends` for the two customisation layers and the ``ActionOutcome`` fields.
+
+.. warning::
+
+   ``FormActionBackend.shape_response`` routes partial requests through the patch-envelope shaping first, so this override restamps patch envelopes too.
+   Gate the status change on ``not is_partial_request(request)`` from ``next.partial`` to keep the partial wire contract at 200.
 
 Surface Actions to the System Checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -147,13 +153,21 @@ A from-scratch backend overrides the hook so its actions participate in checks s
    :caption: notes/backends.py
 
    from collections.abc import Iterable
+   from typing import Any
+
    from next.forms import FormActionBackend
    from next.forms.backends import ActionMeta
 
    class CustomBackend(FormActionBackend):
+       def __init__(self, config: dict[str, Any] | None = None) -> None:
+           self._config = config or {}
+           self._metas: dict[str, ActionMeta] = {}
+
        def iter_actions(self) -> Iterable[ActionMeta]:
            yield from self._metas.values()
 
+The fragment shows only the storage and the hook.
+A from-scratch backend also implements the four abstract methods ``register_action``, ``get_action_url``, ``generate_urls``, and ``dispatch``, which fill and consume ``self._metas``.
 The yielded dicts carry the action ``name``, the target, the ``uid``, and the access ``guard``, the same shape ``get_meta`` returns.
 
 Verification

--- a/docs/content/howto/write-a-static-backend.rst
+++ b/docs/content/howto/write-a-static-backend.rst
@@ -102,7 +102,8 @@ Tenant URL Prefix
 A common multi-tenant pattern is to prefix every collected URL with a tenant slug so static files are scoped per tenant.
 Override all three renderer methods and delegate to the parent after rewriting the URL.
 Leave absolute URLs untouched.
-The shipped multi-tenant example omits ``render_module_tag`` because it serves no ``.mjs`` assets.
+The shipped multi-tenant example overrides only ``render_link_tag`` and ``render_script_tag``, so its ``.mjs`` assets bypass the prefix.
+The snippet below overrides all three methods so every kind stays consistent.
 
 .. code-block:: python
    :caption: notes/backends.py

--- a/docs/content/internals/action-dispatch.rst
+++ b/docs/content/internals/action-dispatch.rst
@@ -32,7 +32,9 @@ Pipeline
        Guard -- "missing permission" --> Forbidden["HTTP 403"]
        Guard -- "pass, no form_class" --> HandlerOnly["Run handler only"]
        Guard -- "pass, form_class" --> ViewHook{"check_permissions hook"}
-       Guard -- "pass, wizard_class" --> ViewHook
+       Guard -- "pass, wizard_class" --> WizardOrigin{"Origin resolves"}
+       WizardOrigin -- no --> BadRequest["HTTP 400"]
+       WizardOrigin -- yes --> ViewHook
        ViewHook -- "deny" --> HookDenied["HTTP 403 or response"]
        ViewHook -- "deny" --> AccessDenied["form_access_denied signal"]
        ViewHook -- "allow, form_class" --> Build["Build form"]
@@ -43,8 +45,10 @@ Pipeline
        WizardStep --> ObjectHook
        ObjectHook -- "deny" --> ObjectDenied["HTTP 403 or response"]
        ObjectHook -- "deny" --> AccessDenied
-       ObjectHook -- "allow, form_class" --> Validate{"Form valid"}
-       ObjectHook -- "allow, wizard_class" --> WizardValid{"Step valid"}
+       ObjectHook -- allow --> ValidateOnly{"Validate-only intent"}
+       ValidateOnly -- yes --> ValidateEnvelope["Validation envelope, no handler"]
+       ValidateOnly -- "no, form_class" --> Validate{"Form valid"}
+       ValidateOnly -- "no, wizard_class" --> WizardValid{"Step valid"}
        Validate -- yes --> Handler["Run handler"]
        Handler --> Response["Handler response"]
        Handler --> ActionDispatched
@@ -86,7 +90,7 @@ Modules
    ``FormActionBackend`` abstract contract, ``RegistryFormActionBackend`` default implementation, ``FormActionFactory``, and the ``FormActionNotFoundError`` exception.
 
 ``next.forms.uid``.
-   ``redirect_to_origin``, ``reverse_form_action``, and ``validated_origin_path`` helpers for the origin page round trip, plus the ``ORIGIN_FIELD_NAME`` wire constant.
+   ``redirect_to_origin``, ``reverse_form_action``, and ``validated_origin_path`` helpers for the origin page round trip, plus the ``ORIGIN_FIELD_NAME`` wire constant and the ``FORM_ORIGIN_OVERRIDE_KEY`` render-context key the partial shaping layer sets on a wizard advance.
 
 ``next.forms.origin``.
    Resolution of the posted origin path into the page module and the typed URL kwargs, memoised per request.
@@ -138,6 +142,15 @@ A wizard enforces ``check_permissions`` once per step POST before the step binds
 A wizard step binds without ``get_initial`` or ``Meta.instance_from_url``, so a ``ModelForm`` step reads an unbound ``self.instance`` in that hook, not the URL-addressed target the standalone path loads.
 The guide covers the authoring contract at :ref:`topics-forms-actions-dynamic-guards`.
 
+Validate-Only Short Circuit
+---------------------------
+
+A partial request whose intent carries validate fields short-circuits the pipeline on the already bound form.
+The branch fires in the form path and in the wizard step path only after the static guard, the ``check_permissions`` hook, the form binding, and the ``has_object_permission`` hook have all passed, so a guarded validator is never an anonymous oracle.
+The dispatcher answers with the validation envelope, the handler never runs, the success signals never fire, and wizard storage stays untouched.
+A request without validate fields falls through to the normal submit path.
+See :doc:`/content/topics/partial-rendering/scenarios` for the client-side flow.
+
 Origin Resolution
 -----------------
 
@@ -183,7 +196,8 @@ The page manager caches the composed template source and its compiled ``Template
 Signals
 -------
 
-Six signals fire: ``action_registered`` at import time, the other five per request.
+Six signals fire.
+``action_registered`` fires at import time and the other five fire per request.
 
 - ``action_registered`` fires at import time, once per registration when the registry stores the action target.
   The target is a handler, a form class, or a wizard class.
@@ -204,6 +218,7 @@ Extension Points
 
 - Subclass ``RegistryFormActionBackend`` and override ``dispatch`` to wrap the standard pipeline.
 - Override ``render_invalid_page`` for custom validation-error HTML, or ``shape_response`` for a custom response envelope.
+  The base ``shape_response`` routes a partial request through ``shape_partial`` before the default full-page envelope, so an override that never calls ``super().shape_response`` disables the patch envelopes.
 - Register the custom backend through ``FORM_ACTION_BACKENDS``.
 - Subscribe to ``action_dispatched`` for audit and cache invalidation.
 - Subscribe to ``form_validation_failed`` for alerting on failure rates.

--- a/docs/content/internals/autoreload.rst
+++ b/docs/content/internals/autoreload.rst
@@ -37,7 +37,8 @@ The pipeline is wired by ``next.apps.autoreload.install()``, which ``NextFramewo
 ``install`` performs two actions:
 
 #. Replaces ``django.utils.autoreload.StatReloader`` with ``NextStatReloader``.
-   The swap is idempotent: subsequent calls are no-ops if ``StatReloader`` is already a ``NextStatReloader`` subclass.
+   The swap is idempotent.
+   Subsequent calls are no-ops when ``StatReloader`` is already a ``NextStatReloader`` subclass.
 #. Connects ``_watch_next_filesystem`` to Django's ``autoreload_started`` signal so the watch specs are registered the moment the dev server starts.
 
 .. note::
@@ -80,7 +81,7 @@ A watch spec is a tuple of a root path and one glob pattern.
 User code calls ``iter_all_autoreload_watch_specs`` instead, which wraps the built-in set with the registered extra specs.
 
 - Each page root contributes a ``**/page.py`` spec.
-- Each page root paired with its components folder name contributes a ``**/_components/**/component.py`` spec.
+- Each page root paired with its components folder name contributes a ``**/<components-folder>/**/component.py`` spec, ``_components`` by default.
 - Each extra component root from ``COMPONENT_BACKENDS`` contributes a ``**/component.py`` spec.
 
 Only Python entrypoints are watched.
@@ -115,7 +116,8 @@ Signals
 The autoreload pipeline fires ``watch_specs_ready`` after the watch-spec aggregation completes.
 The sender is the ``iter_all_autoreload_watch_specs`` function itself, so a receiver connected with ``sender=iter_all_autoreload_watch_specs`` fires only for that aggregation.
 
-Custom routers subscribe to ``watch_specs_ready`` to register additional patterns.
+Receivers subscribe to ``watch_specs_ready`` to log or assert on the resolved spec set.
+Registration goes through ``register_autoreload_watch_spec``.
 
 Extension Points
 ----------------

--- a/docs/content/internals/component-pipeline.rst
+++ b/docs/content/internals/component-pipeline.rst
@@ -83,12 +83,13 @@ A component reference resolves through the visibility resolver.
 The resolver collects every component visible from the template path, then scores each by scope specificity.
 The highest score wins.
 A component nested in a sub-folder of the template's own page tree outscores a same-named component contributed at a tree root or through a ``DIRS`` root.
-A page-tree root and a ``DIRS`` root both score zero, so the tie breaks on registration order.
+A page-tree root and a ``DIRS`` root both score zero, so the tie breaks on origin, and the page-tree component wins.
 
-The full sort key is ``(-score, component.name, registration_position)``.
-Equal scores break first by component name, then by registration order, so the component discovered first shadows a later same-named one.
+The full sort key is ``(-score, dirs_origin, component.name, registration_position)``, where ``dirs_origin`` is ``0`` for a page-tree component and ``1`` for a ``DIRS`` component.
+At equal score a page-tree component sorts before a ``DIRS`` one, so a project-local component shadows a shared ``DIRS`` entry.
+A remaining same-origin tie breaks first by component name, then by registration order, so within one origin the component discovered first shadows a later same-named one.
 Registration order operates inside a single ``FileComponentsBackend``.
-The page-tree backend records its roots during the URL router walk before ``DIRS`` roots are scanned, so its components shadow same-name entries from ``DIRS``.
+``DIRS`` roots are scanned at app ready, before the URL router walk registers page-tree folders, but the origin dimension of the sort key makes the page-tree component win regardless of that order.
 Across backends, the order of entries in ``COMPONENT_BACKENDS`` decides which backend is consulted first.
 
 Two components in the same scope with the same name are reported by ``next.E020``.

--- a/docs/content/internals/di-resolver.rst
+++ b/docs/content/internals/di-resolver.rst
@@ -14,7 +14,8 @@ Overview
 
 The resolver is a singleton instance of ``DependencyResolver``.
 Every page context function, every page render, and every component context function is invoked through the resolver.
-The form dispatch adds its own call sites: the form-class factory, ``get_initial``, the ``@action`` handler, ``on_valid``, and ``wizard.done``.
+The form dispatch adds its own call sites.
+These are the form-class factory, ``get_initial``, the ``@action`` handler, ``on_valid``, and ``wizard.done``.
 
 Pipeline
 --------
@@ -93,7 +94,7 @@ ResolutionContext
 -----------------
 
 Each call builds a fresh ``ResolutionContext``.
-It carries the current request, the captured URL kwargs, the template scope carried as ``context_data``, the bound form when one exists, the dependency cache, and the resolution stack.
+It carries the current request, the captured URL kwargs, the template scope as ``context_data``, the bound form when one exists, the dependency cache, and the resolution stack.
 Query-string values are read off the request by the query provider.
 Providers read what they need and never mutate the context.
 
@@ -108,7 +109,7 @@ It lives on the ``ResolutionContext`` for that pass and holds named dependency v
 The cache key is the dependency name string alone, with no type component.
 
 ``FormActionDispatch.dispatch`` creates a fresh dispatch cache dict on every POST and attaches it to the request under the attribute named ``REQUEST_DEP_CACHE_ATTR``.
-The cache is shared across each stage of the dispatch: ``get_initial``, the factory resolution, the handler call, and any re-render after validation failure.
+The cache is shared across each stage of the dispatch, from ``get_initial`` and the factory resolution to the handler call and any re-render after validation failure.
 On a re-render the page context and component context renderers read it back through ``get_request_dep_cache`` and rejoin the same cache.
 An ordinary page request that does not pass through the form dispatcher never sees this attribute.
 
@@ -130,7 +131,7 @@ The error message lists the chain of named dependencies that closed the loop, re
 Signals
 -------
 
-The resolver fires ``provider_registered`` once per provider when the class enters the registry.
+``provider_registered`` fires once per provider when the subclass enters the ``RegisteredParameterProvider`` registry.
 Subscribe to track custom providers across reloads.
 
 Extension Points

--- a/docs/content/internals/index.rst
+++ b/docs/content/internals/index.rst
@@ -5,7 +5,8 @@ Internals
 
 The internals section explains how next.dj works under the hood.
 Each page traces one pipeline with a mermaid diagram, lists the modules involved, and points at the public hooks used to extend it.
-The pages read top to bottom, from a whole-framework map down to each subsystem pipeline.
+The pages read top to bottom, from a whole-framework map down to individual subsystem pipelines.
+The partial rendering pipeline is traced in :doc:`/content/topics/partial-rendering/how-it-works` rather than on a page here.
 
 :doc:`overview`
    Map of every subsystem with a signals fan-out diagram.

--- a/docs/content/internals/overview.rst
+++ b/docs/content/internals/overview.rst
@@ -65,17 +65,19 @@ Bootstrap
 
 Django calls ``NextFrameworkConfig.ready()`` once per process after all applications load.
 The hook calls ``register_all()`` to register the framework system checks.
-It then runs five startup hooks in a fixed order that wire the subsystems into the Django runtime, autoreload, templates, staticfiles, components, and form autodiscovery.
+It then runs five startup hooks in a fixed order.
+The hooks wire autoreload, templates, staticfiles, components, and form autodiscovery into the Django runtime.
 The final hook ``autodiscover_forms()`` registers shared forms before the first request arrives.
 See :doc:`/content/ref/apps` for the canonical ordering and the full API.
 
 How They Compose
 ----------------
 
-A request hands off ``next.urls`` to ``next.pages`` to ``next.deps`` to ``next.static`` and ``next.components`` before the final HTML returns to the client.
+A request passes from ``next.urls`` through ``next.pages`` and ``next.deps`` to ``next.static`` and ``next.components`` before the final HTML returns to the client.
 Form submissions take a parallel path through ``next.forms``, which on validation failure reuses the same render pipeline.
 Partial requests take a zone-patch path through ``next.partial``, which renders the targeted zones through the same render pipeline and returns patches instead of a full page.
-:doc:`request-lifecycle` traces both paths end to end.
+:doc:`request-lifecycle` traces the render and form paths end to end.
+:doc:`/content/topics/partial-rendering/how-it-works` traces the zone-patch path.
 
 Signals Fan Out
 ---------------
@@ -150,7 +152,8 @@ Each subsystem keeps a flat module layout.
    * - ``next.urls``
      - ``manager``, ``backends``, ``dispatcher``, ``parser``, ``markers``, ``reverse``, ``checks``, ``signals``.
    * - ``next.forms``
-     - ``manager``, ``dispatch``, ``backends``, ``decorators``, ``base``, ``markers``, ``serializers``, ``formsets``, ``uid``, ``rendering``, ``autodiscover``, ``wizard``, ``widgets``, ``origin``, ``diagnostics``, ``checks``, ``signals``.
+     - ``manager``, ``dispatch``, ``backends``, ``decorators``, ``base``, ``markers``, ``serializers``, ``formsets``,
+       ``uid``, ``rendering``, ``autodiscover``, ``wizard``, ``widgets``, ``origin``, ``diagnostics``, ``checks``, ``signals``.
    * - ``next.static``
      - ``manager``, ``collector``, ``discovery``, ``backends``, ``assets``, ``scripts``, ``serializers``, ``defaults``, ``finders``, ``checks``, ``signals``.
    * - ``next.partial``

--- a/docs/content/internals/page-discovery.rst
+++ b/docs/content/internals/page-discovery.rst
@@ -12,7 +12,7 @@ This page covers how the framework discovers pages from the filesystem, register
 Overview
 --------
 
-Discovery runs once at startup and again whenever the autoreload watcher fires.
+Discovery runs lazily on the first URL access and again whenever the autoreload watcher fires.
 The result is a set of Django URL patterns plus the context callables and layout chains attached to each ``page.py``.
 
 Pipeline
@@ -75,7 +75,9 @@ When the body source is a ``render`` function that returns an ``HttpResponseBase
 Composed-Template Cache
 -----------------------
 
-``Page`` keeps two parallel dicts that short-circuit the layout composition step when nothing on disk has changed.
+``Page`` keeps two parallel dicts that short-circuit layout composition for the callers of ``composed_template_for``.
+Those callers are the form re-render after a validation failure, the standalone zone render, and direct ``Page.render`` calls such as ``next.testing.render_page``.
+The canonical full-page path never consults the cache and recomposes the body and layout chain from the disk sources on each request.
 
 ``_template_registry``.
    Maps a ``page.py`` path to its already-composed template string.
@@ -83,9 +85,8 @@ Composed-Template Cache
 ``_template_source_mtimes``.
    Snapshots the modification time of every file that contributed to the composition, including the page body source and each ancestor ``layout.djx``.
 
-On every request ``_is_template_stale`` compares the current mtimes against the snapshot.
+On each cache read ``_is_template_stale`` compares the current mtimes against the snapshot.
 A change to any contributing file evicts the entry, the composition step rebuilds the template string, and the new snapshot is stored.
-The dynamic ``render`` path bypasses this cache entirely, so a ``render`` function that returns a fresh body never poisons the registry.
 
 Layout Composition
 ------------------
@@ -111,7 +112,7 @@ Context Resolution
 2. ``PageContextRegistry.collect_context`` runs in two sub-steps.
 
    a. Inherited context.
-      Every ``@context(..., inherit_context=True)`` callable registered in ancestor ``page.py`` files, walked from the current page upward toward the page root.
+      Every ``@context(..., inherit_context=True)`` callable registered in ancestor ``page.py`` files, walked from the current page upward through every ancestor directory, bounded at 64 levels.
    b. Page-level context.
       The ``@context`` callables declared in the current ``page.py``, evaluated after inherited values are in place so the page can shadow any inherited key.
 
@@ -121,7 +122,9 @@ Context Resolution
    Each surviving processor returns a dict that updates the merged scope, so a later processor overrides an earlier key on a collision.
 4. Component-level context functions run on demand as each ``{% component %}`` tag is evaluated during rendering.
 
-The dependency resolver shares a per-request cache across all four steps so a value resolved once (for example, the current user from ``Depends``) is not recomputed.
+The dependency resolver shares one cache between the inherited and page-level sub-steps of a single ``collect_context`` call, so a value resolved at an ancestor is not recomputed for the page.
+On a regular GET that cache does not extend to components, and each component render starts its own cache.
+A cache that spans the page and its components exists only on the form-dispatch re-render after a validation failure, where the dispatcher attaches its cache to the request.
 
 The canonical description is in :doc:`/content/topics/context`.
 This page focuses on which module performs each step.

--- a/docs/content/internals/request-lifecycle.rst
+++ b/docs/content/internals/request-lifecycle.rst
@@ -4,7 +4,7 @@ Request Lifecycle
 =================
 
 This page traces an HTTP request from the Django entry point through next.dj to the rendered response.
-It covers the regular page request flow plus the parallel path used for form submissions.
+It covers the regular page request flow, the zone branch for partial requests, and the parallel path used for form submissions.
 
 .. contents::
    :local:
@@ -30,8 +30,11 @@ Pipeline
        Loader --> BodySource{"Body source"}
        BodySource -- "render() function" --> RenderFn["Call render(), resolve its arguments"]
        BodySource -- "template / template.djx" --> StaticBody["Read static body string"]
-       RenderFn --> ContextCtx["Run context functions"]
-       StaticBody --> ContextCtx
+       RenderFn --> ZoneIntent{"Partial intent"}
+       StaticBody --> ZoneIntent
+       ZoneIntent -- "zone request" --> ZoneResp["Zone response"]
+       ZoneResp --> Response
+       ZoneIntent -- "full page" --> ContextCtx["Run context functions"]
        ContextCtx --> LayoutChain["Compose layout chain"]
        LayoutChain --> CollectAssets["Static collector"]
        CollectAssets --> InjectTags["Emit collected tags"]
@@ -68,10 +71,17 @@ When the body comes from the ``template`` attribute or a ``template.djx`` file t
 After the body is in hand the view builds the render context and runs every ``@context`` function in order.
 Captured URL kwargs from the matched route are seeded into the context dict before any ``@context`` function runs.
 
+Zone Requests
+~~~~~~~~~~~~~
+
+After the body source resolves, the view inspects the request for a partial intent.
+A request that targets named zones receives a zone response instead of the full page render.
+See :doc:`/content/topics/partial-rendering/how-it-works` for the zone request wire format and the patch envelope.
+
 Layout Chain
 ~~~~~~~~~~~~
 
-The framework collects every ancestor ``layout.djx`` walking from the page directory up to the page root.
+The framework collects every ancestor ``layout.djx`` walking upward from the page directory through every ancestor, bounded at 64 levels.
 Each layout substitutes the wrapped content into its ``{% block template %}`` placeholder.
 The innermost layout wraps the page body, the outermost layout wraps everything.
 

--- a/docs/content/internals/static-pipeline.rst
+++ b/docs/content/internals/static-pipeline.rst
@@ -119,6 +119,8 @@ The pipeline fires four signals.
 - ``html_injected`` once per request after the manager replaces the placeholder slots.
 - ``backend_loaded`` once per backend instance when the factory builds it.
 
+A standalone zone render runs the same discovery but ships the collected assets in the patch envelope, so ``collector_finalized`` and ``html_injected`` fire only on full-page renders.
+
 Extension Points
 ----------------
 

--- a/docs/content/internals/url-router.rst
+++ b/docs/content/internals/url-router.rst
@@ -53,7 +53,7 @@ Modules
    See :doc:`/content/topics/dependency-injection` for the marker semantics and the provider order.
 
 ``next.urls.reverse``.
-   ``page_reverse`` and ``with_query`` helpers.
+   ``page_reverse``, ``page_reverse_lazy``, and ``with_query`` helpers.
 
 URL Name Computation
 --------------------
@@ -61,7 +61,7 @@ URL Name Computation
 Names follow ``next:page_<segments>`` where the segments come from the directory path.
 
 - Static segments contribute their directory name unchanged.
-- Captured segments contribute their parameter name without the type prefix.
+- Captured segments contribute the raw bracket text with separators collapsed to underscores, so a converter prefix such as ``int:`` stays in the name.
 - Wildcard segments contribute the parameter name without brackets.
 
 The template ``URL_NAME_TEMPLATE`` controls the format.

--- a/docs/content/intro/tutorial02.rst
+++ b/docs/content/intro/tutorial02.rst
@@ -45,7 +45,7 @@ For the Notes application the most common layout sits next to the page tree at `
 
 Writing the ``{% block template %}`` placeholder explicitly is the recommended practice because it controls where the page body lands.
 The framework substitutes the body of each page into that block.
-When a layout omits the block, the framework still wraps the page body in a ``{% block template %}`` block so an ancestor layout's placeholder stays valid.
+When the page has no sibling ``layout.djx``, the framework wraps the page body in a ``{% block template %}`` block itself, so an ancestor layout's placeholder stays valid.
 
 Reverse names such as ``next:page_`` come from the file router.
 See :doc:`/content/topics/file-router` for how directories become URLs and :doc:`/content/topics/url-reversing` for helpers such as ``page_reverse``.
@@ -205,10 +205,9 @@ Inherited context flows from the root ``page.py`` down to every page.
 Common Pitfalls
 ---------------
 
-Layout shows but page body does not.
-   Add ``{% block template %}{% endblock template %}`` to the innermost ``layout.djx`` that wraps the page.
-   An ancestor layout that omits the block still wraps its descendants because the framework folds the inner layout into a ``{% block template %}`` block on the way out.
-   The placeholder is mandatory only in the innermost layout that should host the page body.
+A layout's markup does not appear on the page.
+   A ``layout.djx`` that omits the placeholder is skipped during composition.
+   Add ``{% block template %}{% endblock template %}`` to the layout whose markup disappeared.
 
 ``DUrl`` resolves to ``None`` when the captured segment is missing.
    ``DUrl[T]`` reads the segment whose name matches the parameter and coerces the value to ``T``.

--- a/docs/content/intro/tutorial03.rst
+++ b/docs/content/intro/tutorial03.rst
@@ -126,7 +126,7 @@ Tell the layout where to emit the collected style and script tags.
 
 The ``{% collect_styles %}`` tag emits one ``<link>`` per discovered stylesheet.
 ``{% collect_scripts %}`` does the same for JavaScript.
-Each asset is hashed and deduplicated, so the same file referenced from two components is emitted once.
+Each asset is deduplicated by its URL, so the same file referenced from two components is emitted once.
 
 Reload ``/`` and confirm that the served HTML now contains a ``<link>`` to ``note_card/component.css``.
 

--- a/docs/content/intro/tutorial04.rst
+++ b/docs/content/intro/tutorial04.rst
@@ -46,7 +46,8 @@ Create ``notes/forms.py``.
 
 ``next.forms.ModelForm`` and ``next.forms.Form`` are the framework form base classes.
 Subclassing either one auto-registers the form.
-The action name is derived from the class name in ``snake_case``: ``CreateNoteForm`` registers as ``create_note_form``, ``DeleteNoteForm`` registers as ``delete_note_form``.
+The action name is derived from the class name in ``snake_case``.
+``CreateNoteForm`` registers as ``create_note_form`` and ``DeleteNoteForm`` registers as ``delete_note_form``.
 Override ``on_valid`` to run code after the form passes validation.
 The default ``on_valid`` on ``ModelForm`` calls ``self.save()`` then redirects back.
 ``redirect_to_origin`` sends the visitor back to the page that rendered the form.
@@ -225,7 +226,8 @@ Extend the detail template.
 
 The rendered form carries several hidden inputs from different sources.
 ``confirm`` is a real field on ``DeleteNoteForm``, so the template posts it explicitly.
-The ``{% form %}`` tag emits the framework fields itself: ``csrfmiddlewaretoken`` carries the CSRF token and ``_next_form_origin`` records the page URL, such as ``/notes/7/``.
+The ``{% form %}`` tag emits the framework fields itself.
+``csrfmiddlewaretoken`` carries the CSRF token and ``_next_form_origin`` records the page URL, such as ``/notes/7/``.
 The dispatcher resolves that path against the URLconf, which recovers the captured ``id`` through the URL converter, so the action handler resolves ``DUrl["id", int]`` without any extra argument on the tag.
 Add the delete handler to the detail page.
 ``DeleteNoteForm`` is declared in ``notes/forms.py`` and registers automatically at startup via autodiscovery.

--- a/docs/content/intro/tutorial05.rst
+++ b/docs/content/intro/tutorial05.rst
@@ -15,7 +15,8 @@ Prerequisites
 
 You have finished :doc:`tutorial04`.
 The application creates, edits, and deletes notes through registered actions.
-The patterns below mirror :doc:`/content/topics/testing`. Keep that page open if you want the full helper catalog.
+The patterns below mirror :doc:`/content/topics/testing`.
+Keep that page open if you want the full helper catalog.
 
 Walkthrough
 -----------

--- a/docs/content/intro/tutorial06.rst
+++ b/docs/content/intro/tutorial06.rst
@@ -126,9 +126,15 @@ The server re-renders only the ``note-list`` zone and answers with a single morp
      "ops": [
        {"op": "morph", "target": {"zone": "note-list"},
         "html": "<ul data-next-zone=\"note-list\">…matching notes…</ul>"}
-     ]
+     ],
+     "assets": [
+       {"kind": "css", "url": "…/note_card/component.css"},
+       {"kind": "js", "url": "…/note_card/component.js"}
+     ],
+     "form": null
    }
 
+The envelope also ships the co-located assets of the zone body, here the ``note_card`` styles and script, and adds a ``context`` op with the js-context delta when one applies.
 The runtime syncs the address bar with ``history.replaceState``, so ``/?q=gro`` stays shareable.
 A new keystroke aborts an in-flight request, and a stale response that arrives after a fresher one is discarded.
 
@@ -162,7 +168,8 @@ Teach its handler to answer a partial request with a patch instead of a redirect
 
 ``is_partial_request`` is ``True`` only when the runtime made the submission.
 On that path the handler saves the note and returns a morph of the ``note-list`` zone, which re-renders the list from the ``notes`` context with the new note included.
-On the no-JavaScript path ``super().on_valid`` keeps the inherited behaviour: it saves and redirects to origin, and the reload shows the new note.
+On the no-JavaScript path ``super().on_valid`` keeps the inherited behaviour.
+It saves and redirects to origin, and the reload shows the new note.
 
 The form tag itself does not change.
 

--- a/docs/content/misc/design-philosophy.rst
+++ b/docs/content/misc/design-philosophy.rst
@@ -43,7 +43,6 @@ Composition Over Inheritance
 
 Layouts compose by string substitution, not by Django ``{% extends %}``.
 Components compose by name resolution, not by class hierarchies.
-The framework prefers data over class inheritance whenever it makes sense.
 
 Stable URLs
 -----------

--- a/docs/content/misc/examples.rst
+++ b/docs/content/misc/examples.rst
@@ -21,8 +21,8 @@ The **Primary docs** column points to the sections of this manual where the tech
      - Focus
      - Primary docs
    * - `shortener <https://github.com/next-dj/next-dj/tree/main/examples/shortener>`__
-     - File router, DI providers, LocMemCache, management command
-     - :doc:`/content/topics/file-router`, :doc:`/content/topics/dependency-injection`
+     - File router, DI providers, LocMemCache, ``{% zone %}`` lists patched through ``Patches`` envelopes, management command
+     - :doc:`/content/topics/file-router`, :doc:`/content/topics/dependency-injection`, :doc:`/content/topics/partial-rendering/index`
    * - `markdown-blog <https://github.com/next-dj/next-dj/tree/main/examples/markdown-blog>`__
      - Markdown posts, nested layouts, ``@context(serialize=True)``, context processor, co-located ``component.js``
      - :doc:`/content/topics/layouts`, :doc:`/content/topics/context`, :doc:`/content/topics/static-assets/js-context`
@@ -30,14 +30,14 @@ The **Primary docs** column points to the sections of this manual where the tech
      - Composite ``feature_guard``, signal receivers, cache invalidation
      - :doc:`/content/topics/components`, :doc:`/content/topics/signals`
    * - `audit-forms <https://github.com/next-dj/next-dj/tree/main/examples/audit-forms>`__
-     - Compliance audit trail. ``FormWizard`` access-request flow, custom ``FormActionBackend``, ``action_dispatched`` / ``form_validation_failed``, dual audit channels
-     - :doc:`/content/topics/forms/wizard`, :doc:`/content/topics/forms/backends`, :doc:`/content/topics/forms/signals`
+     - Custom ``FormActionBackend``, ``action_dispatched`` / ``form_validation_failed`` signals, dual audit channels, ``FormWizard`` in a modal layer, lazy audit-table zone
+     - :doc:`/content/topics/forms/wizard`, :doc:`/content/topics/forms/backends`, :doc:`/content/topics/forms/signals`, :doc:`/content/topics/partial-rendering/index`
    * - `search-catalog <https://github.com/next-dj/next-dj/tree/main/examples/search-catalog>`__
      - Faceted site search. ``DQuery[T]``, faceted filters, nested layouts, ``inherit_context=True``, cached search
      - :doc:`/content/topics/dependency-injection`, :doc:`/content/topics/context`
    * - `wiki <https://github.com/next-dj/next-dj/tree/main/examples/wiki>`__
-     - ``HybridRouterBackend``, ``router_manager.reload()`` on signal, DI, forms with live Markdown preview
-     - :doc:`/content/topics/file-router`, :doc:`/content/howto/write-a-router-backend`
+     - ``HybridRouterBackend``, ``router_manager.reload()`` on signal, DI, live search zone, forms with live Markdown preview
+     - :doc:`/content/topics/file-router`, :doc:`/content/howto/write-a-router-backend`, :doc:`/content/topics/partial-rendering/index`
    * - `multi-tenant <https://github.com/next-dj/next-dj/tree/main/examples/multi-tenant>`__
      - Tenant middleware, request-scoped static URLs, shared blocks via ``COMPONENT_BACKENDS`` ``DIRS``
      - :doc:`/content/howto/scope-requests-per-tenant`, :doc:`/content/topics/static-assets/backends`
@@ -45,14 +45,14 @@ The **Primary docs** column points to the sections of this manual where the tech
      - Custom ``StaticBackend``, ``.jsx`` kind, ``DeepMergePolicy``, ``HashContentDedup``, composite components
      - :doc:`/content/topics/static-assets/asset-kinds`, :doc:`/content/topics/static-assets/deduplication`
    * - `live-polls <https://github.com/next-dj/next-dj/tree/main/examples/live-polls>`__
-     - Server-Sent Events broker, ``action_dispatched`` fan-out, Vue SFC asset kind, nested layouts
-     - :doc:`/content/howto/stream-live-updates-with-sse`, :doc:`/content/topics/extending`
+     - Framework SSE bridge, ``refresh`` patches, request-id echo, ``action_dispatched`` fan-out, Vue SFC asset kind
+     - :doc:`/content/topics/partial-rendering/sse`, :doc:`/content/howto/stream-live-updates-with-sse`, :doc:`/content/topics/extending`
    * - `observability <https://github.com/next-dj/next-dj/tree/main/examples/observability>`__
-     - Signal groups, custom ``ComponentsBackend``, ``DedupStrategy``, global and per-key ``JsContextSerializer``
-     - :doc:`/content/topics/signals`, :doc:`/content/topics/extending`
+     - Signal groups, custom ``ComponentsBackend``, ``DedupStrategy``, polling and lazy zones, custom patch verb, per-key ``JsContextSerializer``
+     - :doc:`/content/topics/signals`, :doc:`/content/topics/extending`, :doc:`/content/topics/partial-rendering/index`
    * - `admin <https://github.com/next-dj/next-dj/tree/main/examples/admin>`__
-     - Django admin beside next.dj pages, request-aware form factories, two page roots, middleware guard
-     - :doc:`/content/howto/integrate-django-admin`, :doc:`/content/topics/multi-project`
+     - Django admin UI rebuilt on next.dj, request-aware form factories, server-opened modal layers, two page roots, middleware guard
+     - :doc:`/content/howto/integrate-django-admin`, :doc:`/content/topics/multi-project`, :doc:`/content/topics/partial-rendering/index`
 
 Shared assets
 -------------

--- a/docs/content/misc/glossary.rst
+++ b/docs/content/misc/glossary.rst
@@ -82,6 +82,10 @@ Terms used throughout the next.dj documentation.
       The ``inherit_context=True`` flag on ``@context`` in ``page.py``.
       Publishes the context value to every descendant page under that directory, not only to the page that declares it.
 
+   layer
+      A server-initiated overlay stacked above the current page, opened by the ``layer.open`` patch verb or a ``data-next-layer`` link.
+      The client runtime hosts each layer in its own ``<dialog>`` element and closes the top layer on accept, dismissal, or Back.
+
    layout
       A ``layout.djx`` file in an ancestor directory.
       Wraps every descendant page.
@@ -101,6 +105,10 @@ Terms used throughout the next.dj documentation.
       The singleton orchestrator for one subsystem.
       Examples include ``page``, ``components_manager``, ``router_manager``, ``form_action_manager``.
 
+   morph
+      The default patch verb.
+      Reconciles the target element in place instead of replacing it, and ``data-next-key`` lets it reuse the node a keyed child already owns.
+
    origin page
       The page that rendered a form.
       Identified at dispatch time by resolving the hidden ``_next_form_origin`` URL path against the URLconf.
@@ -119,6 +127,18 @@ Terms used throughout the next.dj documentation.
    multi-project layout
       Multiple Django applications or explicit ``DIRS`` entries each contributing page trees while optionally sharing component directories through ``COMPONENT_BACKENDS``.
       See :doc:`/content/topics/multi-project`.
+
+   partial request
+      A request the client runtime marks with the ``X-Next-Request`` header.
+      ``is_partial_request`` detects it on the server, so a handler can answer with a patch envelope instead of a redirect.
+
+   patch
+      One addressed DOM operation inside a patch envelope.
+      Carries a verb such as ``morph`` or ``remove``, a target selector, and optional HTML.
+
+   patch envelope
+      The wire object of a partial response.
+      Carries the asset version, the ordered patch ops, the co-located assets of the rendered targets, and the machine-readable form meta.
 
    provider
       A class that produces a value for a parameter.
@@ -173,6 +193,10 @@ Terms used throughout the next.dj documentation.
    virtual route
       A directory with only ``template.djx`` and no ``page.py``.
       No Python module is invoked for the route itself, but ancestor ``layout.djx`` files still wrap it and co-located static assets are still collected.
+
+   zone
+      A named slice of a page template wrapped in ``{% zone %}``.
+      The server re-renders the slice standalone, and patches address it by its name.
 
 See Also
 --------

--- a/docs/content/ref/apps.rst
+++ b/docs/content/ref/apps.rst
@@ -9,7 +9,14 @@ Module Summary
 ``next.apps`` contains the Django ``AppConfig`` and the helpers that the framework runs at application startup.
 
 ``NextFrameworkConfig.ready()`` first runs ``next.checks.register_all()`` to register the framework system checks.
-It then calls five installer hooks in a fixed order: ``autoreload.install()``, ``templates.install()``, ``staticfiles.install()``, ``components.install()``, and ``autodiscover_forms()``.
+It then calls five installer hooks in a fixed order.
+
+#. ``autoreload.install()``
+#. ``templates.install()``
+#. ``staticfiles.install()``
+#. ``components.install()``
+#. ``autodiscover_forms()``
+
 ``autodiscover_forms()`` imports the ``forms`` submodule of every installed app so shared forms register before the first request arrives.
 It respects the ``FORM_AUTODISCOVER`` setting and is a no-op when that setting is ``False``.
 
@@ -18,6 +25,9 @@ Public API
 
 .. automodule:: next.apps
    :members:
+
+The installer submodules below are called exclusively from ``NextFrameworkConfig.ready`` and are not part of the project-level public API.
+They are documented here for framework contributors and for projects that instrument startup behaviour.
 
 Template Tag Registration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -35,9 +45,6 @@ Staticfiles Integration
 
 Autoreload Installer
 ~~~~~~~~~~~~~~~~~~~~
-
-The two installer submodules below are called exclusively from ``NextFrameworkConfig.ready`` and are not part of the project-level public API.
-They are documented here for framework contributors and for projects that instrument startup behaviour.
 
 .. automodule:: next.apps.autoreload
    :members:

--- a/docs/content/ref/components.rst
+++ b/docs/content/ref/components.rst
@@ -11,7 +11,7 @@ The names in this reference are grouped by their intended audience.
 
 .. note::
 
-   The three API tiers discussed in :doc:`/content/faq/general` apply to this package.
+   The Application Imports, Framework Extension, and Internal Infrastructure tiers follow the public-surface rules in :ref:`faq-safe-symbols`.
    Underscore-prefixed render helpers under *Internal Infrastructure* are hooks for tests and framework code, not for everyday imports in applications.
 
 Application Imports
@@ -105,7 +105,8 @@ Prefer the Application Imports tier unless you are building framework tooling.
 .. autoclass:: next.components.ComponentInfo
    :members:
 
-``scope_key`` is the stable grouping tuple the duplicate-name check uses to detect same-scope collisions.
+``scope_key`` is a stable value-object tuple for grouping by name and scope.
+The duplicate-name check groups by ``(scope_root, name)`` and ignores ``scope_relative``, so two same-named components anywhere in one tree collide under ``next.E020``.
 
 .. autoclass:: next.components.ContextFunction
    :members:

--- a/docs/content/ref/decorators.rst
+++ b/docs/content/ref/decorators.rst
@@ -46,7 +46,8 @@ Pass ``serializer=`` to route that key through a custom ``JsContextSerializer``.
 .. py:decorator:: @action(name=None, *, form_class=None, scope=None, login_required=False, permission_required=None)
 
 Registers a plain callable as a named form action.
-The name is optional: a bare ``@action`` or an empty ``@action()`` registers the function under its own name, and ``@action("custom_name")`` overrides it.
+The name is optional.
+A bare ``@action`` or an empty ``@action()`` registers the function under its own name, and ``@action("custom_name")`` overrides it.
 The name must be unique within its scope, see :doc:`/content/topics/forms/actions`.
 Used without ``form_class``, the handler runs with no form validation.
 Reach for it for delete confirmations or logout buttons.

--- a/docs/content/ref/forms.rst
+++ b/docs/content/ref/forms.rst
@@ -33,6 +33,8 @@ Advanced.
    the frozen specs (``FieldSpec``, ``FormsetSpec``, ``FormSpec``, ``FormSectionSpec``,
    ``FormsetRowSpec``, ``FieldKind``), the spec helpers (``field_spec``, ``form_spec``,
    ``formset_spec``), the formset helper ``cleanup_extra_initial``,
+   the origin helpers (``OriginMatch``, ``resolve_origin``, ``resolve_url_to_match``,
+   ``resolve_url_to_page``),
    the ``PermissionOutcome`` type alias for the dynamic permission hooks,
    and the ``signals`` and ``checks`` submodules.
    Use these when writing a custom backend or a form renderer.
@@ -52,8 +54,8 @@ Framework machinery.
    ``RegistrationDiagnostics`` and the ``registration_diagnostics`` instance live in
    ``next.forms.diagnostics``.
    The UID helpers ``FORM_ACTION_REVERSE_NAME``, ``URL_NAME_FORM_ACTION``,
-   ``ORIGIN_FIELD_NAME``, ``reverse_form_action``, and ``validated_origin_path``
-   live in ``next.forms.uid``.
+   ``ORIGIN_FIELD_NAME``, ``FORM_ORIGIN_OVERRIDE_KEY``, ``reverse_form_action``,
+   and ``validated_origin_path`` live in ``next.forms.uid``.
    The test isolation helper ``reset_form_registration_state`` belongs to ``next.testing``,
    documented under :doc:`/content/ref/testing`.
 
@@ -259,9 +261,21 @@ the namespaced ``next:form_action`` route or the bare ``form_action`` route.
 It lives in ``next.forms.uid`` and is not re-exported at the package level.
 ``ORIGIN_FIELD_NAME`` is the wire name of the hidden origin field every rendered form carries, ``"_next_form_origin"``.
 ``validated_origin_path`` accepts a posted origin value only as a same-site path.
+``FORM_ORIGIN_OVERRIDE_KEY`` names the render-context key whose value overrides the origin of a rendered form, which the partial shaping layer sets to the next step URL on a wizard advance.
 
 .. automodule:: next.forms.uid
    :members:
+
+Origin Resolution
+~~~~~~~~~~~~~~~~~
+
+``OriginMatch``, ``resolve_origin``, ``resolve_url_to_match``, and ``resolve_url_to_page`` are re-exported from ``next.forms``.
+``resolve_origin`` resolves the posted ``_next_form_origin`` field into an ``OriginMatch`` and memoises the result on the request, so the dispatcher and every ``{% form %}`` tag on a re-rendered page share one resolution.
+``resolve_url_to_match`` resolves any same-site URL against the URLconf, and passing ``filter_reserved=False`` keeps the captured URL kwargs raw instead of dropping the names the dependency resolver reserves.
+``resolve_url_to_page`` returns only the page path of the resolved view, or ``None`` when the URL does not name a routed page.
+
+.. automodule:: next.forms.origin
+   :members: OriginMatch, resolve_origin, resolve_url_to_match, resolve_url_to_page
 
 Formset Helpers
 ~~~~~~~~~~~~~~~

--- a/docs/content/ref/pages.rst
+++ b/docs/content/ref/pages.rst
@@ -64,7 +64,7 @@ The manager already consults ``module.template`` directly, so registering this l
 .. autoclass:: next.pages.loaders.PythonTemplateLoader
    :members:
 
-``LayoutTemplateLoader`` composes nested ``layout.djx`` wrappers around the page template, walking the directory chain from the page up to the page root.
+``LayoutTemplateLoader`` composes nested ``layout.djx`` wrappers around the page template, walking every ancestor directory upward from the page, bounded at 64 levels.
 It runs on a dedicated path and is not registered through ``TEMPLATE_LOADERS``.
 
 .. autoclass:: next.pages.loaders.LayoutTemplateLoader

--- a/docs/content/ref/partial.rst
+++ b/docs/content/ref/partial.rst
@@ -6,12 +6,9 @@ Partial Rendering Reference
 Module Summary
 --------------
 
-``next.partial`` exposes the server side of partial rendering: the ``Patches`` builder
-that authors a patch envelope, the response and stream classes that carry it, the
-zone-render and origin helpers, the custom-verb registration hook, and the protocol
-backend that serialises the wire format.
-The wire protocol, the ``data-next-*`` attributes, and the client runtime live in the
-topic section, see :doc:`/content/topics/partial-rendering/reference`.
+``next.partial`` exposes the server side of partial rendering.
+The surface covers the ``Patches`` builder that authors a patch envelope, the response and stream classes that carry it, the zone-render and origin helpers, the custom-verb registration hook, and the protocol backend that serialises the wire format.
+The wire protocol, the ``data-next-*`` attributes, and the client runtime live in the topic section, see :doc:`/content/topics/partial-rendering/reference`.
 
 API Tiers
 ---------

--- a/docs/content/ref/server.rst
+++ b/docs/content/ref/server.rst
@@ -16,7 +16,8 @@ Autoreload
 ~~~~~~~~~~
 
 ``NextStatReloader`` subclasses Django's ``StatReloader``.
-In addition to watching ``.py`` mtimes, it recomputes the discovered route set on every tick and triggers a reload when pages appear or disappear from the routing tree, even when no file mtime changed.
+In addition to watching ``.py`` mtimes, it recomputes the discovered route set on every tick.
+A reload triggers when pages appear or disappear from the routing tree, even when no file mtime changed.
 ``.djx`` templates are not watched.
 They are re-read on render with mtime-based invalidation.
 

--- a/docs/content/ref/settings.rst
+++ b/docs/content/ref/settings.rst
@@ -14,11 +14,13 @@ For production-specific recommendations (which values to change and why), see :d
 Key Naming
 ----------
 
-Keys inside ``NEXT_FRAMEWORK`` carry no ``DEFAULT_`` prefix. The dict itself is the framework defaults namespace. A plural ``*_BACKENDS`` key
-holds an ordered list of sources the manager consults in order. A
-singular ``*_BACKEND`` key holds the one engine for a concern. A
-subsystem prefix (``PAGE_``, ``COMPONENT_``, ``STATIC_``, ``FORM_``,
-``URL_``, ``TEMPLATE_``, ``JS_``) groups related keys.
+Keys inside ``NEXT_FRAMEWORK`` carry no ``DEFAULT_`` prefix.
+The dict itself is the framework defaults namespace.
+A plural ``*_BACKENDS`` key holds an ordered list of sources the manager consults in order.
+``PARTIAL_BACKENDS`` is the exception.
+Partial rendering uses a single protocol backend, so only the first entry runs.
+A singular ``*_BACKEND`` key holds the one engine for a concern.
+A subsystem prefix (``PAGE_``, ``COMPONENT_``, ``STATIC_``, ``FORM_``, ``URL_``, ``TEMPLATE_``, ``JS_``) groups related keys.
 
 Backends
 --------
@@ -147,7 +149,8 @@ Default value.
 The bundled ``SessionFormWizardBackend`` stores each step's cleaned data in the Django session through a typed value codec, so drafts share the durability of the session engine.
 It reads no ``OPTIONS`` keys.
 The bundled ``CacheFormWizardBackend`` stores drafts in the Django cache instead.
-It reads two keys from ``OPTIONS``: ``CACHE_ALIAS`` names the cache to use, defaulting to ``"default"``, and ``TIMEOUT`` sets the draft expiry in seconds, defaulting to ``SESSION_COOKIE_AGE``.
+It reads two keys from ``OPTIONS``.
+``CACHE_ALIAS`` names the cache to use, defaulting to ``"default"``, and ``TIMEOUT`` sets the draft expiry in seconds, defaulting to ``SESSION_COOKIE_AGE``.
 Set ``BACKEND`` to a dotted path that subclasses ``FormWizardBackend`` to swap the persistence layer.
 See :doc:`/content/topics/forms/wizard-backend` for the contract, the codec, and a custom backend.
 
@@ -156,6 +159,7 @@ PARTIAL_BACKENDS
 
 List of partial protocol backend configurations.
 The first entry is active and owns the patch wire format that partial rendering serialises over HTTP and Server-Sent Events.
+Entries after the first are ignored, and ``manage.py check`` reports them with ``next.W071``.
 
 Default value.
 
@@ -176,7 +180,9 @@ Default value.
    ]
 
 The ``OPTIONS`` keys tune the active backend.
-``VERSION`` is the source of the ``X-Next-Version`` stamp: the sentinel ``"manifest"`` hashes the staticfiles manifest when the active storage hashes its files, an explicit string pins the version yourself, and without a manifest the version guard stays silent and raises ``next.W069``.
+``VERSION`` is the source of the ``X-Next-Version`` stamp.
+The sentinel ``"manifest"`` hashes the staticfiles manifest when the active storage hashes its files, and an explicit string pins the version yourself.
+Without a manifest storage the version guard stays silent at runtime, and ``manage.py check`` reports ``next.W069``.
 ``PUSH_WIZARD_STEPS`` is the global default for pushing wizard steps to browser history, which a wizard's ``Meta.push_steps`` overrides per wizard.
 ``SSE.HEARTBEAT_SECONDS`` is the keepalive period in seconds for an async stream source, and ``SSE.RETRY_MS`` is the ``EventSource`` reconnect hint in milliseconds sent in the leading stream frame.
 
@@ -236,7 +242,9 @@ The class is instantiated with no arguments and its ``dumps`` method encodes eve
 Default value ``None``, which selects the built-in ``JsonJsContextSerializer``.
 
 ``resolve_serializer`` reads this setting on every call, so ``override_settings`` takes effect without a restart.
-A value that does not resolve to a usable serializer triggers the ``next.W042`` warning during ``manage.py check`` and the framework falls back to ``JsonJsContextSerializer``.
+A value that does not resolve to a usable serializer triggers the ``next.W042`` warning during ``manage.py check``.
+At render time such a value raises ``ImportError`` or ``TypeError`` on first use, so fix the dotted path rather than rely on a fallback.
+The built-in ``JsonJsContextSerializer`` steps in only when the setting is unset.
 
 See :doc:`static` under *JS Context Serializer* for the protocol and the bundled serializers.
 

--- a/docs/content/ref/signals.rst
+++ b/docs/content/ref/signals.rst
@@ -55,7 +55,10 @@ not be retained past the receiver call.
    * - ``collector_finalized``
      - The static collector
      - ``page_path``, ``request``
-     - When the static manager begins injection, after template rendering completes. ``page_path`` may be ``None`` for partial renders. ``request`` may be ``None`` outside a request.
+     - When the static manager begins injection, after template rendering completes.
+       ``page_path`` is the file path of the rendered page.
+       A standalone zone render does not fire this signal.
+       ``request`` may be ``None`` outside a request.
    * - ``component_backend_loaded``
      - ``ComponentsManager``
      - ``backend``, ``config``

--- a/docs/content/ref/signals.rst
+++ b/docs/content/ref/signals.rst
@@ -78,10 +78,10 @@ not be retained past the receiver call.
      - After a context callable is attached to a page module.
    * - ``field_validated``
      - The active partial protocol backend class
-     - ``action_name``, ``uid``, ``request``, ``field_names``, ``error_count``.
+     - ``action_name``, ``uid``, ``request``, ``field_names``, ``error_count``
+     - After a validate-only blur pass runs, always behind the action guard so unauthenticated validate traffic never reaches telemetry.
        ``field_names`` is the validated subset.
        ``error_count`` is the number of fields that failed.
-     - After a validate-only blur pass runs, always behind the action guard so unauthenticated validate traffic never reaches telemetry.
    * - ``form_access_denied``
      - ``FormActionDispatch``
      - ``action_name``, ``uid``, ``request``, ``layer``, ``reason``

--- a/docs/content/ref/static.rst
+++ b/docs/content/ref/static.rst
@@ -81,7 +81,8 @@ The mapping is rebuilt on each lookup so assets added at runtime are picked up.
 The finder is appended to ``STATICFILES_FINDERS`` automatically by ``NextFrameworkConfig.ready`` through ``next.apps.staticfiles.install``.
 The install step is idempotent and skips the entry when it is already present.
 You do not need to list it in ``STATICFILES_FINDERS`` yourself.
-The dotted path is ``next.static.NextStaticFilesFinder``. You can confirm it is active by running ``manage.py findstatic next/some-component/component.css``.
+The dotted path is ``next.static.NextStaticFilesFinder``.
+Confirm it is active by running ``manage.py findstatic next/components/note_card.css``.
 
 Signals
 -------

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -14,7 +14,8 @@ Check Registration
 
 ``next.checks.register_all`` runs during ``AppConfig.ready``.
 It imports each subsystem ``checks`` module so the ``@register`` side effects take effect.
-The imported modules are ``next.conf.checks``, ``next.pages.checks``, ``next.urls.checks``, ``next.components.checks``, ``next.forms.checks``, ``next.server.checks``, ``next.static.checks``, ``next.partial.checks``, and ``next.apps.checks``.
+The imported modules are ``next.conf.checks``, ``next.pages.checks``, ``next.urls.checks``, ``next.components.checks``, and ``next.forms.checks``.
+The list continues with ``next.server.checks``, ``next.static.checks``, ``next.partial.checks``, and ``next.apps.checks``.
 
 Most of these modules register checks. ``next.server.checks`` registers no Django system checks.
 The dependency injection layer contributes no Django system checks.
@@ -91,7 +92,8 @@ There is no ``next.ENNN`` code for a missing provider or a bad marker graph.
 
 .. note::
 
-   Expect misconfiguration at **runtime**: unresolved parameters become ``None``, and cycles raise ``DependencyCycleError``.
+   Expect misconfiguration at **runtime**.
+   Unresolved parameters become ``None``, and cycles raise ``DependencyCycleError``.
    Troubleshooting lives in :doc:`/content/topics/dependency-injection` and :doc:`/content/faq/troubleshooting`.
 
 Check Code Reference
@@ -357,7 +359,9 @@ Warnings
      - A partial backend sets ``VERSION: "manifest"`` while the staticfiles storage does not hash files, so the version guard stays silent.
      - ``next.partial.checks``
    * - ``next.W070``
-     - A ``{% form %}`` renders directly inside a ``{% for %}`` of a composed page without a ``key=`` or a ``zone=``, so a partial morph cannot tell the repeated instances apart. The check does not descend into a component template, so a looped ``{% component %}`` that holds the form is not flagged. Thread a ``key=`` into the form to keep the repeated morph correct.
+     - A ``{% form %}`` renders directly inside a ``{% for %}`` of a composed page without a ``key=`` or a ``zone=``, so a partial morph cannot tell the repeated instances apart.
+       The check does not descend into a component template, so a looped ``{% component %}`` that holds the form is not flagged.
+       Thread a ``key=`` into the form to keep the repeated morph correct.
      - ``next.partial.checks``
    * - ``next.W071``
      - ``PARTIAL_BACKENDS`` has more than one entry. Partial rendering uses a single protocol backend, so only the first entry runs and the rest are ignored.

--- a/docs/content/ref/template-tags.rst
+++ b/docs/content/ref/template-tags.rst
@@ -30,6 +30,7 @@ Forms
       * - ``action`` with the dispatch URL.
       * - ``method="post"``.
       * - ``data-next-action`` with the action UID when the registry meta is available.
+      * - The ``data-next-*`` attributes compiled from the partial params.
       * - ``enctype="multipart/form-data"`` when the form is multipart.
       * - The attributes passed to the tag.
 
@@ -40,7 +41,8 @@ Forms
    The tag owns the ``action`` and ``method`` attributes plus every attribute starting with ``data-next-``, and passing any of them raises ``TemplateSyntaxError`` at parse time.
    ``data-next-*`` is the single framework namespace in rendered markup.
 
-   The ``validate``, ``trigger``, ``debounce``, ``zone``, and ``key`` params compile to the matching ``data-next-*`` attributes, the authored seam for partial behaviour.
+   The ``validate``, ``trigger``, ``debounce``, ``zone``, and ``key`` params compile to ``data-next-*`` attributes, the authored seam for partial behaviour.
+   Each param maps to the attribute of the same name except ``zone``, which compiles to ``data-next-target``.
    ``key`` distinguishes one instance of a repeated form, rendered in a loop, so a partial morph lands on the submitted instance rather than the first.
    See :doc:`/content/topics/partial-rendering/scenarios`.
 
@@ -48,13 +50,15 @@ Forms
 
    The tag requires ``request`` in the template context for the CSRF token.
    It also uses ``current_page_module_path`` when present to scope the action lookup to the origin page, which is how the file router renders it.
-   That context value is not strictly required: when it is absent the action lookup falls back to the name index.
+   That context value is not strictly required.
+   When it is absent the action lookup falls back to the name index.
 
 .. describe:: {% action_url "<name>" %}
 
    Returns the dispatch endpoint URL for a registered action.
    The first argument is the action name, a quoted string or a context variable that resolves to a string.
-   The lookup uses the same page scoping as ``{% form %}``: a page-scoped match for the rendering page wins over a shared one, read from ``current_page_module_path`` when present.
+   The lookup uses the same page scoping as ``{% form %}``.
+   A page-scoped match for the rendering page wins over a shared one, read from ``current_page_module_path`` when present.
 
    As a ``simple_tag`` it supports assignment, ``{% action_url "delete_note" as delete_url %}``.
 
@@ -169,7 +173,8 @@ Partial Rendering
    It is valid only between a ``{% zone %}`` and its ``{% endzone %}``, and a lazy zone without it raises ``next.E064``.
    The branch belongs to lazy zones only, so a zone without ``lazy=`` rejects it with ``TemplateSyntaxError`` when the template compiles.
 
-A zone belongs to a page or layout, not a component, and may not sit inside a ``{% for %}``, an ``{% if %}``, or directly inside a ``{% with %}``.
+A zone belongs to a page or layout, not a component, and may not sit inside a ``{% for %}`` or an ``{% if %}``.
+A zone directly inside a ``{% with %}`` draws the ``next.W067`` warning because the bindings are invisible to a standalone zone render.
 The :doc:`zone placement checks </content/ref/system-checks>` enforce each rule at ``manage.py check`` time.
 
 Layouts

--- a/docs/content/ref/testing.rst
+++ b/docs/content/ref/testing.rst
@@ -6,7 +6,7 @@ Testing Reference
 Module Summary
 --------------
 
-``next.testing`` exposes a test client, signal recorder, registry isolation, action helpers, HTML utilities, rendering helpers, loaders, patching helpers, and dependency context builders.
+``next.testing`` exposes a test client, partial envelope decoding, signal recorder, registry isolation, action helpers, HTML utilities, rendering helpers, loaders, patching helpers, and dependency context builders.
 
 Public API
 ----------
@@ -14,7 +14,7 @@ Public API
 Client
 ~~~~~~
 
-``NextClient`` extends Django's test client with form-action shortcuts for end to end HTTP tests.
+``NextClient`` extends Django's test client with form-action shortcuts and the partial-request helpers ``get_zones``, ``envelope_of``, and ``PartialEnvelope`` for end to end HTTP tests.
 
 .. automodule:: next.testing.client
    :members:

--- a/docs/content/ref/urls.rst
+++ b/docs/content/ref/urls.rst
@@ -29,7 +29,9 @@ Manager
 
 ``urlpatterns`` is a ``list`` subclass that recollects router and form-action patterns from the active backends on each access.
 The backends themselves are cached by ``router_manager`` and are only rebuilt when ``router_manager.reload()`` runs or when ``PAGE_BACKENDS`` changes.
-A route added after import is therefore visible without a process restart, but each access still iterates the cached backend list rather than walking the page tree again.
+Laziness here means the patterns are collected on the first URL access rather than at import time.
+A page added on disk after that first collection needs ``router_manager.reload()``, which rebuilds the backends and clears the Django resolver cache.
+Within a backend the per-application pattern lists are memoised after the first scan, while the roots configured in ``DIRS`` are rescanned on every recollection.
 The ``list`` subclass overrides ``__reversed__`` so Django's resolver observes the recollected patterns rather than the empty internal buffer of the ``list`` base.
 Django's resolver iterates ``reversed(urlpatterns)``, so the override feeds it the fresh patterns.
 ``RouterManager`` owns the active backend list, and the ``router_manager`` singleton exposes ``reload()`` to rebuild it.

--- a/docs/content/security/csp-and-nonce.rst
+++ b/docs/content/security/csp-and-nonce.rst
@@ -4,7 +4,7 @@ CSP and Nonce
 =============
 
 A Content Security Policy restricts which scripts a page may run.
-The partial runtime is designed to live under one, and this page covers how the runtime carries a nonce, why scripts in patches never run, and what ``'strict-dynamic'`` does and does not guarantee.
+The client runtime is designed to live under one, and this page covers how the runtime carries a nonce, why scripts in patches never run, and what ``'strict-dynamic'`` does and does not guarantee.
 
 .. contents::
    :local:
@@ -25,7 +25,8 @@ Scripts in Patches Never Run
 
 A ``<script>`` inside patch HTML is never executed by any insertion path.
 The applier removes every script element from parsed patch HTML before it reaches the document.
-This is structural neutralisation, not a parser side effect: the script is cut out, so there is no element for the browser to evaluate and no nonce question to answer.
+This is structural neutralisation, not a parser side effect.
+The script is cut out, so there is no element for the browser to evaluate and no nonce question to answer.
 
 The consequence for a CSP is that a morph cannot smuggle an inline script past the policy, because a morph cannot run an inline script at all.
 Behaviour arrives only through the co-located asset manifest, whose scripts are nonced, and through the ``event`` verb, which carries no code.

--- a/docs/content/security/csrf-and-forms.rst
+++ b/docs/content/security/csrf-and-forms.rst
@@ -27,10 +27,9 @@ Origin Validation
 
 The framework adds a second hidden field named ``_next_form_origin``.
 The ``{% form %}`` tag sets it to the URL path the form was rendered under, so the HTML never exposes the server filesystem layout.
-The dispatcher resolves the field only when it has to re-render the origin page: on a validation failure, and when a form-backed handler returns ``None`` so the page renders again.
-A valid submission whose handler returns a response never resolves the field, so the check is a re-render lookup, not a pre-handler origin gate.
-
-When the field is resolved, these checks apply.
+The dispatcher resolves the field on every POST to recover the origin page's URL kwargs for dependency injection.
+The checks below are enforced only when the dispatcher has to re-render the origin page, on a validation failure and when a form-backed handler returns ``None``.
+A missing or unresolvable origin never blocks a valid submission whose handler returns a response.
 
 The value must be a same-site path that starts with ``/`` and not with ``//``.
 It must resolve against the URLconf through :func:`django.urls.resolve`, and the resolved view must carry the ``next_page_path`` attribute the file router sets on every routed page.
@@ -159,7 +158,7 @@ Form post without ``_next_form_origin``.
 Language switch between render and submit.
    Under :func:`django.conf.urls.i18n.i18n_patterns` the origin resolves under the language active on the POST.
    A user who changes the language in between posts an origin whose prefix no longer resolves, so a failing validation answers HTTP 400 instead of re-rendering.
-   The success path is unaffected because it never resolves the origin.
+   The success path is unaffected because the origin checks are enforced only on the re-render.
 
 Stale token after deploy.
    Cached page renders carry the previous token.

--- a/docs/content/security/index.rst
+++ b/docs/content/security/index.rst
@@ -16,7 +16,7 @@ This section covers how each surface protects against common attacks and how to 
    Origin, hash, and integrity for shipped CSS and JS.
 
 :doc:`csp-and-nonce`
-   Serving the partial runtime under a Content Security Policy.
+   Serving the client runtime under a Content Security Policy.
 
 :doc:`di-and-untrusted-input`
    Treating URL, query, and form values as untrusted.

--- a/docs/content/security/overview.rst
+++ b/docs/content/security/overview.rst
@@ -71,6 +71,11 @@ Open redirect.
    Validate destinations before passing user input into a redirect target.
    The partial ``redirect(href, external=True)`` patch is the same escape hatch on the client side, see `Server-Authored Redirects`_.
 
+Object-level authorization.
+   A lookup keyed only on a URL value loads whatever row matches, regardless of who owns it.
+   The ModelForm ``Meta.instance_from_url`` lookup is unscoped, so scope it to the user or tenant.
+   See :doc:`/content/topics/forms/modelforms` for the ownership-scoped pattern and :doc:`di-and-untrusted-input` for the posted origin path that feeds the lookup.
+
 Server-Authored Redirects
 -------------------------
 
@@ -81,12 +86,8 @@ The ``external=True`` flag promotes the navigation to a full visit and bypasses 
 The flag trusts the caller to author the href.
 Pass only a server-controlled destination through it, never a value derived from URL, query, or form input.
 A user-supplied href behind ``external=True`` turns the page into an open redirect, the same risk Django guards against in :doc:`its login next-page handling <django:topics/auth/default>`.
-The rule mirrors the plain ``HttpResponseRedirect`` case above: validate or whitelist any destination that traces back to a request value before it reaches the patch.
-
-Object-level authorization.
-   A lookup keyed only on a URL value loads whatever row matches, regardless of who owns it.
-   The ModelForm ``Meta.instance_from_url`` lookup is unscoped, so scope it to the user or tenant.
-   See :doc:`/content/topics/forms/modelforms` for the ownership-scoped pattern and :doc:`di-and-untrusted-input` for the posted origin path that feeds the lookup.
+The rule mirrors the plain ``HttpResponseRedirect`` case above.
+Validate or whitelist any destination that traces back to a request value before it reaches the patch.
 
 Access Control
 --------------

--- a/docs/content/topics/components.rst
+++ b/docs/content/topics/components.rst
@@ -118,7 +118,8 @@ Local scope.
 Global scope.
    Components in directories listed under ``DIRS`` are visible from every template, regardless of tree.
 
-Two components with the same name in different scopes are valid only when one is local to a tree and the other is in another tree.
+Two components with the same name are valid when their scope roots differ, for example one in a page tree and one in a ``DIRS`` root, or one in each of two page trees.
+Within one tree the name must be unique regardless of nesting depth.
 The same-scope name clash is reported by a system check, covered in the `System Checks`_ section below.
 
 Calling a Component
@@ -391,11 +392,10 @@ The Render Function
 
 A composite component can define a ``render`` function in ``component.py`` that returns the component body as a string in place of the template.
 The function receives DI-resolved parameters drawn from the surrounding template scope, including props and page context variables.
-The lazy ``csrf_token`` and any ``@component.context`` callables are not run on this path.
 Return an empty string to render nothing, which turns the component into a server side gate.
 
 A ``render`` function takes over completely.
-The component template and ``@component.context`` callables do not run for that component.
+The component template, the lazy ``csrf_token``, and the ``@component.context`` callables do not run for that component.
 The function may return a string or an :class:`~django.http.HttpResponse`.
 When it returns an :class:`~django.http.HttpResponse`, the body is decoded as UTF-8 regardless of the response's ``Content-Type`` charset and spliced into the page.
 The response status code and headers are not propagated.
@@ -461,10 +461,13 @@ The components subsystem contributes Django system checks.
 
 - ``next.E020`` reports two components with the same name in the same scope.
   Rename one of the colliding components or move it to a different scope root.
+- ``next.E021`` reports a ``component.py`` that uses ``context`` from ``next.pages``.
+  Use ``@component.context`` from ``next.components`` instead.
 - ``next.E034`` reports one component name used at the root route scope of more than one page tree.
   Rename one of the colliding components or move it to a different scope root.
 
 Run them with ``uv run python manage.py check``.
+The full catalog lives in :doc:`/content/ref/system-checks`.
 
 Common Patterns
 ---------------

--- a/docs/content/topics/context.rst
+++ b/docs/content/topics/context.rst
@@ -36,7 +36,8 @@ Component context.
 Framework-Provided Keys
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Every page render starts with three keys already populated, before any user-defined ``@context`` callable runs.
+Every rendered template starts with three keys populated.
+The two path keys are seeded before any user-defined ``@context`` callable runs, while ``request`` joins the scope after context collection finishes.
 
 ``request``.
    The active :class:`~django.http.HttpRequest`, when the route was reached through the HTTP stack.
@@ -68,8 +69,8 @@ The decorator takes a single key and the function returns the value.
 .. code-block:: python
    :caption: notes/pages/page.py
 
-   from notes.models import Note
    from next.pages import context
+   from notes.models import Note
 
    @context("notes")
    def recent_notes() -> list[Note]:
@@ -122,8 +123,8 @@ Treat ``context("key")`` as a callable that registers an existing function.
 .. code-block:: python
    :caption: registering an external function
 
-   from notes.cache import pending_clicks
    from next.pages import context
+   from notes.cache import pending_clicks
 
    context("pending_clicks")(pending_clicks)
 
@@ -153,9 +154,9 @@ The factory takes its own dependency-injected arguments, so it can ask for the r
 .. code-block:: python
    :caption: notes/pages/notes/[int:note_id]/page.py
 
-   from notes.models import Note
    from next.pages import Context, context
    from next.urls import DUrl
+   from notes.models import Note
 
    def load_note(note_id: DUrl[int]) -> Note:
        return Note.objects.get(pk=note_id)
@@ -177,7 +178,7 @@ Resolution Order
 The framework computes the template scope in this order.
 
 1. URL kwargs from the matched route are seeded into the context dict.
-2. Inherited context functions from every ancestor ``page.py``, walked from the current page upward toward the page root.
+2. Inherited context functions from every ancestor ``page.py``, walked from the current page upward through every ancestor directory, bounded at 64 levels.
 3. Page level context functions declared in the current ``page.py``.
 4. Context processors run after every ``@context`` callable.
    The first source is ``OPTIONS.context_processors`` on each page backend entry inside ``PAGE_BACKENDS``.
@@ -201,6 +202,8 @@ The framework walks up from the current ``page.py`` directory and runs every ``@
 - A ``page.py`` at ``notes/pages/admin/`` publishes inherited values only for pages under ``/admin/``.
 - A page at ``/admin/links/`` sees both layers because it sits below both directories.
 
+When two ancestor directories publish the same inherited key, the value from the outermost ancestor currently wins.
+
 The current page can shadow an inherited value by declaring a context function with the same key.
 The page level value takes precedence, and every layout wrapper in the chain sees that value.
 
@@ -208,15 +211,15 @@ Inherited Function That Names a URL Parameter
 ---------------------------------------------
 
 When an inherited context function is keyed under the same name as a captured URL segment, the parameter it asks for changes type across runs.
-On the first run it holds the raw URL string.
-On a descendant re-run it holds the resolved object the function already produced.
-Leave the parameter untyped and return early if it is already an instance of the model.
+On a descendant request the callable runs once and receives the raw URL string.
+On the declaring page's own request it runs twice, first in the inherited pass with the raw string, then in the page pass with the object the first run produced.
+Leave the parameter untyped and return early when it is already a model instance.
 
 .. code-block:: python
    :caption: notes/pages/notes/[category]/page.py
 
-   from notes.models import Category
    from next.pages import context
+   from notes.models import Category
 
    @context("category", inherit_context=True)
    def category(category: object) -> Category:
@@ -289,9 +292,9 @@ Publish the page title from each page.
 .. code-block:: python
    :caption: notes/pages/notes/[id]/page.py
 
-   from notes.models import Note
    from next.pages import context
    from next.urls import DUrl
+   from notes.models import Note
 
    @context("page_title")
    def page_title(note_id: DUrl[int]) -> str:

--- a/docs/content/topics/dependency-injection.rst
+++ b/docs/content/topics/dependency-injection.rst
@@ -14,7 +14,8 @@ The resolver answers all of those calls through the same pipeline.
 Overview
 --------
 
-The resolver runs at several call sites: page context functions, the page render function, component context functions, and the form dispatch.
+The resolver runs at several call sites.
+Page context functions, the page render function, component context functions, and the form dispatch all pass through it.
 The form dispatch resolves the form-class factory, ``get_initial``, ``@action`` handlers, ``on_valid``, and ``wizard.done``.
 Every call site shares one provider list and one set of markers.
 Custom providers and tests can import ``resolver`` from ``next.deps`` and call ``resolver.resolve_dependencies``.
@@ -49,7 +50,8 @@ The order makes the default-driven and marker-driven providers decisive.
 ``DUrl`` and ``DQuery`` look only at the annotation.
 The context-by-name provider sits ahead of the form, URL, and query providers because a context key under the same name is considered a deliberate publication.
 The form provider matches the parameter name ``form``, the marker ``DForm[FormClass]``, and any plain class annotation whose type the bound form is an instance of.
-The URL-kwargs provider is the last fallback that matches on the bare parameter name, after every marker provider has had a chance to claim the parameter.
+The URL-kwargs provider is the by-name fallback after the ``Depends``, ``Context``, form, request, and ``DUrl`` providers.
+It runs before the ``DQuery`` provider, so a ``DQuery`` parameter that shares a captured segment name receives the URL value, not the query value.
 
 .. note::
 
@@ -373,7 +375,7 @@ Import before resolution.
 A custom provider that does not declare ``priority`` inherits the ``RegisteredParameterProvider`` default of ``100``.
 The nine built-in providers occupy the range ``10`` (named dependency) through ``80`` (query string), so the default keeps a custom provider after every built-in.
 ``FormProvider`` and ``CleanedDataProvider`` share priority ``40``.
-Set ``priority`` on the subclass when the new provider has to claim a parameter the built-ins would otherwise match, for example a value below ``50`` for an annotation that should outrank ``DUrl``.
+Set ``priority`` on the subclass when the new provider has to claim a parameter the built-ins would otherwise match, for example a value below ``60`` for an annotation that should outrank ``DUrl``.
 
 Resolution Cache
 ----------------
@@ -389,7 +391,8 @@ To share one value across several context functions in the same render, publish 
 The cache memoises named dependencies but not raw provider calls.
 See :doc:`/content/howto/share-context-across-pages` for a worked example.
 
-The same cache is shared between the initial render of a form page and the re-render on validation failure.
+The cache lives for one form dispatch.
+Every stage of that POST, from ``get_initial`` through the validation-failure re-render, shares it.
 ``FormActionDispatch`` attaches its dependency cache to the request, and ``get_request_dep_cache`` reads it back.
 The function returns ``None`` outside a form dispatch, so callers handle the missing case.
 
@@ -438,6 +441,7 @@ See Also
 
    :doc:`context` for the ``@context`` decorator and inheritance flow.
    :doc:`file-router` for ``DUrl`` and captured URL parameters.
+   :doc:`testing` for the ``override_dependency`` and ``override_provider`` test helpers.
    :doc:`/content/faq/troubleshooting` for concrete resolver and dispatch errors.
    :doc:`/content/howto/share-context-across-pages` for the inherited context pattern.
    :doc:`/content/internals/di-resolver` for the resolver internals.

--- a/docs/content/topics/extending.rst
+++ b/docs/content/topics/extending.rst
@@ -15,7 +15,7 @@ The Five Mechanisms
 
 Backend.
    Replace or augment a complete subsystem.
-   Used for URL routing, components, forms dispatch, and the :doc:`static pipeline <static-assets/index>`.
+   Used for URL routing, components, forms dispatch, the :doc:`static pipeline <static-assets/index>`, and the :doc:`partial patch protocol <partial-rendering/index>`.
 
 Registry.
    Add new entries to a global list at startup.
@@ -59,9 +59,13 @@ Subclass an abstract base class and register the dotted path in ``NEXT_FRAMEWORK
    * - Static pipeline
      - ``STATIC_BACKENDS``
      - ``next.static.backends.StaticBackend``
+   * - Partial protocol
+     - ``PARTIAL_BACKENDS``
+     - ``next.partial.PartialProtocolBackend``
 
 A backend always implements the full contract.
 A custom backend usually subclasses the default so it inherits every default behaviour.
+``PARTIAL_BACKENDS`` differs from the other backend lists in that only its first entry is active.
 
 .. code-block:: python
    :caption: registering a custom backend
@@ -114,7 +118,6 @@ Register entries in ``AppConfig.ready`` or through a settings key.
 The registry pattern is the right choice when the framework already knows how to consume the values and only needs to learn about a new entry.
 
 The asset-stem registry is the extension point for teaching the static discovery scanner about a new asset filename next to a page, layout, or component.
-``default_stems`` is not re-exported from the ``next.static`` package, so the registration requires the deep import ``from next.static.discovery import default_stems``.
 Call ``default_stems.register(...)`` from ``AppConfig.ready`` so the new stem is known before the first component scan.
 
 .. code-block:: python
@@ -231,6 +234,7 @@ Use the entries below as a quick map.
 - **Recognise a new asset filename next to a page, layout, or component.** Register a custom stem (``default_stems``).
 - **Validate every dispatch.** Implement a form action backend.
 - **Log every dispatch.** Subscribe to the ``action_dispatched`` signal.
+- **Change the patch wire format.** Register a partial protocol backend under ``PARTIAL_BACKENDS``.
 - **Change how URLs land in HTML.** Customise a static backend.
 - **Vary URLs by request.** Use a request-aware static backend.
 - **Inspect every rendered page.** Subscribe to the ``page_rendered`` signal.

--- a/docs/content/topics/file-router.rst
+++ b/docs/content/topics/file-router.rst
@@ -107,9 +107,9 @@ Name your directories without hyphens when you want the parameter name and the d
 .. code-block:: python
    :caption: routes/posts/[int:post_id]/page.py
 
-   from notes.models import Note
    from next.pages import context
    from next.urls import DUrl
+   from notes.models import Note
 
    @context("note")
    def fetch_note(post_id: DUrl[int]) -> Note:
@@ -200,6 +200,27 @@ App directories.
 Project directories.
    The ``DIRS`` list adds absolute or project-relative paths to the scan.
    The router walks each directory in order and registers every ``page.py`` and ``template.djx`` it finds.
+
+Fallback root.
+   With ``APP_DIRS`` set to ``False`` and no usable path entry in ``DIRS``, the router falls back to scanning ``BASE_DIR / PAGES_DIR``.
+   This shape serves a project that keeps every page in a single tree without a page-bearing application.
+
+.. code-block:: python
+   :caption: config/settings.py, pages without applications
+
+   NEXT_FRAMEWORK = {
+       "PAGE_BACKENDS": [
+           {
+               "BACKEND": "next.urls.FileRouterBackend",
+               "APP_DIRS": False,
+               "DIRS": [],
+               "PAGES_DIR": "pages",
+               "OPTIONS": {"context_processors": []},
+           }
+       ]
+   }
+
+With this configuration the router serves every page under ``<BASE_DIR>/pages/``.
 
 You can use both sources at once.
 URL patterns are built in this order, first from application directories then from each entry in ``DIRS``.

--- a/docs/content/topics/forms/actions.rst
+++ b/docs/content/topics/forms/actions.rst
@@ -131,7 +131,7 @@ The method signature uses the same dependency-injection rules as any other DI-re
 
 ``self`` is the bound, validated form instance.
 ``request`` is the current ``HttpRequest``.
-Any additional parameter is resolved through the DI injector: ``DUrl[...]`` markers, ``Depends`` providers, and so on.
+Any additional parameter is resolved through the DI injector, through ``DUrl[...]`` markers, ``Depends`` providers, and similar mechanisms.
 
 The default implementation on ``BaseForm`` redirects to ``Meta.success_url`` when declared, otherwise it returns ``redirect_to_origin(request)``.
 The default implementation on ``BaseModelForm`` calls ``self.save()`` then follows the same redirect rule.
@@ -168,7 +168,8 @@ The dispatcher calls it through the dependency injector before the initial rende
 ``request`` is supplied by the framework.
 A parameter whose name matches a captured URL segment is filled from the URL, so ``note_id`` above receives the ``note_id`` route kwarg.
 Any other parameter resolves through a registered provider, the same as on a handler.
-The base signatures carry no positional arguments of their own: ``BaseForm.get_initial(cls)`` takes none, and ``BaseModelForm.get_initial(cls, **url_kwargs)`` accepts the URL kwargs as keywords.
+The base signatures carry no positional arguments of their own.
+``BaseForm.get_initial(cls)`` takes none, and ``BaseModelForm.get_initial(cls, **url_kwargs)`` accepts the URL kwargs as keywords.
 Declare only the parameters an override actually reads.
 
 Form-Less Actions
@@ -191,13 +192,17 @@ A bare ``@action`` or an empty ``@action()`` registers the function under its ow
        Note.objects.filter(pk=note_id).delete()
        return redirect_to_origin(request)
 
-The scope of a form-less action follows the same anchor-file rule: ``page.py`` and ``component.py`` produce page-scoped actions.
+A form-less handler that returns ``None`` answers with HTTP 204 and never re-renders the origin page, unlike the ``None`` return of a form-bound handler.
+
+The scope of a form-less action follows the same anchor-file rule.
+``page.py`` and ``component.py`` produce page-scoped actions.
 All other files produce shared actions.
 Pass ``scope="page"`` or ``scope="shared"`` to override the file-derived scope, the same override ``Meta.scope`` provides for a form class.
 Any other value triggers ``next.E047`` and the action is not registered.
 The ``login_required`` and ``permission_required`` keywords guard the endpoint, see `Access Guards`_.
 
-Applying ``@action`` to a class registers no action: the decorator records the misuse, returns the class unchanged, and ``manage.py check`` reports it as ``next.E053``.
+Applying ``@action`` to a class registers no action.
+The decorator records the misuse, returns the class unchanged, and ``manage.py check`` reports it as ``next.E053``.
 Form classes register through ``__init_subclass__`` and must not use ``@action``.
 
 Injecting the Form Into a Handler
@@ -208,15 +213,17 @@ A parameter named ``form`` resolves to it, untyped.
 Annotate the parameter with ``DForm[FormClass]`` to type the form for editors and type checkers.
 
 ``form_class=`` accepts the form class directly when that class does not register an endpoint of its own.
-A ``next.forms`` base marked ``Meta.abstract = True`` is the canonical case: it skips auto-registration yet keeps the ``get_initial`` classmethod the dispatcher calls.
+A ``next.forms`` base marked ``Meta.abstract = True`` is the canonical case.
+It skips auto-registration yet keeps the ``get_initial`` classmethod the dispatcher calls.
 Passing a class that already registered itself raises ``TypeError`` at decoration time.
 Mark such a class abstract, or move the handler logic into its ``on_valid``.
 
 .. code-block:: python
    :caption: page.py
 
-   import next.forms
    from django.shortcuts import redirect
+
+   import next.forms
    from next.forms import action
    from next.forms.markers import DForm
 
@@ -307,8 +314,9 @@ Declare the access requirements on the action itself.
 .. code-block:: python
    :caption: page.py
 
-   import next.forms
    from django.http import HttpRequest
+
+   import next.forms
    from next.forms import action, redirect_to_origin
    from next.urls import DUrl
 
@@ -347,13 +355,14 @@ The ``next.W060`` check warns when ``permission_required`` is declared while ``d
 Dynamic Permission Hooks
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The static guard answers a fixed question frozen at import time: is the user authenticated and does the user hold a named permission.
+The static guard answers a fixed question frozen at import time, whether the user is authenticated and holds a named permission.
 A permission that depends on the request, the database, the current tenant, or the target row needs a decision taken per request.
 Two opt-in hooks resolve such a decision, layered on top of the static guard rather than replacing it.
 
 ``check_permissions`` is a view-level ``@classmethod``.
 ``has_object_permission`` is an object-level instance method.
-Both are dependency-injected exactly like ``get_initial`` and ``on_valid``: the base signatures take no parameters of their own, and an override declares only what it reads.
+Both are dependency-injected exactly like ``get_initial`` and ``on_valid``.
+The base signatures take no parameters of their own, and an override declares only what it reads.
 The signature is open, so an override pulls ``request``, captured URL kwargs, ``DUrl[...]`` markers, ``Depends(...)`` providers, or nothing at all, following the same rule as the other DI hooks.
 
 Unlike the static guard, the dynamic hooks intentionally run application code.
@@ -381,11 +390,12 @@ Declare ``request`` to read the user, and any further parameter the injector res
 .. code-block:: python
    :caption: page.py — view-level gate reading the request, a URL kwarg, and a provider
 
-   import next.forms
    from django.http import HttpRequest
+   from notes.models import Note
+
+   import next.forms
    from next.deps import Depends
    from next.urls import DUrl
-   from notes.models import Note
 
    class WorkspaceNoteForm(next.forms.ModelForm):
        class Meta:
@@ -408,9 +418,10 @@ The object-level hook reads the bound instance.
 .. code-block:: python
    :caption: page.py — object-level gate on the loaded row
 
-   import next.forms
    from django.http import HttpRequest
    from notes.models import Note
+
+   import next.forms
 
    class NoteEditForm(next.forms.ModelForm):
        class Meta:
@@ -472,7 +483,7 @@ A wizard step binds from posted data and ``get_form_kwargs`` and never runs ``ge
 Success Feedback
 ----------------
 
-Two ``Meta`` keys describe what a valid submission tells the user: a flash message and a redirect target.
+Two ``Meta`` keys describe what a valid submission tells the user, a flash message and a redirect target.
 
 Success Messages
 ~~~~~~~~~~~~~~~~
@@ -494,7 +505,7 @@ An empty return value sends nothing.
 The message is sent only when the action outcome shapes into a response with a status below 400, so a failed validation flashes nothing.
 On a ``FormWizard`` the message is sent once, after ``done`` succeeds, interpolated over the merged step data.
 
-The messages framework must be fully installed: ``django.contrib.messages`` in ``INSTALLED_APPS`` and ``MessageMiddleware`` in ``MIDDLEWARE``.
+The messages framework must be fully installed, with ``django.contrib.messages`` in ``INSTALLED_APPS`` and ``MessageMiddleware`` in ``MIDDLEWARE``.
 Without it a valid submission raises ``MessageFailure`` rather than silently dropping the message, and the ``next.W061`` check reports the gap at ``manage.py check`` time.
 
 A handler-only action has no ``cleaned_data`` to interpolate, so ``@action`` takes no ``success_message`` keyword.
@@ -532,7 +543,8 @@ The value is a path string, a lazy object, or a zero-argument callable returning
            success_url = page_reverse_lazy("attachments")
 
 On a ``ModelForm`` the default ``on_valid`` saves first, then follows ``success_url``.
-A custom ``on_valid`` or handler that saves an instance can lean on the model itself: returning the instance redirects to its ``get_absolute_url()``, the ``CreateView`` idiom.
+A custom ``on_valid`` or handler that saves an instance can lean on the model itself.
+Returning the instance redirects to its ``get_absolute_url()``, the ``CreateView`` idiom.
 
 .. code-block:: python
 

--- a/docs/content/topics/forms/backends.rst
+++ b/docs/content/topics/forms/backends.rst
@@ -82,7 +82,12 @@ A backend subclasses ``next.forms.FormActionBackend``, an abstract base class wi
 ``dispatch(request, uid)``.
    Runs the handler for the given action UID and returns an ``HttpResponse``.
 
-The base class also offers four optional override points: ``get_meta``, ``iter_actions``, ``render_invalid_page``, and ``shape_response``.
+The base class also offers four optional override points.
+
+- ``get_meta``
+- ``iter_actions``
+- ``render_invalid_page``
+- ``shape_response``
 
 ``get_meta`` and Multi-Backend Routing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -96,9 +101,9 @@ The base implementation returns ``None``.
 
 ``get_meta`` is the routing key for the namespace build and the uid stamping when more than one backend is configured.
 ``FormActionManager`` asks each backend's ``get_meta`` in order and routes those two concerns to the first backend that answers with a non-``None`` meta.
-The URL reverse takes a different path: the manager calls each backend's ``get_action_url`` in order and returns the first answer, collecting ``FormActionNotFoundError`` suggestions along the way, so ``get_meta`` plays no part in it.
+The URL reverse takes a different path.
+The manager calls each backend's ``get_action_url`` in order and returns the first answer, collecting ``FormActionNotFoundError`` suggestions along the way, so ``get_meta`` plays no part in it.
 The proxy method ``FormActionManager.get_action_meta`` exposes the meta resolution, and the ``{% form %}`` tag calls it to stamp the meta's ``uid`` key onto the ``data-next-action`` attribute of the rendered ``<form>`` element.
-A backend whose meta omits ``uid`` therefore renders forms without that attribute, and the dispatch-time signals carry ``uid=None`` for its actions.
 A custom backend whose ``get_meta`` returns ``None`` for its own actions still resolves their URLs through ``get_action_url``, so the ``{% form %}`` tag renders the form element.
 That form renders without ``data-next-action`` and without a bound form instance, and the dispatch-time signals carry ``uid=None``.
 Return a truthy meta for owned names to restore the attribute, the bound form, and the uid.
@@ -116,14 +121,24 @@ Shaping the Response
 ~~~~~~~~~~~~~~~~~~~~
 
 Every outcome of the dispatch pipeline leaves through exactly one call to the backend's ``shape_response(request, outcome)``.
-The ``outcome`` is an ``ActionOutcome``, a frozen keyword-only dataclass whose ``kind`` field is an ``ActionOutcomeKind`` member: ``RESULT`` for a handler return value, ``INVALID`` for a failed validation, and ``WIZARD_ADVANCE`` for a wizard step that moved forward.
+The ``outcome`` is an ``ActionOutcome``, a frozen keyword-only dataclass whose ``kind`` field is an ``ActionOutcomeKind`` member.
+``RESULT`` marks a handler return value, ``INVALID`` marks a failed validation, and ``WIZARD_ADVANCE`` marks a wizard step that moved forward.
 A successful submission is always a ``RESULT`` outcome, including a handler that returns ``None``, so a backend keying off ``INVALID`` only ever sees genuine validation failures.
-The other fields carry what each kind needs: the ``action_name`` and ``uid``, the raw handler return value, the bound failing ``form``, the resolved ``url_kwargs``, the wizard ``redirect_to`` target, and the live ``wizard`` instance.
-On ``INVALID`` outcomes the ``page_path`` and ``origin`` fields carry the identity of the origin page that the dispatcher resolved from the posted ``_next_form_origin`` field, and a ``page_path`` of ``None`` makes the default envelope answer HTTP 400.
-Fields may be added in future versions, so construct an ``ActionOutcome`` with keywords only.
+The other fields carry what each kind needs.
 
-The base implementation delegates to ``FormActionDispatch.shape_response``, the default envelope.
-An invalid submission re-renders the origin page with HTTP 200, the ``X-Next-Form: invalid`` header, and the ``X-Next-Action`` header when the outcome carries a ``uid``.
+- The ``action_name`` and ``uid``.
+- The raw handler return value.
+- The bound failing ``form``.
+- The resolved ``url_kwargs``.
+- The wizard ``redirect_to`` target.
+- The live ``wizard`` instance.
+
+On ``INVALID`` outcomes the ``page_path`` and ``origin`` fields carry the identity of the origin page that the dispatcher resolved from the posted ``_next_form_origin`` field, and a ``page_path`` of ``None`` makes the default envelope answer HTTP 400.
+The dataclass may grow fields over time, so construct an ``ActionOutcome`` with keywords only.
+
+The base implementation first routes a partial request through ``shape_partial`` for a patch envelope, and only a plain request reaches ``FormActionDispatch.shape_response``, the default full-page envelope.
+An override that never calls ``super().shape_response`` therefore disables the partial envelopes for every action the backend dispatches, see :doc:`/content/topics/partial-rendering/how-it-works`.
+On the default full-page path an invalid submission re-renders the origin page with HTTP 200, the ``X-Next-Form: invalid`` header, and the ``X-Next-Action`` header when the outcome carries a ``uid``.
 A wizard advance redirects with HTTP 302.
 Both are behaviour of the default backend, not a guarantee of the endpoint.
 A custom backend may answer with any envelope.
@@ -148,33 +163,43 @@ The four abstract methods must all be present.
    :caption: a minimal from-scratch backend skeleton
 
    from typing import Any
+
    from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
-   from django.urls import path
+   from django.urls import path, reverse
    from django.views.decorators.http import require_http_methods
+
    from next.forms import ActionRegistration, FormActionBackend
+   from next.forms.backends import ActionMeta
    from next.forms.dispatch import FormActionDispatch
 
    class CustomBackend(FormActionBackend):
        def __init__(self, config: dict[str, Any] | None = None) -> None:
-           self._actions: dict[str, ActionRegistration] = {}
+           self._actions: dict[str, ActionMeta] = {}
 
        def register_action(self, registration: ActionRegistration) -> None:
-           self._actions[registration.name] = registration
+           self._actions[registration.name] = ActionMeta(
+               name=registration.name,
+               handler=registration.handler,
+               form_class=registration.form_class,
+               wizard_class=registration.wizard_class,
+               guard=registration.guard,
+           )
 
        def get_action_url(self, action_name: str, *, page_path: str | None = None) -> str:
-           ...
+           return reverse("custom_form_action", kwargs={"uid": action_name})
 
        def generate_urls(self) -> list:
            view = require_http_methods(["GET", "POST"])(self.dispatch)
-           return [path("_next/custom/<str:uid>/", view)]
+           return [path("_next/custom/<str:uid>/", view, name="custom_form_action")]
 
        def dispatch(self, request: HttpRequest, uid: str) -> HttpResponse:
-           entry = self._entry_for_uid(uid)
-           if entry is None:
+           meta = self._actions.get(uid)
+           if meta is None:
                return HttpResponseNotFound()
-           action_name, meta = entry
-           return FormActionDispatch.dispatch(self, request, action_name, meta)
+           return FormActionDispatch.dispatch(self, request, meta["name"], meta)
 
+The skeleton keys its dispatch URL by the plain action name, where the bundled backend derives a hashed UID from the scope key and the name.
+Its meta stores no ``uid``, so the rendered forms carry no ``data-next-action`` attribute, as `get_meta and Multi-Backend Routing`_ describes.
 The bundled backend wraps its dispatch view in ``require_http_methods(["GET", "POST"])`` so the endpoint rejects other verbs, and a from-scratch backend should restrict its own view the same way.
 
 ``dispatch`` answers an unknown UID with a 404, either by returning ``HttpResponseNotFound`` or by raising :exc:`~django.http.Http404` with a message.
@@ -284,6 +309,9 @@ Testing
 Tests that register actions through ``@action`` must drop the global registry between cases so action names from one test do not leak into the next.
 Call :func:`next.testing.reset_form_actions` from a pytest fixture or a ``setUp`` method.
 The helper invokes ``form_action_manager._reload_config()``, which rebuilds the backend list from the current ``NEXT_FRAMEWORK["FORM_ACTION_BACKENDS"]`` setting and discards any actions registered against the previous backend instances.
+
+A test that registers extra actions on a live ``RegistryFormActionBackend`` takes a snapshot first and restores it afterwards.
+``backend.snapshot()`` returns a ``RegistryBackendSnapshot``, an immutable copy of the three registry maps, and ``backend.restore(snapshot)`` puts the registry back exactly as it was, without reaching into the backend's private state.
 
 See :doc:`/content/topics/testing` for the surrounding helpers and fixtures.
 

--- a/docs/content/topics/forms/index.rst
+++ b/docs/content/topics/forms/index.rst
@@ -16,8 +16,7 @@ Read :doc:`overview` first, then jump to the page that matches the part you are 
 
 :doc:`actions`
    Register a handler with ``@action`` and decide which parameters to ask for.
-   Also covers the static access guards (``login_required``, ``permission_required``) and the success contracts (``success_url``, ``success_message``).
-   Covers the dynamic permission hooks (``check_permissions``, ``has_object_permission``) for per-request authorization.
+   Also covers the access guards, the dynamic permission hooks, and the success contracts (``success_url``, ``success_message``).
 
 :doc:`templates`
    Render a form with ``{% form %}`` and link several forms on a single page.

--- a/docs/content/topics/forms/modelforms.rst
+++ b/docs/content/topics/forms/modelforms.rst
@@ -91,8 +91,8 @@ When the kwarg is present but no row matches, :func:`~django.shortcuts.get_objec
 The field named by ``instance_from_url`` should be unique.
 :func:`~django.shortcuts.get_object_or_404` turns only the not-found case into a 404, so a lookup matching several rows surfaces as a server error instead.
 
-Security: the lookup is not ownership-scoped
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ownership Is Not Scoped by Default
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning::
 
@@ -171,7 +171,8 @@ Create and Edit With One Class
 ------------------------------
 
 The same ModelForm class can drive both a create page and an edit page.
-The URL shape encodes the intent: a route that captures the lookup kwarg means edit, and a route without it means create.
+The URL shape encodes the intent.
+A route that captures the lookup kwarg means edit, and a route without it means create.
 The route shape decides which mode the form runs in, with no branching in the form.
 
 On a create page the route has no captured kwarg, so the form renders unbound and ``self.save()`` inserts a new row.
@@ -193,7 +194,8 @@ On an edit page the route captures the kwarg named by ``instance_from_url``, so 
 The class above behaves as a create form on ``notes/new/`` and as an edit form on ``notes/edit/[slug]/``, with no per-page branching.
 One action name and one action URL for both pages require shared scope.
 Declare the class outside ``page.py`` and ``component.py`` as above, or set ``Meta.scope = "shared"`` inside a page module.
-A page-scoped class works differently: declaring a copy in each ``page.py`` keeps the shared action name, but every per-file registration gets its own action URL.
+A page-scoped class works differently.
+Declaring a copy in each ``page.py`` keeps the shared action name, but every per-file registration gets its own action URL.
 See :doc:`actions` for the scope derivation and the UID rules.
 
 Separate create and edit forms are an option, and the repository examples take that route, see :doc:`/content/misc/examples`.

--- a/docs/content/topics/forms/overview.rst
+++ b/docs/content/topics/forms/overview.rst
@@ -5,7 +5,7 @@ Forms Overview
 
 A Django form usually costs a URL entry, a view, manual CSRF handling, and a redirect-on-success per action before it accepts a single POST.
 The forms subsystem removes that wiring.
-Declaring a subclass of ``next.forms.Form`` or ``next.forms.ModelForm`` is enough to make that form reachable by name in any template in the project, with a POST endpoint, CSRF, and re-render-on-failure already attached.
+Declaring a subclass of ``next.forms.Form`` or ``next.forms.ModelForm`` is enough to make that form reachable by name from every template its scope covers, with a POST endpoint, CSRF, and re-render-on-failure already attached.
 No decorator, no manual registry call, and no URL wiring is required.
 
 .. contents::
@@ -17,7 +17,7 @@ Auto-Registration
 
 Every subclass of ``next.forms.BaseForm`` or ``next.forms.BaseModelForm`` registers itself through the ``__init_subclass__`` hook the moment Python executes the ``class`` statement.
 
-The framework derives the action name from the class name by converting ``CamelCase`` to ``snake_case``:
+The framework derives the action name from the class name by converting ``CamelCase`` to ``snake_case``.
 ``ArticleEditForm`` becomes ``article_edit_form``, ``ContactForm`` becomes ``contact_form``.
 
 The framework also records which file the class was declared in and uses that to decide its scope.
@@ -26,8 +26,9 @@ The framework also records which file the class was declared in and uses that to
 .. code-block:: python
    :caption: page.py — auto-registered as ``article_edit_form``
 
-   import next.forms
    from django.http import HttpRequest
+
+   import next.forms
    from next.forms import redirect_to_origin
 
    class ArticleEditForm(next.forms.ModelForm):

--- a/docs/content/topics/forms/signals.rst
+++ b/docs/content/topics/forms/signals.rst
@@ -79,7 +79,8 @@ action_dispatched
 -----------------
 
 Fires after a handler runs and the response has been coerced.
-It also fires once per valid wizard step: a step advance runs no handler and reports ``duration_ms`` as ``0.0``, and the finalising step times the ``done`` call.
+It also fires once per valid wizard step.
+A step advance runs no handler and reports ``duration_ms`` as ``0.0``, and the finalising step times the ``done`` call.
 The sender is ``FormActionDispatch``.
 
 The payload carries ``action_name``, ``uid``, ``request``, ``form``, ``url_kwargs``, ``duration_ms``, ``response_status``, and ``dep_cache``.
@@ -88,7 +89,8 @@ The payload carries ``action_name``, ``uid``, ``request``, ``form``, ``url_kwarg
    The registry identity of the action, matching the dispatch URL and the ``data-next-action`` attribute, or ``None`` for a backend without meta.
 
 ``request``.
-   The live ``HttpRequest``. Do not retain it past the receiver call.
+   The live ``HttpRequest``.
+   Do not retain it past the receiver call.
 
 ``form``.
    The bound form after the handler returns normally and the response has been coerced, or ``None`` for a handler-only action registered without a ``form_class``.
@@ -98,11 +100,13 @@ The payload carries ``action_name``, ``uid``, ``request``, ``form``, ``url_kwarg
    A copy of the URL kwargs the dispatcher resolved before invoking the handler.
 
 ``duration_ms``.
-   Wall-clock time the handler itself took, in milliseconds. It does not include form validation or dependency resolution.
+   Wall-clock time the handler itself took, in milliseconds.
+   It does not include form validation or dependency resolution.
    A wizard step advance runs no handler and reports ``0.0``, so receivers averaging handler latency should skip zero-duration wizard events.
 
 ``dep_cache``.
-   A snapshot of the dispatch dependency cache. Receivers can read named ``Depends("name")`` values resolved during the dispatch without re-running their providers.
+   A snapshot of the dispatch dependency cache.
+   Receivers can read named ``Depends("name")`` values resolved during the dispatch without re-running their providers.
    The dict is a shallow copy taken when the signal fires, so mutating it does not change the live dispatch cache.
 
 A receiver that needs request data reads it from ``request`` directly or from ``dep_cache``, without keeping a reference after it returns.

--- a/docs/content/topics/forms/templates.rst
+++ b/docs/content/topics/forms/templates.rst
@@ -35,6 +35,7 @@ The tag does the following.
 6. Publishes ``form`` inside the block body (see `The form Variable`_ below).
 
 On the validation-error re-render the request targets the dispatch endpoint, so the tag re-emits the posted origin of the original page instead of ``request.path``.
+On a wizard advance in a partial render the shaping layer sets the ``FORM_ORIGIN_OVERRIDE_KEY`` context key to the next step URL, and that value wins over the posted origin.
 
 The ``data-next-action`` attribute carries the action UID, the registry identity that also names the dispatch URL.
 The tag emits it when the action meta is available, which makes the form addressable from client-side scripts without parsing the ``action`` URL.
@@ -90,7 +91,9 @@ The tag compiles each one to a ``data-next-*`` attribute the client runtime read
      - The zone the partial response replaces.
    * - ``key``
      - ``data-next-key``
-     - The stable key that pairs the form with its partial target.
+     - The match key that names the form instance among repeated forms, so a partial morph lands on the submitted copy.
+
+See :doc:`/content/topics/partial-rendering/reference` for the attribute semantics and :doc:`/content/topics/partial-rendering/index` for the topic.
 
 Pass each as a ``key="value"`` argument like any other, and the value resolves as a string literal or a context variable the same way an HTML attribute value does.
 
@@ -105,7 +108,7 @@ Scope Resolution
 ----------------
 
 When the template renders inside a page, the tag first looks for a page-scoped registration whose file matches the current ``page.py``.
-If no page-scoped match exists the tag falls back to the shared registry.
+If no page-scoped match exists the tag falls back to the first registration of that name and accepts it only when its scope is shared.
 This means a page-local ``NoteForm`` takes precedence over a shared ``NoteForm`` with the same derived name.
 
 The ``form`` Variable
@@ -128,7 +131,8 @@ Captured URL Parameters
 -----------------------
 
 The tag does not need any extra argument to forward URL parameters.
-The captured kwargs travel inside the origin path itself: the dispatcher resolves the posted ``_next_form_origin`` against the URLconf and recovers every kwarg through the real URL converters, skipping names reserved by the dependency resolver.
+The captured kwargs travel inside the origin path itself.
+The dispatcher resolves the posted ``_next_form_origin`` against the URLconf and recovers every kwarg through the real URL converters, skipping names reserved by the dependency resolver.
 
 .. code-block:: jinja
    :caption: page for /notes/<int:note_id>/
@@ -227,7 +231,8 @@ Forms in Hand-Written Views
 
 A ``{% form %}`` tag also works inside a template rendered by an ordinary Django view, outside the file router.
 The success path needs nothing extra, the handler runs and its response goes out.
-The error re-render is different: the dispatcher resolves the posted origin to a view and reads the page source location from its ``next_page_path`` attribute, which the file router sets on every routed view and a hand-written view lacks.
+The error re-render is different.
+The dispatcher resolves the posted origin to a view and reads the page source location from its ``next_page_path`` attribute, which the file router sets on every routed view and a hand-written view lacks.
 Without it an invalid submission returns HTTP 400 instead of re-rendering.
 
 Opt in by setting the attribute on the view function yourself, as a ``Path`` or a string naming the ``page.py`` location whose body the dispatcher should compose on the error re-render.

--- a/docs/content/topics/forms/validation-rerender.rst
+++ b/docs/content/topics/forms/validation-rerender.rst
@@ -62,6 +62,7 @@ A custom backend overrides that one method to change how validation errors rende
 The default backend answers an invalid submission with HTTP 200, the full origin page, and the headers ``X-Next-Form: invalid`` and ``X-Next-Action: <uid>``.
 A success re-render of a handler that returned ``None`` carries no such headers, so a client can branch on the headers without scraping the HTML.
 The status and the headers are behaviour of the default backend, not a guarantee of the endpoint, and the ``X-Next-*`` header namespace is reserved for the framework.
+A request carrying the partial-runtime headers receives the same outcome as a patch envelope instead of the full page, see :doc:`/content/topics/partial-rendering/how-it-works`.
 See :doc:`backends` for the override signature and the bundled implementation.
 
 What Survives Re-render
@@ -108,7 +109,7 @@ The template can render error messages inline with each field.
 On re-render the dispatcher always supplies the bound failing form under the action-named context key so the user sees the input that triggered the failure.
 ``get_initial`` still runs on the POST bind to seed the form's ``initial``, but the submitted values win in the rendered fields.
 
-Multiple Forms On The Same Page
+Multiple Forms on the Same Page
 -------------------------------
 
 A page that hosts several actions only re-renders the failing form.
@@ -175,7 +176,8 @@ This guarantee makes it safe to put database writes and external calls inside th
 .. warning::
 
    A page level context function runs again on every re-render, so any write or external call it makes happens a second time on every validation failure.
-   Keep context functions read only. Put writes inside the action handler where they run once on success, or in a custom provider whose result is cached on the request.
+   Keep context functions read only.
+   Put writes inside the action handler where they run once on success, or in a custom provider whose result is cached on the request.
 
 Signals
 -------
@@ -195,15 +197,24 @@ See :doc:`signals` for the full list and payload shapes.
 Edge Cases
 ----------
 
-- A missing or unresolvable ``_next_form_origin`` field returns HTTP 400 on the invalid branch. A plain HTML form must set the field to the URL path of its page, the value the tag emits.
+- A missing or unresolvable ``_next_form_origin`` field returns HTTP 400 on the invalid branch.
+  A plain HTML form must set the field to the URL path of its page, the value the tag emits.
 - A route removed in a deploy between the render and the POST no longer resolves, so the invalid branch returns HTTP 400.
-- Under :func:`django.conf.urls.i18n.i18n_patterns` the origin resolves under the active language of the POST. A user who switches the language between the render and the submit posts an origin whose language prefix no longer resolves, and the invalid branch returns HTTP 400. The success path never resolves the origin and is unaffected.
-- The UID is hashed from the scope key and the action name, not the name alone. For a page-scoped form the scope key is the absolute ``page.py`` path, so moving the file or renaming the class changes the UID. For a shared form the scope key is the dotted module, so moving the module changes the UID. See :ref:`UID stability <topics-forms-actions-uid>` in :doc:`actions`.
-- A handler that returns ``HttpResponseRedirect`` skips the re-render path entirely. Use this on success only.
+- Under :func:`django.conf.urls.i18n.i18n_patterns` the origin resolves under the active language of the POST.
+  A user who switches the language between the render and the submit posts an origin whose language prefix no longer resolves, and the invalid branch returns HTTP 400.
+  The success path never resolves the origin and is unaffected.
+- The UID is hashed from the scope key and the action name, not the name alone.
+  For a page-scoped form the scope key is the absolute ``page.py`` path, so moving the file or renaming the class changes the UID.
+  For a shared form the scope key is the dotted module, so moving the module changes the UID.
+  See :ref:`UID stability <topics-forms-actions-uid>` in :doc:`actions`.
+- A handler that returns ``HttpResponseRedirect`` skips the re-render path entirely.
+  Use this on success only.
 - Virtual page origins backed by ``template.djx`` resolve through the template loader, as :ref:`topics-forms-validation-rerender-origin` explains above.
 - The re-render emits a fresh ``csrfmiddlewaretoken`` through ``get_token``, so the browser cookie stays valid and the resubmission passes CSRF without a reload.
-- File inputs reset on re-render because the HTTP spec does not let a server re-populate them. Set ``enctype="multipart/form-data"`` and re-prompt the user for the upload.
-- Text, select, checkbox, and textarea widgets keep their raw submitted values because the dispatcher binds the failing form to ``request.POST``. Password widgets clear unless ``render_value=True``.
+- File inputs reset on re-render because the HTTP spec does not let a server re-populate them.
+  Set ``enctype="multipart/form-data"`` and re-prompt the user for the upload.
+- Text, select, checkbox, and textarea widgets keep their raw submitted values because the dispatcher binds the failing form to ``request.POST``.
+  Password widgets clear unless ``render_value=True``.
 
 Common Patterns
 ---------------

--- a/docs/content/topics/forms/wizard-backend.rst
+++ b/docs/content/topics/forms/wizard-backend.rst
@@ -64,7 +64,8 @@ A row deleted between steps decodes to ``None``, so ``done`` must not assume the
 An unsaved instance has no primary key to store, so encoding it raises ``ImproperlyConfigured`` at save time.
 
 A value the codec does not recognise raises ``ImproperlyConfigured`` naming the offending type.
-The error suggests the way out: configure ``CacheFormWizardBackend`` or a custom ``FormWizardBackend`` for cleaned data that does not fit JSON.
+The error suggests the fix.
+Configure ``CacheFormWizardBackend`` or a custom ``FormWizardBackend`` for cleaned data that does not fit JSON.
 
 The Cache Backend
 -----------------
@@ -125,7 +126,8 @@ Draft Expiry Mid-Wizard
 
 A draft can vanish between two steps when the session ends, when the cache backend's ``TIMEOUT`` is short, or when the cache evicts under pressure.
 The backend reads a missing entry as an empty mapping.
-The dispatcher does not finalise over the gap: a final-step submission while an earlier step has no stored data redirects to the first incomplete step, so the visitor re-enters the lost data instead of triggering ``done`` with a partial draft.
+The dispatcher does not finalise over the gap.
+A final-step submission while an earlier step has no stored data redirects to the first incomplete step, so the visitor re-enters the lost data instead of triggering ``done`` with a partial draft.
 
 .. warning::
 

--- a/docs/content/topics/forms/wizard.rst
+++ b/docs/content/topics/forms/wizard.rst
@@ -44,10 +44,11 @@ Each form class is a plain ``django.forms.Form`` or ``django.forms.ModelForm``.
 .. code-block:: python
    :caption: access/views/request/[step]/page.py — auto-registered as ``access_request_wizard``
 
-   import next.forms
    from access.models import AccessRequest
    from django import forms
    from django.http import HttpRequest
+
+   import next.forms
    from next.forms import redirect_to_origin
 
    class IdentityStep(forms.ModelForm):
@@ -81,8 +82,9 @@ Under the default settings the same files live in ``access/pages/request/[step]/
 
 Every step form subclasses ``django.forms`` directly.
 A step is not a standalone action, so a plain Django form has nothing to register and nothing to suppress.
-The wizard never calls the ``next.forms`` hooks on a step, so the framework base classes buy a step nothing, see `How Step Forms Differ From Standalone Forms`_.
-A ``next.forms`` base can still serve as a step, but then it must set ``Meta.abstract = True``: without the flag ``__init_subclass__`` registers the step as its own form action whose default ``on_valid`` saves a partial row, and the ``next.W057`` system check warns about the double role.
+The wizard never runs ``get_initial`` or ``on_valid`` on a step, so a plain Django form is the canonical base, see `How Step Forms Differ From Standalone Forms`_.
+A ``next.forms`` base can still serve as a step, but then it must set ``Meta.abstract = True``.
+Without the flag ``__init_subclass__`` registers the step as its own form action whose default ``on_valid`` saves a partial row, and the ``next.W057`` system check warns about the double role.
 See :ref:`Preventing Registration <topics-forms-actions-abstract>` for the ``Meta.abstract`` semantics.
 
 ``Meta.steps`` is required.
@@ -98,8 +100,8 @@ It defaults to ``"step"``, so a route segment of ``[step]`` works with no furthe
 Per-step drafts persist through the configured ``FORM_WIZARD_BACKEND``, which the project sets once for every wizard.
 See :doc:`wizard-backend` for the backend contract and its options.
 
-The done Method
----------------
+The ``done`` Method
+-------------------
 
 ``done`` runs once after the last step validates.
 It receives ``request`` and the merged ``cleaned_data`` of every stored step, so the keys from each step form are flattened into one mapping.
@@ -152,14 +154,16 @@ Beyond the reserved names, ``done`` declares markers and named dependencies like
        return redirect_to_origin(request)
 
 ``self.url_kwargs`` still carries the captured URL values for code that prefers an explicit read.
-A wizard module falls under the DI annotation rule: do not add ``from __future__ import annotations`` to a module whose ``done`` the resolver inspects, see :doc:`/content/topics/dependency-injection`.
+A wizard module falls under the DI annotation rule.
+Do not add ``from __future__ import annotations`` to a module whose ``done`` the resolver inspects, see :doc:`/content/topics/dependency-injection`.
 
 The ``done`` Return Value
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The return value of ``done`` follows the same coercion as an action handler.
 
-- An ``HttpResponse`` subclass is sent as is. A redirect is the usual choice.
+- An ``HttpResponse`` subclass is sent as is.
+  A redirect is the usual choice.
 - A string becomes an ``HttpResponse`` body with status 200.
 - A model instance with a ``get_absolute_url`` method redirects to that URL, the ``CreateView``-style idiom for a finaliser that saves and shows the result.
 - A value with a truthy ``url`` attribute becomes an ``HttpResponseRedirect`` to that URL.
@@ -190,7 +194,8 @@ Two hooks that fire for a standalone ``next.forms`` action never fire for a step
    Put per-step side effects nowhere, and put the single finalising write in ``done``.
 
 A step built on a ``next.forms`` base that defines ``get_initial`` or ``on_valid`` sees neither method run inside the wizard.
-Both are silently inert on a step class, so subclassing ``next.forms`` buys a step nothing and costs the ``Meta.abstract`` flag.
+Both are silently inert on a step class.
+A ``next.forms`` base does give a step the object-level ``has_object_permission`` hook, which the dispatcher enforces after the step binds, at the cost of the ``Meta.abstract`` flag, see :ref:`topics-forms-actions-dynamic-guards`.
 
 Rendering
 ---------
@@ -295,6 +300,7 @@ Routing and Back-Navigation
 
 The wizard lives on a route that captures the step segment, such as ``request/[step]/``.
 The captured kwarg name matches ``Meta.url_param``.
+A route that captures kwargs but not the ``Meta.url_param`` name raises :exc:`~django.core.exceptions.ImproperlyConfigured` at request time instead of silently pinning the wizard to its first step, which also covers shared wizards the static ``next.E054`` check cannot see.
 
 On a valid non-final step the dispatcher saves the step data and redirects to the next step's URL.
 The redirect reuses the current page path and swaps the step segment, so ``request/identity/`` becomes ``request/scope/``.

--- a/docs/content/topics/layouts.rst
+++ b/docs/content/topics/layouts.rst
@@ -26,9 +26,13 @@ The composition is purely structural, driven by directory placement.
 Layout Discovery
 ----------------
 
-The framework walks from the page directory upward until it reaches the page root.
+The framework walks every ancestor directory upward from the page directory, bounded at 64 levels.
 Every directory along the way is inspected for a ``layout.djx`` file.
 The collected layouts are composed in order, with the closest layout wrapping the page body and the farthest layout wrapping everything else.
+
+The walk does not stop at the page root.
+A ``layout.djx`` in a directory above the page root, such as the application package directory, also joins the chain and wraps every page below it.
+Keep layout files inside the page tree unless that wrapping is intended.
 
 .. code-block:: text
    :caption: layout discovery
@@ -81,8 +85,8 @@ The closing tag can be written either way.
    </html>
 
 Without the placeholder that layout emits its own markup and discards the wrapped content, so the page body and every inner layout below the broken layer vanish from the output without an error.
-The ``check_layout_templates`` system check emits ``next.W001`` for any ``layout.djx`` that lacks a ``{% block template %}`` block.
-Run ``uv run python manage.py check`` to catch layouts that miss the placeholder.
+The ``check_layout_templates`` system check emits ``next.W001`` for a ``layout.djx`` sitting next to a discovered page when it lacks a ``{% block template %}`` block.
+A layout in an intermediate segment directory without a sibling page is not covered, so ``uv run python manage.py check`` does not catch every broken layout.
 
 Layouts can declare layout-level CSS and JS through the static collector tags shown above.
 The tags also live in inner layouts when you want a section-scoped style sheet.
@@ -96,8 +100,8 @@ Use it to publish values that the layout markup needs and, with ``inherit_contex
 .. code-block:: python
    :caption: notes/pages/page.py
 
-   from notes.models import Note
    from next.pages import context
+   from notes.models import Note
 
    @context("site_name", inherit_context=True)
    def site_name() -> str:
@@ -153,8 +157,8 @@ The static collector emits the file only when a request reaches a page below tha
 Multiple Backends and Layout Roots
 ----------------------------------
 
-Each entry in ``PAGE_BACKENDS`` produces an independent layout tree.
-Two backends can have entirely different root layouts even when both scan the same applications.
+Two backends that scan different directories produce two separate layout chains.
+The separation comes from the directories, not from the backends, because layout discovery is purely filesystem-based.
 
 .. code-block:: python
    :caption: config/settings.py
@@ -180,7 +184,10 @@ Two backends can have entirely different root layouts even when both scan the sa
 
 The first backend reads ``notes/pages/`` and uses ``notes/pages/layout.djx`` as its root.
 The second backend reads ``notes/admin_routes/`` and uses ``notes/admin_routes/layout.djx`` as its root.
-The two trees do not share layouts.
+The two chains stay separate only because the two directories share no ancestor that carries a ``layout.djx``.
+A layout in a shared ancestor directory, such as the ``notes`` package directory itself, wraps pages from both backends.
+Root layouts collected from ``DIRS`` are also global.
+The framework gathers them from every ``PAGE_BACKENDS`` entry and appends them to the chain of every page, regardless of which backend discovered the page.
 
 Project Level Root Layout
 -------------------------
@@ -230,7 +237,7 @@ Inherited context not visible to a sub-page.
    Without it the value is not injected into descendant routes.
 
 Two roots produce one composed page.
-   Each backend has its own layout tree.
+   A page composes its layout chain from its own ancestor directories.
    A page lives under exactly one backend, even when the file path is also reachable from another backend.
 
 See Also

--- a/docs/content/topics/pages.rst
+++ b/docs/content/topics/pages.rst
@@ -59,7 +59,7 @@ This is the authoritative ordering for the page render path.
 A ``render`` function therefore cannot read a value that a ``@context`` callable would publish, because the callables have not run yet.
 
 A partial-zone request takes a different path.
-When the request targets named zones, the view returns a zone response before step 3, so the layout composition does not run.
+When the request targets named zones, the view returns a zone response before step 3, so the full page render does not run.
 See :doc:`/content/topics/partial-rendering/zones` for the zone-morph request.
 
 The ``render`` Function
@@ -71,8 +71,8 @@ The most common shape is ``request`` plus captured URL parameters and marker-dri
 .. code-block:: python
    :caption: notes/pages/reports/[int:report_id]/page.py
 
-   from notes.models import Report
    from next.urls import DUrl
+   from notes.models import Report
 
    def render(request, report_id: DUrl[int]) -> str:
        report = Report.objects.get(pk=report_id)
@@ -230,10 +230,13 @@ Register additional loaders in ``NEXT_FRAMEWORK["TEMPLATE_LOADERS"]`` to support
 A user-provided ``NEXT_FRAMEWORK["TEMPLATE_LOADERS"]`` replaces the default list entirely.
 Include ``DjxTemplateLoader`` explicitly when you still want sibling ``template.djx`` files to load.
 
-Call ``next.pages.page.register_template(file_path, template_str)`` from an app's ``ready()`` to attach an in-process template string to a page path without authoring a loader class.
+``next.pages.page.register_template(file_path, template_str)`` seeds the composed-template cache that ``composed_template_for`` reads.
+That cache serves direct ``Page.render`` calls, including ``next.testing.render_page``, the form re-render after a validation failure, and standalone zone renders.
+A regular HTTP request for the page bypasses the cache and resolves the body from its disk source, so a registered string never serves the page at its URL.
 The method stores the supplied body verbatim, with no layout composition, so no ancestor ``layout.djx`` wraps it.
 Pre-compose the body through the layout chain before registering it when wrapping is required.
 See :doc:`/content/ref/pages` for the full ``Page`` surface.
+See :doc:`/content/howto/add-a-custom-template-loader` for the recipe-shaped walkthrough of a loader class.
 
 Loader Contract
 ~~~~~~~~~~~~~~~~~
@@ -318,25 +321,28 @@ Streaming Response
 Reach for ``StreamingHttpResponse`` when the body is produced incrementally, such as Server Sent Events or a large export.
 
 .. code-block:: python
-   :caption: notes/pages/notes/[id]/stream/page.py
+   :caption: notes/pages/notes/[int:note_id]/stream/page.py
 
+   import time
    from collections.abc import Iterator
 
    from django.http import StreamingHttpResponse
+   from next.urls import DUrl
    from notes.models import Note
-   from notes.providers import DNote
 
    def event_stream(note_id: int) -> Iterator[bytes]:
-       ...  # see examples/live-polls for a worked generator
+       while True:
+           note = Note.objects.get(pk=note_id)
+           yield f"data: {note.title}\n\n".encode()
+           time.sleep(5)
 
-   def render(note: DNote[Note]) -> StreamingHttpResponse:
+   def render(note_id: DUrl[int]) -> StreamingHttpResponse:
        return StreamingHttpResponse(
-           event_stream(note.pk),
+           event_stream(note_id),
            content_type="text/event-stream",
            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
        )
 
-``DNote`` is a custom DI provider that resolves the note from the captured URL segment, defined in ``notes/providers.py``.
 A synchronous generator works under WSGI and the development server.
 An ASGI deployment can yield from an async generator instead.
 See ``examples/live-polls`` for a worked SSE broker.
@@ -370,7 +376,8 @@ The pages subsystem contributes Django system checks. The ``check_page_functions
 ``next.W043``.
    More than one body source is declared in the same directory, see *Priority Resolution*.
 
-The ``check_context_functions`` check inspects every ``page.py`` for keyless ``@context`` callables.
+The ``check_context_functions`` check inspects ``page.py`` files under one representative pages root per router for keyless ``@context`` callables.
+In a project with several page-bearing applications the remaining roots are not scanned, so ``next.E029`` surfaces only for pages under the scanned root.
 
 ``next.E029``.
    A keyless ``@context`` callable has a return annotation that is not a mapping type.

--- a/docs/content/topics/partial-rendering/co-located-js.rst
+++ b/docs/content/topics/partial-rendering/co-located-js.rst
@@ -7,7 +7,7 @@ A morph replaces DOM nodes.
 A node that arrives in a patch was not in the document when the page loaded, and a node that a morph removes takes any listener bound to it with it.
 Co-located JavaScript has to survive that, and the rule is to attach behaviour to something that outlives the morph rather than to the markup itself.
 
-Each asset URL runs exactly once per page lifetime.
+Each asset runs exactly once per page lifetime, a URL deduped by its address and an inline body by its content.
 A module loaded for the first zone that needs it is not re-run when a later patch brings more of the same markup.
 A module that wires itself up at load time finds the markup that exists at load time and nothing later.
 Use one of the three idioms below.
@@ -73,6 +73,8 @@ It is the one-for-one replacement of a ``DOMContentLoaded`` scan.
    });
 
 The callback fires for the matching elements present at load and for every matching element that a later patch brings.
+The callback also re-runs for a matching element the morph reconciled in place, so it must be idempotent per element.
+Guard the setup with a data flag or a ``WeakSet`` so a second run over the same element does nothing.
 Reach for this when a module wired itself on ``DOMContentLoaded`` before and needs the same per-element setup to keep working under partial updates.
 
 The Anti-Pattern
@@ -95,10 +97,8 @@ The second open of a modal is worse.
 The asset URL is already in the runtime's loaded registry from the first open, so the module is not re-executed at all, and a scan inside it never runs a second time.
 
 Migrate a module-load scan to one of the three idioms above.
-A search catalogue's minimum-length hint and a wiki's markdown preview both moved from a load-time scan to ``onMount`` for exactly this reason.
-In a development build the runtime prints a ``console.warn`` for every inline
-``<script>`` it neutralises out of a patch, which surfaces a widget that died silently
-rather than letting it fail in quiet.
+The search catalogue's minimum-length hint and the wiki's markdown preview both register through ``onMount`` for exactly this reason.
+In a development build the runtime prints a ``console.warn`` for every ``<script>`` it neutralises out of a patch, which surfaces a widget that died silently rather than letting it fail in quiet.
 
 Scripts in Patches Never Run
 ----------------------------
@@ -108,6 +108,12 @@ The applier removes every script element from parsed patch HTML before it reache
 Behaviour is delivered only through the co-located asset manifest and the ``event`` verb, never through inline script in a morph.
 This is structural, not a parser side effect, and it is why an inline widget initialiser has to move to one of the idioms above.
 See :doc:`/content/security/csp-and-nonce` for how this interacts with a Content Security Policy.
+
+What the applier neutralises is the script inside the patch markup itself.
+The zone's co-located assets travel separately, in the envelope's asset manifest, and those do load.
+A stylesheet or module URL the page has not seen is inserted, and so is an inline body it has not seen, each once per page lifetime.
+Behaviour co-located with a zone therefore arrives on a standalone zone render.
+It must still use the three idioms above because of the once-per-page execution, not because a delivery channel is missing.
 
 See Also
 --------

--- a/docs/content/topics/partial-rendering/done-choreographies.rst
+++ b/docs/content/topics/partial-rendering/done-choreographies.rst
@@ -25,7 +25,7 @@ The wizard does not know the list exists.
 .. code-block:: python
    :caption: request/[step]/page.py
 
-   def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> PatchResponse:
+   def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> HttpResponse:
        """Create the access request and close the layer with a result."""
        access_request = AccessRequest.objects.create(**cleaned_data)
        return (
@@ -63,7 +63,7 @@ The wizard is portable.
 It sits on any page without a change, and ``data-next-accepted`` moves with the markup.
 
 This is the cycle of a redirect with reloaded props.
-The cost is one extra GET after the modal closes, masked by the ``aria-busy`` busy gate the runtime sets on the target.
+The cost is one extra GET after the modal closes.
 
 Server OOB Through Page Addressing
 ----------------------------------
@@ -78,12 +78,12 @@ The builder takes ``page=`` and ``url_kwargs=`` alongside ``zone=``, and the req
 .. code-block:: python
    :caption: request/[step]/page.py
 
-   from django.http import Http404
+   from django.http import Http404, HttpResponse
 
    from next.partial import resolve_partial_origin
 
 
-   def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> PatchResponse:
+   def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> HttpResponse:
        """Create the access request and patch the host page list in one response."""
        access_request = AccessRequest.objects.create(**cleaned_data)
        origin = resolve_partial_origin(request)
@@ -145,7 +145,7 @@ The Comparison
      - Drops onto any page, ``data-next-accepted`` moves with it
      - ``done`` hard-codes the zone or branches on the origin
    * - UX atomicity
-     - A one-GET gap between close and list, masked by ``aria-busy``
+     - A one-GET gap between close and list
      - Close, list, and toast apply in one envelope
    * - Without the runtime
      - Identical: a 303 to ``fallback``

--- a/docs/content/topics/partial-rendering/extending.rst
+++ b/docs/content/topics/partial-rendering/extending.rst
@@ -5,8 +5,8 @@ Extending the Protocol
 
 The protocol is closed by design.
 The server authors every verb and the client never invents one, so a page cannot be asked to do anything the server did not name.
-Three seams open that protocol to an application without forking the runtime: a custom verb, a server-pushed context value, and a server-fired event.
-Each rides the same envelope and the same apply pipeline as the built-ins.
+Three seams open that protocol to an application without forking the runtime.
+A custom verb, a server-pushed context value, and a server-fired event each ride the same envelope and the same apply pipeline as the built-ins.
 
 .. contents::
    :local:
@@ -57,7 +57,7 @@ Supply the handler on the client through a co-located asset.
 
 The handler receives the patch and an apply context.
 The patch carries the payload fields the server authored, here ``patch.count``.
-The context exposes ``dispatch`` for a ``CustomEvent`` on the ``Next.on`` bus, ``mergeContext`` for a context merge, ``root`` for the document, and ``dev`` for the development-build flag.
+The context exposes ``dispatch`` for an event on the ``Next.on`` bus, ``mergeContext`` for a context merge, ``root`` for the document, and ``dev`` for the development-build flag.
 Registering the handler at load time is safe, because ``defineOp`` records a handler rather than scanning the DOM.
 
 The envelope carries the custom verb beside the built-ins.
@@ -155,6 +155,18 @@ Consume it with a delegated document listener or the ``Next.on`` bus.
    });
 
 The ``toast`` verb is sugar over ``event`` with a built-in container, so a project that wants its own notification surface listens for ``next:toast`` and renders the toast itself.
+The item still lands in the built-in ``[data-next-toasts]`` tray, so such a project also hides the tray with CSS.
+
+One Active Backend
+------------------
+
+The three seams above extend the envelope from inside.
+The wire format itself is replaced rather than extended, and the replacement lives in the protocol backend.
+``PARTIAL_BACKENDS`` holds the protocol backends and only the first entry is active.
+The rest are ignored, so multi-backend selection is not a supported seam.
+A configuration with more than one entry earns the ``next.W071`` warning at ``manage.py check``.
+An application that needs a different envelope shape subclasses ``PartialProtocolBackend``, serialises its own wire format, and makes the subclass the single entry of ``PARTIAL_BACKENDS``.
+See :doc:`/content/ref/partial` for the ``PartialProtocolBackend`` API.
 
 See Also
 --------

--- a/docs/content/topics/partial-rendering/framework-islands.rst
+++ b/docs/content/topics/partial-rendering/framework-islands.rst
@@ -22,9 +22,8 @@ The Mount and Unmount Pair
 ``next:removed`` fires on a node immediately before it detaches, for every detach the runtime performs.
 Both bubble to the document, so one delegated listener catches every island, and the pair brackets the life of a node inside the document.
 
-Mount through :ref:`Next.partial.onMount <topics-partial-rendering-co-located-js>`, which
-runs its callback over the matching elements present at load and over every matching
-element a later patch inserts, descendants included.
+Mount through :ref:`Next.partial.onMount <topics-partial-rendering-co-located-js>`.
+The registry runs its callback over the matching elements present at load and over every matching element a later patch inserts, descendants included.
 Unmount through ``next:removed``, walking the detached subtree for islands, because the event fires on the detached root rather than on each descendant.
 
 A React Island
@@ -39,6 +38,7 @@ A React Island
    const roots = new WeakMap();
 
    Next.partial.onMount("[data-chart]", (el) => {
+     if (roots.has(el)) return;
      const root = createRoot(el);
      root.render(Chart(JSON.parse(el.dataset.props ?? "{}")));
      roots.set(el, root);
@@ -59,6 +59,7 @@ A React Island
      }
    });
 
+The ``roots.has(el)`` guard keeps the mount idempotent, because ``onMount`` re-runs its callback over a matching element the morph reconciled in place.
 The ``next:removed`` handler walks the subtree because a morph that removes the zone containing the chart fires the event on the zone, not on the chart inside it.
 Matching the node itself and its descendants covers both the island-as-root and the island-inside-a-removed-zone cases.
 
@@ -74,6 +75,7 @@ A Vue Island
    const apps = new WeakMap();
 
    Next.partial.onMount("[data-chart]", (el) => {
+     if (apps.has(el)) return;
      const app = createApp(Chart, { ...el.dataset });
      app.mount(el);
      apps.set(el, app);
@@ -119,7 +121,8 @@ The morph syncs no attributes and walks none of its children, so a framework tha
 
 A custom element, a tag with a hyphen, and any node carrying a shadow root are atomic in a narrower sense.
 The morph still syncs their attributes, then stops at the boundary and never enters the children or the shadow tree.
-The attribute sync is the point: a server re-render that ships a stale attribute on a custom element overwrites the live one the framework was managing.
+The attribute sync is the point.
+A server re-render that ships a stale attribute on a custom element overwrites the live one the framework was managing.
 
 Use ``data-next-keep`` for an island whose attributes the framework drives after mount.
 Lean on the built-in custom-element atomicity only when the server attributes and the framework attributes never disagree, for example a web component the server seeds once and never re-authors.

--- a/docs/content/topics/partial-rendering/how-it-works.rst
+++ b/docs/content/topics/partial-rendering/how-it-works.rst
@@ -24,9 +24,8 @@ The Request
 
 An interaction issues a partial request instead of a full navigation.
 A form submit, an auto-submitting filter, a paginating link, a lazy zone scrolling into view, and a Server-Sent Events message each reach the same pipeline.
-The request carries an ``Accept`` of the patch media type, which doubles as the switch
-the server reads to choose a partial response over a full page, and ``X-Next-*`` headers
-that name the zone, the origin page, and the asset version.
+The request carries the ``X-Next-Request`` switch the server reads to choose a partial response over a full page.
+It also carries an ``Accept`` naming the patch media type at the content-negotiation level and further ``X-Next-*`` headers that name the zone, the origin page, and the asset version.
 
 The Envelope
 ------------

--- a/docs/content/topics/partial-rendering/index.rst
+++ b/docs/content/topics/partial-rendering/index.rst
@@ -8,19 +8,17 @@ A form re-renders only the form that failed, a filter swaps only the result list
 The server authors every DOM operation and the client applies it.
 Selectors and swap strategies never cross the wire.
 
-Every interaction in this section degrades to a full page cycle when JavaScript is off.
-The runtime is an enhancement layered on top of the same ``POST`` then ``303`` then ``GET`` flow the framework already serves.
-A page that works without the runtime keeps working with it, and gains the partial behaviour for free.
+Every interaction in this section degrades to a full page cycle when JavaScript is off, layered on top of the same ``POST`` then ``303`` then ``GET`` flow the framework already serves.
 
 Read :doc:`scenarios` first.
 It walks seven concrete tasks from markup to handler, and the rest of the section deepens one concern at a time.
 
-.. rubric:: The tutorial
+.. rubric:: The Tutorial
 
 :doc:`scenarios`
-   Seven scenarios from task to markup to handler: neighbouring forms, inline validation,
-   an auto-submitting filter, pagination and infinite scroll, a live stream, a modal
-   wizard that refreshes a list, and lazy zones.
+   Seven scenarios from task to markup to handler, from neighbouring forms and inline
+   validation to an auto-submitting filter, pagination and infinite scroll, a live
+   stream, a modal wizard that refreshes a list, and lazy zones.
 
 .. rubric:: Concepts
 
@@ -43,9 +41,12 @@ It walks seven concrete tasks from markup to handler, and the rest of the sectio
    Streaming patch envelopes over Server-Sent Events, the WSGI and ASGI contract, and the refresh fan-out pattern.
 
 :doc:`extending`
-   The three seams that open the protocol to an application: a custom verb, a server-pushed context value, and a server-fired event.
+   The three seams that open the protocol to an application, a custom verb, a server-pushed context value, and a server-fired event.
 
 .. rubric:: Reference
+
+:doc:`limitations`
+   The boundaries the model draws on purpose, from the synchronous zone render to the single active backend, and what to reach for at each one.
 
 :doc:`reference`
    The patch verbs, request and response headers, ``data-next-*`` attributes, and ``PARTIAL_BACKENDS`` settings, in tables.
@@ -66,4 +67,5 @@ It walks seven concrete tasks from markup to handler, and the rest of the sectio
    framework-islands
    sse
    extending
+   limitations
    reference

--- a/docs/content/topics/partial-rendering/limitations.rst
+++ b/docs/content/topics/partial-rendering/limitations.rst
@@ -1,0 +1,59 @@
+.. _topics-partial-rendering-limitations:
+
+Limitations
+===========
+
+The partial model has a deliberate shape.
+The server authors every operation, the client applies them, and the protocol stays closed.
+The boundaries below follow from that shape, and each one names where the model stops and what to reach for instead.
+
+.. contents::
+   :local:
+   :depth: 1
+
+Zones Render Synchronously
+--------------------------
+
+A zone renders standalone over the full page context in one synchronous pass.
+There is no server-side suspense flush, so a slow zone holds the response rather than streaming a placeholder and a later patch.
+A ``lazy=`` zone defers its first render behind a placeholder, but the deferral is a separate client-driven round trip, not a server-held stream.
+
+Real Time Is Server-Sent Events Only
+------------------------------------
+
+The streaming transport is Server-Sent Events, one direction from server to client, see :doc:`sse`.
+There is no WebSocket transport, so client-to-server push over a persistent socket is outside the current model.
+A client that needs to send state changes uses the same forms and actions every page already has.
+
+Polling Zones Are Client-Timed
+------------------------------
+
+``poll=`` is a client timer, not a server push.
+The runtime re-GETs the zone on the interval while the tab is visible, a hidden tab holds no timers, and the floor is one second.
+A change the server wants to announce the moment it happens is a stream's job, not a poll's.
+See the poll section of :doc:`zones`.
+
+One Active Backend
+------------------
+
+``PARTIAL_BACKENDS`` activates its first entry and ignores the rest.
+Multi-backend selection is not supported, and a list with more than one entry earns the ``next.W071`` warning at ``manage.py check``.
+A different wire format is a subclass of ``PartialProtocolBackend`` installed as the single entry, see :doc:`extending`.
+
+Scripts in Patch HTML Never Run
+-------------------------------
+
+A zone's co-located assets ship on a standalone render, inline bodies and URLs alike, through the envelope's asset manifest.
+What never runs is a ``<script>`` inside the patch HTML itself, which the applier strips before the markup reaches the document.
+Every asset executes once per page lifetime, so behaviour binds through the mount idioms rather than a load-time scan.
+See :doc:`co-located-js`.
+
+See Also
+--------
+
+.. seealso::
+
+   :doc:`zones` for the zone tag, polling, and the keying rules.
+   :doc:`sse` for the streaming transport and the refresh fan-out pattern.
+   :doc:`extending` for the seams that open the protocol without forking the runtime.
+   :doc:`co-located-js` for the idioms that keep behaviour alive across a morph.

--- a/docs/content/topics/partial-rendering/reference.rst
+++ b/docs/content/topics/partial-rendering/reference.rst
@@ -283,6 +283,7 @@ Lifecycle Events
 The runtime fires events on three channels, the element, the document, and the ``Next.on`` bus.
 The ``next:*`` node events fire on the element as a bubbling ``CustomEvent`` caught with ``addEventListener``.
 The apply-stage ``partial:*`` events and ``next:toast`` fire on the document and the ``Next.on`` bus.
+A ``partial:error`` of kind ``asset``, raised when a co-located stylesheet fails to load or its version mismatches, reaches only the bus.
 ``ready``, ``context-updated``, ``partial:before-request``, and the fetch-stage ``partial:error`` reach only the bus.
 The ``next:mounted``, ``next:removed``, and ``next:morph-*`` node events live only on ``document.addEventListener`` and never reach the bus, so ``Next.on("next:mounted")`` is a silent no-op.
 

--- a/docs/content/topics/partial-rendering/reference.rst
+++ b/docs/content/topics/partial-rendering/reference.rst
@@ -16,6 +16,7 @@ Patch Verbs
 A patch is one addressed DOM operation with a verb, an optional target, optional HTML, and verb-specific extras.
 The operations apply in list order.
 The server is the only author of a target, the client never names one.
+The envelope around the list always carries the ``assets`` and ``form`` keys, serialised as ``[]`` and ``null`` when empty, and the JSON examples in this section omit them.
 
 .. list-table::
    :header-rows: 1
@@ -67,7 +68,8 @@ The server is the only author of a target, the client never names one.
      - ``variant: "info"``
    * - ``layer.open``
      - ``layer_open()``
-     - Open a layer from the server, by zone or href.
+     - Open a layer from the server. The client acts only when the op carries both
+       the zone container name and the href to GET into it, a single seed is ignored.
      - none
    * - ``layer.close``
      - ``layer_close()``
@@ -121,13 +123,13 @@ All values are ASCII, and zone names are ASCII slugs.
      - Pagination
      - ``append`` or ``prepend``, the merge intent.
    * - ``X-Next-Version``
-     - Every intercepted request
-     - The asset version the client holds.
+     - Every request once a version is learned
+     - The asset version the client holds. The first request of a page asserts none.
    * - ``X-Next-Request-Id``
      - Every mutation
      - The ring id used to suppress an SSE echo.
    * - ``X-Next-Origin``
-     - Server OOB choreography only
+     - Every layer request, the open GET and the accept re-GET
      - The path and query string of the page that hosts a layer, for a server-side morph of its zones.
    * - CSRF header
      - Every unsafe method
@@ -178,8 +180,12 @@ Status Codes
      - A success with no patch to apply, for example a wizard advance with no redirect target. The runtime applies nothing.
    * - 303
      - A mutation succeeded without the runtime, the existing full cycle.
-   * - 302 or 403 without an envelope
-     - A guard denial or a CSRF failure served outside the shaping path. The runtime navigates fully.
+   * - 302 without an envelope
+     - A guard redirect served outside the shaping path. The runtime navigates fully to the final URL.
+   * - 403 without an envelope
+     - A guard denial or a CSRF failure served outside the shaping path. On a mutation the runtime
+       stays in place and fires ``partial:error`` with the status and body. On a safe method it
+       navigates fully.
    * - 400
      - An intent that did not validate: an unknown zone, a bad origin, a zone in a dynamic page body.
    * - 404
@@ -193,7 +199,7 @@ Attributes
 ----------
 
 The single namespace the runtime reads is ``data-next-*``.
-The form-behaviour attributes are written by the ``{% form %}`` tag from Python parameters, not hand-authored as a string DSL.
+The form-behaviour attributes are written by the ``{% form %}`` tag from its parameters, not hand-authored as a string DSL.
 
 .. list-table::
    :header-rows: 1
@@ -225,8 +231,10 @@ The form-behaviour attributes are written by the ``{% form %}`` tag from Python 
      - ``<form>``
      - Inline validation, source is the ``validate=`` tag parameter.
    * - ``data-next-target``
-     - ``<a>``, GET ``<form>``
-     - Route the response into a zone, source is the ``zone=`` tag parameter on a form.
+     - ``<a>``, ``<form>``
+     - Route the response into a zone. On a GET filter it names the zone to morph,
+       and on a POST form it is written by the ``zone=`` tag parameter and travels
+       as the morph target of the submission.
    * - ``data-next-trigger``
      - Filter ``<form>``, sort ``<select>``
      - The event that auto-submits a GET filter, ``input`` or ``change``. Submit and click interception are wired by ``data-next-action`` and ``data-next-merge``, not this attribute.
@@ -272,9 +280,10 @@ The form-behaviour attributes are written by the ``{% form %}`` tag from Python 
 Lifecycle Events
 ----------------
 
-The runtime fires events on the document and the ``Next.on`` bus.
+The runtime fires events on three channels, the element, the document, and the ``Next.on`` bus.
 The ``next:*`` node events fire on the element as a bubbling ``CustomEvent`` caught with ``addEventListener``.
-The ``partial:*``, ``ready``, ``context-updated``, and ``next:toast`` events also reach the ``Next.on`` bus.
+The apply-stage ``partial:*`` events and ``next:toast`` fire on the document and the ``Next.on`` bus.
+``ready``, ``context-updated``, ``partial:before-request``, and the fetch-stage ``partial:error`` reach only the bus.
 The ``next:mounted``, ``next:removed``, and ``next:morph-*`` node events live only on ``document.addEventListener`` and never reach the bus, so ``Next.on("next:mounted")`` is a silent no-op.
 
 .. list-table::
@@ -403,7 +412,8 @@ Settings
 --------
 
 The partial subsystem reads ``PARTIAL_BACKENDS`` inside ``NEXT_FRAMEWORK``.
-The list holds the protocol backends, with the first one active.
+The list holds the protocol backends, and only the first entry is active.
+The rest are ignored, multi-backend selection is not supported, and a list with more than one entry earns the ``next.W071`` warning at ``manage.py check``.
 
 .. code-block:: python
    :caption: the default

--- a/docs/content/topics/partial-rendering/scenarios.rst
+++ b/docs/content/topics/partial-rendering/scenarios.rst
@@ -42,9 +42,8 @@ The zone is an optional optimisation, not required markup.
      {% form "rename_board_form" zone="rename-board" %}…{% endform %}
    {% endzone %}
 
-The ``zone="rename-board"`` argument on the tag compiles to ``data-next-target`` on the
-``<form>``, so the runtime sends the zone name with the submission and the server
-re-renders only that zone with the bound form.
+The ``zone="rename-board"`` argument on the tag compiles to ``data-next-target`` on the ``<form>``.
+The runtime then sends the zone name with the submission and the server re-renders only that zone with the bound form.
 
 Submitting an empty title posts to the form endpoint with the partial switch set.
 
@@ -80,7 +79,7 @@ Inline Validation on Blur
 A wizard step carries an email field.
 The user should see a format error the moment focus leaves the field, before submitting, and with no server code.
 
-One Python parameter on the existing tag turns it on.
+One parameter on the existing ``{% form %}`` tag turns it on.
 
 .. code-block:: jinja
    :caption: request/[step]/template.djx
@@ -407,6 +406,7 @@ On click the runtime opens a native ``<dialog>``, builds the ``access-wizard`` z
    GET /request/identity/ HTTP/1.1
    X-Next-Request: 1
    X-Next-Zone: access-wizard
+   X-Next-Origin: /
 
 .. code-block:: json
    :caption: response body
@@ -423,7 +423,8 @@ On click the runtime opens a native ``<dialog>``, builds the ``access-wizard`` z
 A step submitted with an error answers 200 with a morph of the wizard zone and the form meta.
 No operation names the layer, so the modal lives on.
 The dialog carries the ``data-next-dialog`` attribute so project CSS can target it without relying on tag or internal structure.
-A valid non-last step advances without a 302: the dispatcher builds the next wizard and the unbound form of the next step, and morphs the wizard zone to the next step.
+A valid non-last step advances without a 302.
+The dispatcher builds the next wizard and the unbound form of the next step, and morphs the wizard zone to the next step.
 
 Wizard steps inside a layer are not pushed to history by default.
 The per-uid mutation lock makes a double-click on Submit request impossible by construction, it lets exactly one fetch through.
@@ -435,7 +436,7 @@ The default ``done`` closes the layer with a result and asks the opening link to
 .. code-block:: python
    :caption: request/[step]/page.py
 
-   def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> PatchResponse:
+   def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> HttpResponse:
        """Create the access request and close the layer with a result."""
        access_request = AccessRequest.objects.create(**cleaned_data)
        return (

--- a/docs/content/topics/partial-rendering/sse.rst
+++ b/docs/content/topics/partial-rendering/sse.rst
@@ -64,7 +64,8 @@ The fan-out is built on ``refresh`` rather than a ``context`` patch on purpose.
 A ``context`` patch carries the value of a registered serialize provider, and the builder reads that value from the origin page of the request that creates it.
 A stream source has no page-render origin, so it cannot build a ``context`` patch from one.
 A stream that needs to push fresh context drives a ``refresh``, and the re-fetched zone delivers the new context through its own render.
-This is a documented limitation: the stream source addresses zones to refresh, not provider values to push directly.
+This is a documented limitation.
+The stream source addresses zones to refresh, not provider values to push directly.
 
 Echo Suppression
 ----------------
@@ -79,7 +80,8 @@ The application channel threads the mutation's ``X-Next-Request-Id`` to the stre
 
 The serialiser stamps ``echo_of`` as the envelope's ``request_id``.
 The client keeps a ring buffer of its recent ``X-Next-Request-Id`` values and drops an event whose id matches.
-When the buffer overflows under a flood of submissions the degradation is safe: an extra ``refresh``, not a failure.
+When the buffer overflows under a flood of submissions the degradation is safe.
+The subscriber applies an extra ``refresh`` rather than failing.
 
 The framework does not smuggle the request id through the broker.
 A change event has to carry it, which the broker does by recording the request id of the mutation that produced it.
@@ -132,7 +134,10 @@ Stream Politeness
 
 On the client a background tab pauses the stream by closing the connection.
 When the tab becomes visible the runtime reconnects and re-fetches the zones the stream addressed since the connection opened.
-Events missed while paused are not lost, because ``refresh`` is idempotent: the re-fetch brings the current state regardless of how many fan-outs were missed.
+A brief flicker between tabs reconnects the stream but skips the re-fetches, because only a tab hidden past a short threshold revalidates.
+The set of tracked zones is bounded, so a long sleep cannot storm the server on resume.
+Events missed while paused are not lost, because ``refresh`` is idempotent.
+The re-fetch brings the current state regardless of how many fan-outs were missed.
 
 See Also
 --------

--- a/docs/content/topics/partial-rendering/zones.rst
+++ b/docs/content/topics/partial-rendering/zones.rst
@@ -35,7 +35,7 @@ The whole page renders even though one form is kept.
      "form": {"uid": "ab12cd34", "valid": false, "errors": {"title": ["…"]}}
    }
 
-This is the price today, not a regression, because an invalid submission always re-rendered the full page before partial rendering.
+The extract default costs no more than the no-runtime cycle, which re-renders the full page on every invalid submission.
 The runtime turns that same full render into a targeted DOM update for free.
 
 Adding a Zone
@@ -69,6 +69,15 @@ The envelope addresses the zone by name and the client morphs it in place.
 The network payload shrinks from a page to a zone, and the server render shrinks with it.
 Reach for a zone when a page is heavy, when a form sits among expensive siblings, or when the response size matters.
 Leave it off when the page is small and the extract default already does the job.
+
+Zone Assets on a Standalone Render
+----------------------------------
+
+A standalone zone render collects the co-located assets its body registers, component widgets included.
+The envelope carries them outward as an asset manifest, URL-form and inline alike.
+The client loads only what the page does not already have, missing CSS before the operations apply and missing JS after, and each asset executes once per page lifetime.
+On a zone ``GET`` the envelope also ships the values of the page's ``serialize=True`` context providers, introduced in :doc:`/content/topics/context`, as a ``context`` patch, so ``Next.context`` stays in step with the re-rendered zone.
+See :doc:`co-located-js` for what once-per-page execution means for behaviour, and :doc:`/content/topics/static-assets/index` for how the assets are discovered and bundled.
 
 Poll a Zone on an Interval
 --------------------------

--- a/docs/content/topics/signals.rst
+++ b/docs/content/topics/signals.rst
@@ -130,9 +130,7 @@ each signal.
      - Configuration
      - After the settings layer drops its caches.
 
-The forms and static signals have dedicated topic pages with worked receiver
-examples: :doc:`/content/topics/forms/signals` and
-:doc:`/content/topics/static-assets/signals`.
+The forms and static signals have dedicated topic pages with worked receiver examples, see :doc:`/content/topics/forms/signals` and :doc:`/content/topics/static-assets/signals`.
 The partial-rendering stream signals appear in context in
 :doc:`/content/topics/partial-rendering/sse`.
 

--- a/docs/content/topics/static-assets/asset-kinds.rst
+++ b/docs/content/topics/static-assets/asset-kinds.rst
@@ -171,7 +171,7 @@ The ``module`` kind carries no ``inline_tag``, so it renders an inline body verb
 System Checks
 -------------
 
-The static system checks ``next.W030`` and ``next.W031`` validate the backend configuration.
+The static system checks ``next.W030``, ``next.W031``, and ``next.E036`` through ``next.E038`` validate the backend configuration.
 The ``next.W042`` check validates the ``JS_CONTEXT_SERIALIZER`` setting.
 They do not validate kind registration.
 A bad call to ``default_kinds.register`` raises ``ValueError`` during ``AppConfig.ready``.

--- a/docs/content/topics/static-assets/co-located-files.rst
+++ b/docs/content/topics/static-assets/co-located-files.rst
@@ -32,11 +32,11 @@ Discovery groups stems into three roles.
 .. code-block:: text
    :caption: directory layout
 
-   notes/_components/note_card/
-     component.djx
-     component.css
-     component.js
    notes/pages/
+     _components/note_card/
+       component.djx
+       component.css
+       component.js
      layout.djx
      layout.css
      page.py
@@ -124,7 +124,7 @@ External URLs via Module Lists
 Declare ``styles`` and ``scripts`` at module level in ``page.py`` or ``component.py`` to register external URLs alongside co-located files.
 
 .. code-block:: python
-   :caption: notes/_components/note_card/component.py
+   :caption: notes/pages/_components/note_card/component.py
 
    styles = ["https://cdn.example.com/reset.css"]
    scripts = ["https://cdn.example.com/vendor.js", "/static/local/widget.mjs"]
@@ -133,6 +133,7 @@ Each variable is a list of strings.
 The slot is picked from the registered placeholder name, ``styles`` or ``scripts``.
 The kind is inferred from the URL extension through the kind registry.
 URLs with an unknown extension are dropped with a debug log.
+A URL whose kind belongs to a different slot than the list name is also dropped with a debug log, so a stylesheet URL in ``scripts`` never renders.
 
 See Also
 --------

--- a/docs/content/topics/static-assets/deduplication.rst
+++ b/docs/content/topics/static-assets/deduplication.rst
@@ -55,7 +55,7 @@ The static manager builds the collector per request and reads the strategy dotte
    }
 
 The ``DEDUP_STRATEGY`` value is the dotted path to a dedup strategy class.
-The collector instantiates it once per request.
+The manager instantiates it once per request when it builds the collector.
 When the key is absent the collector uses ``UrlDedup``.
 
 Inline Assets
@@ -107,8 +107,7 @@ Point the backend ``OPTIONS`` at the new strategy.
        ]
    }
 
-The collector instantiates the strategy once per request.
-A strategy can therefore hold per request state.
+The strategy lives for one request, so it can hold per request state.
 
 Common Patterns
 ---------------

--- a/docs/content/topics/static-assets/js-context.rst
+++ b/docs/content/topics/static-assets/js-context.rst
@@ -212,7 +212,7 @@ Register the key server-side with ``serialize=True``.
 Co-located JS and inline scripts then read the value under ``window.Next.context``.
 
 .. code-block:: javascript
-   :caption: notes/_components/note_card/component.js
+   :caption: notes/pages/_components/note_card/component.js
 
    document.addEventListener("DOMContentLoaded", () => {
      const count = window.Next.context.note_count ?? 0;
@@ -232,12 +232,15 @@ Code that needs the context the moment it lands subscribes through ``Next.on`` r
 The function removes that listener when called.
 The ``listener`` receives the context object as its only argument and reads its values.
 
-Two events fire.
+Two context events reach the bus.
 The ``"context-updated"`` event fires whenever the framework loads a new context.
+A partial zone render ships a js-context delta in its patch envelope, see :doc:`/content/topics/partial-rendering/how-it-works`.
+The runtime merges the delta into ``window.Next.context`` and fires ``context-updated`` again.
 The ``"ready"`` event fires once the first context is loaded, and a listener registered after that point receives an immediate replay with the current context.
+The partial runtime fires further ``partial:*`` events on the same bus, see :doc:`/content/topics/partial-rendering/reference`.
 
 .. code-block:: javascript
-   :caption: notes/_components/note_card/component.js
+   :caption: notes/pages/_components/note_card/component.js
 
    const unsubscribe = window.Next.on("ready", (context) => {
      const count = context.note_count ?? 0;

--- a/docs/content/topics/static-assets/overview.rst
+++ b/docs/content/topics/static-assets/overview.rst
@@ -50,7 +50,7 @@ StaticAsset
 
 ``url`` and ``inline`` are mutually exclusive.
 A URL asset carries a non-empty ``url`` and a ``None`` ``inline``.
-An inline asset carries a ``None`` or empty ``url`` and a non-empty ``inline`` body.
+An inline asset carries an empty ``url`` and a non-empty ``inline`` body.
 
 Asset Kinds
 -----------

--- a/docs/content/topics/static-assets/signals.rst
+++ b/docs/content/topics/static-assets/signals.rst
@@ -6,6 +6,7 @@ Static Signals
 The static pipeline emits ``asset_registered``, ``collector_finalized``, ``html_injected``, and ``backend_loaded`` from ``next.static.signals``.
 
 Import either from ``next.static.signals`` or from the aggregator ``next.signals``.
+Import receiver modules from ``AppConfig.ready`` so receivers exist before the first request.
 
 Signals and Payloads
 --------------------
@@ -40,7 +41,8 @@ collector_finalized
 
 Fires when the static manager begins injection, after template rendering has completed and the collector is sealed.
 The sender is the collector.
-The payload carries ``page_path``, which is ``None`` for partial renders, and ``request``, which is the active ``HttpRequest`` or ``None`` for renders outside a request lifecycle.
+The payload carries ``page_path``, the file path of the rendered page, and ``request``, the active ``HttpRequest`` or ``None`` for renders outside a request lifecycle.
+A standalone zone render never fires this signal because its assets travel in the patch envelope instead of through injection.
 
 .. code-block:: python
    :caption: inspect collected slots per request
@@ -87,8 +89,6 @@ backend_loaded
 Fires after the static factory instantiates a backend.
 The sender is the backend class.
 The payload carries ``config`` and ``instance``.
-
-Register imports from ``AppConfig.ready`` so receivers exist before the first request.
 
 .. note::
 

--- a/docs/content/topics/testing.rst
+++ b/docs/content/topics/testing.rst
@@ -72,8 +72,8 @@ The table below maps each testing goal to the helper and its import path.
    * - Force-import pages or components in tests
      - ``eager_load_components``, ``eager_load_pages``, ``clear_loaded_dirs``
      - ``next.testing`` or ``next.testing.loaders``
-   * - Clear registries between tests
-     - ``reset_registries`` (call from an autouse fixture), or narrower ``reset_components`` / ``reset_form_actions`` / ``reset_page_cache``
+   * - Reload backends after mutating settings or registries
+     - ``reset_registries`` (opt-in), or narrower ``reset_components`` / ``reset_form_actions`` / ``reset_page_cache``
      - ``next.testing`` or ``next.testing.isolation``
    * - Clear the form registries, diagnostics, and wizard backend
      - ``reset_form_registration_state``
@@ -102,38 +102,73 @@ Pytest.
 Stdlib ``unittest``.
    Call ``django.setup()`` once before importing any ``next.testing`` helper, then run the suite with the standard runner.
 
-Isolate Registries
-------------------
+Registry State Between Tests
+----------------------------
 
-Add an ``autouse`` fixture in ``conftest.py`` to clear every registry between tests.
+Action and component registrations are side effects of importing ``page.py`` and ``component.py`` modules.
+The canonical scaffold imports them once per session with the eager loaders from ``next.testing.loaders`` and leaves the registries alone between tests.
 
 .. code-block:: python
    :caption: conftest.py
 
+   from pathlib import Path
+
    import pytest
-   from next.testing.isolation import reset_registries
+   from next.testing import eager_load_pages
 
-   @pytest.fixture(autouse=True)
-   def _next_isolation():
-       reset_registries()
-       yield
-       reset_registries()
+   PROJECT_ROOT = Path(__file__).resolve().parent
 
-The helper reloads the form-action and component backends from the current settings.
+   @pytest.fixture(autouse=True, scope="session")
+   def _load_pages() -> None:
+       eager_load_pages(PROJECT_ROOT / "notes" / "pages")
+
+The session fixture runs the ``@context`` and ``@action`` decorators before the first test dispatches a request.
+Every project under ``examples/`` uses this scaffold.
+
+.. note::
+
+   When ``LAZY_COMPONENT_MODULES = True`` in ``NEXT_FRAMEWORK``, bulk import of ``component.py`` modules from configured component roots is skipped during ``AppConfig.ready``.
+   Call ``eager_load_components()`` from ``next.testing.loaders`` once per session to import every registered ``component.py`` regardless of the flag.
+
+   .. code-block:: python
+      :caption: conftest.py, eager loading with lazy modules
+
+      import pytest
+      from next.testing.loaders import eager_load_components
+
+      @pytest.fixture(autouse=True, scope="session")
+      def _load_components() -> None:
+          eager_load_components()
+
+   With the default ``LAZY_COMPONENT_MODULES = False``, all registrations are in place after ``AppConfig.ready``, so the extra call is unnecessary.
+   See :ref:`ref-settings` for the full description of ``LAZY_COMPONENT_MODULES``.
+
+Resetting Registries
+~~~~~~~~~~~~~~~~~~~~
+
+``reset_registries()`` is an opt-in helper for tests that mutate ``NEXT_FRAMEWORK`` or the registries themselves.
+It reloads the form-action and component backends from the current settings.
 Two narrower helpers reset a single registry.
 
 - ``reset_components()`` reloads only the component backends.
 - ``reset_form_actions()`` reloads only the form-action backends.
+
+.. warning::
+
+   A reset does not bring import-time registrations back.
+   Python does not re-import a module that is already in ``sys.modules``, so ``@action`` handlers and page-tree components registered by earlier imports stay absent after the reset.
+   Do not call ``reset_registries()`` from an autouse fixture in an ordinary suite.
+   Reserve it for tests that verify registry behaviour itself.
 
 A third helper, ``reset_page_cache()``, resets no registry.
 It drops the page template cache and is useful when a test rewrites template files on disk.
 
 For tests that probe registration itself, ``reset_form_registration_state()`` clears every form registry, the registration diagnostics buffer, and resets the wizard backend in one call.
 
-Tests that write ``template.djx`` or ``page.py`` files to ``tmp_path`` need both helpers:
+Tests that write ``template.djx`` or ``page.py`` files to ``tmp_path`` register fresh state on every run, so a suite dedicated to them pairs a registry reset with a page-cache reset.
 
 .. code-block:: python
-   :caption: conftest.py
+   :caption: conftest.py for a tmp_path suite
 
    import pytest
    from next.testing.isolation import reset_page_cache, reset_registries
@@ -144,29 +179,6 @@ Tests that write ``template.djx`` or ``page.py`` files to ``tmp_path`` need both
        yield
        reset_registries()
        reset_page_cache()
-
-.. note::
-
-   When ``LAZY_COMPONENT_MODULES = True`` in ``NEXT_FRAMEWORK``, bulk import of ``component.py`` modules from configured component roots is skipped during ``AppConfig.ready``.
-   After ``reset_registries()``, decorator side effects from those modules are absent until resolve time.
-   Call ``eager_load_components()`` from ``next.testing.loaders`` to import every registered ``component.py`` regardless of the flag.
-
-   .. code-block:: python
-      :caption: conftest.py, eager loading with lazy modules
-
-      import pytest
-      from next.testing.isolation import reset_registries
-      from next.testing.loaders import eager_load_components
-
-      @pytest.fixture(autouse=True)
-      def _next_isolation():
-          reset_registries()
-          eager_load_components()
-          yield
-          reset_registries()
-
-   With the default ``LAZY_COMPONENT_MODULES = False``, all registrations are in place after ``AppConfig.ready``, so the extra call is unnecessary.
-   See :ref:`ref-settings` for the full description of ``LAZY_COMPONENT_MODULES``.
 
 Eager Page Loading
 ~~~~~~~~~~~~~~~~~~
@@ -180,8 +192,8 @@ A normal test suite does not call it, since each pytest session starts a fresh i
 NextClient
 ----------
 
-``NextClient`` is a thin subclass of Django's ``Client`` that adds ``post_action`` and ``get_action_url``.
-Both resolve an action name through ``resolve_action_url`` before delegating to the underlying client.
+``NextClient`` is a thin subclass of Django's ``Client`` that adds ``post_action``, ``get_action_url``, and ``get_zones``.
+``post_action`` and ``get_action_url`` resolve an action name through ``resolve_action_url`` before delegating to the underlying client.
 
 .. code-block:: python
    :caption: tests/test_index.py
@@ -264,6 +276,7 @@ Both ``post_action`` and ``get_zones`` accept a ``version=`` keyword that stamps
 ``envelope_of(response)`` decodes a patch response into a ``PartialEnvelope``.
 It raises when the response is not a patch envelope, so a navigation fallback never passes a structural assertion.
 ``PartialEnvelope`` exposes ``version``, ``ops``, and ``assets``, plus ``op_verbs``, ``targets``, ``zone_targets``, ``form_targets``, ``form_meta``, ``toasts``, and ``html_for_zone`` for asserting on the server contract without parsing HTML.
+See :doc:`/content/topics/partial-rendering/index` for the zone and patch model these helpers exercise.
 
 Render a Page
 -------------
@@ -444,9 +457,10 @@ Its ``.collector`` attribute holds the collector built inside the block, so a te
 Pass ``factory=`` to swap the collector implementation entirely.
 The callable runs in place of the default ``create_collector`` and returns a custom ``StaticCollector`` for the duration of the block.
 
-Use ``patch_static_collector(capture=True)`` to inspect which assets a page emits:
+Use ``patch_static_collector(capture=True)`` to inspect which assets a page emits.
 
 .. code-block:: python
+   :caption: tests/test_static_capture.py
 
    from next.testing.patching import patch_static_collector
    from next.testing.client import NextClient
@@ -461,6 +475,7 @@ Use ``patch_static_collector(capture=True)`` to inspect which assets a page emit
 .. code-block:: python
    :caption: temporary settings
 
+   from next.testing.client import NextClient
    from next.testing.patching import override_next_settings
 
    def test_with_strict_context() -> None:
@@ -469,6 +484,44 @@ Use ``patch_static_collector(capture=True)`` to inspect which assets a page emit
        assert response.status_code == 200
 
 The patch reverts on exit, so the next test sees the original configuration.
+
+``override_dependency`` binds a stub value to a ``Depends("name")`` registration for the block, and restores the previous registration on exit.
+
+.. code-block:: python
+   :caption: stubbing a named dependency
+
+   from next.testing.client import NextClient
+   from next.testing.patching import override_dependency
+
+   def test_stubbed_theme() -> None:
+       with override_dependency("layout_theme", {"name": "Stub"}):
+           response = NextClient().get("/")
+       assert b"Stub" in response.content
+
+``override_provider`` prepends a provider instance to the resolver's provider list for the block.
+The prepended provider wins over every auto-registered provider that would otherwise claim the same parameter.
+Implement the ``ParameterProvider`` protocol on a plain class for the stub, because subclassing ``RegisteredParameterProvider`` registers the provider globally.
+
+.. code-block:: python
+   :caption: prepending a stub provider
+
+   from next.testing.deps import resolve_call
+   from next.testing.patching import override_provider
+
+   class EveryIntIsSeven:
+       def can_handle(self, param, context) -> bool:
+           return param.annotation is int
+
+       def resolve(self, param, context) -> int:
+           return 7
+
+   def count_notes(limit: int) -> int:
+       return limit
+
+   def test_provider_wins() -> None:
+       with override_provider(EveryIntIsSeven()):
+           kwargs = resolve_call(count_notes)
+       assert kwargs == {"limit": 7}
 
 Resolution Context Doubles
 --------------------------
@@ -489,15 +542,8 @@ Both accept the same loose keyword arguments, ``request``, ``form``, ``url_kwarg
 Pass ``resolve_call`` a callable whose annotated parameters a provider can fill, then assert on the returned mapping.
 Use these helpers for testing custom providers without booting the router.
 
-Common Patterns
----------------
-
-.. seealso::
-
-   :doc:`/content/howto/test-a-page-with-actions` walks a full end to end flow, a form validation failure, and a signal emission assertion with working code.
-
 System Checks
-~~~~~~~~~~~~~
+-------------
 
 Pytest can run ``manage.py check`` as part of the suite.
 
@@ -514,6 +560,6 @@ See Also
 
 .. seealso::
 
-   :doc:`/content/howto/test-a-page-with-actions` for a recipe.
+   :doc:`/content/howto/test-a-page-with-actions` for a full end to end flow, a form validation failure, and a signal emission assertion with working code.
    :doc:`/content/ref/testing` for the public API.
    :doc:`/content/topics/signals` for the signal catalog.

--- a/docs/content/topics/url-reversing.rst
+++ b/docs/content/topics/url-reversing.rst
@@ -98,6 +98,8 @@ It pairs with ``page_reverse`` the way Django pairs :func:`~django.urls.reverse`
 .. code-block:: python
    :caption: class-level URL
 
+   from attachments.models import Attachment
+   from next.forms import ModelForm
    from next.urls import page_reverse_lazy
 
    class AttachmentForm(ModelForm):
@@ -185,9 +187,9 @@ An action handler can return an ``HttpResponseRedirect`` to a reversed page URL.
    :caption: notes/pages/page.py
 
    from django.http import HttpRequest, HttpResponseRedirect
-   from notes.models import Note
    from next.forms import ModelForm
    from next.urls import page_reverse
+   from notes.models import Note
 
    class CreateNoteForm(ModelForm):
        class Meta:
@@ -206,9 +208,9 @@ A component can compute a URL through ``@component.context``.
 .. code-block:: python
    :caption: _components/note_link/component.py
 
-   from notes.models import Note
    from next.components import component
    from next.urls import page_reverse
+   from notes.models import Note
 
    @component.context("href")
    def href(note: Note) -> str:

--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -73,6 +73,9 @@ class TenantPrefixStaticBackend(StaticFilesBackend):
 
     def render_script_tag(self, url, *, request=None):
         return super().render_script_tag(_prefixed(url, request))
+
+    def render_module_tag(self, url, *, request=None):
+        return super().render_module_tag(_prefixed(url, request))
 ```
 
 The settings entry is a single line:

--- a/examples/multi-tenant/notes/backends.py
+++ b/examples/multi-tenant/notes/backends.py
@@ -40,6 +40,15 @@ class TenantPrefixStaticBackend(StaticFilesBackend):
         """Return a JS script tag with the per-tenant prefix injected."""
         return super().render_script_tag(_prefixed(url, request))
 
+    def render_module_tag(
+        self,
+        url: str,
+        *,
+        request: HttpRequest | None = None,
+    ) -> str:
+        """Return a module script tag with the per-tenant prefix injected."""
+        return super().render_module_tag(_prefixed(url, request))
+
 
 def _prefixed(url: str, request: HttpRequest | None) -> str:
     """Return `url` with `/_t/<slug>` injected before its path."""

--- a/examples/multi-tenant/tests/test_e2e.py
+++ b/examples/multi-tenant/tests/test_e2e.py
@@ -333,6 +333,22 @@ class TestNoteEditPage:
         assert note.title in body
         assert "Preview" in body
 
+    @override_settings(DEBUG=False)
+    def test_edit_page_prefixes_component_module(
+        self, client: NextClient, acme: Tenant
+    ) -> None:
+        note = _acme_note(acme)
+        response = client.get(
+            f"/notes/{note.pk}/edit/",
+            HTTP_X_TENANT="acme",
+        )
+        body = response.content.decode()
+        assert (
+            '<script type="module" '
+            'src="/_t/acme/static/next/components/markdown_preview.mjs">' in body
+        )
+        assert 'src="/static/next/components/markdown_preview.mjs"' not in body
+
 
 class TestDebugAffordance:
     """Browser demo path: ?tenant=<slug> sets a cookie and redirects."""

--- a/examples/multi-tenant/tests/test_unit.py
+++ b/examples/multi-tenant/tests/test_unit.py
@@ -217,6 +217,17 @@ class TestTenantPrefixStaticBackend:
         )
         assert 'src="/_t/acme/static/next/a.js"' in rendered
 
+    def test_module_tag_prepends_prefix(self) -> None:
+        backend = TenantPrefixStaticBackend()
+        request = HttpRequest()
+        request.tenant = Tenant(slug="acme", name="Acme")  # type: ignore[attr-defined]
+        rendered = backend.render_module_tag(
+            "/static/next/components/markdown_preview.mjs",
+            request=request,
+        )
+        assert 'type="module"' in rendered
+        assert 'src="/_t/acme/static/next/components/markdown_preview.mjs"' in rendered
+
     def test_absolute_external_url_passes_through(self) -> None:
         backend = TenantPrefixStaticBackend()
         request = HttpRequest()

--- a/next/client/layers.test.ts
+++ b/next/client/layers.test.ts
@@ -233,6 +233,66 @@ describe("layer stack", () => {
     expect(after).toBe(before);
   });
 
+  it("closing a layer fires next:removed on the dialog so an island inside unmounts", async () => {
+    await layers.open(null, "/w/", "z");
+    const dialog = document.querySelector("[data-next-dialog]")!;
+    const root = dialog.querySelector('[data-next-zone="z"]')!;
+    const island = document.createElement("div");
+    island.setAttribute("data-island", "");
+    root.append(island);
+    const removed: { target: Element; connected: boolean }[] = [];
+    const unmounted: Element[] = [];
+    const listener = (event: Event): void => {
+      const node = event.target as Element;
+      removed.push({ target: node, connected: node.isConnected });
+      // The documented island adapter walks the detached root for its islands.
+      const islands = node.matches("[data-island]")
+        ? [node]
+        : Array.from(node.querySelectorAll("[data-island]"));
+      unmounted.push(...islands);
+    };
+    document.addEventListener("next:removed", listener);
+    layers.close({ result: 1 });
+    document.removeEventListener("next:removed", listener);
+    expect(removed).toHaveLength(1);
+    expect(removed[0]!.target).toBe(dialog);
+    expect(removed[0]!.connected).toBe(true);
+    expect(unmounted).toEqual([island]);
+  });
+
+  it("a double remove on one layer fires next:removed only once", async () => {
+    let captured: HTMLDialogElement | null = null;
+    const seen: ((reason: string) => void)[] = [];
+    const adapter: DialogAdapter = {
+      open(dialog, onDismiss) {
+        captured = dialog;
+        seen.push(onDismiss);
+        return () => undefined;
+      },
+    };
+    const local = createLayers({
+      dispatch: () => undefined,
+      fetch: async () => {
+        // A dismiss gesture tears the layer down while this GET is in flight,
+        // then the rejection lands open's catch on the already-spliced layer.
+        seen[0]!("escape");
+        throw new Error("boom");
+      },
+      document,
+      dialog: adapter,
+      history: { push: () => undefined, replace: () => undefined },
+    });
+    const removed: Element[] = [];
+    const listener = (event: Event): void => {
+      removed.push(event.target as Element);
+    };
+    document.addEventListener("next:removed", listener);
+    await expect(local.open(null, "/w/", "z")).rejects.toThrow("boom");
+    document.removeEventListener("next:removed", listener);
+    expect(removed).toEqual([captured]);
+    expect(local.size()).toBe(0);
+  });
+
   it("returns focus only to an HTMLElement, skipping a null activeElement", async () => {
     // A document proxy whose activeElement is null exercises the focus guard's
     // false arm, which jsdom cannot reach since its activeElement is the body.

--- a/next/client/layers.ts
+++ b/next/client/layers.ts
@@ -13,6 +13,7 @@
 
 import { defaultDialog, defaultHistory, defaultPopState } from "./adapters";
 import type { HistoryAdapter } from "./apply";
+import { fireRemoved } from "./morph";
 import {
   HEADER_ORIGIN,
   HEADER_ZONE,
@@ -311,6 +312,10 @@ export function createLayers(deps: LayerDeps): LayerStack {
     if (index === -1) return;
     stack.splice(index, 1);
     layer.close();
+    // Fire next:removed on the detaching dialog root, the same contract the
+    // apply verbs keep, so an island mounted inside the modal unmounts before
+    // the subtree leaves the document rather than leaking its listeners.
+    fireRemoved(layer.dialog);
     layer.dialog.remove();
     if (layer.returnFocus instanceof HTMLElement) layer.returnFocus.focus();
     // A programmatic close still sits on the pushed URL, so replace it back to

--- a/next/components/registry.py
+++ b/next/components/registry.py
@@ -116,7 +116,9 @@ class ComponentVisibilityResolver:
         self._result_cache: OrderedDict[Path, Mapping[str, ComponentInfo]] = (
             OrderedDict()
         )
-        self._scope_index: dict[Path, list[tuple[int, ComponentInfo]]] = {}
+        self._scope_index: dict[
+            Path, tuple[int, list[tuple[int, int, ComponentInfo]]]
+        ] = {}
         self._scope_index_registry_version = -1
         self._cached_registry_version = -1
         self._resolved_path_cache: dict[Path, Path] = {}
@@ -126,19 +128,23 @@ class ComponentVisibilityResolver:
             return
         self._scope_index = {}
         for position, ci in enumerate(self._registry.get_all()):
-            self._scope_index.setdefault(ci.resolved_scope_root, []).append(
-                (position, ci)
-            )
+            root = ci.resolved_scope_root
+            group = self._scope_index.get(root)
+            if group is None:
+                dirs_origin = 1 if self._registry.is_root(root) else 0
+                group = (dirs_origin, [])
+                self._scope_index[root] = group
+            group[1].append((position, group[0], ci))
         self._scope_index_registry_version = self._registry.version
 
     def _candidate_components(
         self, template_path: Path
-    ) -> list[tuple[int, ComponentInfo]]:
+    ) -> list[tuple[int, int, ComponentInfo]]:
         self._ensure_scope_index()
         tmpl_dir = template_path.parent
-        out: list[tuple[int, ComponentInfo]] = []
-        for scope_root, infos in self._scope_index.items():
-            if self._registry.is_root(scope_root):
+        out: list[tuple[int, int, ComponentInfo]] = []
+        for scope_root, (dirs_origin, infos) in self._scope_index.items():
+            if dirs_origin:
                 out.extend(infos)
                 continue
             try:
@@ -169,20 +175,25 @@ class ComponentVisibilityResolver:
             self._result_cache.move_to_end(template_path)
             return self._result_cache[template_path]
 
-        candidates: list[tuple[int, str, int, ComponentInfo]] = []
-        for position, component in self._candidate_components(template_path):
+        candidates: list[tuple[int, int, str, int, ComponentInfo]] = []
+        for position, dirs_origin, component in self._candidate_components(
+            template_path
+        ):
             score = self._calculate_visibility_score(component, template_path)
             if score is not None:
-                candidates.append((score, component.name, position, component))
+                candidates.append(
+                    (score, dirs_origin, component.name, position, component)
+                )
 
-        # Higher score wins. Equal score and name fall back to registration
-        # order, so the component discovered first shadows a later same-named
-        # one. Roots are scanned in DIRS order, so an earlier DIRS entry wins.
-        candidates.sort(key=lambda x: (-x[0], x[1], x[2]))
+        # Higher score wins. At equal score a page-tree component shadows a
+        # shared DIRS root one, so a project-local override takes precedence.
+        # Same-origin ties fall back to name then registration order, keeping
+        # the component discovered first ahead of a later same-named sibling.
+        candidates.sort(key=lambda x: (-x[0], x[1], x[2], x[3]))
 
         seen: set[str] = set()
         result: dict[str, ComponentInfo] = {}
-        for _score, name, _position, info in candidates:
+        for _score, _origin, name, _position, info in candidates:
             if name not in seen:
                 result[name] = info
                 seen.add(name)

--- a/next/static/scripts.py
+++ b/next/static/scripts.py
@@ -37,6 +37,18 @@ NEXT_JS_STATIC_PATH: Final = "next/next.min.js"
 
 CSRF_PAYLOAD_KEY: Final = "$csrf"
 
+# Escape the inline-init payload for the HTML `<script>` context, mirroring
+# Django's `json_script`. These code points only ever appear inside JSON string
+# literals, so `\u00XX` and `\u202X` keep the value semantically identical while
+# stopping a `serialize=True` value from closing the element with `</script>`.
+_SCRIPT_ESCAPES: Final[dict[int, str]] = {
+    ord("<"): "\\u003C",
+    ord(">"): "\\u003E",
+    ord("&"): "\\u0026",
+    ord("\u2028"): "\\u2028",
+    ord("\u2029"): "\\u2029",
+}
+
 
 def csrf_header_name() -> str:
     """Return the CSRF header name in HTTP wire form from Django settings.
@@ -155,7 +167,9 @@ class NextScriptBuilder:
         `encoded` rather than serialised a second time. A key missing from
         `encoded` falls back to its serializer. Compact top-level separators
         keep the output byte-identical to a whole-dict dump for the compact
-        serializers the framework ships.
+        serializers the framework ships. The assembled payload is escaped for
+        the inline `<script>` context so a `serialize=True` value whose text
+        holds `</script>` cannot break out of the element.
         """
         default = resolve_serializer()
         serializers = key_serializers or {}
@@ -167,6 +181,7 @@ class NextScriptBuilder:
             encoded_key = json.dumps(k, separators=(",", ":"))
             fragments.append(f"{encoded_key}:{frag}")
         payload = "{" + ",".join(fragments) + "}"
+        payload = payload.translate(_SCRIPT_ESCAPES)
         return self._init_template.format(payload=payload)
 
     @classmethod

--- a/next/static/signals.py
+++ b/next/static/signals.py
@@ -12,9 +12,10 @@ and the keyword arguments are `collector` and `backend`.
 The `collector_finalized` signal fires when the static manager begins
 injection, after template rendering has completed and the collector
 is sealed. The sender is the collector. The keyword arguments are
-`page_path`, which may be None for partial renders, and `request`,
-which is the active `HttpRequest` or None for renders outside a
-request lifecycle.
+`page_path`, the rendered page's file path, and `request`, the active
+`HttpRequest` or None for renders outside a request lifecycle. A
+standalone zone render does not fire this signal, since it ships its
+assets through the patch envelope rather than through injection.
 
 The `html_injected` signal fires after placeholder replacement
 completes. The sender is the static manager. The keyword arguments

--- a/tests/components/test_registry.py
+++ b/tests/components/test_registry.py
@@ -281,7 +281,7 @@ class TestComponentVisibilityResolver:
     def _resolve_same_name_from_two_roots(
         self, base: Path, first: str, second: str
     ) -> ComponentInfo:
-        """Register a same-named component from two global roots in given order."""
+        """Register a same-named component from two DIRS roots in given order."""
         reg = ComponentRegistry()
         for name in (first, second):
             root = (base / name).resolve()
@@ -296,7 +296,7 @@ class TestComponentVisibilityResolver:
         return resolved["button"]
 
     def test_equal_score_tie_breaks_on_registration_order(self, tmp_path: Path) -> None:
-        """Two equal-score global roots resolve to the one registered first."""
+        """Two equal-score same-origin DIRS roots resolve to the one registered first."""
         winner = self._resolve_same_name_from_two_roots(
             tmp_path / "case1", "z_root", "a_root"
         )
@@ -306,3 +306,49 @@ class TestComponentVisibilityResolver:
             tmp_path / "case2", "a_root", "z_root"
         )
         assert other.scope_root == (tmp_path / "case2" / "a_root").resolve()
+
+    def _register_page_tree_and_dirs_button(
+        self, base: Path
+    ) -> tuple[ComponentRegistry, Path, Path]:
+        """Register a DIRS `button` then a page-tree `button` under `base`."""
+        pages = (base / "pages").resolve()
+        dirs_root = (base / "shared").resolve()
+        (pages / "_components").mkdir(parents=True)
+        dirs_root.mkdir(parents=True)
+        reg = ComponentRegistry()
+        reg.register(
+            ComponentInfo(
+                "button", dirs_root, "", dirs_root / "button.djx", None, True
+            )
+        )
+        reg.mark_as_root(dirs_root)
+        reg.register(
+            ComponentInfo(
+                "button",
+                pages,
+                "",
+                pages / "_components" / "button.djx",
+                None,
+                True,
+            )
+        )
+        return reg, pages, dirs_root
+
+    def test_page_tree_component_shadows_dirs_root_at_equal_score(
+        self, tmp_path: Path
+    ) -> None:
+        """A project-local page-tree component wins over a same-name DIRS root."""
+        reg, pages, _dirs_root = self._register_page_tree_and_dirs_button(tmp_path)
+        tmpl = pages / "home.djx"
+        tmpl.write_text("x")
+        resolved = ComponentVisibilityResolver(reg).resolve_visible(tmpl)
+        assert resolved["button"].scope_root == pages
+
+    def test_dirs_root_button_visible_outside_page_tree(self, tmp_path: Path) -> None:
+        """A template outside the page tree still sees the shared DIRS button."""
+        reg, _pages, dirs_root = self._register_page_tree_and_dirs_button(tmp_path)
+        outside = tmp_path / "elsewhere" / "t.djx"
+        outside.parent.mkdir(parents=True)
+        outside.write_text("x")
+        resolved = ComponentVisibilityResolver(reg).resolve_visible(outside)
+        assert resolved["button"].scope_root == dirs_root

--- a/tests/static/test_scripts.py
+++ b/tests/static/test_scripts.py
@@ -52,6 +52,14 @@ class _MarkSerializer:
         return json.dumps({"mark": value}, separators=(",", ":"))
 
 
+class _RawSeparatorSerializer:
+    """Per-key serializer that leaves non-ASCII raw via `ensure_ascii=False`."""
+
+    def dumps(self, value: object) -> str:
+        """Return compact JSON with raw non-ASCII characters."""
+        return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+
+
 class TestScriptInjectionPolicy:
     """Enum values drive conditional injection in StaticManager."""
 
@@ -245,6 +253,56 @@ class TestInitScriptGoldenParity:
             encoded=collector.js_context_encoded(),
         )
         assert '"$csrf":{"header":"X-CSRFToken","token":"tok"}' in out
+
+
+class TestInitScriptEscaping:
+    """The assembled payload is escaped for the inline `<script>` context.
+
+    A `serialize=True` value whose text holds `</script>`, `<!--`, or the
+    JS line separators must not break out of the inline init element.
+    """
+
+    def _payload(self, out: str) -> str:
+        """Return the `Next._init` argument stripped of the script wrapper."""
+        prefix = "<script>Next._init("
+        suffix = ");</script>"
+        assert out.startswith(prefix)
+        assert out.endswith(suffix)
+        return out[len(prefix) : -len(suffix)]
+
+    def test_script_close_sequence_cannot_break_out(self) -> None:
+        builder = NextScriptBuilder(URL)
+        payload = self._payload(builder.init_script({"x": "</script><b>pwn"}))
+        assert "</script>" not in payload
+        assert "\\u003C/script\\u003E" in payload
+
+    def test_angle_and_amp_each_escape(self) -> None:
+        builder = NextScriptBuilder(URL)
+        payload = self._payload(builder.init_script({"x": "<&>"}))
+        assert "<" not in payload
+        assert ">" not in payload
+        assert "&" not in payload
+        assert "\\u003C\\u0026\\u003E" in payload
+
+    def test_line_separator_from_custom_serializer_is_escaped(self) -> None:
+        builder = NextScriptBuilder(URL)
+        payload = self._payload(
+            builder.init_script(
+                {"x": "a" + chr(0x2028) + "b" + chr(0x2029) + "c"},
+                key_serializers={"x": _RawSeparatorSerializer()},
+            )
+        )
+        assert chr(0x2028) not in payload
+        assert chr(0x2029) not in payload
+        assert "\\u2028" in payload
+        assert "\\u2029" in payload
+
+    def test_clean_payload_is_byte_identical_to_compact_dump(self) -> None:
+        builder = NextScriptBuilder(URL)
+        value = {"user": "alice", "score": 42}
+        out = builder.init_script(value)
+        expected = resolve_serializer().dumps(value)
+        assert out == f"<script>Next._init({expected});</script>"
 
 
 class TestNextJsStaticPath:


### PR DESCRIPTION
## Description

Finalises the partial-rendering documentation against the curated public API and wire protocol, then runs a full documentation review against the core and fixes every confirmed drift, prose defect, and the real bugs the review surfaced.

**Docs**

- Align the out-of-band done choreography on the single `morph(page=)` canon and demote `resolve_partial_origin` to the Advanced tier alongside the curated `__all__`.
- Name the one-active-backend contract with `next.W071` in the extending guide and the settings reference, and describe a standalone zone's co-located assets honestly.
- Add a partial-rendering limitations page and wire it into the toctree.
- Sync the whole doc set with the core across forms, pages, routing, components, deps, testing, static assets, partial rendering, and the platform reference, correcting symbol, signature, settings, and behaviour drift on more than 150 points.
- Sweep the prose for mid-sentence colons and other style-guide defects.

**Core**

- Escape `serialize=True` js-context values before they enter the inline init script, so a value carrying `</script>` can no longer break out.
- Fire `next:removed` when a layer closes, so an island mounted inside a modal unmounts instead of leaking its listeners.
- Make a project-local page-tree component shadow a same-name `DIRS` component at equal score, so per-project overrides work as documented.
- Prefix the multi-tenant example module asset so it no longer escapes tenant isolation.

## How to test

- `make test` passes at 100% coverage for `next/`.
- `make docs` is clean under `-W`.
- `make test-js` and `make test-examples` pass.
- `make bench` holds the `median:99%` gate, the component resolver is slightly faster.
- Run `make ci` before merging for the full aggregate gate.

## Related issues

<!-- Fixes #123 / Closes #456 -->

## Checklist

- [x] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [x] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable
