### PR TITLE
feat(urls): unified bracket parser, deterministic routing checks, lazy-patterns rework

### DIFF
--- a/docs/content/internals/request-lifecycle.rst
+++ b/docs/content/internals/request-lifecycle.rst
@@ -56,8 +56,8 @@ Authentication, sessions, CSRF, common middleware, and any project specific midd
 URL Resolver
 ~~~~~~~~~~~~
 
-The framework registers its URL patterns through ``include("next.urls")`` in ``config/urls.py``.
-The Django URL resolver matches the request path against those patterns.
+The framework registers its URL patterns through ``include("next.urls")`` in ``config/urls.py``, which mounts the framework's ``TrieURLResolver``.
+The resolver narrows the request path to a few candidate patterns and matches them with standard Django pattern resolution, as :doc:`url-router` describes.
 A file routed match dispatches to the page view.
 A match on ``/_next/form/<str:uid>/`` dispatches to the form dispatcher instead.
 

--- a/docs/content/internals/url-router.rst
+++ b/docs/content/internals/url-router.rst
@@ -24,8 +24,9 @@ Pipeline
        Walk[Filesystem walk] --> Parser[Parser]
        Parser --> Patterns[URL patterns]
        Patterns --> Manager[RouterManager]
-       Manager --> Resolver[Django URL resolver]
-       Resolver --> PageView[Page view]
+       Manager --> Trie[TrieURLResolver]
+       Resolver[Django URL resolver] --> Trie
+       Trie --> PageView[Page view]
        Manager -- reload --> Reload[Rebuild patterns]
        Reload --> Patterns
 
@@ -44,6 +45,10 @@ Modules
 
 ``next.urls.manager``.
    ``RouterManager`` builds the active pattern list, exposes ``reload``, and emits the ``router_reloaded`` signal.
+   The module-level ``urlpatterns`` is a list with one ``TrieURLResolver`` wrapping the lazy router and form-action pattern sequence.
+
+``next.urls.resolver``.
+   ``TrieURLResolver`` narrows each ``resolve()`` call to a few candidates through a static route map and a segment trie, with the inherited linear scan as fallback.
 
 ``next.urls.dispatcher``.
    ``FilesystemTreeDispatcher`` walks the pages directory tree and yields ``(url_path, page_file)`` pairs that the router turns into URL patterns.
@@ -71,14 +76,42 @@ The default ``page_{name}`` produces the names listed in :doc:`/content/topics/f
 The name computation collapses ``/``, brackets, ``:``, ``-``, and ``_`` into a single underscore, so distinct routes such as ``foo-bar`` and ``foo_bar`` can produce the same name.
 The ``check_reverse_name_collisions`` system check walks every page tree of every router, computes the reverse name of each route through the same parser, and fails with ``next.E039`` when two distinct routes collapse to one name, listing the conflicting paths.
 
+Resolution Algorithm
+--------------------
+
+``include("next.urls")`` mounts a single ``TrieURLResolver`` that wraps the lazy router and form-action pattern sequence.
+The sequence caches the concatenated pattern list against a pair of version counters, one bumped by ``router_manager.reload()`` and one bumped when form actions register or clear through the form-action manager.
+The counters are read after the pattern build, because expanding page modules can register form actions mid-build, so the cache stays valid for the post-registration state.
+A registration that writes into a backend directly, bypassing the manager, is not tracked.
+
+The resolver builds a route index from the same sequence and versions it with the same counter pair.
+
+- A route without parameters lands in a static map keyed by the full route string, so a static hit is one dictionary lookup.
+- A parameterised route becomes a path through a segment trie.
+  A literal segment becomes a literal edge, and a segment whose converters all match within one segment, ``int``, ``str``, ``slug``, or ``uuid``, becomes a param edge.
+- A segment that can span slashes, such as ``<path:...>`` or a custom converter, stops indexing at its node, and the candidate matches any remaining tail from there.
+- A pattern that is not a route-string pattern, such as one built with :func:`~django.urls.re_path`, is never indexed and joins the candidate list of every lookup.
+
+``resolve()`` collects candidates from the static map and a depth-first walk over the trie, following the literal edge before the param edge at every node and picking up tail candidates along the way.
+The candidates are sorted by their original position in the pattern list and tried with the standard ``pattern.resolve()``, so overlapping routes keep Django's first-match-wins rule and converters run unchanged.
+When no candidate matches, the resolver falls back to the inherited linear scan, which raises the canonical ``Resolver404`` with the complete ``tried`` list.
+The fallback also covers any pattern the trie could not index.
+
+On a successful match ``ResolverMatch.tried`` contains only the candidates that were actually tried, not every pattern that precedes the winner in the list.
+A 404 goes through the fallback, so its ``tried`` is identical to the linear scan.
+
+Setting ``URL_RESOLVER`` in ``NEXT_FRAMEWORK`` to ``"django.urls.resolvers.URLResolver"`` replaces the trie resolver with the stock Django class and routes every call through the plain linear scan.
+The resolver is rebuilt on settings reload, so the swap takes effect without a restart.
+
 Reload Mechanics
 ----------------
 
-``router_manager.reload()`` does three things in order.
+``router_manager.reload()`` does four things in order.
 
-1. Rebuilds the backend list from ``PAGE_BACKENDS``.
-2. Clears the Django URL resolver cache.
-3. Emits the ``router_reloaded`` signal.
+1. Bumps the version counter that invalidates the cached pattern concat and the resolver's route index.
+2. Rebuilds the backend list from ``PAGE_BACKENDS``.
+3. Clears the Django URL resolver cache.
+4. Emits the ``router_reloaded`` signal.
 
 The next request observes the new patterns without a process restart.
 Long lived processes such as websocket subscribers listen for the signal to refresh cached URL references.
@@ -88,7 +121,7 @@ Multiple Backends
 
 The settings list accepts more than one backend.
 Each backend reports its own list of patterns.
-The Django URL resolver checks them in order and the first match wins.
+Resolution preserves the concatenated list order, so the first match wins.
 
 If two routes convert to exactly the same Django path string the ``check_url_patterns`` system check reports the conflict at startup as ``next.E015``, whether they come from one tree or several.
 The comparison is string equality after bracket conversion, so semantic overlap between typed converters, such as ``posts/[int:id]`` next to ``posts/[id]``, is not reported.

--- a/docs/content/internals/url-router.rst
+++ b/docs/content/internals/url-router.rst
@@ -40,6 +40,7 @@ Modules
 ``next.urls.parser``.
    Turns directory names into URL patterns.
    Recognises ``[name]``, ``[type:name]``, and ``[[name]]`` shapes.
+   The ``default_url_parser.parse_url_pattern`` method is the single source of bracket conversion, used by both the router and the system checks, so a route and its check always agree on the resulting Django path string.
 
 ``next.urls.manager``.
    ``RouterManager`` builds the active pattern list, exposes ``reload``, and emits the ``router_reloaded`` signal.
@@ -67,6 +68,9 @@ Names follow ``next:page_<segments>`` where the segments come from the directory
 The template ``URL_NAME_TEMPLATE`` controls the format.
 The default ``page_{name}`` produces the names listed in :doc:`/content/topics/file-router`.
 
+The name computation collapses ``/``, brackets, ``:``, ``-``, and ``_`` into a single underscore, so distinct routes such as ``foo-bar`` and ``foo_bar`` can produce the same name.
+The ``check_reverse_name_collisions`` system check walks every page tree of every router, computes the reverse name of each route through the same parser, and fails with ``next.E039`` when two distinct routes collapse to one name, listing the conflicting paths.
+
 Reload Mechanics
 ----------------
 
@@ -86,7 +90,10 @@ The settings list accepts more than one backend.
 Each backend reports its own list of patterns.
 The Django URL resolver checks them in order and the first match wins.
 
-If two routes resolve to the same Django path the ``next.E015`` system check reports the conflict at startup, whether they come from one tree or several.
+If two routes convert to exactly the same Django path string the ``check_url_patterns`` system check reports the conflict at startup as ``next.E015``, whether they come from one tree or several.
+The comparison is string equality after bracket conversion, so semantic overlap between typed converters, such as ``posts/[int:id]`` next to ``posts/[id]``, is not reported.
+The same collection pass owns the duplicate parameter report, failing with ``next.E028`` and listing every conflicting name in one message, and reports a router whose collection raises as ``next.E016``.
+``check_reverse_name_collisions`` reuses the collection but drops its errors, so ``next.E016`` and ``next.E028`` never appear twice.
 
 Extension Points
 ----------------

--- a/docs/content/ref/settings.rst
+++ b/docs/content/ref/settings.rst
@@ -202,6 +202,22 @@ The framework normalises the path through the parser and substitutes ``{name}`` 
 Slashes, square brackets, colons, hyphens, and underscores are collapsed to a single underscore, and the leading and trailing underscores are stripped.
 The directory path ``notes/[id]`` becomes ``notes_id`` and produces the URL name ``page_notes_id``.
 
+URL_RESOLVER
+~~~~~~~~~~~~
+
+Dotted path to the resolver class that wraps the framework urlpatterns.
+
+Default value ``"next.urls.TrieURLResolver"``.
+
+The class is instantiated with a root route pattern and the lazy sequence of router and form-action patterns, so it owns every resolution under the ``include("next.urls")`` mount.
+The default ``TrieURLResolver`` resolves a static route through a dictionary lookup and a parameterised route through a walk over a segment trie, with the final match delegated to standard Django pattern resolution.
+Set the key to ``"django.urls.resolvers.URLResolver"`` to opt out of the trie and run every resolution through Django's plain linear scan.
+A custom value must name a :class:`~django.urls.URLResolver` subclass whose constructor accepts the same pattern and pattern-sequence pair.
+A path that fails to import, or one that names anything other than a ``URLResolver`` subclass, raises :exc:`~django.core.exceptions.ImproperlyConfigured` at startup.
+The resolver is rebuilt on settings reload, so ``override_settings`` swaps it without a restart.
+
+See :doc:`/content/internals/url-router` for the resolution algorithm.
+
 Templates
 ---------
 

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -187,7 +187,7 @@ Errors
      - A ``COMPONENTS_DIR`` or ``PAGES_DIR`` value is not a string.
      - ``next.components.checks``, ``next.urls.checks``
    * - ``next.E028``
-     - A route repeats the same bracket parameter name.
+     - A route repeats one or more bracket parameter names, all listed in the error.
      - ``next.urls.checks``
    * - ``next.E029``
      - A keyless ``@context`` callable is not annotated as returning a dict.
@@ -219,6 +219,9 @@ Errors
    * - ``next.E038``
      - ``STATIC_BACKENDS`` contains a duplicate ``BACKEND`` entry.
      - ``next.static.checks``
+   * - ``next.E039``
+     - Two distinct routes collapse to the same reverse URL name after separator normalisation.
+     - ``next.urls.checks``
    * - ``next.E040``
      - A configured context processor does not accept a ``request`` parameter.
      - ``next.pages.checks``

--- a/docs/content/ref/urls.rst
+++ b/docs/content/ref/urls.rst
@@ -10,6 +10,7 @@ Module Summary
 It also exposes the ``RouterFactory`` and ``RouterManager`` that build and own them.
 The ``URLPatternParser`` for bracket-segment parsing is part of the public surface.
 It also exposes the ``page_reverse``, ``page_reverse_lazy``, and ``with_query`` reverse helpers, the ``get_multi_values`` query reader, and the Django integration name ``app_name``.
+The ``TrieURLResolver`` that dispatches URL resolution through a route trie completes the routing surface.
 The parameter providers and the dependency markers ``DUrl`` (captured path segments) and ``DQuery`` (query string parameters) round out the public surface.
 
 Public API
@@ -27,17 +28,37 @@ The form dispatcher reads it when it resolves a posted origin URL back to the pa
 Manager
 ~~~~~~~
 
-``urlpatterns`` is a lazy sequence that recollects router and form-action patterns from the active backends on each access.
-It is deliberately not a ``list`` subclass, so :func:`~django.urls.include` defers the collection to the first URL resolution instead of iterating the patterns eagerly while the root URLconf imports.
+``urlpatterns`` is a list holding a single ``TrieURLResolver`` that wraps a lazy sequence of router and form-action patterns.
+:func:`~django.urls.include` therefore mounts one resolver, and the pattern collection is deferred to the first URL resolution instead of running while the root URLconf imports.
+Code that reads ``next.urls.urlpatterns`` directly observes that one-element list, not the individual page patterns.
+The wrapped sequence caches the concatenated pattern list against a pair of version counters, one owned by ``RouterManager`` and one by the form-action manager.
+``router_manager.reload()`` bumps the router counter, and registering or clearing form actions through ``form_action_manager`` bumps the forms counter, so the next access rebuilds the list exactly when something changed.
+The counters are read after the pattern build, because expanding page modules can register form actions mid-build, so the cache stays valid for the post-registration state.
+A registration that bypasses the manager and writes into a backend directly is not tracked by the counters and does not appear in the cached list.
 The backends themselves are cached by ``router_manager`` and are only rebuilt when ``router_manager.reload()`` runs or when ``PAGE_BACKENDS`` changes.
 A page added on disk after that first collection needs ``router_manager.reload()``, which rebuilds the backends and clears the Django resolver cache.
 Within a backend both the per-application pattern lists and the patterns from the roots configured in ``DIRS`` are memoised after the first scan, and a settings reload recreates the backend with fresh caches.
-Django's resolver iterates ``reversed(urlpatterns)``, which the sequence answers through an explicit ``__reversed__`` that builds the pattern list once per pass.
+Reverse-name population iterates the wrapped sequence with ``reversed()``, which it answers through an explicit ``__reversed__`` that builds the pattern list once per pass.
 ``RouterManager`` owns the active backend list, and the ``router_manager`` singleton exposes ``reload()`` to rebuild it.
 ``reload()`` logs and skips a backend entry whose construction raises ``ValueError``, ``TypeError``, ``KeyError``, or ``ImportError``.
 Any other exception from a custom backend propagates and stops startup.
 
 .. automodule:: next.urls.manager
+   :members:
+
+Resolver
+~~~~~~~~
+
+``TrieURLResolver`` subclasses :class:`~django.urls.URLResolver` and narrows each ``resolve()`` call to a handful of candidate patterns.
+A route without parameters hits a dictionary keyed by the full route string, and a parameterised route is collected by a walk over a trie of path segments.
+The candidates are then tried with the standard ``pattern.resolve()`` in their original list order, so overlapping routes keep Django's first-match-wins semantics and converters behave as in plain Django.
+A miss falls back to the inherited linear scan, which raises the canonical ``Resolver404`` with a complete ``tried`` list and also covers patterns the trie cannot index, such as ones built with :func:`~django.urls.re_path`.
+On a successful match ``ResolverMatch.tried`` lists only the candidates that were actually tried, not every pattern preceding the winner.
+The internal route index is versioned by the same counters as the pattern concat, so a router reload or a late form-action registration rebuilds it before the next resolution.
+The ``URL_RESOLVER`` setting names the resolver class, so pointing it at ``django.urls.resolvers.URLResolver`` or a custom subclass replaces the trie dispatch.
+See :doc:`/content/internals/url-router` for the algorithm walk-through.
+
+.. automodule:: next.urls.resolver
    :members:
 
 Parser

--- a/docs/content/ref/urls.rst
+++ b/docs/content/ref/urls.rst
@@ -27,14 +27,15 @@ The form dispatcher reads it when it resolves a posted origin URL back to the pa
 Manager
 ~~~~~~~
 
-``urlpatterns`` is a ``list`` subclass that recollects router and form-action patterns from the active backends on each access.
+``urlpatterns`` is a lazy sequence that recollects router and form-action patterns from the active backends on each access.
+It is deliberately not a ``list`` subclass, so :func:`~django.urls.include` defers the collection to the first URL resolution instead of iterating the patterns eagerly while the root URLconf imports.
 The backends themselves are cached by ``router_manager`` and are only rebuilt when ``router_manager.reload()`` runs or when ``PAGE_BACKENDS`` changes.
-Laziness here means the patterns are collected on the first URL access rather than at import time.
 A page added on disk after that first collection needs ``router_manager.reload()``, which rebuilds the backends and clears the Django resolver cache.
-Within a backend the per-application pattern lists are memoised after the first scan, while the roots configured in ``DIRS`` are rescanned on every recollection.
-The ``list`` subclass overrides ``__reversed__`` so Django's resolver observes the recollected patterns rather than the empty internal buffer of the ``list`` base.
-Django's resolver iterates ``reversed(urlpatterns)``, so the override feeds it the fresh patterns.
+Within a backend both the per-application pattern lists and the patterns from the roots configured in ``DIRS`` are memoised after the first scan, and a settings reload recreates the backend with fresh caches.
+Django's resolver iterates ``reversed(urlpatterns)``, which the sequence answers through an explicit ``__reversed__`` that builds the pattern list once per pass.
 ``RouterManager`` owns the active backend list, and the ``router_manager`` singleton exposes ``reload()`` to rebuild it.
+``reload()`` logs and skips a backend entry whose construction raises ``ValueError``, ``TypeError``, ``KeyError``, or ``ImportError``.
+Any other exception from a custom backend propagates and stops startup.
 
 .. automodule:: next.urls.manager
    :members:
@@ -163,11 +164,15 @@ Checks
 ``check_next_pages_configuration``.
    Validates the ``NEXT_FRAMEWORK['PAGE_BACKENDS']`` structure, the ``BACKEND`` path, and per-backend ``DIRS``/``APP_DIRS``/``PAGES_DIR``/``OPTIONS`` keys.
 
-``check_duplicate_url_parameters``.
-   Fails with :ref:`next.E028 <ref-system-checks>` when one route repeats a captured parameter name.
-
 ``check_url_patterns``.
-   Fails with :ref:`next.E015 <ref-system-checks>` when two file routes resolve to the same Django path string.
+   Collects patterns from every configured tree, application pages and root ``DIRS`` alike.
+   Fails with :ref:`next.E015 <ref-system-checks>` when two file routes convert to exactly the same Django path string.
+   Fails with :ref:`next.E028 <ref-system-checks>` when a route repeats a captured parameter name, listing every conflicting name.
+   Reports :ref:`next.E016 <ref-system-checks>` when pattern collection from a router raises.
+
+``check_reverse_name_collisions``.
+   Fails with :ref:`next.E039 <ref-system-checks>` when two distinct routes collapse to the same reverse URL name.
+   It reuses the same pattern collection but leaves collection errors to ``check_url_patterns``, so :ref:`next.E016 <ref-system-checks>` surfaces only once.
 
 .. automodule:: next.urls.checks
    :members:

--- a/docs/content/topics/file-router.rst
+++ b/docs/content/topics/file-router.rst
@@ -224,7 +224,8 @@ With this configuration the router serves every page under ``<BASE_DIR>/pages/``
 
 You can use both sources at once.
 URL patterns are built in this order, first from application directories then from each entry in ``DIRS``.
-If two routes resolve to the same Django path the system check ``next.E015`` reports the conflict, whether they come from one tree or several.
+If two routes convert to exactly the same Django path string the system check ``next.E015`` reports the conflict, whether they come from one tree or several.
+The comparison is string equality after bracket conversion, so semantic overlap between typed converters stays silent, and ``posts/[int:id]`` next to ``posts/[id]`` is not reported.
 
 .. code-block:: python
    :caption: config/settings.py
@@ -367,9 +368,10 @@ The router contributes Django system checks that validate the configuration at s
 - ``check_pages_structure`` validates directory naming, captured parameter syntax, and the presence of ``page.py`` or ``template.djx``.
 - ``check_page_functions`` reports :ref:`next.E012 <ref-system-checks>` when a directory has neither a render function nor a template.
 - ``check_pages_structure`` and ``check_page_functions`` come from ``next.pages`` and appear here because they validate the same page tree the router scans.
-- ``check_url_patterns`` reports two routes that resolve to the same Django path, whether they come from one tree or several (:ref:`next.E015 <ref-system-checks>`).
-- ``check_duplicate_url_parameters`` fails when one route repeats a captured parameter name (:ref:`next.E028 <ref-system-checks>`).
-  It scans one representative pages root per router, so in a project with several page-bearing applications ``next.E028`` surfaces only for routes under the scanned root.
+- ``check_url_patterns`` reports two routes that convert to exactly the same Django path string, whether they come from one tree or several (:ref:`next.E015 <ref-system-checks>`).
+  The comparison is string equality after bracket conversion, so ``posts/[int:id]`` next to ``posts/[id]`` is not reported.
+  While collecting patterns it also reports a route that repeats a captured parameter name (:ref:`next.E028 <ref-system-checks>`), listing every conflicting name, so parameter duplicates surface from every scanned tree.
+- ``check_reverse_name_collisions`` fails when two distinct routes collapse to the same reverse URL name after separator normalisation, such as ``foo-bar`` next to ``foo_bar`` (:ref:`next.E039 <ref-system-checks>`).
 
 Run them through ``uv run python manage.py check``.
 A clean exit confirms that every page resolves and every name is unique.
@@ -391,6 +393,7 @@ Database Driven Routes
 
 A hybrid backend combines file routes with routes built from database rows.
 Subclass ``FileRouterBackend`` and override ``generate_urls`` to call ``super().generate_urls()`` for the file routes, then append one named pattern per row.
+The base method returns a fresh list on every call, so appending to it never mutates the cached file routes.
 Register the backend in ``PAGE_BACKENDS`` and call ``router_manager.reload()`` from a model signal so the row-derived patterns rebuild when the data changes.
 
 See :doc:`/content/howto/write-a-router-backend` for the full worked recipe.

--- a/docs/content/topics/file-router.rst
+++ b/docs/content/topics/file-router.rst
@@ -322,9 +322,18 @@ Each backend can read from a different directory, register a different ``PAGES_D
    }
 
 Two backends produce two independent sets of URLs.
-The Django URL resolver checks them in order.
+Resolution preserves the concatenated list order.
 The first match wins.
 Both backends emit the same signals and follow the same naming rules.
+
+Resolution Performance
+----------------------
+
+URL resolution scales with the depth of the request path, not with the number of registered pages.
+A static route resolves through one dictionary lookup, and a parameterised route resolves through a walk over a trie of path segments that yields a handful of candidates.
+The final match runs through standard Django pattern resolution, so converters and first-match-wins ordering behave as in plain Django.
+Setting ``URL_RESOLVER`` in ``NEXT_FRAMEWORK`` to ``"django.urls.resolvers.URLResolver"`` restores the plain linear scan.
+See :doc:`/content/internals/url-router` for the algorithm and :doc:`/content/ref/settings` for the setting.
 
 Common Patterns
 ---------------

--- a/next/checks/__init__.py
+++ b/next/checks/__init__.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from next.static.checks import check_js_context_serializer
     from next.urls.checks import (
         check_next_pages_configuration,
+        check_reverse_name_collisions,
         check_url_patterns,
     )
 
@@ -63,6 +64,7 @@ _LAZY_SOURCES_BY_MODULE: dict[str, tuple[str, ...]] = {
     "next.static.checks": ("check_js_context_serializer",),
     "next.urls.checks": (
         "check_next_pages_configuration",
+        "check_reverse_name_collisions",
         "check_url_patterns",
     ),
 }

--- a/next/checks/__init__.py
+++ b/next/checks/__init__.py
@@ -35,7 +35,6 @@ if TYPE_CHECKING:
     from next.pages.loaders import _load_python_module
     from next.static.checks import check_js_context_serializer
     from next.urls.checks import (
-        check_duplicate_url_parameters,
         check_next_pages_configuration,
         check_url_patterns,
     )
@@ -63,7 +62,6 @@ _LAZY_SOURCES_BY_MODULE: dict[str, tuple[str, ...]] = {
     "next.pages.loaders": ("_load_python_module",),
     "next.static.checks": ("check_js_context_serializer",),
     "next.urls.checks": (
-        "check_duplicate_url_parameters",
         "check_next_pages_configuration",
         "check_url_patterns",
     ),

--- a/next/conf/defaults.py
+++ b/next/conf/defaults.py
@@ -26,6 +26,7 @@ DEFAULTS: dict[str, Any] = {
         },
     ],
     "URL_NAME_TEMPLATE": "page_{name}",
+    "URL_RESOLVER": "next.urls.TrieURLResolver",
     "COMPONENT_BACKENDS": [
         {
             "BACKEND": "next.components.FileComponentsBackend",

--- a/next/conf/settings.py
+++ b/next/conf/settings.py
@@ -87,7 +87,7 @@ class NextFrameworkSettings:
             if key not in user:
                 continue
             raw = user[key]
-            if key == "URL_NAME_TEMPLATE" and isinstance(raw, str):
+            if key in {"URL_NAME_TEMPLATE", "URL_RESOLVER"} and isinstance(raw, str):
                 out[key] = raw
             elif key == "FORM_WIZARD_BACKEND" and isinstance(raw, dict):
                 merged = copy.deepcopy(self.DEFAULTS[key])

--- a/next/forms/manager.py
+++ b/next/forms/manager.py
@@ -28,6 +28,11 @@ logger = logging.getLogger(__name__)
 class FormActionManager:
     """Holds one or more backends and yields their URL patterns."""
 
+    _version: int = 0
+    """Cache token for the lazy urlpatterns concat. Registrations that
+    bypass the manager and hit a backend directly are not tracked, as
+    they were never supported."""
+
     def __init__(
         self,
         backends: "list[FormActionBackend] | None" = None,
@@ -47,6 +52,7 @@ class FormActionManager:
             yield from backend.generate_urls()
 
     def _reload_config(self) -> None:
+        self._version += 1
         self._backends = []
         configs = cast(
             "list[Any]",
@@ -81,9 +87,11 @@ class FormActionManager:
     def register_action(self, registration: "ActionRegistration") -> None:
         """Forward registration to the first backend."""
         self._first_backend().register_action(registration)
+        self._version += 1
 
     def clear_registries(self) -> None:
         """Clear every backend exposing `clear_registry`. For test isolation."""
+        self._version += 1
         for backend in self._backends:
             clear = getattr(backend, "clear_registry", None)
             if callable(clear):

--- a/next/pages/manager.py
+++ b/next/pages/manager.py
@@ -604,7 +604,17 @@ class Page:
         url_parser: URLPatternParser,
     ) -> URLPattern | None:
         """Return a `path()` pattern for a page, template, or virtual entry."""
-        django_pattern, parameters = url_parser.parse_url_pattern(url_path)
+        # The error class is reached through the parser because a top-level
+        # import of next.urls here would close the next.pages <-> next.urls
+        # circular import.
+        try:
+            django_pattern, parameters = url_parser.parse_url_pattern(url_path)
+        except url_parser.duplicate_parameter_error as exc:
+            raise url_parser.duplicate_parameter_error(
+                exc.param_name,
+                exc.url_path,
+                file_path=file_path,
+            ) from exc
         clean_name = url_parser.prepare_url_name(url_path)
 
         if file_path.exists():

--- a/next/urls/__init__.py
+++ b/next/urls/__init__.py
@@ -9,6 +9,7 @@ Built-in entry points.
 - `DuplicateURLParameterError` raised on conflicting bracket names.
 - `DUrl` marker used in `@context` annotations for URL path segments.
 - `DQuery` marker used in `@context` annotations for query parameters.
+- `TrieURLResolver` dispatching resolve() through a route trie.
 - Django integration via `app_name` and `urlpatterns`.
 
 Deep-import paths expose `FilesystemTreeDispatcher`, `scan_pages_tree`,
@@ -28,6 +29,7 @@ from .markers import (
     get_multi_values,
 )
 from .parser import DuplicateURLParameterError, URLPatternParser
+from .resolver import TrieURLResolver
 from .reverse import page_reverse, page_reverse_lazy, with_query
 
 
@@ -41,6 +43,7 @@ __all__ = [
     "RouterBackend",
     "RouterFactory",
     "RouterManager",
+    "TrieURLResolver",
     "URLPatternParser",
     "UrlByAnnotationProvider",
     "UrlKwargsProvider",

--- a/next/urls/__init__.py
+++ b/next/urls/__init__.py
@@ -6,6 +6,7 @@ Built-in entry points.
 - `RouterFactory` to map dotted paths to backend classes.
 - `RouterManager` plus singleton `router_manager`.
 - `URLPatternParser` for bracket-segment parsing.
+- `DuplicateURLParameterError` raised on conflicting bracket names.
 - `DUrl` marker used in `@context` annotations for URL path segments.
 - `DQuery` marker used in `@context` annotations for query parameters.
 - Django integration via `app_name` and `urlpatterns`.
@@ -26,13 +27,14 @@ from .markers import (
     UrlKwargsProvider,
     get_multi_values,
 )
-from .parser import URLPatternParser
+from .parser import DuplicateURLParameterError, URLPatternParser
 from .reverse import page_reverse, page_reverse_lazy, with_query
 
 
 __all__ = [
     "DQuery",
     "DUrl",
+    "DuplicateURLParameterError",
     "FileRouterBackend",
     "HttpRequestProvider",
     "QueryParamProvider",

--- a/next/urls/backends.py
+++ b/next/urls/backends.py
@@ -91,6 +91,8 @@ class FileRouterBackend(RouterBackend):
         self.options = _narrow_file_router_options(raw_opts)
         self._patterns_cache: dict[str, list[URLPattern | URLResolver]] = {}
         self._app_pages_path_cache: dict[str, Path | None] = {}
+        self._root_patterns_cache: list[URLPattern | URLResolver] | None = None
+        self._root_pages_paths_cache: list[Path] | None = None
         self._url_parser = default_url_parser
 
     @staticmethod
@@ -164,11 +166,17 @@ class FileRouterBackend(RouterBackend):
         return urls
 
     def _generate_root_urls(self) -> list[URLPattern | URLResolver]:
-        """Patterns from each configured root pages directory."""
-        urls: list[URLPattern | URLResolver] = []
-        for pages_path in self._get_root_pages_paths():
-            urls.extend(self._generate_patterns_from_directory(pages_path))
-        return urls
+        """Return cached patterns from each configured root pages directory.
+
+        Returns a copy so callers appending to `generate_urls` results
+        never mutate the cache.
+        """
+        if self._root_patterns_cache is None:
+            urls: list[URLPattern | URLResolver] = []
+            for pages_path in self._get_root_pages_paths():
+                urls.extend(self._generate_patterns_from_directory(pages_path))
+            self._root_patterns_cache = urls
+        return list(self._root_patterns_cache)
 
     def _get_installed_apps(self) -> Generator[str, None, None]:
         """Yield installed app names except django framework packages."""
@@ -194,7 +202,13 @@ class FileRouterBackend(RouterBackend):
         return result
 
     def _get_root_pages_paths(self) -> list[Path]:
-        """Return paths from `DIRS` plus optional `BASE_DIR` / `pages_dir`."""
+        """Return paths from `DIRS` plus optional `BASE_DIR` / `pages_dir`.
+
+        Memoised per instance. A settings reload recreates the backend,
+        so the memo never outlives its configuration.
+        """
+        if self._root_pages_paths_cache is not None:
+            return self._root_pages_paths_cache
         result: list[Path] = [p.resolve() for p in self._extra_root_paths if p.exists()]
         if not self.app_dirs and not result:
             base_dir = resolve_base_dir()
@@ -202,6 +216,7 @@ class FileRouterBackend(RouterBackend):
                 pages_path = base_dir / self.pages_dir
                 if pages_path.exists():
                     result.append(pages_path)
+        self._root_pages_paths_cache = result
         return result
 
     def _generate_urls_for_app(self, app_name: str) -> list[URLPattern | URLResolver]:

--- a/next/urls/checks.py
+++ b/next/urls/checks.py
@@ -42,6 +42,9 @@ _FILE_ROUTER_PAGE_CONFIG_KEYS = frozenset(
 
 _NON_FILE_ROUTER_PAGE_CONFIG_KEYS = frozenset({"BACKEND"})
 
+_CollectedPattern = tuple[str, str, str, frozenset[str]]
+"""`(django_pattern, url_path, source, parameter_names)` for one route."""
+
 
 def _router_backend_path_is_valid(backend_path: str) -> bool:
     """Return True when `backend_path` names a registered or importable backend."""
@@ -369,16 +372,20 @@ def check_reverse_name_collisions(
     # they are dropped here instead of being reported twice.
     all_patterns, _ = _collect_all_patterns(router_manager)
 
-    names: dict[str, dict[str, list[str]]] = {}
-    for _pattern, url_path, source in all_patterns:
+    # reverse() picks by arguments, so a collision needs a shared name and
+    # a shared parameter set.
+    grouped: dict[tuple[str, frozenset[str]], dict[str, list[str]]] = {}
+    for _pattern, url_path, source, parameters in all_patterns:
         full_name = next_framework_settings.URL_NAME_TEMPLATE.format(
             name=default_url_parser.prepare_url_name(url_path),
         )
-        names.setdefault(full_name, {}).setdefault(url_path, []).append(source)
+        grouped.setdefault((full_name, parameters), {}).setdefault(
+            url_path,
+            [],
+        ).append(source)
 
-    for full_name, routes in names.items():
-        # Identical route trails from several trees are an E015 path
-        # conflict, so only distinct trails count as a name collision.
+    for (full_name, _signature), routes in grouped.items():
+        # One trail from several trees is an E015 path conflict, not this.
         if len(routes) == 1:
             continue
         sources = ", ".join(
@@ -399,9 +406,9 @@ def check_reverse_name_collisions(
 
 def _collect_all_patterns(
     router_manager: RouterManager,
-) -> tuple[list[tuple[str, str, str]], list[CheckMessage]]:
-    """Collect `(pattern, url_path, source)` triples from every router backend."""
-    all_patterns: list[tuple[str, str, str]] = []
+) -> tuple[list[_CollectedPattern], list[CheckMessage]]:
+    """Collect one `_CollectedPattern` per route from every router backend."""
+    all_patterns: list[_CollectedPattern] = []
     errors: list[CheckMessage] = []
 
     for router in router_manager._backends:
@@ -423,7 +430,7 @@ def _collect_all_patterns(
 
 def _collect_app_patterns(
     router: RouterBackend,
-    all_patterns: list[tuple[str, str, str]],
+    all_patterns: list[_CollectedPattern],
     errors: list[CheckMessage],
 ) -> None:
     """Append patterns discovered under each app's `pages_dir`."""
@@ -451,7 +458,7 @@ def _collect_app_patterns(
 
 def _collect_root_patterns(
     router: RouterBackend,
-    all_patterns: list[tuple[str, str, str]],
+    all_patterns: list[_CollectedPattern],
     errors: list[CheckMessage],
 ) -> None:
     """Append patterns from each configured root pages directory."""
@@ -469,13 +476,13 @@ def _collect_root_patterns(
 
 
 def _check_url_conflicts(
-    all_patterns: list[tuple[str, str, str]],
+    all_patterns: list[_CollectedPattern],
     errors: list[CheckMessage],
     _warnings: list[CheckMessage],
 ) -> None:
     """Report an error when the same Django path string comes from multiple sources."""
     pattern_dict: dict[str, list[str]] = {}
-    for pattern, _url_path, source in all_patterns:
+    for pattern, _url_path, source, _parameters in all_patterns:
         if pattern in pattern_dict:
             pattern_dict[pattern].append(source)
         else:
@@ -498,20 +505,20 @@ def _collect_url_patterns(
     context: str,
     errors: list[CheckMessage],
     skip_dir_names: Iterable[str] = (),
-) -> list[tuple[str, str, str]]:
-    """Collect `(pattern, url_path, source)` triples from one pages root.
+) -> list[_CollectedPattern]:
+    """Collect one `_CollectedPattern` per route from one pages root.
 
     Conversion and skip set match the router, so the check sees exactly
     the routes the router registers.
     """
-    patterns: list[tuple[str, str, str]] = []
+    patterns: list[_CollectedPattern] = []
 
     if not pages_path.exists():
         return patterns
 
     for url_path, page_file in scan_pages_tree(pages_path, skip_dir_names):
         try:
-            django_pattern, _parameters = default_url_parser.parse_url_pattern(
+            django_pattern, parameters = default_url_parser.parse_url_pattern(
                 url_path,
             )
         except DuplicateURLParameterError as exc:
@@ -533,7 +540,9 @@ def _collect_url_patterns(
             continue
         else:
             source = f"{context}: {page_file.relative_to(pages_path)}"
-            patterns.append((django_pattern, url_path, source))
+            patterns.append(
+                (django_pattern, url_path, source, frozenset(parameters)),
+            )
 
     return patterns
 

--- a/next/urls/checks.py
+++ b/next/urls/checks.py
@@ -248,7 +248,6 @@ def _validate_config_fields(
             ),
         )
 
-    # Check if backend is FileRouterBackend or a subclass
     is_file_router = False
     if backend == FILE_ROUTER_BACKEND:
         is_file_router = True

--- a/next/urls/checks.py
+++ b/next/urls/checks.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
@@ -12,16 +11,19 @@ from django.utils.module_loading import import_string
 from next.checks.common import (
     errors_for_unknown_keys,
     get_router_manager,
-    iter_scanned_page_pairs,
 )
 from next.conf import next_framework_settings
 
 from .backends import FileRouterBackend, RouterBackend, RouterFactory
-from .parser import URLPatternParser
+from .dispatcher import scan_pages_tree
+from .parser import DuplicateURLParameterError, default_url_parser
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
+
+    from .manager import RouterManager
 
 
 FILE_ROUTER_BACKEND = "next.urls.FileRouterBackend"
@@ -324,87 +326,19 @@ def check_next_pages_configuration(
     return errors
 
 
-def _get_duplicate_parameters(url_path: str, parser: URLPatternParser) -> list[str]:
-    """Return parameter names that appear more than once in bracket segments."""
-    param_matches = parser._param_pattern.findall(url_path)
-    param_names = []
-    for param_str in param_matches:
-        param_name, _ = parser._parse_param_name_and_type(param_str)
-        param_names.append(param_name)
-
-    if len(param_names) == len(set(param_names)):
-        return []
-
-    return [name for name in set(param_names) if param_names.count(name) > 1]
-
-
-@register(Tags.urls)
-def check_duplicate_url_parameters(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
-    """Fail when the same bracket parameter name is repeated in one route."""
-    errors: list[CheckMessage] = []
-
-    router_manager, init_errors = get_router_manager()
-    if router_manager is None:
-        return init_errors
-
-    parser = URLPatternParser()
-
-    for router in router_manager._backends:
-        for url_path, page_path in iter_scanned_page_pairs(router):
-            if not page_path.exists():
-                continue
-
-            try:
-                parser.parse_url_pattern(url_path)
-                duplicates = _get_duplicate_parameters(url_path, parser)
-
-                if duplicates:
-                    errors.append(
-                        Error(
-                            f"URL pattern '{url_path}' has duplicate parameter "
-                            f"names: {duplicates}. "
-                            "Each parameter must have a unique name.",
-                            obj=str(page_path),
-                            id="next.E028",
-                        ),
-                    )
-            except (ValueError, TypeError, AttributeError):
-                continue
-
-    return errors
-
-
 @register(Tags.urls)
 def check_url_patterns(
     *_args: object,
     **_kwargs: object,
 ) -> list[CheckMessage]:
     """Collect patterns from routers and flag duplicate Django path strings."""
-    errors: list[CheckMessage] = []
     warnings: list[CheckMessage] = []
 
     router_manager, init_errors = get_router_manager()
     if router_manager is None:
-        return init_errors + warnings
+        return init_errors
 
-    all_patterns: list[tuple[str, str]] = []
-
-    for router in router_manager._backends:
-        try:
-            if hasattr(router, "app_dirs") and router.app_dirs:
-                _collect_app_patterns(router, all_patterns)
-            _collect_root_patterns(router, all_patterns)
-        except (AttributeError, OSError) as e:
-            errors.append(
-                Error(
-                    f"Error collecting patterns from router: {e}",
-                    obj=settings,
-                    id="next.E016",
-                ),
-            )
+    all_patterns, errors = _collect_all_patterns(router_manager)
 
     try:
         _check_url_conflicts(all_patterns, errors, warnings)
@@ -420,9 +354,78 @@ def check_url_patterns(
     return errors + warnings
 
 
+@register(Tags.urls)
+def check_reverse_name_collisions(
+    *_args: object,
+    **_kwargs: object,
+) -> list[CheckMessage]:
+    """Fail when two distinct routes collapse to the same reverse URL name."""
+    errors: list[CheckMessage] = []
+
+    router_manager, init_errors = get_router_manager()
+    if router_manager is None:
+        return init_errors
+
+    # Collection errors surface through check_url_patterns already, so
+    # they are dropped here instead of being reported twice.
+    all_patterns, _ = _collect_all_patterns(router_manager)
+
+    names: dict[str, dict[str, list[str]]] = {}
+    for _pattern, url_path, source in all_patterns:
+        full_name = next_framework_settings.URL_NAME_TEMPLATE.format(
+            name=default_url_parser.prepare_url_name(url_path),
+        )
+        names.setdefault(full_name, {}).setdefault(url_path, []).append(source)
+
+    for full_name, routes in names.items():
+        # Identical route trails from several trees are an E015 path
+        # conflict, so only distinct trails count as a name collision.
+        if len(routes) == 1:
+            continue
+        sources = ", ".join(
+            source for route_sources in routes.values() for source in route_sources
+        )
+        errors.append(
+            Error(
+                f'Reverse URL name collision: "{full_name}" is produced by '
+                f"multiple routes: {sources}. reverse() resolves only one of "
+                "them. Rename the conflicting directories.",
+                obj=settings,
+                id="next.E039",
+            ),
+        )
+
+    return errors
+
+
+def _collect_all_patterns(
+    router_manager: RouterManager,
+) -> tuple[list[tuple[str, str, str]], list[CheckMessage]]:
+    """Collect `(pattern, url_path, source)` triples from every router backend."""
+    all_patterns: list[tuple[str, str, str]] = []
+    errors: list[CheckMessage] = []
+
+    for router in router_manager._backends:
+        try:
+            if hasattr(router, "app_dirs") and router.app_dirs:
+                _collect_app_patterns(router, all_patterns, errors)
+            _collect_root_patterns(router, all_patterns, errors)
+        except (AttributeError, OSError) as e:
+            errors.append(
+                Error(
+                    f"Error collecting patterns from router: {e}",
+                    obj=settings,
+                    id="next.E016",
+                ),
+            )
+
+    return all_patterns, errors
+
+
 def _collect_app_patterns(
     router: RouterBackend,
-    all_patterns: list[tuple[str, str]],
+    all_patterns: list[tuple[str, str, str]],
+    errors: list[CheckMessage],
 ) -> None:
     """Append patterns discovered under each app's `pages_dir`."""
     if not hasattr(router, "_get_installed_apps"):
@@ -438,31 +441,42 @@ def _collect_app_patterns(
         if not pages_path:
             continue
 
-        patterns = _collect_url_patterns(pages_path, f"App '{app_name}'")
+        patterns = _collect_url_patterns(
+            pages_path,
+            f"App '{app_name}'",
+            errors,
+            skip_dir_names=getattr(router, "_skip_dir_names", frozenset()),
+        )
         all_patterns.extend(patterns)
 
 
 def _collect_root_patterns(
     router: RouterBackend,
-    all_patterns: list[tuple[str, str]],
+    all_patterns: list[tuple[str, str, str]],
+    errors: list[CheckMessage],
 ) -> None:
     """Append patterns from each configured root pages directory."""
     if not hasattr(router, "_get_root_pages_paths"):
         return
     for i, pages_path in enumerate(router._get_root_pages_paths()):
         context = "Root" if i == 0 else f"Root ({pages_path})"
-        patterns = _collect_url_patterns(pages_path, context)
+        patterns = _collect_url_patterns(
+            pages_path,
+            context,
+            errors,
+            skip_dir_names=getattr(router, "_skip_dir_names", frozenset()),
+        )
         all_patterns.extend(patterns)
 
 
 def _check_url_conflicts(
-    all_patterns: list[tuple[str, str]],
+    all_patterns: list[tuple[str, str, str]],
     errors: list[CheckMessage],
     _warnings: list[CheckMessage],
 ) -> None:
     """Report an error when the same Django path string comes from multiple sources."""
     pattern_dict: dict[str, list[str]] = {}
-    for pattern, source in all_patterns:
+    for pattern, _url_path, source in all_patterns:
         if pattern in pattern_dict:
             pattern_dict[pattern].append(source)
         else:
@@ -480,41 +494,53 @@ def _check_url_conflicts(
             )
 
 
-def _collect_url_patterns(pages_path: Path, context: str) -> list[tuple[str, str]]:
-    """Collect URL patterns from a pages directory for conflict comparison."""
-    patterns: list[tuple[str, str]] = []
+def _collect_url_patterns(
+    pages_path: Path,
+    context: str,
+    errors: list[CheckMessage],
+    skip_dir_names: Iterable[str] = (),
+) -> list[tuple[str, str, str]]:
+    """Collect `(pattern, url_path, source)` triples from one pages root.
+
+    Conversion and skip set match the router, so the check sees exactly
+    the routes the router registers.
+    """
+    patterns: list[tuple[str, str, str]] = []
 
     if not pages_path.exists():
         return patterns
 
-    for page_file in pages_path.rglob("page.py"):
+    for url_path, page_file in scan_pages_tree(pages_path, skip_dir_names):
         try:
-            relative_path = page_file.relative_to(pages_path)
-            url_path = str(relative_path.parent)
-
-            if django_pattern := _convert_to_django_pattern(url_path):
-                patterns.append((django_pattern, f"{context}: {relative_path}"))
-
-        except (OSError, ValueError):
+            django_pattern, _parameters = default_url_parser.parse_url_pattern(
+                url_path,
+            )
+        except DuplicateURLParameterError as exc:
+            # Two wildcards with distinct names raise without a name
+            # duplicate, so fall back to the name the parser flagged.
+            names = default_url_parser.duplicate_parameter_names(url_path) or [
+                exc.param_name,
+            ]
+            errors.append(
+                Error(
+                    f"URL pattern '{url_path}' has duplicate parameter "
+                    f"names: {names}. "
+                    "Each parameter must have a unique name.",
+                    obj=str(page_file),
+                    id="next.E028",
+                ),
+            )
+        except (ValueError, TypeError):
             continue
+        else:
+            source = f"{context}: {page_file.relative_to(pages_path)}"
+            patterns.append((django_pattern, url_path, source))
 
     return patterns
 
 
-def _convert_to_django_pattern(url_path: str) -> str | None:
-    """Convert bracket syntax to `<str:>` / `<path:>` for conflict comparison."""
-    if not url_path:
-        return ""
-
-    args_pattern = re.compile(r"\[\[([^\[\]]+)\]\]")
-    url_path = args_pattern.sub(r"<path:\1>", url_path)
-
-    param_pattern = re.compile(r"\[([^\[\]]+)\]")
-    return param_pattern.sub(r"<str:\1>", url_path)
-
-
 __all__ = [
-    "check_duplicate_url_parameters",
     "check_next_pages_configuration",
+    "check_reverse_name_collisions",
     "check_url_patterns",
 ]

--- a/next/urls/dispatcher.py
+++ b/next/urls/dispatcher.py
@@ -52,6 +52,8 @@ class FilesystemTreeDispatcher:
         except OSError as e:
             logger.debug("Cannot list directory %s: %s", current_path, e)
             return
+        has_page = False
+        has_template = False
         for item in items:
             if item.is_dir():
                 if item.name in self._skip_set:
@@ -67,13 +69,13 @@ class FilesystemTreeDispatcher:
                 new_url_path = f"{url_path}/{dir_name}" if url_path else dir_name
                 yield from self._visit(item, tree_root, new_url_path)
             elif item.name == "page.py":
+                has_page = True
                 yield url_path, item
+            elif item.name == "template.djx":
+                has_template = True
 
-        if current_path.is_dir():
-            page_file = current_path / "page.py"
-            template_file = current_path / "template.djx"
-            if not page_file.exists() and template_file.exists():
-                yield url_path, current_path / "page.py"
+        if has_template and not has_page:
+            yield url_path, current_path / "page.py"
 
 
 def scan_pages_tree(

--- a/next/urls/manager.py
+++ b/next/urls/manager.py
@@ -19,6 +19,7 @@ from django.urls import URLPattern, URLResolver, clear_url_caches
 from django.urls.resolvers import RoutePattern
 
 from next.conf import next_framework_settings
+from next.conf.defaults import DEFAULTS
 from next.conf.imports import import_class_cached
 from next.conf.signals import settings_reloaded
 from next.forms.manager import form_action_manager
@@ -179,7 +180,8 @@ class _LazyUrlPatterns(Sequence["URLPattern | URLResolver"]):
         return self._patterns()[key]
 
 
-_DEFAULT_URL_RESOLVER = "next.urls.TrieURLResolver"
+# Single-sourced so the circular-import guard below cannot drift from it.
+_DEFAULT_URL_RESOLVER: str = DEFAULTS["URL_RESOLVER"]
 
 
 def _build_url_resolver() -> URLResolver:

--- a/next/urls/manager.py
+++ b/next/urls/manager.py
@@ -1,17 +1,16 @@
-"""Router manager, lazy urlpatterns list, and settings-reload wiring.
+"""Router manager, lazy urlpatterns sequence, and settings-reload wiring.
 
 `RouterManager` owns the list of active `RouterBackend` instances and
 rebuilds it from `NEXT_FRAMEWORK["PAGE_BACKENDS"]` whenever
-framework settings change. `_LazyUrlPatterns` is a `list`-subclass
-used as Django's `urlpatterns` so the first access triggers router
-and form-action resolution without walking the page tree at import
-time.
+framework settings change. `_LazyUrlPatterns` is the sequence used as
+Django's `urlpatterns` so the first resolve triggers router and
+form-action resolution without walking the page tree at import time.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, SupportsIndex, overload, override
+from typing import TYPE_CHECKING, Any, override
 
 from django.urls import clear_url_caches
 
@@ -75,7 +74,7 @@ class RouterManager:
         for config in configs:
             try:
                 self._backends.append(RouterFactory.create_backend(config))
-            except Exception:
+            except (ValueError, TypeError, KeyError, ImportError):
                 logger.exception("error creating router from config %s", config)
 
         clear_url_caches()
@@ -104,15 +103,12 @@ def _on_settings_reloaded(**_kwargs: object) -> None:
 settings_reloaded.connect(_on_settings_reloaded)
 
 
-class _LazyUrlPatterns(list):
+class _LazyUrlPatterns:
     """Defer expanding router and form patterns until first use.
 
-    Avoids walking the tree at import time. Rebuilds from
-    `router_manager` and `form_action_manager` on each access.
-    Subclasses `list` so `isinstance(urlpatterns, list)` holds.
-    Overrides `__reversed__` because the inherited empty internal
-    buffer would break `reversed(urlpatterns)` in Django's URL
-    resolver.
+    Not a `list` subclass, so `include()` defers materialisation to the
+    first resolve. Explicit `__reversed__` keeps the resolver's reverse
+    walk to one list build instead of one per index.
     """
 
     def _patterns(self) -> list[URLPattern | URLResolver]:
@@ -121,29 +117,17 @@ class _LazyUrlPatterns(list):
             *list(form_action_manager),
         ]
 
-    @override
     def __iter__(self) -> Iterator[URLPattern | URLResolver]:
         return iter(self._patterns())
 
-    @override
     def __reversed__(self) -> Iterator[URLPattern | URLResolver]:
         return reversed(self._patterns())
 
-    @override
     def __len__(self) -> int:
         return len(self._patterns())
 
-    @overload
-    def __getitem__(self, key: SupportsIndex, /) -> URLPattern | URLResolver:
-        raise NotImplementedError
-
-    @overload
-    def __getitem__(self, key: slice, /) -> list[URLPattern | URLResolver]:
-        raise NotImplementedError
-
-    @override
     def __getitem__(
-        self, key: SupportsIndex | slice, /
+        self, key: int | slice, /
     ) -> URLPattern | URLResolver | list[URLPattern | URLResolver]:
         return self._patterns()[key]
 

--- a/next/urls/manager.py
+++ b/next/urls/manager.py
@@ -1,31 +1,35 @@
 """Router manager, lazy urlpatterns sequence, and settings-reload wiring.
 
 `RouterManager` owns the list of active `RouterBackend` instances and
-rebuilds it from `NEXT_FRAMEWORK["PAGE_BACKENDS"]` whenever
-framework settings change. `_LazyUrlPatterns` is the sequence used as
-Django's `urlpatterns` so the first resolve triggers router and
-form-action resolution without walking the page tree at import time.
+rebuilds it from `NEXT_FRAMEWORK["PAGE_BACKENDS"]` whenever framework
+settings change. `_LazyUrlPatterns` is the sequence wrapped by the
+module-level resolver built from `NEXT_FRAMEWORK["URL_RESOLVER"]` so the
+first resolve triggers router and form-action resolution without walking
+the page tree at import time.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, override
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, overload, override
 
-from django.urls import clear_url_caches
+from django.core.exceptions import ImproperlyConfigured
+from django.urls import URLPattern, URLResolver, clear_url_caches
+from django.urls.resolvers import RoutePattern
 
 from next.conf import next_framework_settings
+from next.conf.imports import import_class_cached
 from next.conf.signals import settings_reloaded
 from next.forms.manager import form_action_manager
 
 from .backends import RouterBackend, RouterFactory
+from .resolver import TrieURLResolver
 from .signals import router_reloaded
 
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterator
-
-    from django.urls import URLPattern, URLResolver
 
 
 logger = logging.getLogger(__name__)
@@ -33,6 +37,9 @@ logger = logging.getLogger(__name__)
 
 class RouterManager:
     """Load `RouterBackend` instances from `NEXT_FRAMEWORK` and iterate them."""
+
+    _version: int = 0
+    """Cache token for the lazy urlpatterns concat, bumped by `reload()`."""
 
     def __init__(self) -> None:
         """Empty backend list until first iteration."""
@@ -67,6 +74,7 @@ class RouterManager:
         list. The `router_reloaded` signal fires after the rebuild and
         the cache flush so receivers observe a consistent state.
         """
+        self._version += 1
         self._config_cache = None
         self._backends.clear()
 
@@ -96,44 +104,112 @@ router_manager = RouterManager()
 
 
 def _on_settings_reloaded(**_kwargs: object) -> None:
-    """Rebuild router backends when framework settings reload."""
+    """Rebuild router backends and the URL resolver on settings reload.
+
+    The resolver is swapped in place so `urlpatterns` keeps its identity
+    for the outer include resolver, which iterates the list on every
+    resolve and picks up the replacement.
+    """
     router_manager.reload()
+    urlpatterns[0] = _build_url_resolver()
 
 
 settings_reloaded.connect(_on_settings_reloaded)
 
 
-class _LazyUrlPatterns:
+class _LazyUrlPatterns(Sequence["URLPattern | URLResolver"]):
     """Defer expanding router and form patterns until first use.
 
     Not a `list` subclass, so `include()` defers materialisation to the
     first resolve. Explicit `__reversed__` keeps the resolver's reverse
-    walk to one list build instead of one per index.
+    walk to one list build instead of one per index. The concat is cached
+    against the router and form-action manager versions.
     """
 
-    def _patterns(self) -> list[URLPattern | URLResolver]:
-        return [
-            *list(router_manager),
-            *list(form_action_manager),
-        ]
+    def __init__(self) -> None:
+        """Empty cache until the first pattern build."""
+        self._cache: tuple[int, int, list[URLPattern | URLResolver]] | None = None
 
+    def version_token(self) -> tuple[int, int]:
+        """Router and form-action versions keying caches derived from this."""
+        return (router_manager._version, form_action_manager._version)
+
+    def _patterns(self) -> list[URLPattern | URLResolver]:
+        cache = self._cache
+        if cache is not None and (cache[0], cache[1]) == (
+            router_manager._version,
+            form_action_manager._version,
+        ):
+            return cache[2]
+        patterns: list[URLPattern | URLResolver] = [
+            *router_manager,
+            *form_action_manager,
+        ]
+        # Versions are read after the build because expanding pages can
+        # register form actions and bump the forms version mid-build.
+        self._cache = (
+            router_manager._version,
+            form_action_manager._version,
+            patterns,
+        )
+        return patterns
+
+    @override
     def __iter__(self) -> Iterator[URLPattern | URLResolver]:
         return iter(self._patterns())
 
+    @override
     def __reversed__(self) -> Iterator[URLPattern | URLResolver]:
         return reversed(self._patterns())
 
+    @override
     def __len__(self) -> int:
         return len(self._patterns())
 
+    @overload
+    def __getitem__(self, key: int, /) -> URLPattern | URLResolver: ...
+
+    @overload
+    def __getitem__(self, key: slice, /) -> list[URLPattern | URLResolver]: ...
+
+    @override
     def __getitem__(
         self, key: int | slice, /
     ) -> URLPattern | URLResolver | list[URLPattern | URLResolver]:
         return self._patterns()[key]
 
 
+_DEFAULT_URL_RESOLVER = "next.urls.TrieURLResolver"
+
+
+def _build_url_resolver() -> URLResolver:
+    """Instantiate the resolver class named by `NEXT_FRAMEWORK["URL_RESOLVER"]`."""
+    dotted = next_framework_settings.URL_RESOLVER
+    if dotted == _DEFAULT_URL_RESOLVER:
+        # The package binds `TrieURLResolver` only after importing this
+        # module, so the import helper would hit a partially initialised
+        # `next.urls` when the default is built during package import.
+        cls: type[Any] = TrieURLResolver
+    else:
+        try:
+            cls = import_class_cached(dotted)
+        except ImportError as exc:
+            msg = (
+                f"NEXT_FRAMEWORK['URL_RESOLVER'] {dotted!r} could not be "
+                f"imported: {exc}"
+            )
+            raise ImproperlyConfigured(msg) from exc
+    if not isinstance(cls, type) or not issubclass(cls, URLResolver):
+        msg = (
+            f"NEXT_FRAMEWORK['URL_RESOLVER'] {dotted!r} is not a "
+            "django.urls.resolvers.URLResolver subclass."
+        )
+        raise ImproperlyConfigured(msg)
+    return cls(RoutePattern(""), _LazyUrlPatterns())
+
+
 app_name = "next"
-urlpatterns = _LazyUrlPatterns()
+urlpatterns = [_build_url_resolver()]
 
 
 __all__ = [

--- a/next/urls/parser.py
+++ b/next/urls/parser.py
@@ -16,6 +16,7 @@ from uuid import UUID
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
 
 
 def _coerce_bool(text: str) -> bool:
@@ -50,6 +51,35 @@ def _coerce_url_value(value: object, hint: object) -> object:
         return value
 
 
+class DuplicateURLParameterError(ValueError):
+    """Raised when bracket segments in one route conflict after normalisation.
+
+    Covers a repeated normalised parameter name (`-` maps to `_`) and a
+    second `[[wildcard]]` segment, both of which Django would otherwise
+    reject only at resolve time or resolve ambiguously.
+    """
+
+    def __init__(
+        self,
+        param_name: str,
+        url_path: str,
+        file_path: Path | None = None,
+    ) -> None:
+        """Build the message from the conflicting name and the source path."""
+        self.param_name = param_name
+        self.url_path = url_path
+        self.file_path = file_path
+        message = (
+            f"Duplicate URL parameter '{param_name}' in URL pattern "
+            f"'{url_path}'. Parameter names must be unique after '-' to '_' "
+            "normalisation and a route can hold at most one [[wildcard]] "
+            "segment."
+        )
+        if file_path is not None:
+            message = f"{message} Page file: {file_path}."
+        super().__init__(message)
+
+
 class URLPatternParser:
     """Map bracket segments in a file-based path to Django path converters.
 
@@ -59,37 +89,66 @@ class URLPatternParser:
     page-tree scanner.
     """
 
-    _param_pattern: ClassVar[re.Pattern[str]] = re.compile(r"\[([^\[\]]+)\]")
-    _args_pattern: ClassVar[re.Pattern[str]] = re.compile(r"\[\[([^\[\]]+)\]\]")
+    duplicate_parameter_error: ClassVar[type[DuplicateURLParameterError]] = (
+        DuplicateURLParameterError
+    )
+
+    # The wildcard alternative must come first so `[[x]]` never matches
+    # the single-bracket branch with a `[` inside the captured name.
+    _bracket_pattern: ClassVar[re.Pattern[str]] = re.compile(
+        r"\[\[(?P<wild>[^\[\]]+)\]\]|\[(?P<param>[^\[\]]+)\]",
+    )
 
     def parse_url_pattern(self, url_path: str) -> tuple[str, dict[str, str]]:
         """Return the Django path string and parameter names for `url_path`."""
-        django_pattern = url_path
         parameters: dict[str, str] = {}
+        wildcard_seen = False
 
-        if args_match := self._args_pattern.search(django_pattern):
-            args_name = args_match.group(1)
-            django_args_name = args_name.replace("-", "_")
-            django_pattern = self._args_pattern.sub(
-                f"<path:{django_args_name}>",
-                django_pattern,
+        def _convert(match: re.Match[str]) -> str:
+            nonlocal wildcard_seen
+            wild = match.group("wild")
+            if wild is not None:
+                name = wild.replace("-", "_")
+                if wildcard_seen or name in parameters:
+                    raise DuplicateURLParameterError(name, url_path)
+                wildcard_seen = True
+                parameters[name] = name
+                return f"<path:{name}>"
+            param_name, param_type = self._parse_param_name_and_type(
+                match.group("param"),
             )
-            parameters[django_args_name] = django_args_name
+            name = param_name.replace("-", "_")
+            if name in parameters:
+                raise DuplicateURLParameterError(name, url_path)
+            parameters[name] = name
+            return f"<{param_type}:{name}>"
 
-        param_matches = self._param_pattern.findall(url_path)
-        for param_str in param_matches:
-            param_name, param_type = self._parse_param_name_and_type(param_str)
-            django_param_name = param_name.replace("-", "_")
-            django_pattern = django_pattern.replace(
-                f"[{param_str}]",
-                f"<{param_type}:{django_param_name}>",
-            )
-            parameters[django_param_name] = django_param_name
+        django_pattern = self._bracket_pattern.sub(_convert, url_path)
 
         if django_pattern and not django_pattern.endswith("/"):
             django_pattern = f"{django_pattern}/"
 
         return django_pattern, parameters
+
+    def duplicate_parameter_names(self, url_path: str) -> list[str]:
+        """Return normalised bracket names repeated within `url_path`.
+
+        Lets diagnostics name every duplicate where `parse_url_pattern`
+        raises on the first.
+        """
+        seen: set[str] = set()
+        duplicates: list[str] = []
+        for match in self._bracket_pattern.finditer(url_path):
+            wild = match.group("wild")
+            if wild is not None:
+                name = wild.replace("-", "_")
+            else:
+                raw_name, _ = self._parse_param_name_and_type(match.group("param"))
+                name = raw_name.replace("-", "_")
+            if name in seen and name not in duplicates:
+                duplicates.append(name)
+            seen.add(name)
+        return duplicates
 
     def _parse_param_name_and_type(self, param_str: str) -> tuple[str, str]:
         """Split bracket text into a name and converter label (default `str`)."""
@@ -108,4 +167,4 @@ class URLPatternParser:
 default_url_parser: URLPatternParser = URLPatternParser()
 
 
-__all__ = ["URLPatternParser", "default_url_parser"]
+__all__ = ["DuplicateURLParameterError", "URLPatternParser", "default_url_parser"]

--- a/next/urls/resolver.py
+++ b/next/urls/resolver.py
@@ -1,0 +1,214 @@
+"""Trie-backed URL resolver that narrows resolve() to a few candidates.
+
+The file router owns its whole subtree, so the route list is a ready-made
+trie. Candidates for a path are picked in O(depth) from a static route map
+plus a segment trie, then tried in original pattern order, which keeps
+Django's first-match-wins semantics for overlapping routes.
+"""
+
+from __future__ import annotations
+
+import operator
+import re
+from typing import TYPE_CHECKING, Any, cast, override
+
+from django.urls import Resolver404, URLPattern, URLResolver
+from django.urls.resolvers import ResolverMatch, RoutePattern
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+type _Candidate = tuple[int, URLPattern | URLResolver]
+type _Tried = list[list[URLPattern | URLResolver]]
+
+_PARAM_RE = re.compile(r"<(?:([^>:]+):)?[^>]+>")
+_SINGLE_SEGMENT_CONVERTERS = frozenset({"int", "slug", "str", "uuid"})
+_by_index = operator.itemgetter(0)
+
+
+def _is_single_segment(segment: str) -> bool:
+    """Tell whether every converter in the segment matches within one segment."""
+    converters = _PARAM_RE.findall(segment)
+    return all((name or "str") in _SINGLE_SEGMENT_CONVERTERS for name in converters)
+
+
+class _TrieNode:
+    """Trie node with literal children, one param edge, and terminals."""
+
+    __slots__ = ("literals", "param", "tail_terminals", "terminals")
+
+    def __init__(self) -> None:
+        self.literals: dict[str, _TrieNode] = {}
+        self.param: _TrieNode | None = None
+        self.terminals: list[_Candidate] = []
+        self.tail_terminals: list[_Candidate] = []
+
+
+def _collect(
+    node: _TrieNode,
+    segments: list[str],
+    depth: int,
+    found: list[_Candidate],
+) -> None:
+    found.extend(node.tail_terminals)
+    if depth == len(segments):
+        found.extend(node.terminals)
+        return
+    segment = segments[depth]
+    literal_child = node.literals.get(segment)
+    if literal_child is not None:
+        _collect(literal_child, segments, depth + 1, found)
+    if node.param is not None and segment:
+        _collect(node.param, segments, depth + 1, found)
+
+
+class _RouteIndex:
+    """Static route map plus a segment trie for parameterised routes."""
+
+    __slots__ = ("root", "static", "unindexed")
+
+    def __init__(self, patterns: Iterable[URLPattern | URLResolver]) -> None:
+        self.static: dict[str, _Candidate] = {}
+        self.root = _TrieNode()
+        self.unindexed: list[_Candidate] = []
+        for index, pattern in enumerate(patterns):
+            self._add((index, pattern))
+
+    def _add(self, candidate: _Candidate) -> None:
+        pattern = candidate[1]
+        if not isinstance(pattern, URLPattern) or not isinstance(
+            pattern.pattern, RoutePattern
+        ):
+            self.unindexed.append(candidate)
+            return
+        route = str(pattern.pattern)
+        if "<" not in route:
+            self.static.setdefault(route, candidate)
+            return
+        node = self.root
+        for segment in route.split("/"):
+            if "<" not in segment:
+                node = node.literals.setdefault(segment, _TrieNode())
+            elif _is_single_segment(segment):
+                if node.param is None:
+                    node.param = _TrieNode()
+                node = node.param
+            else:
+                # `<path:...>` and custom converters can span "/", so the
+                # candidate must match any remaining tail from this node.
+                node.tail_terminals.append(candidate)
+                return
+        node.terminals.append(candidate)
+
+    def candidates(self, path: str) -> list[_Candidate]:
+        found = list(self.unindexed)
+        static_hit = self.static.get(path)
+        if static_hit is not None:
+            found.append(static_hit)
+        _collect(self.root, path.split("/"), 0, found)
+        found.sort(key=_by_index)
+        return found
+
+
+def _extend_tried(
+    tried: _Tried,
+    pattern: URLPattern | URLResolver,
+    sub_tried: list[list[URLPattern | URLResolver]] | None = None,
+) -> None:
+    # Mirrors URLResolver._extend_tried, which django-stubs does not expose.
+    if sub_tried is None:
+        tried.append([pattern])
+    else:
+        tried.extend([pattern, *t] for t in sub_tried)
+
+
+def _join_route(route1: str, route2: str) -> str:
+    # Mirrors URLResolver._join_route, which django-stubs does not expose.
+    if not route1:
+        return route2
+    return route1 + route2.removeprefix("^")
+
+
+class TrieURLResolver(URLResolver):
+    """URLResolver that dispatches resolve() through a route trie.
+
+    The index is rebuilt whenever the `version_token()` of the wrapped
+    patterns changes. Any miss falls back to the inherited linear scan
+    for the canonical `Resolver404` with a complete `tried` list.
+    """
+
+    _index_cache: tuple[tuple[int, int], _RouteIndex] | None = None
+
+    def _current_token(self) -> tuple[int, int]:
+        source = getattr(self.url_patterns, "version_token", None)
+        if source is None:
+            return (0, 0)
+        return cast("tuple[int, int]", source())
+
+    def _route_index(self) -> _RouteIndex:
+        cached = self._index_cache
+        if cached is not None and cached[0] == self._current_token():
+            return cached[1]
+        index = _RouteIndex(self.url_patterns)
+        # The token is read after the build because materialising lazy
+        # patterns can register form actions and bump their version.
+        self._index_cache = (self._current_token(), index)
+        return index
+
+    @override
+    def resolve(self, path: str) -> ResolverMatch:
+        """Resolve via trie candidates with a linear-scan fallback."""
+        path = str(path)
+        match = self.pattern.match(path)
+        if match is not None:
+            new_path, args, kwargs = match
+            tried: _Tried = []
+            for _, pattern in self._route_index().candidates(new_path):
+                try:
+                    sub_match = pattern.resolve(new_path)
+                except Resolver404 as exc:
+                    _extend_tried(tried, pattern, exc.args[0].get("tried"))
+                    continue
+                if sub_match is None:
+                    tried.append([pattern])
+                    continue
+                return self._wrap_sub_match(pattern, sub_match, (args, kwargs), tried)
+        return super().resolve(path)
+
+    def _wrap_sub_match(
+        self,
+        pattern: URLPattern | URLResolver,
+        sub_match: ResolverMatch,
+        outer: tuple[tuple[Any, ...], dict[str, Any]],
+        tried: _Tried,
+    ) -> ResolverMatch:
+        """Wrap a candidate sub-match the same way URLResolver.resolve does."""
+        args, kwargs = outer
+        sub_match_dict = {**kwargs, **self.default_kwargs}
+        sub_match_dict.update(sub_match.kwargs)
+        sub_match_args = sub_match.args
+        if not sub_match_dict:
+            sub_match_args = args + sub_match.args
+        current_route = "" if isinstance(pattern, URLPattern) else str(pattern.pattern)
+        _extend_tried(tried, pattern, sub_match.tried)
+        return ResolverMatch(
+            sub_match.func,
+            sub_match_args,
+            sub_match_dict,
+            sub_match.url_name,
+            [self.app_name, *sub_match.app_names],
+            [self.namespace, *sub_match.namespaces],
+            _join_route(current_route, sub_match.route),
+            tried,
+            # django-stubs omits these two ResolverMatch attributes.
+            captured_kwargs=getattr(sub_match, "captured_kwargs", None),
+            extra_kwargs={
+                **self.default_kwargs,
+                **getattr(sub_match, "extra_kwargs", {}),
+            },
+        )
+
+
+__all__ = ["TrieURLResolver"]

--- a/tests/benchmarks/urls/test_bench_resolver.py
+++ b/tests/benchmarks/urls/test_bench_resolver.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING
+
+import pytest
+from django.http import HttpResponse
+from django.urls import Resolver404, URLResolver, path
+from django.urls.resolvers import RoutePattern
+
+from next.urls import TrieURLResolver
+
+
+if TYPE_CHECKING:
+    from django.urls import URLPattern
+
+
+_SECTIONS = 10
+_PAGES = 12
+
+
+def _bench_view(_request, **_kwargs: object) -> HttpResponse:
+    return HttpResponse(b"bench")
+
+
+def _build_patterns() -> list[URLPattern]:
+    patterns = [
+        path(f"sec{i}/page{j}/", _bench_view, name=f"bench_s{i}_p{j}")
+        for i in range(_SECTIONS)
+        for j in range(_PAGES)
+    ]
+    patterns.append(
+        path("deep/<slug:one>/mid/<slug:two>/leaf/", _bench_view, name="bench_deep")
+    )
+    patterns.append(path("items/<int:item_id>/", _bench_view, name="bench_item"))
+    patterns.append(path("files/<path:rest>/", _bench_view, name="bench_files"))
+    return patterns
+
+
+@pytest.fixture(scope="module")
+def route_patterns() -> list[URLPattern]:
+    return _build_patterns()
+
+
+@pytest.fixture(scope="module", params=["trie", "linear"])
+def resolver(request, route_patterns: list[URLPattern]) -> URLResolver:
+    resolver_cls = TrieURLResolver if request.param == "trie" else URLResolver
+    built = resolver_cls(RoutePattern(""), route_patterns)
+    with contextlib.suppress(Resolver404):
+        built.resolve("warmup/miss/")
+    return built
+
+
+class TestBenchResolverModes:
+    @pytest.mark.benchmark(group="urls.resolver")
+    def test_static_hit_last_route(self, resolver: URLResolver, benchmark) -> None:
+        benchmark(resolver.resolve, "sec9/page11/")
+
+    @pytest.mark.benchmark(group="urls.resolver")
+    def test_dynamic_hit_int_converter(self, resolver: URLResolver, benchmark) -> None:
+        benchmark(resolver.resolve, "items/12345/")
+
+    @pytest.mark.benchmark(group="urls.resolver")
+    def test_deep_dynamic_path(self, resolver: URLResolver, benchmark) -> None:
+        benchmark(resolver.resolve, "deep/alpha/mid/beta/leaf/")
+
+    @pytest.mark.benchmark(group="urls.resolver")
+    def test_path_tail_hit(self, resolver: URLResolver, benchmark) -> None:
+        benchmark(resolver.resolve, "files/docs/guide/intro.txt/")
+
+    @pytest.mark.benchmark(group="urls.resolver")
+    def test_miss_raises_resolver404(self, resolver: URLResolver, benchmark) -> None:
+        def run() -> None:
+            with contextlib.suppress(Resolver404):
+                resolver.resolve("missing/route/")
+
+        benchmark(run)

--- a/tests/conf/test_settings.py
+++ b/tests/conf/test_settings.py
@@ -184,6 +184,50 @@ class TestFlatNextFrameworkBehavior:
             del next_framework_settings._coverage_probe
 
 
+class TestUrlResolverSetting:
+    """URL_RESOLVER default, string merge, and check acceptance."""
+
+    def test_default_is_trie_resolver_path(self) -> None:
+        """The setting defaults to the trie resolver dotted path."""
+        assert (
+            NextFrameworkSettings.DEFAULTS["URL_RESOLVER"]
+            == "next.urls.TrieURLResolver"
+        )
+        next_framework_settings.reload()
+        assert next_framework_settings.URL_RESOLVER == "next.urls.TrieURLResolver"
+
+    def test_string_override_reaches_merged_settings(self) -> None:
+        """A dotted-path string lands in next_framework_settings unchanged."""
+        with override_settings(
+            NEXT_FRAMEWORK={"URL_RESOLVER": "django.urls.resolvers.URLResolver"},
+        ):
+            next_framework_settings.reload()
+            assert (
+                next_framework_settings.URL_RESOLVER
+                == "django.urls.resolvers.URLResolver"
+            )
+
+    @pytest.mark.parametrize(
+        "raw",
+        [123, None, ["next.urls.TrieURLResolver"]],
+        ids=["int", "none", "list"],
+    )
+    def test_non_string_override_keeps_default(self, raw: object) -> None:
+        """A non-string value is ignored by the merge and the default stays."""
+        with override_settings(NEXT_FRAMEWORK={"URL_RESOLVER": raw}):  # type: ignore[dict-item]
+            next_framework_settings.reload()
+            assert next_framework_settings.URL_RESOLVER == "next.urls.TrieURLResolver"
+
+    def test_key_passes_unknown_key_check(self) -> None:
+        """System checks accept URL_RESOLVER as a known top-level key."""
+        with override_settings(
+            NEXT_FRAMEWORK={"URL_RESOLVER": "next.urls.TrieURLResolver"},
+        ):
+            next_framework_settings.reload()
+            errors = check_next_framework_unknown_top_level_keys()
+        assert errors == []
+
+
 class TestNextFrameworkChecksUnknownKeys:
     """System checks reject keys that are not part of the supported schema."""
 

--- a/tests/forms/test_backends.py
+++ b/tests/forms/test_backends.py
@@ -1044,6 +1044,43 @@ class TestManagerClearRegistries:
         manager.clear_registries()
 
 
+class TestFormActionManagerVersion:
+    """The `_version` cache token bumps on every registry mutation."""
+
+    def test_register_action_bumps_version(self) -> None:
+        """register_action increments the version after forwarding."""
+        manager = FormActionManager(backends=[RegistryFormActionBackend()])
+        before = manager._version
+        manager.register_action(
+            ActionRegistration(
+                name="version_bump_action",
+                file_path=_FAKE_FILE,
+                scope="shared",
+                handler=lambda: None,
+            )
+        )
+        assert manager._version == before + 1
+
+    def test_clear_registries_bumps_version(self) -> None:
+        """clear_registries increments the version."""
+        manager = FormActionManager(backends=[RegistryFormActionBackend()])
+        before = manager._version
+        manager.clear_registries()
+        assert manager._version == before + 1
+
+    def test_reload_config_bumps_version(self, settings) -> None:
+        """_reload_config increments the version alongside the backend rebuild."""
+        settings.NEXT_FRAMEWORK = {
+            "FORM_ACTION_BACKENDS": [
+                {"BACKEND": "next.forms.RegistryFormActionBackend"},
+            ],
+        }
+        manager = FormActionManager()
+        before = manager._version
+        manager._reload_config()
+        assert manager._version == before + 1
+
+
 class TestFileToDottedModule:
     """file_to_dotted_module returns dotted module path for files inside packages."""
 

--- a/tests/pages/test_checks.py
+++ b/tests/pages/test_checks.py
@@ -8,7 +8,6 @@ import next.pages.loaders as loaders_module
 from next.checks import (
     _has_template_or_djx,
     check_context_functions,
-    check_duplicate_url_parameters,
     check_layout_templates,
     check_page_functions,
 )
@@ -395,52 +394,6 @@ class TestBodySourceConflicts:
                 msg = w043[0].msg
                 assert f"{expected_winner} takes priority" in msg
                 assert expected_shadowed in msg
-
-
-class TestDuplicateUrlParametersChecks:
-    """Test cases for duplicate URL parameters checks."""
-
-    @pytest.mark.parametrize(
-        ("test_case", "url_patterns", "expected_errors", "expected_error_msg"),
-        [
-            (
-                "no_duplicates",
-                [("user/[id]/post/[slug]", "page_file")],
-                0,
-                None,
-            ),
-            (
-                "with_duplicates",
-                [("user/[id]/[id]", "page_file")],
-                1,
-                "duplicate parameter names",
-            ),
-        ],
-        ids=["no_duplicates", "with_duplicates"],
-    )
-    def test_check_duplicate_url_parameters_scenarios(
-        self,
-        tmp_path,
-        test_case,
-        url_patterns,
-        expected_errors,
-        expected_error_msg,
-    ) -> None:
-        """Test check_duplicate_url_parameters with different URL pattern scenarios."""
-        page_file = tmp_path / "page.py"
-        page_file.write_text("")
-
-        with patch_checks_router_manager(
-            pages_directory=tmp_path,
-            scan_routes=[(pattern, page_file) for pattern, _ in url_patterns],
-        ):
-            errors = check_duplicate_url_parameters(None)
-            assert len(errors) == expected_errors
-
-            if expected_errors > 0 and expected_error_msg:
-                assert expected_error_msg in errors[0].msg
-                if "duplicate parameter names" in expected_error_msg:
-                    assert "id" in errors[0].msg
 
 
 class TestContextFunctionsChecks:

--- a/tests/urls/test_backends.py
+++ b/tests/urls/test_backends.py
@@ -303,7 +303,6 @@ class TestFileRouterBackend:
             assert first == ["p1"]
             assert second == first
             assert second is not first
-            # Mutating a returned list must never poison the cache.
             second.append("appended")
             third = router.generate_urls()
         assert third == ["p1"]
@@ -466,11 +465,9 @@ class TestFileRouterBackend:
         """Nested directories produce multiple route entries."""
         router = FileRouterBackend()
 
-        # create a mock directory structure
         root_dir = Path("/tmp/pages")
 
         with patch("pathlib.Path.iterdir") as mock_iterdir:
-            # mock the directory structure
             mock_iterdir.side_effect = [
                 [Mock(name="dir1", is_dir=lambda: True)],
                 [Mock(name="page.py", is_dir=lambda: False)],

--- a/tests/urls/test_backends.py
+++ b/tests/urls/test_backends.py
@@ -290,6 +290,58 @@ class TestFileRouterBackend:
         result = router._get_root_pages_paths()
         assert result == []
 
+    def test_generate_root_urls_cached_across_calls(self, tmp_path) -> None:
+        """A second generate_urls reuses cached root patterns without re-walking."""
+        router = FileRouterBackend(app_dirs=False, extra_root_paths=[tmp_path])
+        with patch.object(
+            router,
+            "_generate_patterns_from_directory",
+            return_value=iter(["p1"]),
+        ) as mock_gen:
+            first = router.generate_urls()
+            second = router.generate_urls()
+            assert first == ["p1"]
+            assert second == first
+            assert second is not first
+            # Mutating a returned list must never poison the cache.
+            second.append("appended")
+            third = router.generate_urls()
+        assert third == ["p1"]
+        mock_gen.assert_called_once()
+
+    def test_subclass_append_does_not_grow_root_cache(self, tmp_path) -> None:
+        """The documented super().generate_urls() + append pattern stays idempotent."""
+
+        class _AppendingRouter(FileRouterBackend):
+            def generate_urls(self):
+                urls = super().generate_urls()
+                urls.append("extra")
+                return urls
+
+        router = _AppendingRouter(app_dirs=False, extra_root_paths=[tmp_path])
+        with patch.object(
+            router,
+            "_generate_patterns_from_directory",
+            return_value=iter(["p1"]),
+        ):
+            first = router.generate_urls()
+            second = router.generate_urls()
+        assert first == ["p1", "extra"]
+        assert second == ["p1", "extra"]
+
+    def test_get_root_pages_paths_memoised_per_instance(self, tmp_path) -> None:
+        """Repeated calls return the cached list without touching the filesystem."""
+        router = FileRouterBackend(extra_root_paths=[tmp_path])
+        first = router._get_root_pages_paths()
+        with (
+            patch.object(Path, "resolve") as mock_resolve,
+            patch.object(Path, "exists") as mock_exists,
+        ):
+            second = router._get_root_pages_paths()
+        assert second is first
+        mock_resolve.assert_not_called()
+        mock_exists.assert_not_called()
+
     def test_generate_urls_includes_root_when_app_dirs_and_extra_roots(
         self, tmp_path
     ) -> None:

--- a/tests/urls/test_checks.py
+++ b/tests/urls/test_checks.py
@@ -229,6 +229,30 @@ class TestCheckReverseNameCollisions:
         assert "foo-bar/page.py" in messages[0].msg
         assert "foo_bar/page.py" in messages[0].msg
 
+    def test_e039_ignores_routes_with_distinct_signatures(self, tmp_path) -> None:
+        """`[year]/[month]` and literal `year/month` share a name, not a signature."""
+        _write_page(tmp_path, "[year]/[month]")
+        _write_page(tmp_path, "year/month")
+        router = _TreeRouter(root_trees=[tmp_path])
+
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            messages = check_reverse_name_collisions(None)
+
+        assert messages == []
+
+    def test_e039_flags_routes_sharing_name_and_signature(self, tmp_path) -> None:
+        """`a/[x]` and `a-[x]` share both the reverse name and the `x` parameter."""
+        _write_page(tmp_path, "a/[x]")
+        _write_page(tmp_path, "a-[x]")
+        router = _TreeRouter(root_trees=[tmp_path])
+
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            messages = check_reverse_name_collisions(None)
+
+        assert len(messages) == 1
+        assert messages[0].id == "next.E039"
+        assert '"page_a_x"' in messages[0].msg
+
     def test_e039_name_uses_custom_url_name_template(self, tmp_path) -> None:
         """The reported name honours `URL_NAME_TEMPLATE` instead of `page_`."""
         _write_page(tmp_path, "foo-bar")

--- a/tests/urls/test_checks.py
+++ b/tests/urls/test_checks.py
@@ -1,0 +1,287 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from django.core.checks import Error
+
+from next.testing import override_next_settings
+from next.urls.checks import (
+    _collect_url_patterns,
+    check_reverse_name_collisions,
+    check_url_patterns,
+)
+from tests.support import patch_checks_router_manager_with_routers
+
+
+def _write_page(tree: Path, route: str) -> Path:
+    directory = tree / route
+    directory.mkdir(parents=True, exist_ok=True)
+    page_file = directory / "page.py"
+    page_file.write_text('template = "ok"\n')
+    return page_file
+
+
+def _write_virtual_page(tree: Path, route: str) -> Path:
+    directory = tree / route
+    directory.mkdir(parents=True, exist_ok=True)
+    template_file = directory / "template.djx"
+    template_file.write_text("<h1>ok</h1>\n")
+    return template_file
+
+
+class _TreeRouter:
+    """Minimal router stub exposing the multi-tree traversal surface."""
+
+    def __init__(
+        self,
+        app_trees: dict[str, Path] | None = None,
+        root_trees: list[Path] | None = None,
+        skip_dir_names: frozenset[str] = frozenset(),
+    ) -> None:
+        """Store app and root pages trees plus the router skip set."""
+        self._app_trees = dict(app_trees or {})
+        self._root_trees = list(root_trees or [])
+        self._skip_dir_names = skip_dir_names
+        self.app_dirs = bool(self._app_trees)
+
+    def _get_installed_apps(self) -> list[str]:
+        return list(self._app_trees)
+
+    def _get_app_pages_path(self, app_name: str) -> Path:
+        return self._app_trees[app_name]
+
+    def _get_root_pages_paths(self) -> list[Path]:
+        return list(self._root_trees)
+
+
+class _BrokenRouter:
+    """Router stub whose tree listing fails with OSError."""
+
+    app_dirs = False
+
+    def _get_root_pages_paths(self) -> list[Path]:
+        msg = "pages roots unavailable"
+        raise OSError(msg)
+
+
+class TestCheckUrlPatterns:
+    """`check_url_patterns` compares Django path strings across all trees."""
+
+    def test_e015_for_equivalent_brackets_across_trees(self, tmp_path) -> None:
+        """`[id]` and `[str:id]` from an app tree and a root tree conflict."""
+        app_tree = tmp_path / "app_pages"
+        root_tree = tmp_path / "root_pages"
+        _write_page(app_tree, "things/[id]")
+        _write_page(root_tree, "things/[str:id]")
+        router = _TreeRouter(app_trees={"shop": app_tree}, root_trees=[root_tree])
+
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            messages = check_url_patterns(None)
+
+        e015 = [m for m in messages if m.id == "next.E015"]
+        assert len(e015) == 1
+        assert '"things/<str:id>/"' in e015[0].msg
+        assert "App 'shop'" in e015[0].msg
+        assert "Root" in e015[0].msg
+
+    def test_virtual_template_page_joins_e015_conflict(self, tmp_path) -> None:
+        """A `template.djx`-only page collides with a real page from another tree."""
+        app_tree = tmp_path / "app_pages"
+        root_tree = tmp_path / "root_pages"
+        _write_virtual_page(app_tree, "about")
+        _write_page(root_tree, "about")
+        router = _TreeRouter(app_trees={"shop": app_tree}, root_trees=[root_tree])
+
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            messages = check_url_patterns(None)
+
+        e015 = [m for m in messages if m.id == "next.E015"]
+        assert len(e015) == 1
+        assert '"about/"' in e015[0].msg
+
+    def test_identical_route_from_two_trees_is_e015_not_e039(self, tmp_path) -> None:
+        """The same route trail in two trees is a path conflict, not a name one."""
+        tree_a = tmp_path / "tree_a"
+        tree_b = tmp_path / "tree_b"
+        _write_page(tree_a, "blog")
+        _write_page(tree_b, "blog")
+        router = _TreeRouter(root_trees=[tree_a, tree_b])
+
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            path_messages = check_url_patterns(None)
+            name_messages = check_reverse_name_collisions(None)
+
+        assert [m.id for m in path_messages] == ["next.E015"]
+        assert name_messages == []
+
+    def test_e028_for_normalised_duplicate_in_one_route(self, tmp_path) -> None:
+        """`[a-b]/[a_b]` collapses to one parameter name and reports the page file."""
+        page_file = _write_page(tmp_path, "[a-b]/[a_b]")
+        router = _TreeRouter(root_trees=[tmp_path])
+
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            messages = check_url_patterns(None)
+
+        e028 = [m for m in messages if m.id == "next.E028"]
+        assert len(e028) == 1
+        assert "duplicate parameter" in e028[0].msg
+        assert "'a_b'" in e028[0].msg
+        assert e028[0].obj == str(page_file)
+
+    def test_no_e028_for_distinct_parameter_names(self, tmp_path) -> None:
+        """Unique parameter names in one route pass the check."""
+        _write_page(tmp_path, "user/[id]/post/[slug]")
+        router = _TreeRouter(root_trees=[tmp_path])
+
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            messages = check_url_patterns(None)
+
+        assert [m.id for m in messages] == []
+
+    def test_e028_for_repeated_param_reports_page_file(self, tmp_path) -> None:
+        """A plain repeated bracket name yields one E028 naming the page file."""
+        page_file = _write_page(tmp_path, "user/[id]/[id]")
+        router = _TreeRouter(root_trees=[tmp_path])
+
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            messages = check_url_patterns(None)
+
+        e028 = [m for m in messages if m.id == "next.E028"]
+        assert len(e028) == 1
+        assert "duplicate parameter" in e028[0].msg
+        assert "'id'" in e028[0].msg
+        assert e028[0].obj == str(page_file)
+
+    def test_e028_message_lists_every_duplicate_name(self, tmp_path) -> None:
+        """Two independent duplicates in one route both land in the message."""
+        page_file = _write_page(tmp_path, "a/[id]/[int:id]/[slug]/[slug]")
+        router = _TreeRouter(root_trees=[tmp_path])
+
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            messages = check_url_patterns(None)
+
+        e028 = [m for m in messages if m.id == "next.E028"]
+        assert len(e028) == 1
+        assert "['id', 'slug']" in e028[0].msg
+        assert e028[0].obj == str(page_file)
+
+    def test_e028_falls_back_to_parser_name_for_distinct_wildcards(
+        self, tmp_path
+    ) -> None:
+        """Two wildcards with distinct names still fail and name the second one."""
+        page_file = _write_page(tmp_path, "[[a]]/[[b]]")
+        router = _TreeRouter(root_trees=[tmp_path])
+
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            messages = check_url_patterns(None)
+
+        e028 = [m for m in messages if m.id == "next.E028"]
+        assert len(e028) == 1
+        assert "['b']" in e028[0].msg
+        assert e028[0].obj == str(page_file)
+
+    def test_e028_reported_once_across_both_url_checks(self, tmp_path) -> None:
+        """A duplicate route yields exactly one E028 over the whole check run."""
+        _write_page(tmp_path, "user/[id]/[id]")
+        router = _TreeRouter(root_trees=[tmp_path])
+
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            messages = [
+                *check_url_patterns(None),
+                *check_reverse_name_collisions(None),
+            ]
+
+        assert [m.id for m in messages] == ["next.E028"]
+
+    def test_components_dirs_are_skipped_via_router_skip_set(self, tmp_path) -> None:
+        """The router skip set keeps `_components` out of the pattern collection."""
+        tree_a = tmp_path / "tree_a"
+        tree_b = tmp_path / "tree_b"
+        _write_page(tree_a, "_components/widget")
+        _write_page(tree_b, "_components/widget")
+
+        unskipped = _TreeRouter(root_trees=[tree_a, tree_b])
+        with patch_checks_router_manager_with_routers(routers=[unskipped]):
+            assert any(m.id == "next.E015" for m in check_url_patterns(None))
+
+        skipped = _TreeRouter(
+            root_trees=[tree_a, tree_b],
+            skip_dir_names=frozenset({"_components"}),
+        )
+        with patch_checks_router_manager_with_routers(routers=[skipped]):
+            assert check_url_patterns(None) == []
+
+
+class TestCheckReverseNameCollisions:
+    """`check_reverse_name_collisions` flags routes sharing one reverse name."""
+
+    def test_e039_lists_both_paths_once(self, tmp_path) -> None:
+        """`foo-bar` and `foo_bar` collapse to one name and yield a single error."""
+        _write_page(tmp_path, "foo-bar")
+        _write_page(tmp_path, "foo_bar")
+        router = _TreeRouter(root_trees=[tmp_path])
+
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            messages = check_reverse_name_collisions(None)
+
+        assert len(messages) == 1
+        assert messages[0].id == "next.E039"
+        assert '"page_foo_bar"' in messages[0].msg
+        assert "foo-bar/page.py" in messages[0].msg
+        assert "foo_bar/page.py" in messages[0].msg
+
+    def test_e039_name_uses_custom_url_name_template(self, tmp_path) -> None:
+        """The reported name honours `URL_NAME_TEMPLATE` instead of `page_`."""
+        _write_page(tmp_path, "foo-bar")
+        _write_page(tmp_path, "foo_bar")
+        router = _TreeRouter(root_trees=[tmp_path])
+
+        with (
+            override_next_settings(URL_NAME_TEMPLATE="next-{name}"),
+            patch_checks_router_manager_with_routers(routers=[router]),
+        ):
+            messages = check_reverse_name_collisions(None)
+
+        assert len(messages) == 1
+        assert '"next-foo_bar"' in messages[0].msg
+        assert "page_foo_bar" not in messages[0].msg
+
+    def test_init_errors_returned_when_manager_missing(self) -> None:
+        """A failed manager initialisation short-circuits into its own errors."""
+        init_error = Error("router manager unavailable", id="next.E007")
+
+        with patch(
+            "next.urls.checks.get_router_manager",
+            return_value=(None, [init_error]),
+        ):
+            messages = check_reverse_name_collisions(None)
+
+        assert messages == [init_error]
+
+    def test_e016_comes_only_from_check_url_patterns(self) -> None:
+        """A collection OSError is one E016 from the path check, not the name one."""
+        with patch_checks_router_manager_with_routers(routers=[_BrokenRouter()]):
+            path_messages = check_url_patterns(None)
+            name_messages = check_reverse_name_collisions(None)
+
+        assert len(path_messages) == 1
+        assert path_messages[0].id == "next.E016"
+        assert "pages roots unavailable" in path_messages[0].msg
+        assert name_messages == []
+
+
+class TestCollectUrlPatterns:
+    """`_collect_url_patterns` tolerates parser failures it cannot attribute."""
+
+    def test_parser_value_error_skips_route_silently(self, tmp_path) -> None:
+        """Plain ValueError from the parser drops the route without an error."""
+        _write_page(tmp_path, "broken")
+        errors: list[Error] = []
+
+        with patch(
+            "next.urls.checks.default_url_parser.parse_url_pattern",
+            side_effect=ValueError("unparsable"),
+        ):
+            patterns = _collect_url_patterns(tmp_path, "Root", errors)
+
+        assert patterns == []
+        assert errors == []

--- a/tests/urls/test_manager.py
+++ b/tests/urls/test_manager.py
@@ -1,9 +1,11 @@
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 from django.test import RequestFactory, override_settings
+from django.urls import include, path
 
 from next.conf import next_framework_settings
 from next.pages import page
@@ -111,13 +113,44 @@ class TestRouterManager:
         """Backend creation failure leaves routers empty but cache is still set."""
         with patch(
             "next.urls.RouterFactory.create_backend",
-            side_effect=Exception("Test error"),
+            side_effect=ValueError("Test error"),
         ):
             manager.reload()
             assert len(manager._backends) == 0
             assert manager._config_cache is not None
             assert len(manager._config_cache) == 1
             assert manager._config_cache[0]["BACKEND"] == "next.urls.FileRouterBackend"
+
+    @pytest.mark.parametrize(
+        "exc_type",
+        [ValueError, TypeError, KeyError, ImportError],
+        ids=["value_error", "type_error", "key_error", "import_error"],
+    )
+    def test_reload_swallows_expected_config_errors(
+        self, manager, caplog, exc_type
+    ) -> None:
+        """Each config-error type from backend creation is logged and swallowed."""
+        with (
+            patch(
+                "next.urls.RouterFactory.create_backend",
+                side_effect=exc_type("boom"),
+            ),
+            caplog.at_level(logging.ERROR, logger="next.urls.manager"),
+        ):
+            manager.reload()
+        assert manager._backends == []
+        assert "error creating router from config" in caplog.text
+
+    def test_reload_propagates_unexpected_errors(self, manager) -> None:
+        """Exceptions outside the config-error set escape reload."""
+        with (
+            patch(
+                "next.urls.RouterFactory.create_backend",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            manager.reload()
 
     def test_get_next_pages_config_uses_cache(self, manager) -> None:
         """Returns cached list when present."""
@@ -152,8 +185,8 @@ class TestGlobalInstances:
         assert router_manager._config_cache is not None
 
     def test_urlpatterns_dynamic(self) -> None:
-        """``urlpatterns`` is a list. Iteration delegates to ``router_manager``."""
-        assert isinstance(urlpatterns, list)
+        """``urlpatterns`` is not a list. Iteration delegates to ``router_manager``."""
+        assert not isinstance(urlpatterns, list)
         assert len(urlpatterns) >= 1
         assert urlpatterns[0] is not None
 
@@ -451,6 +484,59 @@ class TestGlobalInstances:
                 router._url_parser,
             )
             assert pattern is None
+
+
+class TestLazyUrlPatterns:
+    """Sequence protocol and laziness of the module-level ``urlpatterns``."""
+
+    def test_sequence_protocol_without_list_inheritance(self) -> None:
+        """Iteration, len, indexing, slicing, and reversed work without list."""
+        with (
+            patch("next.urls.manager.router_manager", ["r1", "r2"]),
+            patch("next.urls.manager.form_action_manager", ["f1"]),
+        ):
+            assert not isinstance(urlpatterns, list)
+            assert list(urlpatterns) == ["r1", "r2", "f1"]
+            assert len(urlpatterns) == 3
+            assert urlpatterns[0] == "r1"
+            assert urlpatterns[-1] == "f1"
+            assert urlpatterns[1:] == ["r2", "f1"]
+            assert list(reversed(urlpatterns)) == ["f1", "r2", "r1"]
+
+    def test_reversed_override_builds_patterns_once(self) -> None:
+        """Explicit ``__reversed__`` walks one ``_patterns()`` build, not one per index."""
+        assert "__reversed__" in type(urlpatterns).__dict__
+        with patch.object(
+            type(urlpatterns),
+            "_patterns",
+            return_value=["r1", "r2", "f1"],
+        ) as mock_patterns:
+            assert list(reversed(urlpatterns)) == ["f1", "r2", "r1"]
+        assert mock_patterns.call_count == 1
+
+    def test_recomputes_on_each_access(self) -> None:
+        """Concatenation is rebuilt per access, so late form actions appear."""
+        actions = ["f1"]
+        with (
+            patch("next.urls.manager.router_manager", []),
+            patch("next.urls.manager.form_action_manager", actions),
+        ):
+            assert list(urlpatterns) == ["f1"]
+            actions.append("f2")
+            assert list(urlpatterns) == ["f1", "f2"]
+
+    def test_include_defers_materialisation_until_first_resolve(self) -> None:
+        """``include()`` does not iterate patterns, the first resolve does."""
+        with patch.object(
+            RouterManager, "__iter__", return_value=iter([])
+        ) as mock_iter:
+            included = include("next.urls")
+            mock_iter.assert_not_called()
+            resolver = path("lazy/", included)
+            mock_iter.assert_not_called()
+            patterns = resolver.url_patterns
+            mock_iter.assert_called_once()
+        assert patterns is urlpatterns
 
 
 class TestRouterManagerNextPagesConfig:

--- a/tests/urls/test_manager.py
+++ b/tests/urls/test_manager.py
@@ -1,23 +1,49 @@
 import logging
+from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
+from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory, override_settings
-from django.urls import include, path
+from django.urls import Resolver404, URLResolver, include, path
 
 from next.conf import next_framework_settings
+from next.forms import ActionRegistration, RegistryFormActionBackend
+from next.forms.manager import FormActionManager
 from next.pages import page
+from next.testing import override_next_settings
 from next.urls import (
     FileRouterBackend,
     RouterBackend,
     RouterFactory,
     RouterManager,
+    TrieURLResolver,
     router_manager,
     urlpatterns,
 )
+from next.urls.manager import _build_url_resolver, _LazyUrlPatterns
 from tests.support import named_temp_py
+
+
+lazy_urlpatterns = urlpatterns[0].urlconf_name
+
+
+class _StubManager:
+    """Iterable manager stub carrying the `_version` cache token."""
+
+    def __init__(self, items, version=0, on_iter=None) -> None:
+        self.items = list(items)
+        self._version = version
+        self.builds = 0
+        self._on_iter = on_iter
+
+    def __iter__(self) -> Iterator[str]:
+        self.builds += 1
+        if self._on_iter is not None:
+            self._on_iter()
+        return iter(self.items)
 
 
 class TestRouterManager:
@@ -55,7 +81,6 @@ class TestRouterManager:
 
         manager._backends = [mock_router1, mock_router2]
 
-        # __iter__ should return all url patterns combined
         url_patterns = list(manager)
         assert url_patterns == ["url1", "url2", "url3"]
 
@@ -152,6 +177,13 @@ class TestRouterManager:
         ):
             manager.reload()
 
+    def test_reload_bumps_version(self, manager) -> None:
+        """Every reload increments the urlpatterns cache token."""
+        before = manager._version
+        manager.reload()
+        manager.reload()
+        assert manager._version == before + 2
+
     def test_get_next_pages_config_uses_cache(self, manager) -> None:
         """Returns cached list when present."""
         cached_config = ["cached", "config"]
@@ -185,10 +217,11 @@ class TestGlobalInstances:
         assert router_manager._config_cache is not None
 
     def test_urlpatterns_dynamic(self) -> None:
-        """``urlpatterns`` is not a list. Iteration delegates to ``router_manager``."""
-        assert not isinstance(urlpatterns, list)
-        assert len(urlpatterns) >= 1
-        assert urlpatterns[0] is not None
+        """``urlpatterns`` is one TrieURLResolver over the lazy pattern sequence."""
+        assert isinstance(urlpatterns, list)
+        assert len(urlpatterns) == 1
+        assert isinstance(urlpatterns[0], TrieURLResolver)
+        assert isinstance(urlpatterns[0].urlconf_name, _LazyUrlPatterns)
 
         with patch.object(router_manager, "_backends", [Mock()]):
             mock_router = router_manager._backends[0]
@@ -344,7 +377,7 @@ class TestGlobalInstances:
             patch.object(
                 router,
                 "_generate_patterns_from_directory",
-                return_value=iter(["p1", "p2"]),  # generator-like
+                return_value=iter(["p1", "p2"]),
             ),
         ):
             urls = router._generate_root_urls()
@@ -357,7 +390,6 @@ class TestGlobalInstances:
         pages_dir = tmp_path / "testapp" / "pages"
         pages_dir.mkdir(parents=True, exist_ok=True)
 
-        # create nested directories and page.py files
         (pages_dir / "home").mkdir(parents=True, exist_ok=True)
         (pages_dir / "home" / "page.py").write_text(
             "def render(request):\n    return 'home'\n",
@@ -487,56 +519,226 @@ class TestGlobalInstances:
 
 
 class TestLazyUrlPatterns:
-    """Sequence protocol and laziness of the module-level ``urlpatterns``."""
+    """Sequence protocol, laziness, and the versioned concat cache."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_urlpatterns_cache(self):
+        """Keep the module-level concat and trie index caches empty around each test."""
+        lazy_urlpatterns._cache = None
+        urlpatterns[0]._index_cache = None
+        yield
+        lazy_urlpatterns._cache = None
+        urlpatterns[0]._index_cache = None
 
     def test_sequence_protocol_without_list_inheritance(self) -> None:
         """Iteration, len, indexing, slicing, and reversed work without list."""
         with (
-            patch("next.urls.manager.router_manager", ["r1", "r2"]),
-            patch("next.urls.manager.form_action_manager", ["f1"]),
+            patch("next.urls.manager.router_manager", _StubManager(["r1", "r2"])),
+            patch("next.urls.manager.form_action_manager", _StubManager(["f1"])),
         ):
-            assert not isinstance(urlpatterns, list)
-            assert list(urlpatterns) == ["r1", "r2", "f1"]
-            assert len(urlpatterns) == 3
-            assert urlpatterns[0] == "r1"
-            assert urlpatterns[-1] == "f1"
-            assert urlpatterns[1:] == ["r2", "f1"]
-            assert list(reversed(urlpatterns)) == ["f1", "r2", "r1"]
+            lazy = _LazyUrlPatterns()
+            assert not isinstance(lazy, list)
+            assert list(lazy) == ["r1", "r2", "f1"]
+            assert len(lazy) == 3
+            assert lazy[0] == "r1"
+            assert lazy[-1] == "f1"
+            assert lazy[1:] == ["r2", "f1"]
+            assert list(reversed(lazy)) == ["f1", "r2", "r1"]
 
     def test_reversed_override_builds_patterns_once(self) -> None:
         """Explicit ``__reversed__`` walks one ``_patterns()`` build, not one per index."""
-        assert "__reversed__" in type(urlpatterns).__dict__
+        assert "__reversed__" in type(lazy_urlpatterns).__dict__
         with patch.object(
-            type(urlpatterns),
+            type(lazy_urlpatterns),
             "_patterns",
             return_value=["r1", "r2", "f1"],
         ) as mock_patterns:
-            assert list(reversed(urlpatterns)) == ["f1", "r2", "r1"]
+            assert list(reversed(lazy_urlpatterns)) == ["f1", "r2", "r1"]
         assert mock_patterns.call_count == 1
 
-    def test_recomputes_on_each_access(self) -> None:
-        """Concatenation is rebuilt per access, so late form actions appear."""
-        actions = ["f1"]
+    def test_cache_hit_builds_once(self) -> None:
+        """Two accesses with stable versions expand the routers once."""
+        with patch.object(
+            RouterManager,
+            "__iter__",
+            side_effect=lambda *_args: iter([]),
+        ) as mock_iter:
+            first = list(lazy_urlpatterns)
+            second = list(lazy_urlpatterns)
+        assert mock_iter.call_count == 1
+        assert second == first
+
+    def test_invalidated_by_router_reload(self) -> None:
+        """`router_manager.reload()` bumps the version and forces a rebuild."""
+        with patch.object(
+            RouterManager,
+            "__iter__",
+            side_effect=lambda *_args: iter([]),
+        ) as mock_iter:
+            list(lazy_urlpatterns)
+            router_manager.reload()
+            list(lazy_urlpatterns)
+        assert mock_iter.call_count == 2
+
+    def test_late_action_appears_after_forms_version_bump(self) -> None:
+        """A bumped forms version rebuilds the concat, so late actions appear."""
+        router = _StubManager([])
+        forms = _StubManager(["f1"])
         with (
-            patch("next.urls.manager.router_manager", []),
-            patch("next.urls.manager.form_action_manager", actions),
+            patch("next.urls.manager.router_manager", router),
+            patch("next.urls.manager.form_action_manager", forms),
         ):
-            assert list(urlpatterns) == ["f1"]
-            actions.append("f2")
-            assert list(urlpatterns) == ["f1", "f2"]
+            lazy = _LazyUrlPatterns()
+            assert list(lazy) == ["f1"]
+            assert list(lazy) == ["f1"]
+            assert forms.builds == 1
+            forms.items.append("f2")
+            forms._version += 1
+            assert list(lazy) == ["f1", "f2"]
+            assert forms.builds == 2
+
+    def test_invalidated_by_register_action(self) -> None:
+        """`FormActionManager.register_action` invalidates the cached concat."""
+        router = _StubManager(["r1"])
+        forms = FormActionManager(backends=[RegistryFormActionBackend()])
+        with (
+            patch("next.urls.manager.router_manager", router),
+            patch("next.urls.manager.form_action_manager", forms),
+        ):
+            lazy = _LazyUrlPatterns()
+            list(lazy)
+            list(lazy)
+            assert router.builds == 1
+            forms.register_action(
+                ActionRegistration(
+                    name="late_lazy_action",
+                    file_path="/fake/app/forms.py",
+                    scope="shared",
+                    handler=lambda: None,
+                )
+            )
+            list(lazy)
+            assert router.builds == 2
+
+    def test_invalidated_by_clear_registries(self) -> None:
+        """`FormActionManager.clear_registries` invalidates the cached concat."""
+        router = _StubManager(["r1"])
+        forms = FormActionManager(backends=[RegistryFormActionBackend()])
+        with (
+            patch("next.urls.manager.router_manager", router),
+            patch("next.urls.manager.form_action_manager", forms),
+        ):
+            lazy = _LazyUrlPatterns()
+            list(lazy)
+            assert router.builds == 1
+            forms.clear_registries()
+            list(lazy)
+            assert router.builds == 2
+
+    def test_registration_during_build_keeps_cache_valid(self) -> None:
+        """Actions registered while pages expand do not stale the cache."""
+        forms = _StubManager(["f1"])
+
+        def register_during_expand() -> None:
+            forms.items = ["f1", "f2"]
+            forms._version += 1
+
+        router = _StubManager(["r1"], on_iter=register_during_expand)
+        with (
+            patch("next.urls.manager.router_manager", router),
+            patch("next.urls.manager.form_action_manager", forms),
+        ):
+            lazy = _LazyUrlPatterns()
+            assert list(lazy) == ["r1", "f1", "f2"]
+            assert list(lazy) == ["r1", "f1", "f2"]
+            assert router.builds == 1
+            assert forms.builds == 1
+
+    def test_sequence_reads_share_one_cached_build(self) -> None:
+        """reversed, len, indexing, and slicing all read the cached concat."""
+        router = _StubManager(["r1", "r2"])
+        forms = _StubManager(["f1"])
+        with (
+            patch("next.urls.manager.router_manager", router),
+            patch("next.urls.manager.form_action_manager", forms),
+        ):
+            lazy = _LazyUrlPatterns()
+            assert list(reversed(lazy)) == ["f1", "r2", "r1"]
+            assert len(lazy) == 3
+            assert lazy[0] == "r1"
+            assert lazy[1:] == ["r2", "f1"]
+            assert list(lazy) == ["r1", "r2", "f1"]
+            assert router.builds == 1
+            assert forms.builds == 1
 
     def test_include_defers_materialisation_until_first_resolve(self) -> None:
         """``include()`` does not iterate patterns, the first resolve does."""
         with patch.object(
-            RouterManager, "__iter__", return_value=iter([])
+            RouterManager,
+            "__iter__",
+            side_effect=lambda *_args: iter([]),
         ) as mock_iter:
             included = include("next.urls")
             mock_iter.assert_not_called()
             resolver = path("lazy/", included)
             mock_iter.assert_not_called()
             patterns = resolver.url_patterns
+            mock_iter.assert_not_called()
+            with pytest.raises(Resolver404):
+                resolver.resolve("lazy/miss/")
             mock_iter.assert_called_once()
         assert patterns is urlpatterns
+
+
+class TestBuildUrlResolver:
+    """The URL_RESOLVER factory behind urlpatterns[0]."""
+
+    def test_default_short_circuits_the_import_helper(self) -> None:
+        """The default dotted path binds TrieURLResolver without importing."""
+        with patch("next.urls.manager.import_class_cached") as import_helper:
+            resolver = _build_url_resolver()
+        import_helper.assert_not_called()
+        assert type(resolver) is TrieURLResolver
+        assert isinstance(resolver.urlconf_name, _LazyUrlPatterns)
+
+    def test_explicit_default_string_override_builds_trie_resolver(self) -> None:
+        """A user override naming the default class still yields the trie."""
+        with override_next_settings(URL_RESOLVER="next.urls.TrieURLResolver"):
+            assert type(urlpatterns[0]) is TrieURLResolver
+
+    def test_invalid_dotted_path_raises_improperly_configured(self) -> None:
+        """An unimportable dotted path fails loudly at build time."""
+        mock_nf = SimpleNamespace(URL_RESOLVER="no_such_module_zzz.Resolver")
+        with (
+            patch("next.urls.manager.next_framework_settings", mock_nf),
+            pytest.raises(ImproperlyConfigured, match="could not be imported"),
+        ):
+            _build_url_resolver()
+
+    @pytest.mark.parametrize(
+        "dotted",
+        ["next.urls.RouterManager", "next.urls.manager.urlpatterns"],
+        ids=["class_not_a_resolver", "not_a_class"],
+    )
+    def test_non_resolver_target_raises_improperly_configured(self, dotted) -> None:
+        """Importable targets outside URLResolver subclasses are rejected."""
+        mock_nf = SimpleNamespace(URL_RESOLVER=dotted)
+        with (
+            patch("next.urls.manager.next_framework_settings", mock_nf),
+            pytest.raises(ImproperlyConfigured, match="URLResolver subclass"),
+        ):
+            _build_url_resolver()
+
+    def test_settings_reload_swaps_urlpatterns_head_in_place(self) -> None:
+        """A reload replaces urlpatterns[0] while the list keeps its identity."""
+        head_before = urlpatterns[0]
+        with override_next_settings(URL_RESOLVER="django.urls.resolvers.URLResolver"):
+            head_during = urlpatterns[0]
+            assert head_during is not head_before
+            assert type(head_during) is URLResolver
+            assert not isinstance(head_during, TrieURLResolver)
+            assert isinstance(head_during.urlconf_name, _LazyUrlPatterns)
+        assert type(urlpatterns[0]) is TrieURLResolver
 
 
 class TestRouterManagerNextPagesConfig:

--- a/tests/urls/test_parser.py
+++ b/tests/urls/test_parser.py
@@ -1,0 +1,199 @@
+from pathlib import Path
+
+import pytest
+
+from next.urls import DuplicateURLParameterError, URLPatternParser
+
+
+class TestParseUrlPatternHappyPath:
+    """Single-pass bracket conversion keeps the pre-callback behaviour."""
+
+    @pytest.mark.parametrize(
+        ("url_path", "expected_pattern", "expected_params"),
+        [
+            ("", "", {}),
+            ("about", "about/", {}),
+            ("about/", "about/", {}),
+            ("user/[name]", "user/<str:name>/", {"name": "name"}),
+            ("user/[int:id]", "user/<int:id>/", {"id": "id"}),
+            (
+                "post/[slug:post-slug]",
+                "post/<slug:post_slug>/",
+                {"post_slug": "post_slug"},
+            ),
+            ("item/[uuid:pk]", "item/<uuid:pk>/", {"pk": "pk"}),
+            ("files/[[args]]", "files/<path:args>/", {"args": "args"}),
+            ("files/[[args]]/", "files/<path:args>/", {"args": "args"}),
+            (
+                "docs/[[doc-path]]",
+                "docs/<path:doc_path>/",
+                {"doc_path": "doc_path"},
+            ),
+            (
+                "user/[int:id]/files/[[rest]]",
+                "user/<int:id>/files/<path:rest>/",
+                {"id": "id", "rest": "rest"},
+            ),
+        ],
+        ids=[
+            "empty",
+            "plain",
+            "plain_trailing_slash",
+            "str_param",
+            "int_param",
+            "slug_param_hyphen",
+            "uuid_param",
+            "single_wildcard",
+            "wildcard_trailing_slash",
+            "wildcard_hyphen",
+            "param_then_wildcard",
+        ],
+    )
+    def test_parse_url_pattern(
+        self,
+        url_parser,
+        url_path,
+        expected_pattern,
+        expected_params,
+    ) -> None:
+        """Each converter kind maps to its Django path syntax unchanged."""
+        pattern, params = url_parser.parse_url_pattern(url_path)
+        assert pattern == expected_pattern
+        assert params == expected_params
+
+    def test_prepare_url_name_is_injective_on_happy_paths(self, url_parser) -> None:
+        """Distinct routable paths keep distinct reverse names."""
+        url_paths = [
+            "simple",
+            "user/[id]",
+            "user/[int:id]",
+            "user/[int:id]/posts",
+            "post/[slug:post-slug]",
+            "profile/[[args]]",
+        ]
+        names = [url_parser.prepare_url_name(url_path) for url_path in url_paths]
+        assert len(set(names)) == len(names)
+
+
+class TestParseUrlPatternDuplicates:
+    """Conflicting bracket names fail at pattern build time."""
+
+    @pytest.mark.parametrize(
+        ("url_path", "expected_param_name"),
+        [
+            ("a/[[x]]/b/[[y]]", "y"),
+            ("[[a]]/[[b]]", "b"),
+            ("[a-b]/[a_b]", "a_b"),
+            ("[x]/[int:x]", "x"),
+            ("[[x]]/[x]", "x"),
+            ("[x]/[[x]]", "x"),
+        ],
+        ids=[
+            "second_wildcard_apart",
+            "second_wildcard_adjacent",
+            "hyphen_underscore_collision",
+            "repeated_param",
+            "wildcard_then_param",
+            "param_then_wildcard",
+        ],
+    )
+    def test_duplicate_names_raise(
+        self,
+        url_parser,
+        url_path,
+        expected_param_name,
+    ) -> None:
+        """Any repeat of a normalised name, wildcard included, raises."""
+        with pytest.raises(DuplicateURLParameterError) as excinfo:
+            url_parser.parse_url_pattern(url_path)
+        error = excinfo.value
+        assert error.param_name == expected_param_name
+        assert error.url_path == url_path
+        assert error.file_path is None
+        assert expected_param_name in str(error)
+        assert url_path in str(error)
+        assert "Page file" not in str(error)
+
+
+class TestDuplicateParameterNames:
+    """`duplicate_parameter_names` lists every repeated normalised name."""
+
+    @pytest.mark.parametrize(
+        ("url_path", "expected"),
+        [
+            ("a/[id]/[int:id]/[slug]/[slug]", ["id", "slug"]),
+            ("[user-id]/[user_id]", ["user_id"]),
+            ("[[x]]/[x]", ["x"]),
+            ("[x]/[[x]]", ["x"]),
+            ("[[a]]/[[b]]", []),
+            ("user/[id]/post/[slug]", []),
+            ("[x]/[x]/[x]", ["x"]),
+        ],
+        ids=[
+            "two_independent_duplicates",
+            "dash_underscore_collision",
+            "wildcard_then_param",
+            "param_then_wildcard",
+            "distinct_wildcards_are_clean",
+            "no_duplicates",
+            "triple_repeat_listed_once",
+        ],
+    )
+    def test_duplicate_parameter_names(self, url_parser, url_path, expected) -> None:
+        """Duplicates appear once each, in first-repeat order, wild and param alike."""
+        assert url_parser.duplicate_parameter_names(url_path) == expected
+
+
+class TestDuplicateURLParameterError:
+    """Error attributes and optional file context."""
+
+    def test_is_value_error(self) -> None:
+        """The error stays catchable as ValueError for older call sites."""
+        error = DuplicateURLParameterError("x", "[x]/[x]")
+        assert isinstance(error, ValueError)
+
+    def test_message_includes_file_path_when_given(self) -> None:
+        """A known page file lands in the message tail."""
+        file_path = Path("/pages/dup/page.py")
+        error = DuplicateURLParameterError("x", "[x]/[x]", file_path=file_path)
+        assert error.file_path == file_path
+        assert "Page file: /pages/dup/page.py." in str(error)
+
+    def test_classvar_points_at_public_error(self) -> None:
+        """Parser exposes the error class for import-cycle-free callers."""
+        assert URLPatternParser.duplicate_parameter_error is DuplicateURLParameterError
+
+
+class TestCreateUrlPatternFileContext:
+    """Page.create_url_pattern re-raises with the page file attached."""
+
+    def test_reraises_with_file_path(self, page_instance, url_parser, tmp_path) -> None:
+        """The wrapped error names the page file and chains the original."""
+        page_file = tmp_path / "page.py"
+        with pytest.raises(DuplicateURLParameterError) as excinfo:
+            page_instance.create_url_pattern("[a-b]/[a_b]", page_file, url_parser)
+        error = excinfo.value
+        assert error.param_name == "a_b"
+        assert error.url_path == "[a-b]/[a_b]"
+        assert error.file_path == page_file
+        assert str(page_file) in str(error)
+        assert isinstance(error.__cause__, DuplicateURLParameterError)
+        assert error.__cause__.file_path is None
+
+
+class TestGeneratePatternsFileContext:
+    """FileRouterBackend re-raises scan failures with the page file attached."""
+
+    def test_keeps_file_path_from_create_url_pattern(self, router, tmp_path) -> None:
+        """A real duplicate-wildcard tree reports the discovered page.py."""
+        page_dir = tmp_path / "[[x]]" / "[[y]]"
+        page_dir.mkdir(parents=True)
+        page_file = page_dir / "page.py"
+        page_file.write_text("def render(request, **kwargs):\n    return 'ok'\n")
+
+        with pytest.raises(DuplicateURLParameterError) as excinfo:
+            list(router._generate_patterns_from_directory(tmp_path))
+        error = excinfo.value
+        assert error.param_name == "y"
+        assert error.file_path == page_file
+        assert str(page_file) in str(error)

--- a/tests/urls/test_resolver.py
+++ b/tests/urls/test_resolver.py
@@ -1,0 +1,304 @@
+import uuid
+from pathlib import Path
+
+import pytest
+from django.http import HttpResponse
+from django.test import override_settings
+from django.urls import Resolver404, URLResolver, include, path, re_path, reverse
+from django.urls.resolvers import RoutePattern
+
+from next.forms.uid import URL_NAME_FORM_ACTION
+from next.testing import override_form_action, override_next_settings
+from next.urls import TrieURLResolver, page_reverse, router_manager
+from next.urls.manager import urlpatterns
+from tests.support import default_page_router_config
+
+
+_TREE_ROUTES = (
+    "",
+    "home",
+    "blog/2024/post",
+    "items/[int:id]",
+    "tag/[slug:tag]",
+    "u/[uuid:uid]",
+    "name/[username]",
+    "files/[[rest]]",
+    "docs/[[chapter]]/end",
+    "articles/latest",
+    "articles/[slug:topic]",
+    "num/[int:x]",
+    "num/[str:x]",
+)
+
+_RESOLVE_CASES = (
+    ("", "page_", {}),
+    ("home/", "page_home", {}),
+    ("blog/2024/post/", "page_blog_2024_post", {}),
+    ("items/9/", "page_items_int_id", {"id": 9}),
+    ("tag/hello-world/", "page_tag_slug_tag", {"tag": "hello-world"}),
+    (
+        "u/8dbe9c25-6e30-4cc9-9898-52dc697b4bd6/",
+        "page_u_uuid_uid",
+        {"uid": uuid.UUID("8dbe9c25-6e30-4cc9-9898-52dc697b4bd6")},
+    ),
+    ("name/mia/", "page_name_username", {"username": "mia"}),
+    ("num/abc/", "page_num_str_x", {"x": "abc"}),
+    ("files/a/b/c.txt/", "page_files_rest", {"rest": "a/b/c.txt"}),
+    ("docs/x/y/end/", "page_docs_chapter_end", {"chapter": "x/y"}),
+)
+
+_RESOLVE_CASE_IDS = (
+    "root",
+    "static",
+    "static_nested",
+    "int_param",
+    "slug_param",
+    "uuid_param",
+    "default_str_param",
+    "int_rejects_nonnumeric",
+    "path_tail_with_slashes",
+    "path_in_route_middle",
+)
+
+# Overlap winners depend on filesystem registration order, so they are
+# asserted against the linear scan instead of a pinned route.
+_OVERLAP_PATHS = ("articles/latest/", "articles/other/", "num/7/")
+
+_PARITY_FIELDS = (
+    "func",
+    "args",
+    "kwargs",
+    "url_name",
+    "route",
+    "namespaces",
+    "app_names",
+    "captured_kwargs",
+)
+
+
+def _write_page(tree: Path, route: str) -> None:
+    directory = tree / route
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "page.py").write_text('template = "ok"\n')
+
+
+def _plain_view(_request, **_kwargs: object) -> HttpResponse:
+    return HttpResponse(b"plain")
+
+
+def _other_view(_request, **_kwargs: object) -> HttpResponse:
+    return HttpResponse(b"other")
+
+
+def _late_handler() -> None:
+    return None
+
+
+def _tried_pattern_strings(exc_info) -> set[str]:
+    tried = exc_info.value.args[0]["tried"]
+    return {str(pattern.pattern) for entry in tried for pattern in entry}
+
+
+@pytest.fixture()
+def page_tree(tmp_path):
+    """Real page tree on disk wired as the only PAGE_BACKENDS source."""
+    for route in _TREE_ROUTES:
+        _write_page(tmp_path, route)
+    with override_next_settings(PAGE_BACKENDS=default_page_router_config(tmp_path)):
+        yield tmp_path
+
+
+class TestResolveAgainstPageTree:
+    """Trie and linear resolution over a real filesystem page tree."""
+
+    @pytest.mark.parametrize(
+        "resolver_path",
+        ["next.urls.TrieURLResolver", "django.urls.resolvers.URLResolver"],
+        ids=["trie", "linear"],
+    )
+    @pytest.mark.parametrize(
+        ("url", "expected_name", "expected_kwargs"),
+        _RESOLVE_CASES,
+        ids=_RESOLVE_CASE_IDS,
+    )
+    def test_resolves_expected_match_in_both_modes(
+        self, page_tree, resolver_path, url, expected_name, expected_kwargs
+    ) -> None:
+        """Both configured resolver classes produce the expected page match."""
+        with override_next_settings(URL_RESOLVER=resolver_path):
+            match = urlpatterns[0].resolve(url)
+        assert match.url_name == expected_name
+        assert match.kwargs == expected_kwargs
+
+    @pytest.mark.parametrize(
+        "url",
+        [case[0] for case in _RESOLVE_CASES] + list(_OVERLAP_PATHS),
+        ids=[*_RESOLVE_CASE_IDS, "literal_vs_param", "param_sibling", "int_vs_str"],
+    )
+    def test_trie_match_is_identical_to_linear_scan(self, page_tree, url) -> None:
+        """Every ResolverMatch field matches the inherited linear resolve."""
+        resolver = urlpatterns[0]
+        fast = resolver.resolve(url)
+        linear = URLResolver.resolve(resolver, url)
+        for field in _PARITY_FIELDS:
+            assert getattr(fast, field) == getattr(linear, field), field
+
+    @pytest.mark.parametrize(
+        "url",
+        ["missing/", "num/wrong/extra/", "files/", "num//"],
+        ids=["unknown", "extra_segment", "empty_path_tail", "empty_param_segment"],
+    )
+    def test_miss_raises_resolver404_with_vanilla_tried(self, page_tree, url) -> None:
+        """A trie miss raises the canonical Resolver404 with the full tried list."""
+        resolver = urlpatterns[0]
+        with pytest.raises(Resolver404) as fast_exc:
+            resolver.resolve(url)
+        with pytest.raises(Resolver404) as linear_exc:
+            URLResolver.resolve(resolver, url)
+        fast_tried = _tried_pattern_strings(fast_exc)
+        assert fast_tried
+        assert fast_tried == _tried_pattern_strings(linear_exc)
+
+    def test_linear_opt_out_installs_plain_django_resolver(self, page_tree) -> None:
+        """The Django resolver dotted path swaps in a resolver with no trie index."""
+        with override_next_settings(URL_RESOLVER="django.urls.resolvers.URLResolver"):
+            resolver = urlpatterns[0]
+            assert type(resolver) is URLResolver
+            assert not hasattr(resolver, "_route_index")
+            linear_match = resolver.resolve("home/")
+        assert linear_match.url_name == "page_home"
+        trie_match = urlpatterns[0].resolve("home/")
+        assert trie_match.url_name == linear_match.url_name
+        assert trie_match.kwargs == linear_match.kwargs
+
+    def test_index_rebuilt_after_router_reload(self, page_tree) -> None:
+        """A route added on disk resolves after router_manager.reload()."""
+        resolver = urlpatterns[0]
+        with pytest.raises(Resolver404):
+            resolver.resolve("fresh/")
+        _write_page(page_tree, "fresh")
+        router_manager.reload()
+        assert resolver.resolve("fresh/").url_name == "page_fresh"
+
+    def test_late_action_registration_resolves_without_restart(self, page_tree) -> None:
+        """A form action registered after the first resolve gets its URL."""
+        resolver = urlpatterns[0]
+        resolver.resolve("home/")
+        with override_form_action("late_trie_probe", _late_handler):
+            match = resolver.resolve("_next/form/some-uid/")
+        assert match.url_name == URL_NAME_FORM_ACTION
+        assert match.kwargs == {"uid": "some-uid"}
+
+    def test_index_cache_is_reused_while_versions_are_stable(self, page_tree) -> None:
+        """Two resolves without a version change share one built index."""
+        resolver = urlpatterns[0]
+        resolver.resolve("home/")
+        cached = resolver._index_cache
+        assert cached is not None
+        resolver.resolve("items/3/")
+        assert resolver._index_cache is cached
+
+
+class TestReverseOverTrieUrlpatterns:
+    """reverse() and page_reverse() on top of the resolver-wrapped urlpatterns."""
+
+    def test_namespaced_reverse(self, page_tree) -> None:
+        """The `next` namespace reverses through the TrieURLResolver."""
+        url = reverse("next:page_home", urlconf="tests.urls.urls_namespaced")
+        assert url == "/home/"
+
+    def test_page_reverse_and_kwargs(self, page_tree) -> None:
+        """page_reverse builds page URLs from route templates."""
+        with override_settings(ROOT_URLCONF="tests.urls.urls_namespaced"):
+            assert page_reverse("home") == "/home/"
+            assert page_reverse("items/[int:id]", id=3) == "/items/3/"
+
+
+class TestTrieOverPlainPatternList:
+    """TrieURLResolver over an explicit list without a version token."""
+
+    def test_constant_token_builds_index_once(self) -> None:
+        patterns = [
+            path("one/", _plain_view, name="one"),
+            path("p/<val>/", _plain_view, name="typed"),
+        ]
+        resolver = TrieURLResolver(RoutePattern(""), patterns)
+        assert resolver._current_token() == (0, 0)
+        first = resolver.resolve("one/")
+        cached = resolver._index_cache
+        second = resolver.resolve("p/x/")
+        assert resolver._index_cache is cached
+        assert first.url_name == "one"
+        assert second.kwargs == {"val": "x"}
+
+    def test_stale_appended_pattern_found_via_fallback(self) -> None:
+        patterns = [path("one/", _plain_view, name="one")]
+        resolver = TrieURLResolver(RoutePattern(""), patterns)
+        resolver.resolve("one/")
+        cached = resolver._index_cache
+        patterns.append(path("late/", _plain_view, name="late"))
+        match = resolver.resolve("late/")
+        assert match.url_name == "late"
+        assert resolver._index_cache is cached
+
+    def test_unindexed_re_path_competes_at_its_original_index(self) -> None:
+        patterns = [
+            re_path(r"^rx/(?P<num>[0-9]+)/$", _plain_view, name="regex_first"),
+            path("rx/<int:num>/", _other_view, name="path_second"),
+        ]
+        resolver = TrieURLResolver(RoutePattern(""), patterns)
+        match = resolver.resolve("rx/5/")
+        assert match.url_name == "regex_first"
+        assert match.kwargs == {"num": "5"}
+
+    @pytest.mark.parametrize(
+        "literal_first", [True, False], ids=["literal_first", "param_first"]
+    )
+    def test_literal_vs_param_sibling_first_index_wins(self, literal_first) -> None:
+        literal = path("box/new/", _plain_view, name="literal")
+        param = path("box/<str:item>/", _other_view, name="param")
+        patterns = [literal, param] if literal_first else [param, literal]
+        resolver = TrieURLResolver(RoutePattern(""), patterns)
+        match = resolver.resolve("box/new/")
+        assert match.url_name == ("literal" if literal_first else "param")
+        assert match.url_name == URLResolver.resolve(resolver, "box/new/").url_name
+
+    @pytest.mark.parametrize("int_first", [True, False], ids=["int_first", "str_first"])
+    def test_int_vs_str_param_on_the_same_path(self, int_first) -> None:
+        int_pattern = path("v/<int:x>/", _plain_view, name="int")
+        str_pattern = path("v/<str:x>/", _other_view, name="str")
+        patterns = (
+            [int_pattern, str_pattern] if int_first else [str_pattern, int_pattern]
+        )
+        resolver = TrieURLResolver(RoutePattern(""), patterns)
+        assert resolver.resolve("v/7/").url_name == ("int" if int_first else "str")
+        assert resolver.resolve("v/word/").url_name == "str"
+
+    def test_nested_resolver_candidate_joins_route_and_namespaces(self) -> None:
+        sub = [path("a/<int:n>/", _plain_view, name="sub_a")]
+        patterns = [path("inc/", include((sub, "subapp"), namespace="subns"))]
+        resolver = TrieURLResolver(RoutePattern(""), patterns)
+        fast = resolver.resolve("inc/a/5/")
+        linear = URLResolver.resolve(resolver, "inc/a/5/")
+        assert fast.url_name == "sub_a"
+        assert fast.route == "inc/a/<int:n>/"
+        assert fast.app_names == ["subapp"]
+        assert fast.namespaces == ["subns"]
+        for field in _PARITY_FIELDS:
+            assert getattr(fast, field) == getattr(linear, field), field
+
+    def test_nested_resolver_miss_falls_through_to_super(self) -> None:
+        sub = [path("a/", _plain_view, name="sub_a")]
+        patterns = [path("inc/", include((sub, "subapp")))]
+        resolver = TrieURLResolver(RoutePattern(""), patterns)
+        with pytest.raises(Resolver404) as exc:
+            resolver.resolve("inc/missing/")
+        assert any(len(entry) == 2 for entry in exc.value.args[0]["tried"])
+
+    def test_prefix_pattern_mismatch_falls_back_to_super(self) -> None:
+        resolver = TrieURLResolver(
+            RoutePattern("api/"), [path("x/", _plain_view, name="x")]
+        )
+        assert resolver.resolve("api/x/").url_name == "x"
+        with pytest.raises(Resolver404):
+            resolver.resolve("other/x/")

--- a/tests/urls/urls_namespaced.py
+++ b/tests/urls/urls_namespaced.py
@@ -1,0 +1,6 @@
+from django.urls import include, path
+
+
+urlpatterns = [
+    path("", include("next.urls")),
+]


### PR DESCRIPTION
## Description

Fixes three real routing bugs in `next/urls`, removes long-standing footguns, and makes URL resolution faster than vanilla Django with a trie-based resolver.

**Parser.** `parse_url_pattern` is rewritten as a single `re.sub` callback over a combined bracket pattern. Previously two separate passes silently corrupted input: a second `[[wildcard]]` inherited the first one's converter name, and `[a-b]`/`[a_b]` collapsed into one kwarg after hyphen normalisation — both produced patterns that only blew up at first resolve. Now a repeated normalised name or a second wildcard raises the new public `DuplicateURLParameterError` (a `ValueError` exported from `next.urls`) at URLconf build time, carrying the parameter name, the source `url_path` and the page file path. New `URLPatternParser.duplicate_parameter_names()` lists every conflicting name for diagnostics.

**System checks.** The second, divergent bracket-conversion implementation (`_convert_to_django_pattern`) is deleted — checks convert through `default_url_parser.parse_url_pattern`, the same source as the router. Check traversal uses `scan_pages_tree` with the router's skip set instead of `rglob("page.py")`, so virtual `template.djx`-only pages participate in conflict detection and `_components` trees no longer produce phantom routes. `next.E028` has a single owner: `check_url_patterns` walks every tree (apps + all root DIRS) and lists all conflicting names in one message, `check_duplicate_url_parameters` is removed. New `check_reverse_name_collisions` (`next.E039`, Error): two distinct routes collapsing to one reverse name (`foo-bar`/`foo_bar`/`foo/bar`) now fail `manage.py check` instead of `reverse()` silently picking the last registered route. Both checks share one collection helper, `next.E016` is reported once.

**Lazy urlpatterns.** `_LazyUrlPatterns` no longer subclasses `list`: the inherited dead buffer made `urlpatterns += [...]` silently vanish, and the `isinstance` guard in Django's `include()` eagerly materialised the whole tree at import time — `include("next.urls")` now defers materialisation to the first resolve. An explicit `__reversed__` keeps the resolver's reverse walk to a single list build. The router/form-action concat is cached against a pair of version counters bumped on router reload and form-action registration — a cache hit costs two int comparisons (~90 ns) instead of a full O(n) rebuild (~6 µs at 250 routes) on every resolve, and late-registered actions still appear immediately. Versions are read after the build, so actions registered while page modules import cannot stale the cache.

**Trie resolver — faster than vanilla Django.** New `TrieURLResolver` (`next/urls/resolver.py`, a `django.urls.resolvers.URLResolver` subclass) replaces Django's linear per-request pattern scan: static routes resolve via a dict lookup, parameterised routes via a segment-trie DFS (literal edges first, then param edges, then `<path:>` tails), and candidates are confirmed with the stock `pattern.resolve()` in original list order — Django's first-match-wins semantics, converters and `ResolverMatch` fields are preserved bit for bit. A miss falls back to the linear scan for the canonical `Resolver404` with a full `tried` list, which also covers unindexable patterns such as `re_path`. The index is versioned by the same counters and rebuilds atomically on reload. Result: resolution cost is flat (~3-7 µs regardless of route position or site size) versus Django's linear growth — 5.4x faster than vanilla on the last of 250 routes, ~17x at 1000 routes, with parity on misses. The new `urls.resolver` benchmark group pins trie vs linear on the same 123-route tree (4.5-6.3x on hits) in every `make bench` run.

**Resolver configuration.** No feature flag: the optimal resolver is always the default. `NEXT_FRAMEWORK["URL_RESOLVER"]` takes a dotted path in the backend-override style, defaulting to `"next.urls.TrieURLResolver"`. Opting out is just `"URL_RESOLVER": "django.urls.resolvers.URLResolver"` — the stock class with the same constructor signature gives the linear scan, and any custom `URLResolver` subclass works. An invalid path or a non-subclass raises `ImproperlyConfigured` at startup, and a settings reload swaps the resolver in place without a restart. No settings read remains on the hot path.

**Backend hygiene.** `FileRouterBackend` caches root-branch patterns and resolved root paths (the app branch was already cached), ending the re-walk of DIRS roots on every resolve, and `generate_urls()` returns a copy so the documented subclass pattern (`super().generate_urls()` + append) cannot poison the cache. `RouterManager.reload` swallows only `(ValueError, TypeError, KeyError, ImportError)` from backend construction — anything else, including `ImproperlyConfigured` from a custom backend, now fails startup loudly. `FilesystemTreeDispatcher._visit` detects pages in one pass instead of post-loop `exists()` stats.

**Breaking changes (0.x):** `parse_url_pattern` raises `DuplicateURLParameterError` on already-broken configs. `next.urls.urlpatterns` is now a list holding a single `TrieURLResolver` (was a `list` subclass) — `include("next.urls")` users are unaffected. `check_duplicate_url_parameters` and the private `_convert_to_django_pattern` are removed. New `next.E039` is an Error from day one. Unexpected exceptions from custom backend constructors propagate out of `RouterManager.reload`. Form actions registered directly on a backend, bypassing `form_action_manager`, are not tracked by the version counters (never supported, now explicit).

## How to test

`make ci` — the full suite passes locally: 2978 tests, 100% coverage on `next/` (including `next/urls/resolver.py` 119/119), mypy strict, ruff clean, `make docs` (`-W`) green, `make bench` (`median:99%`) green with the new `urls.resolver` benchmark group comparing trie vs linear on one tree. Correctness of the trie is pinned by a parity suite: identical `func`/`args`/`kwargs`/`url_name`/`route`/`namespaces`/`app_names`/`captured_kwargs` against the linear scan across static, typed-converter, `[[path]]`-tail and overlapping routes, identical `tried` composition on 404, plus first positive E015 tests (cross-tree conflicts, virtual pages), E028 across trees with full name lists, E039 with a custom `URL_NAME_TEMPLATE`, `include()` laziness, cache-poisoning and stale-fallback regressions.

## Related issues

<!-- none -->

## Checklist

- [x] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [ ] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable
