### PR TITLE
feat(checks): shared  tag, per-run caches, registry context check

### DIFF
--- a/docs/content/faq/troubleshooting.rst
+++ b/docs/content/faq/troubleshooting.rst
@@ -51,10 +51,7 @@ next.E029 on a Keyless Context Function
 
 A keyless context callable must be annotated as returning a dict.
 Keyless means the decorator carries no key, whether written as ``@context``, ``@page.context``, an aliased import, or an ``async def`` context function.
-
-New ``next.E029`` reports can appear on code that passed for a long time.
-The check reads the context registry, so it now catches every decorator form, including the canonical ``@page.context`` and ``async def`` shapes that an earlier scanner passed over in silence.
-This wider reach is expected rather than a regression.
+The check inspects every keyless form.
 
 Two fixes clear the report.
 Annotate the callable with a dict return type, either ``-> dict`` or a :class:`~typing.TypedDict`.

--- a/docs/content/faq/troubleshooting.rst
+++ b/docs/content/faq/troubleshooting.rst
@@ -46,6 +46,20 @@ The choices are a ``render`` function, a ``template`` module attribute, or a sib
 Other values raise ``TypeError`` naming the ``page.py`` path.
 See :doc:`/content/topics/pages`.
 
+next.E017 on a page.py That Fails to Import
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A ``page.py`` raised while importing, so the framework loads it as nothing.
+Its ``render``, ``template``, and ``@context`` declarations never take effect, and a sibling ``template.djx`` can otherwise hide the failure.
+Fix the syntax or import error named in the report so the module loads.
+
+next.E018 on Multiple Keyless Context Functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A ``page.py`` registers more than one keyless ``@context`` callable.
+Keyless callables share one slot, so only the last one runs and the earlier ones are ignored.
+Give each callable a key such as ``@context("name")``, or merge them into a single callable.
+
 next.E029 on a Keyless Context Function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/content/faq/troubleshooting.rst
+++ b/docs/content/faq/troubleshooting.rst
@@ -5,6 +5,8 @@ Troubleshooting
 
 This page lists the most common errors and warnings plus the actions that resolve them.
 
+Run ``uv run python manage.py check --tag next`` to filter out the built-in Django and third-party checks and see only the next.dj diagnostics while investigating.
+
 .. contents::
    :local:
    :depth: 2
@@ -43,6 +45,20 @@ The choices are a ``render`` function, a ``template`` module attribute, or a sib
 ``render`` must return ``str`` or a Django :class:`~django.http.HttpResponseBase` subclass.
 Other values raise ``TypeError`` naming the ``page.py`` path.
 See :doc:`/content/topics/pages`.
+
+next.E029 on a Keyless Context Function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A keyless context callable must be annotated as returning a dict.
+Keyless means the decorator carries no key, whether written as ``@context``, ``@page.context``, an aliased import, or an ``async def`` context function.
+
+New ``next.E029`` reports can appear on code that passed for a long time.
+The check reads the context registry, so it now catches every decorator form, including the canonical ``@page.context`` and ``async def`` shapes that an earlier scanner passed over in silence.
+This wider reach is expected rather than a regression.
+
+Two fixes clear the report.
+Annotate the callable with a dict return type, either ``-> dict`` or a :class:`~typing.TypedDict`.
+Alternatively give the decorator a key, for example ``@context("name")``, which makes the context keyed and exempt from the check.
 
 Forms
 -----

--- a/docs/content/howto/integrate-django-allauth-forms.rst
+++ b/docs/content/howto/integrate-django-allauth-forms.rst
@@ -163,9 +163,9 @@ Both metaclasses are ``DeclarativeFieldsMetaclass``, so the bases compose.
    class LoginAction(Form, LoginForm):
        def __init__(
            self,
-           *args: object,
+           *args,
            request: HttpRequest | None = None,
-           **kwargs: object,
+           **kwargs,
        ) -> None:
            if request is None:
                request = allauth_context.request

--- a/docs/content/howto/observe-framework-signals.rst
+++ b/docs/content/howto/observe-framework-signals.rst
@@ -26,7 +26,7 @@ Wire One Receiver Per Signal Group
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Keep handlers thin.
-Each receiver reads the payload keyword arguments it needs and leaves the rest in ``**_kwargs``.
+Each receiver reads the payload keyword arguments it needs and leaves the rest in ``**kwargs``.
 The framework emits these signals on hot rendering paths, so receivers stay synchronous and fast.
 
 .. code-block:: python
@@ -46,24 +46,24 @@ The framework emits these signals on hot rendering paths, so receivers stay sync
    def on_page_rendered(
        file_path: object = None,
        duration_ms: float | None = None,
-       **_kwargs: object,
+       **kwargs,
    ) -> None:
        incr("pages.rendered", str(file_path))
        if duration_ms is not None:
            incr("pages.duration_ms_total", str(file_path), by=int(duration_ms) or 1)
 
    @receiver(component_rendered)
-   def on_component_rendered(info: object = None, **_kwargs: object) -> None:
+   def on_component_rendered(info: object = None, **kwargs) -> None:
        name = getattr(info, "name", "<unknown>")
        incr("components.rendered", str(name))
 
    @receiver(action_dispatched)
-   def on_action_dispatched(action_name: str | None = None, **_kwargs: object) -> None:
+   def on_action_dispatched(action_name: str | None = None, **kwargs) -> None:
        incr("forms.action_dispatched", str(action_name))
 
    @receiver(form_validation_failed)
    def on_form_validation_failed(
-       action_name: str | None = None, **_kwargs: object
+       action_name: str | None = None, **kwargs
    ) -> None:
        incr("forms.validation_failed", str(action_name))
 
@@ -72,7 +72,7 @@ The framework emits these signals on hot rendering paths, so receivers stay sync
        action_name: str | None = None,
        layer: str | None = None,
        reason: str | None = None,
-       **_kwargs: object,
+       **kwargs,
    ) -> None:
        incr("forms.access_denied", f"{action_name}:{layer}:{reason}")
 
@@ -105,21 +105,21 @@ The ``html_injected`` payload carries ``injected_bytes``, which is useful as a p
    from .metrics import incr
 
    @receiver(asset_registered)
-   def on_asset_registered(**_kwargs: object) -> None:
+   def on_asset_registered(**kwargs) -> None:
        incr("static", "asset_registered")
 
    @receiver(collector_finalized)
-   def on_collector_finalized(**_kwargs: object) -> None:
+   def on_collector_finalized(**kwargs) -> None:
        incr("static", "collector_finalized")
 
    @receiver(html_injected)
-   def on_html_injected(injected_bytes: int | None = None, **_kwargs: object) -> None:
+   def on_html_injected(injected_bytes: int | None = None, **kwargs) -> None:
        incr("static", "html_injected")
        if injected_bytes:
            incr("static", "injected_bytes_total", by=int(injected_bytes))
 
    @receiver(backend_loaded)
-   def on_static_backend_loaded(**_kwargs: object) -> None:
+   def on_static_backend_loaded(**kwargs) -> None:
        incr("static", "backend_loaded")
 
 Cover the Router
@@ -137,11 +137,11 @@ The URL subsystem emits ``route_registered`` for each route discovered during a 
    from .metrics import incr
 
    @receiver(route_registered)
-   def on_route_registered(url_path: str | None = None, **_kwargs: object) -> None:
+   def on_route_registered(url_path: str | None = None, **kwargs) -> None:
        incr("urls.route", str(url_path))
 
    @receiver(router_reloaded)
-   def on_router_reloaded(**_kwargs: object) -> None:
+   def on_router_reloaded(**kwargs) -> None:
        incr("urls", "router_reloaded")
 
 Connect Receivers at Startup

--- a/docs/content/howto/reload-routes-from-code.rst
+++ b/docs/content/howto/reload-routes-from-code.rst
@@ -29,11 +29,11 @@ Each receiver is decorated with ``@receiver`` at module top level, and ``AppConf
    from notes.models import Note
 
    @receiver(post_save, sender=Note)
-   def reload_router_on_save(**_kwargs) -> None:
+   def reload_router_on_save(**kwargs) -> None:
        router_manager.reload()
 
    @receiver(post_delete, sender=Note)
-   def reload_router_on_delete(**_kwargs) -> None:
+   def reload_router_on_delete(**kwargs) -> None:
        router_manager.reload()
 
 Import the receivers module from ``AppConfig.ready`` so the decorators run at startup.
@@ -64,7 +64,7 @@ Long lived processes that cache URL references can listen to ``router_reloaded``
    from next.urls.signals import router_reloaded
 
    @receiver(router_reloaded)
-   def drop_url_cache(**_kwargs) -> None:
+   def drop_url_cache(**kwargs) -> None:
        my_cache.clear()
 
 Verification

--- a/docs/content/howto/resolve-feature-flags-with-di.rst
+++ b/docs/content/howto/resolve-feature-flags-with-di.rst
@@ -113,11 +113,11 @@ The next ``get_cached_flag`` call refetches from the database.
    from .cache import invalidate_flag
    from .models import Flag
 
-   def _invalidate_on_save(instance: Flag, **_: object) -> None:
+   def _invalidate_on_save(instance: Flag, **kwargs) -> None:
        """Drop the cached entry so the next read reflects the updated row."""
        invalidate_flag(instance.name)
 
-   def _invalidate_on_delete(instance: Flag, **_: object) -> None:
+   def _invalidate_on_delete(instance: Flag, **kwargs) -> None:
        """Drop the cached entry when the flag is removed from the database."""
        invalidate_flag(instance.name)
 

--- a/docs/content/howto/stream-live-updates-with-sse.rst
+++ b/docs/content/howto/stream-live-updates-with-sse.rst
@@ -153,7 +153,7 @@ The signal carries the bound form after validation and the request, so the recei
        action_name: str = "",
        form: django_forms.Form | None = None,
        request: HttpRequest | None = None,
-       **_: object,
+       **kwargs,
    ) -> None:
        if action_name != VOTE_ACTION_NAME or form is None:
            return

--- a/docs/content/howto/write-a-router-backend.rst
+++ b/docs/content/howto/write-a-router-backend.rst
@@ -147,7 +147,7 @@ Connect a receiver to ``post_save`` and ``post_delete`` and call ``router_manage
 
    @receiver(post_save, sender=Article)
    @receiver(post_delete, sender=Article)
-   def reload_router_on_article_change(**_kwargs: object) -> None:
+   def reload_router_on_article_change(**kwargs) -> None:
        """Rebuild URL patterns whenever an article appears or disappears."""
        router_manager.reload()
 

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -23,7 +23,6 @@ The dependency injection layer contributes no Django system checks.
 Every next.dj check carries the ``next`` tag.
 Run ``uv run python manage.py check --tag next`` to execute only the framework checks and skip the built-in Django and third-party ones.
 Checks that also concern templates or URL patterns keep their :doc:`Django tags <django:ref/checks>` (``templates``, ``urls``) alongside ``next``, so filtering by those tags still reaches them.
-The framework configuration checks carry the ``next`` tag rather than the Django ``compatibility`` tag, so a script that selected them through ``--tag compatibility`` reaches them through ``--tag next`` instead.
 
 Shared Helpers
 ~~~~~~~~~~~~~~

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -158,6 +158,12 @@ Errors
    * - ``next.E016``
      - An error was raised while collecting patterns from a router.
      - ``next.urls.checks``
+   * - ``next.E017``
+     - A ``page.py`` raises while importing, so the framework skips the module silently.
+     - ``next.pages.checks``
+   * - ``next.E018``
+     - A ``page.py`` registers more than one keyless ``@context`` callable, and only the last one runs.
+     - ``next.pages.checks``
    * - ``next.E019``
      - ``request`` is missing from the template context (required for ``{% form %}`` and CSRF).
      - ``next.pages.checks``

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -15,10 +15,15 @@ Check Registration
 ``next.checks.register_all`` runs during ``AppConfig.ready``.
 It imports each subsystem ``checks`` module so the ``@register`` side effects take effect.
 The imported modules are ``next.conf.checks``, ``next.pages.checks``, ``next.urls.checks``, ``next.components.checks``, and ``next.forms.checks``.
-The list continues with ``next.server.checks``, ``next.static.checks``, ``next.partial.checks``, and ``next.apps.checks``.
+The list continues with ``next.static.checks``, ``next.partial.checks``, and ``next.apps.checks``.
 
-Most of these modules register checks. ``next.server.checks`` registers no Django system checks.
+Each of these modules registers checks.
 The dependency injection layer contributes no Django system checks.
+
+Every next.dj check carries the ``next`` tag.
+Run ``uv run python manage.py check --tag next`` to execute only the framework checks and skip the built-in Django and third-party ones.
+Checks that also concern templates or URL patterns keep their :doc:`Django tags <django:ref/checks>` (``templates``, ``urls``) alongside ``next``, so filtering by those tags still reaches them.
+The framework configuration checks carry the ``next`` tag rather than the Django ``compatibility`` tag, so a script that selected them through ``--tag compatibility`` reaches them through ``--tag next`` instead.
 
 Shared Helpers
 ~~~~~~~~~~~~~~
@@ -78,11 +83,6 @@ Configuration
 
 .. automodule:: next.conf.checks
    :members:
-
-Server
-~~~~~~
-
-``next.server.checks`` registers no Django system checks, as noted under Check Registration.
 
 Dependency Injection
 ~~~~~~~~~~~~~~~~~~~~
@@ -191,6 +191,8 @@ Errors
      - ``next.urls.checks``
    * - ``next.E029``
      - A keyless ``@context`` callable is not annotated as returning a dict.
+       The check reads the context registry, so it catches ``@context``,
+       ``@page.context``, an aliased import, and ``async def`` alike.
      - ``next.pages.checks``
    * - ``next.E030``
      - An error was raised while checking router pages.

--- a/examples/_shared/_components/nav_link/component.py
+++ b/examples/_shared/_components/nav_link/component.py
@@ -64,11 +64,7 @@ def href(
 
 
 @component.context("is_active")
-def is_active(
-    request: HttpRequest,
-    url_name: str = "",
-    active_when: str = "",
-) -> bool:
+def is_active(request: HttpRequest, url_name: str = "", active_when: str = "") -> bool:
     match = getattr(request, "resolver_match", None)
     if match is None:
         return False
@@ -79,12 +75,7 @@ def is_active(
 
 
 @component.context("classes")
-def classes(
-    *,
-    is_active: bool,
-    variant: str = "tabs",
-    extra: str = "",
-) -> str:
+def classes(*, is_active: bool, variant: str = "tabs", extra: str = "") -> str:
     style = VARIANTS.get(variant, VARIANTS["tabs"])
     state = style["active"] if is_active else style["inactive"]
     parts = [style["base"], state]

--- a/examples/_template/config/settings.py
+++ b/examples/_template/config/settings.py
@@ -42,25 +42,22 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
 }
 
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "next-example-template",
-    },
+    }
 }
 
 LANGUAGE_CODE = "en-us"
@@ -94,16 +91,14 @@ NEXT_FRAMEWORK = {
             # `APP_DIRS=True`.
             "DIRS": [str(BASE_DIR / "chrome")],
             "PAGES_DIR": "routes",
-            "OPTIONS": {
-                "context_processors": [],
-            },
-        },
+            "OPTIONS": {"context_processors": []},
+        }
     ],
     "COMPONENT_BACKENDS": [
         {
             "BACKEND": "next.components.FileComponentsBackend",
             "DIRS": [str(SHARED_DIR / "_components")],
             "COMPONENTS_DIR": "_widgets",
-        },
+        }
     ],
 }

--- a/examples/_template/config/urls.py
+++ b/examples/_template/config/urls.py
@@ -1,6 +1,4 @@
 from django.urls import include, path
 
 
-urlpatterns = [
-    path("", include("next.urls")),
-]
+urlpatterns = [path("", include("next.urls"))]

--- a/examples/admin/README.md
+++ b/examples/admin/README.md
@@ -146,7 +146,7 @@ The [`admin_audit`](admin_audit/) Django app records every admin dispatch throug
 ```python
 @receiver(action_dispatched)
 def log_admin_action(action_name="", form=None, url_kwargs=None,
-                     response_status=0, dep_cache=None, **_):
+                     response_status=0, dep_cache=None, **kwargs):
     ...
     spec = (dep_cache or {}).get("admin_spec")
     user = None

--- a/examples/admin/admin_audit/signals.py
+++ b/examples/admin/admin_audit/signals.py
@@ -22,7 +22,7 @@ def log_admin_action(
     url_kwargs: dict[str, Any] | None = None,
     response_status: int = 0,
     dep_cache: dict[str, Any] | None = None,
-    **_: object,
+    **kwargs,
 ) -> None:
     """Append one `AdminActivityLog` row for every dispatched admin action."""
     kind = _ACTION_TO_KIND.get(action_name)

--- a/examples/admin/config/settings.py
+++ b/examples/admin/config/settings.py
@@ -49,25 +49,22 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
 }
 
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "admin-example",
-    },
+    }
 }
 
 LANGUAGE_CODE = "en-us"
@@ -99,9 +96,9 @@ NEXT_FRAMEWORK = {
             "OPTIONS": {
                 # The hand-crafted logout form in `layout.djx` writes a bare
                 # `{% csrf_token %}`, which reads the token this processor seeds.
-                "context_processors": ["django.template.context_processors.csrf"],
+                "context_processors": ["django.template.context_processors.csrf"]
             },
-        },
+        }
     ],
     "COMPONENT_BACKENDS": [
         {
@@ -111,6 +108,6 @@ NEXT_FRAMEWORK = {
                 str(SHARED_DIR / "_components"),
             ],
             "COMPONENTS_DIR": "_panels",
-        },
+        }
     ],
 }

--- a/examples/admin/config/urls.py
+++ b/examples/admin/config/urls.py
@@ -10,9 +10,6 @@ urlpatterns = [
     # `reverse_lazy` defers resolution until first dispatch — the
     # `next:page_` name comes from the file router's auto-generated
     # name for `shadcn_admin/surfaces/page.py`.
-    path(
-        "",
-        RedirectView.as_view(url=reverse_lazy("next:page_"), permanent=False),
-    ),
+    path("", RedirectView.as_view(url=reverse_lazy("next:page_"), permanent=False)),
     path("admin/", include("next.urls")),
 ]

--- a/examples/admin/conftest.py
+++ b/examples/admin/conftest.py
@@ -46,9 +46,7 @@ def client() -> NextClient:
 @pytest.fixture()
 def admin_user(db):
     return get_user_model().objects.create_superuser(
-        "admin",
-        "admin@example.com",
-        "admin-pass",
+        "admin", "admin@example.com", "admin-pass"
     )
 
 

--- a/examples/admin/library/admin.py
+++ b/examples/admin/library/admin.py
@@ -42,17 +42,10 @@ class BookAdmin(admin.ModelAdmin):
         description="Mark selected %(verbose_name_plural)s as published",
         permissions=["change"],
     )
-    def mark_as_published(
-        self,
-        request: HttpRequest,
-        queryset: QuerySet[Book],
-    ) -> None:
+    def mark_as_published(self, request: HttpRequest, queryset: QuerySet[Book]) -> None:
         """Flip the selected books to `published` status in a single UPDATE."""
         updated = queryset.update(status=Book.PUBLISHED)
-        self.message_user(
-            request,
-            f"{updated} book(s) marked as published.",
-        )
+        self.message_user(request, f"{updated} book(s) marked as published.")
 
 
 @admin.register(Chapter)

--- a/examples/admin/shadcn_admin/_panels/admin_form/component.py
+++ b/examples/admin/shadcn_admin/_panels/admin_form/component.py
@@ -1,11 +1,7 @@
 from typing import Any
 
 from django.http import HttpRequest
-from shadcn_admin.forms import (
-    AdminFormSpec,
-    AdminInlineSpec,
-    build_inline_formsets,
-)
+from shadcn_admin.forms import AdminFormSpec, AdminInlineSpec, build_inline_formsets
 
 from next.components import component
 from next.deps import Depends

--- a/examples/admin/shadcn_admin/_panels/flash_messages/component.py
+++ b/examples/admin/shadcn_admin/_panels/flash_messages/component.py
@@ -19,9 +19,6 @@ _LEVEL_TO_VARIANT = {
 def flashes(request: HttpRequest) -> list[dict[str, Any]]:
     """Drain `messages` for this request and return alert-ready dicts."""
     return [
-        {
-            "text": str(m),
-            "variant": _LEVEL_TO_VARIANT.get(m.level_tag, "info"),
-        }
+        {"text": str(m), "variant": _LEVEL_TO_VARIANT.get(m.level_tag, "info")}
         for m in get_messages(request)
     ]

--- a/examples/admin/shadcn_admin/forms.py
+++ b/examples/admin/shadcn_admin/forms.py
@@ -114,10 +114,7 @@ def build_inline_formsets(spec: AdminFormSpec) -> list[BaseInlineFormSet]:
             if f"{prefix}-TOTAL_FORMS" not in spec.request.POST:
                 continue
             fs = formset_cls(
-                spec.request.POST,
-                spec.request.FILES,
-                instance=parent,
-                prefix=prefix,
+                spec.request.POST, spec.request.FILES, instance=parent, prefix=prefix
             )
         else:
             fs = formset_cls(instance=parent, prefix=prefix)
@@ -256,9 +253,7 @@ class AdminInlineSpec:
     def _row(self, obj: Model, post: QueryDict | None) -> RelatedRow:
         spec = form_spec(self._bind(obj, post))
         return RelatedRow(
-            pk=obj.pk,
-            fields=spec.sections[0].fields,
-            errors=spec.non_field_errors,
+            pk=obj.pk, fields=spec.sections[0].fields, errors=spec.non_field_errors
         )
 
     def _section(self, token: str, target_pk: str) -> RelatedSection:
@@ -320,10 +315,7 @@ def _build_form_class(spec: AdminFormSpec) -> type[django_forms.Form]:
 
 @resolver.dependency("admin_spec")
 def admin_spec(
-    request: HttpRequest,
-    app_label: str,
-    model_name: str,
-    pk: int | None = None,
+    request: HttpRequest, app_label: str, model_name: str, pk: int | None = None
 ) -> AdminFormSpec:
     """Resolve `(model, ModelAdmin, instance)` once per dispatch.
 
@@ -349,10 +341,7 @@ def admin_change_form_factory(
 
 
 def _persist(
-    form: django_forms.ModelForm,
-    spec: AdminFormSpec,
-    *,
-    change: bool,
+    form: django_forms.ModelForm, spec: AdminFormSpec, *, change: bool
 ) -> HttpResponse:
     obj = form.save(commit=False)
     formsets = build_inline_formsets(spec)
@@ -386,8 +375,7 @@ def _redirect_after_save(spec: AdminFormSpec, obj: Model) -> HttpResponseRedirec
 
 @action("admin:add", form_class=admin_add_form_factory, login_required=True)
 def handle_add(
-    form: django_forms.ModelForm,
-    spec: AdminFormSpec = Depends("admin_spec"),
+    form: django_forms.ModelForm, spec: AdminFormSpec = Depends("admin_spec")
 ) -> HttpResponse:
     """Save a new object and its inline formsets, then redirect."""
     if not spec.model_admin.has_add_permission(spec.request):
@@ -397,8 +385,7 @@ def handle_add(
 
 @action("admin:change", form_class=admin_change_form_factory, login_required=True)
 def handle_change(
-    form: django_forms.ModelForm,
-    spec: AdminFormSpec = Depends("admin_spec"),
+    form: django_forms.ModelForm, spec: AdminFormSpec = Depends("admin_spec")
 ) -> HttpResponse:
     """Persist main form and inline formsets via `ModelAdmin.save_model`."""
     if not spec.model_admin.has_change_permission(spec.request, spec.instance):
@@ -450,8 +437,7 @@ def _count_badge(inline: AdminInlineSpec) -> str:
 
 def _flash_save(spec: AdminFormSpec, obj: Model, *, verb: str) -> None:
     messages.success(
-        spec.request,
-        f"The {obj._meta.verbose_name} was {verb} successfully.",
+        spec.request, f"The {obj._meta.verbose_name} was {verb} successfully."
     )
 
 
@@ -481,21 +467,15 @@ def handle_inline_change(
     return (
         Patches(request)
         .replace(
-            {"css": f'form[data-next-key="{obj.pk}"]'},
-            _render_inline_row(inline, obj),
+            {"css": f'form[data-next-key="{obj.pk}"]'}, _render_inline_row(inline, obj)
         )
-        .inner(
-            {"css": f'[data-inline-count="{inline.token}"]'},
-            _count_badge(inline),
-        )
+        .inner({"css": f'[data-inline-count="{inline.token}"]'}, _count_badge(inline))
         .response()
     )
 
 
 @action(
-    "admin:inline_add",
-    form_class=admin_inline_add_form_factory,
-    login_required=True,
+    "admin:inline_add", form_class=admin_inline_add_form_factory, login_required=True
 )
 def handle_inline_add(
     request: HttpRequest,
@@ -524,10 +504,7 @@ def handle_inline_add(
     return (
         Patches(request)
         .layer_open(href=child_change_url, zone="record")
-        .inner(
-            {"css": f'[data-inline-count="{inline.token}"]'},
-            _count_badge(inline),
-        )
+        .inner({"css": f'[data-inline-count="{inline.token}"]'}, _count_badge(inline))
         .response()
     )
 

--- a/examples/admin/shadcn_admin/surfaces/[str:app_label]/[str:model_name]/[int:pk]/delete/page.py
+++ b/examples/admin/shadcn_admin/surfaces/[str:app_label]/[str:model_name]/[int:pk]/delete/page.py
@@ -12,19 +12,14 @@ from next.pages import context
 
 @context("delete_state")
 def delete_state(
-    request: HttpRequest,
-    app_label: str,
-    model_name: str,
-    pk: int,
+    request: HttpRequest, app_label: str, model_name: str, pk: int
 ) -> dict[str, Any]:
     """Build confirmation context: object, deps, protected refs, permissions."""
     model, model_admin, obj = utils.resolve_object_or_404(
         request, app_label, model_name, pk
     )
     _to_delete, model_count, perms_needed, protected = get_deleted_objects(
-        [obj],
-        request,
-        model_admin.admin_site,
+        [obj], request, model_admin.admin_site
     )
     return {
         "app_label": app_label,
@@ -48,10 +43,7 @@ def delete_state(
 
 @action("admin:delete", login_required=True)
 def delete(
-    request: HttpRequest,
-    app_label: str,
-    model_name: str,
-    pk: int,
+    request: HttpRequest, app_label: str, model_name: str, pk: int
 ) -> HttpResponse:
     """Delete the object via `ModelAdmin.delete_model` and redirect."""
     model, model_admin, obj = utils.resolve_object_or_404(
@@ -63,7 +55,6 @@ def delete(
     model_admin.log_deletions(request, [obj])
     model_admin.delete_model(request, obj)
     messages.success(
-        request,
-        f"The {model._meta.verbose_name} {obj_repr} was deleted successfully.",
+        request, f"The {model._meta.verbose_name} {obj_repr} was deleted successfully."
     )
     return HttpResponseRedirect(utils.changelist_url(app_label, model_name))

--- a/examples/admin/shadcn_admin/surfaces/[str:app_label]/[str:model_name]/[int:pk]/history/page.py
+++ b/examples/admin/shadcn_admin/surfaces/[str:app_label]/[str:model_name]/[int:pk]/history/page.py
@@ -13,10 +13,7 @@ _ACTION_LABELS = {1: "Added", 2: "Changed", 3: "Deleted"}
 
 @context("history_state")
 def history_state(
-    request: HttpRequest,
-    app_label: str,
-    model_name: str,
-    pk: int,
+    request: HttpRequest, app_label: str, model_name: str, pk: int
 ) -> dict[str, Any]:
     """Build the history context from `LogEntry` rows for the target object."""
     model, _model_admin, obj = utils.resolve_object_or_404(

--- a/examples/admin/shadcn_admin/surfaces/[str:app_label]/[str:model_name]/page.py
+++ b/examples/admin/shadcn_admin/surfaces/[str:app_label]/[str:model_name]/page.py
@@ -29,10 +29,7 @@ def _visible_columns(cl: ChangeList) -> list[str]:
 
 
 def _columns(
-    cl: ChangeList,
-    visible: list[str],
-    model: type[Model],
-    model_admin: ModelAdmin,
+    cl: ChangeList, visible: list[str], model: type[Model], model_admin: ModelAdmin
 ) -> list[dict[str, Any]]:
     ordering_columns = cl.get_ordering_field_columns()
     sortable_by = cl.sortable_by
@@ -57,11 +54,7 @@ def _columns(
     return [entry(i, name) for i, name in enumerate(visible)]
 
 
-def _row_cell(
-    name: str,
-    obj: Model,
-    model_admin: ModelAdmin,
-) -> str | SafeString:
+def _row_cell(name: str, obj: Model, model_admin: ModelAdmin) -> str | SafeString:
     try:
         field, _attr, value = lookup_field(name, obj, model_admin)
     except (AttributeError, ValueError):  # pragma: no cover
@@ -127,9 +120,7 @@ def _filters(cl: ChangeList) -> list[dict[str, Any]]:
 
 
 def _actions(
-    model_admin: ModelAdmin,
-    model: type[Model],
-    request: HttpRequest,
+    model_admin: ModelAdmin, model: type[Model], request: HttpRequest
 ) -> list[dict[str, Any]]:
     placeholders = {
         "verbose_name": str(model._meta.verbose_name),
@@ -145,9 +136,7 @@ def _actions(
 
 @context("changelist_state")
 def changelist_state(
-    request: HttpRequest,
-    app_label: str,
-    model_name: str,
+    request: HttpRequest, app_label: str, model_name: str
 ) -> dict[str, Any]:
     """Render changelist data from `ModelAdmin.get_changelist_instance(request)`."""
     model, model_admin = utils.resolve_model_admin(app_label, model_name)
@@ -173,22 +162,16 @@ def changelist_state(
 
 
 @action("admin:bulk_action", login_required=True)
-def bulk_action(
-    request: HttpRequest,
-    app_label: str,
-    model_name: str,
-) -> HttpResponse:
+def bulk_action(request: HttpRequest, app_label: str, model_name: str) -> HttpResponse:
     """Run a Django admin bulk action and redirect to the origin changelist."""
     _, model_admin = utils.resolve_model_admin(app_label, model_name)
     if not model_admin.has_view_or_change_permission(request):
         raise PermissionDenied
     response = model_admin.response_action(
-        request,
-        queryset=model_admin.get_queryset(request),
+        request, queryset=model_admin.get_queryset(request)
     )
     if response is None or isinstance(response, HttpResponseRedirect):
         return redirect_to_origin(
-            request,
-            fallback=utils.changelist_url(app_label, model_name),
+            request, fallback=utils.changelist_url(app_label, model_name)
         )
     return response  # pragma: no cover

--- a/examples/admin/shadcn_admin/surfaces/login/page.py
+++ b/examples/admin/shadcn_admin/surfaces/login/page.py
@@ -27,10 +27,7 @@ def login_state(request: HttpRequest) -> dict[str, Any]:
 
 
 @action("admin:login", form_class=admin_login_form_factory)
-def admin_login(
-    request: HttpRequest,
-    form: AuthenticationForm,
-) -> HttpResponse:
+def admin_login(request: HttpRequest, form: AuthenticationForm) -> HttpResponse:
     """Authenticate via `AuthenticationForm.get_user()` and redirect."""
     user = form.get_user()
     if user is None:  # pragma: no cover

--- a/examples/admin/shadcn_admin/utils.py
+++ b/examples/admin/shadcn_admin/utils.py
@@ -16,8 +16,7 @@ LOGOUT_URL = "/admin/logout/"
 
 
 def resolve_model_admin(
-    app_label: str,
-    model_name: str,
+    app_label: str, model_name: str
 ) -> tuple[type[Model], ModelAdmin]:
     """Return `(model, ModelAdmin)` from `admin.site._registry`, or 404."""
     try:
@@ -35,10 +34,7 @@ def resolve_model_admin(
 
 
 def resolve_object_or_404(
-    request: HttpRequest,
-    app_label: str,
-    model_name: str,
-    pk: int,
+    request: HttpRequest, app_label: str, model_name: str, pk: int
 ) -> tuple[type[Model], ModelAdmin, Model]:
     """Like `resolve_model_admin` but also fetches the object — 404 if missing."""
     model, model_admin = resolve_model_admin(app_label, model_name)
@@ -67,9 +63,7 @@ def logout_url() -> str:
 def changelist_url(app_label: str, model_name: str) -> str:
     """URL of the changelist page for one model."""
     return page_reverse(
-        "[str:app_label]/[str:model_name]",
-        app_label=app_label,
-        model_name=model_name,
+        "[str:app_label]/[str:model_name]", app_label=app_label, model_name=model_name
     )
 
 

--- a/examples/admin/tests/test_e2e.py
+++ b/examples/admin/tests/test_e2e.py
@@ -17,9 +17,7 @@ def _action_form_body(body: str, *, action_substring: str = "/_next/form/") -> s
     but with no formset) by picking the last matching form.
     """
     forms = re.findall(
-        r'<form[^>]*?(?<!-)action="([^"]+)"[^>]*>(.+?)</form>',
-        body,
-        re.DOTALL,
+        r'<form[^>]*?(?<!-)action="([^"]+)"[^>]*>(.+?)</form>', body, re.DOTALL
     )
     matching = [text for url, text in forms if action_substring in url]
     return matching[-1] if matching else ""
@@ -36,8 +34,7 @@ def _extract_form_inputs(body: str) -> dict[str, str]:
     target = _action_form_body(body)
     out: dict[str, str] = {}
     for m in re.finditer(
-        r'<input[^>]*name="([^"]+)"(?:[^>]*value="([^"]*)")?[^>]*>',
-        target,
+        r'<input[^>]*name="([^"]+)"(?:[^>]*value="([^"]*)")?[^>]*>', target
     ):
         out[m.group(1)] = m.group(2) or ""
     return out
@@ -143,8 +140,7 @@ class TestActionGuards:
     def test_anonymous_delete_post_redirects_to_login(self, client):
         tag = Tag.objects.create(name="Keep", slug="keep")
         r = client.post_action(
-            "admin:delete",
-            origin=f"/admin/library/tag/{tag.pk}/delete/",
+            "admin:delete", origin=f"/admin/library/tag/{tag.pk}/delete/"
         )
         assert r.status_code == 302
         assert r["Location"].startswith("/admin/login/")
@@ -189,8 +185,7 @@ class TestActionGuards:
         client.force_login(django_user_model.objects.create_user("intruder"))
         tag = Tag.objects.create(name="Keep", slug="keep")
         r = client.post_action(
-            "admin:delete",
-            origin=f"/admin/library/tag/{tag.pk}/delete/",
+            "admin:delete", origin=f"/admin/library/tag/{tag.pk}/delete/"
         )
         assert r.status_code == 403
         assert Tag.objects.filter(pk=tag.pk).exists()
@@ -308,9 +303,7 @@ class TestChangelistChrome:
 class TestBulkAction:
     def test_bulk_action_with_no_selection_redirects(self, admin_client):
         r = admin_client.post_action(
-            "admin:bulk_action",
-            {"action": ""},
-            origin="/admin/library/book/",
+            "admin:bulk_action", {"action": ""}, origin="/admin/library/book/"
         )
         assert r.status_code == 302
         assert r["Location"] == "/admin/library/book/"
@@ -383,8 +376,7 @@ class TestDeleteView:
     def test_delete_post_removes_record(self, admin_client):
         tag = Tag.objects.create(name="Doomed", slug="doomed")
         r = admin_client.post_action(
-            "admin:delete",
-            origin=f"/admin/library/tag/{tag.pk}/delete/",
+            "admin:delete", origin=f"/admin/library/tag/{tag.pk}/delete/"
         )
         assert r.status_code == 302
         assert not Tag.objects.filter(pk=tag.pk).exists()
@@ -395,8 +387,7 @@ class TestDeleteView:
 
     def test_delete_post_unknown_pk_404(self, admin_client):
         r = admin_client.post_action(
-            "admin:delete",
-            origin="/admin/library/tag/99999/delete/",
+            "admin:delete", origin="/admin/library/tag/99999/delete/"
         )
         assert r.status_code == 404
 
@@ -872,10 +863,7 @@ class TestActivityLog:
         book = Book.objects.create(title="B", author=author)
         admin_client.post_action(
             "admin:bulk_action",
-            {
-                "action": "mark_as_published",
-                "_selected_action": [str(book.pk)],
-            },
+            {"action": "mark_as_published", "_selected_action": [str(book.pk)]},
             origin="/admin/library/book/",
         )
         entries = list(AdminActivityLog.objects.filter(action="bulk_action"))
@@ -924,9 +912,7 @@ class TestFlashMessages:
     def test_delete_flashes_success(self, admin_client):
         tag = Tag.objects.create(name="Doomed", slug="doomed")
         r = admin_client.post_action(
-            "admin:delete",
-            origin=f"/admin/library/tag/{tag.pk}/delete/",
-            follow=True,
+            "admin:delete", origin=f"/admin/library/tag/{tag.pk}/delete/", follow=True
         )
         body = r.content.decode()
         assert "The tag Doomed was deleted successfully." in body

--- a/examples/audit-forms/README.md
+++ b/examples/audit-forms/README.md
@@ -115,7 +115,7 @@ The framework fires `next.forms.signals.form_access_denied` **only** on a dynami
 ```python
 # access/receivers.py
 @receiver(form_access_denied)
-def _on_form_access_denied(action_name, layer, reason, **_):
+def _on_form_access_denied(action_name, layer, reason, **kwargs):
     AuditEntry.objects.create(
         action_name=action_name,
         kind=AuditEntry.KIND_ACCESS_DENIED,

--- a/examples/audit-forms/access/backends.py
+++ b/examples/audit-forms/access/backends.py
@@ -13,11 +13,7 @@ if TYPE_CHECKING:
 
 
 _RESERVED_FORM_KEYS = frozenset(
-    {
-        "csrfmiddlewaretoken",
-        "_next_form_origin",
-        "policy_acknowledged",
-    },
+    {"csrfmiddlewaretoken", "_next_form_origin", "policy_acknowledged"}
 )
 
 

--- a/examples/audit-forms/access/models.py
+++ b/examples/audit-forms/access/models.py
@@ -34,10 +34,7 @@ class AuditEntry(models.Model):
 
     SOURCE_BACKEND = "backend"
     SOURCE_SIGNAL = "signal"
-    SOURCE_CHOICES: ClassVar = [
-        (SOURCE_BACKEND, "backend"),
-        (SOURCE_SIGNAL, "signal"),
-    ]
+    SOURCE_CHOICES: ClassVar = [(SOURCE_BACKEND, "backend"), (SOURCE_SIGNAL, "signal")]
 
     action_name = models.CharField(max_length=120)
     kind = models.CharField(max_length=20, choices=KIND_CHOICES)

--- a/examples/audit-forms/access/receivers.py
+++ b/examples/audit-forms/access/receivers.py
@@ -13,10 +13,7 @@ from .models import AuditEntry
 
 @receiver(action_dispatched)
 def _on_action_dispatched(
-    action_name: str,
-    duration_ms: float,
-    response_status: int,
-    **_: object,
+    action_name: str, duration_ms: float, response_status: int, **_: object
 ) -> None:
     """Record one signal-sourced row per successful dispatch.
 
@@ -34,10 +31,7 @@ def _on_action_dispatched(
 
 @receiver(form_validation_failed)
 def _on_form_validation_failed(
-    action_name: str,
-    error_count: int,
-    field_names: tuple[str, ...],
-    **_: object,
+    action_name: str, error_count: int, field_names: tuple[str, ...], **_: object
 ) -> None:
     """Record one signal-sourced row per validation failure."""
     AuditEntry.objects.create(
@@ -51,10 +45,7 @@ def _on_form_validation_failed(
 
 @receiver(form_access_denied)
 def _on_form_access_denied(
-    action_name: str,
-    layer: str,
-    reason: str,
-    **_: object,
+    action_name: str, layer: str, reason: str, **_: object
 ) -> None:
     """Record one signal-sourced row per dynamic permission-hook denial.
 

--- a/examples/audit-forms/access/receivers.py
+++ b/examples/audit-forms/access/receivers.py
@@ -13,7 +13,7 @@ from .models import AuditEntry
 
 @receiver(action_dispatched)
 def _on_action_dispatched(
-    action_name: str, duration_ms: float, response_status: int, **_: object
+    action_name: str, duration_ms: float, response_status: int, **kwargs
 ) -> None:
     """Record one signal-sourced row per successful dispatch.
 
@@ -31,7 +31,7 @@ def _on_action_dispatched(
 
 @receiver(form_validation_failed)
 def _on_form_validation_failed(
-    action_name: str, error_count: int, field_names: tuple[str, ...], **_: object
+    action_name: str, error_count: int, field_names: tuple[str, ...], **kwargs
 ) -> None:
     """Record one signal-sourced row per validation failure."""
     AuditEntry.objects.create(
@@ -44,9 +44,7 @@ def _on_form_validation_failed(
 
 
 @receiver(form_access_denied)
-def _on_form_access_denied(
-    action_name: str, layer: str, reason: str, **_: object
-) -> None:
+def _on_form_access_denied(action_name: str, layer: str, reason: str, **kwargs) -> None:
     """Record one signal-sourced row per dynamic permission-hook denial.
 
     Fires only when a `check_permissions` or `has_object_permission`

--- a/examples/audit-forms/access/views/request/[step]/_blocks/progress_bar/component.py
+++ b/examples/audit-forms/access/views/request/[step]/_blocks/progress_bar/component.py
@@ -4,11 +4,7 @@ from next.components import component
 from next.forms import FormWizard
 
 
-_STEP_LABELS = {
-    "identity": "Identity",
-    "scope": "Scope",
-    "approval": "Approval",
-}
+_STEP_LABELS = {"identity": "Identity", "scope": "Scope", "approval": "Approval"}
 
 
 def _label(step: str) -> str:

--- a/examples/audit-forms/access/views/request/[step]/_blocks/step_section/component.py
+++ b/examples/audit-forms/access/views/request/[step]/_blocks/step_section/component.py
@@ -18,7 +18,7 @@ _FIELDS_TEMPLATE = Template(
         {% endif %}
       </label>
     {% endfor %}
-    """,
+    """
 )
 
 _REVIEW_TEMPLATE = Template(
@@ -35,7 +35,7 @@ _REVIEW_TEMPLATE = Template(
         <dd class="whitespace-pre-line">{{ draft.reason }}</dd>
       </dl>
     </div>
-    """,
+    """
 )
 
 _SAVED_SUMMARY_TEMPLATE = Template(
@@ -46,7 +46,7 @@ _SAVED_SUMMARY_TEMPLATE = Template(
         <dd class="col-span-2 truncate">{{ entry.value }}</dd>
       {% endfor %}
     </dl>
-    """,
+    """
 )
 
 _FIELD_LABELS = {
@@ -58,11 +58,7 @@ _FIELD_LABELS = {
     "expires_in_days": "Expires in days",
 }
 
-_STEP_LABELS = {
-    "identity": "Identity",
-    "scope": "Scope",
-    "approval": "Approval",
-}
+_STEP_LABELS = {"identity": "Identity", "scope": "Scope", "approval": "Approval"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,10 +72,7 @@ class _Section:
     saved: bool
 
 
-def render(
-    form: django_forms.Form,
-    wizard: FormWizard,
-) -> str:
+def render(form: django_forms.Form, wizard: FormWizard) -> str:
     """Render every wizard step as a section gated on its stored state.
 
     The active step shows its bound fields (or the review summary on the

--- a/examples/audit-forms/access/views/request/[step]/page.py
+++ b/examples/audit-forms/access/views/request/[step]/page.py
@@ -68,9 +68,7 @@ class AccessRequestWizard(FormWizard):
         return request.POST.get("policy_acknowledged") == "on"
 
     def done(
-        self,
-        request: HttpRequest,
-        cleaned_data: dict[str, Any],
+        self, request: HttpRequest, cleaned_data: dict[str, Any]
     ) -> PatchResponse | HttpResponse:
         """Create the request, close the wizard layer, and link the next dispatch.
 

--- a/examples/audit-forms/config/settings.py
+++ b/examples/audit-forms/config/settings.py
@@ -41,18 +41,15 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
 }
 
 CACHES = {
@@ -90,21 +87,17 @@ NEXT_FRAMEWORK = {
             # surface in this access-request workflow.
             "DIRS": [str(BASE_DIR / "portal")],
             "PAGES_DIR": "views",
-            "OPTIONS": {
-                "context_processors": [],
-            },
-        },
+            "OPTIONS": {"context_processors": []},
+        }
     ],
     "COMPONENT_BACKENDS": [
         {
             "BACKEND": "next.components.FileComponentsBackend",
             "DIRS": [str(SHARED_DIR / "_components")],
             "COMPONENTS_DIR": "_blocks",
-        },
+        }
     ],
-    "FORM_ACTION_BACKENDS": [
-        {"BACKEND": "access.backends.AuditedFormActionBackend"},
-    ],
+    "FORM_ACTION_BACKENDS": [{"BACKEND": "access.backends.AuditedFormActionBackend"}],
     # Wizard step drafts live in the dedicated `wizards` cache alias rather
     # than the session, with a short lifetime that fits a PII-carrying flow.
     "FORM_WIZARD_BACKEND": {

--- a/examples/audit-forms/config/urls.py
+++ b/examples/audit-forms/config/urls.py
@@ -1,6 +1,4 @@
 from django.urls import include, path
 
 
-urlpatterns = [
-    path("", include("next.urls")),
-]
+urlpatterns = [path("", include("next.urls"))]

--- a/examples/audit-forms/tests/test_e2e.py
+++ b/examples/audit-forms/tests/test_e2e.py
@@ -156,8 +156,7 @@ class TestFullSubmission:
         _walk_three_steps(client)
         rows = list(
             AuditEntry.objects.filter(
-                source=AuditEntry.SOURCE_BACKEND,
-                kind=AuditEntry.KIND_REQUEST_STARTED,
+                source=AuditEntry.SOURCE_BACKEND, kind=AuditEntry.KIND_REQUEST_STARTED
             )
             .order_by("created_at")
             .values_list("step", "action_name")
@@ -185,8 +184,7 @@ class TestValidationFailure:
         assert AccessRequest.objects.exists() is False
 
         rows = AuditEntry.objects.filter(
-            source=AuditEntry.SOURCE_SIGNAL,
-            kind=AuditEntry.KIND_VALIDATION_FAILED,
+            source=AuditEntry.SOURCE_SIGNAL, kind=AuditEntry.KIND_VALIDATION_FAILED
         )
         assert rows.count() == 1
         row = rows.get()
@@ -236,8 +234,7 @@ class TestAccessDenied:
             _post_step_unacknowledged(client, "identity", IDENTITY)
 
         rows = AuditEntry.objects.filter(
-            source=AuditEntry.SOURCE_SIGNAL,
-            kind=AuditEntry.KIND_ACCESS_DENIED,
+            source=AuditEntry.SOURCE_SIGNAL, kind=AuditEntry.KIND_ACCESS_DENIED
         )
         assert rows.count() == 1
         row = rows.get()
@@ -266,8 +263,7 @@ class TestAccessDenied:
         _post_step_unacknowledged(client, "identity", IDENTITY)
         assert (
             AuditEntry.objects.filter(
-                source=AuditEntry.SOURCE_BACKEND,
-                kind=AuditEntry.KIND_DISPATCHED,
+                source=AuditEntry.SOURCE_BACKEND, kind=AuditEntry.KIND_DISPATCHED
             ).count()
             == 0
         )

--- a/examples/audit-forms/tests/test_unit.py
+++ b/examples/audit-forms/tests/test_unit.py
@@ -30,8 +30,7 @@ _progress = _load(
     "audit_progress_bar",
 )
 _audit_row = _load(
-    VIEWS_ROOT / "_blocks" / "audit_row" / "component.py",
-    "audit_audit_row",
+    VIEWS_ROOT / "_blocks" / "audit_row" / "component.py", "audit_audit_row"
 )
 _step_section = _load(
     VIEWS_ROOT / "request" / "[step]" / "_blocks" / "step_section" / "component.py",
@@ -54,9 +53,7 @@ def _wizard(step: str, stored: dict[str, dict[str, object]] | None = None):
     request = HttpRequest()
     request.session = SessionStore()
     wizard = _step_page.AccessRequestWizard(
-        request=request,
-        url_kwargs={"step": step},
-        base_path=f"/request/{step}/",
+        request=request, url_kwargs={"step": step}, base_path=f"/request/{step}/"
     )
     for name, data in (stored or {}).items():
         wizard.save_step(name, data)
@@ -201,9 +198,7 @@ class TestAccessDeniedReceiver:
 
     def test_receiver_stores_layer_and_reason(self) -> None:
         _on_form_access_denied(
-            action_name="access_request_wizard",
-            layer="view",
-            reason="denied",
+            action_name="access_request_wizard", layer="view", reason="denied"
         )
         row = AuditEntry.objects.get(kind=AuditEntry.KIND_ACCESS_DENIED)
         assert row.source == AuditEntry.SOURCE_SIGNAL
@@ -310,18 +305,14 @@ class TestStepFormValidation:
 
     def test_identity_step_requires_email(self) -> None:
         form = _step_page.IdentityStep(
-            data={"full_name": "Ada", "email": "", "team": "Computing"},
+            data={"full_name": "Ada", "email": "", "team": "Computing"}
         )
         assert not form.is_valid()
         assert "email" in form.errors
 
     def test_scope_step_accepts_valid_payload(self) -> None:
         form = _step_page.ScopeStep(
-            data={
-                "project_slug": "engine",
-                "reason": "reads",
-                "expires_in_days": "7",
-            },
+            data={"project_slug": "engine", "reason": "reads", "expires_in_days": "7"}
         )
         assert form.is_valid()
         assert form.cleaned_data["project_slug"] == "engine"
@@ -358,9 +349,7 @@ class TestStepSectionRenderPaths:
 
     def test_invalid_active_step_reports_errors_state(self) -> None:
         wizard = _wizard("identity")
-        form = _step_page.IdentityStep(
-            data={"full_name": "", "email": "", "team": ""},
-        )
+        form = _step_page.IdentityStep(data={"full_name": "", "email": "", "team": ""})
         form.is_valid()
         rendered = _step_section.render(form, wizard)
         assert 'data-state="errors"' in rendered
@@ -375,7 +364,7 @@ class TestStepSectionRenderPaths:
                     "project_slug": "engine",
                     "reason": long_reason,
                     "expires_in_days": 7,
-                },
+                }
             },
         )
         rendered = _step_section.render(wizard.current_form(), wizard)

--- a/examples/feature-flags/README.md
+++ b/examples/feature-flags/README.md
@@ -228,15 +228,15 @@ A denial emits `next.signals.form_access_denied` with `action_name`, `uid`, `req
 
 ```python
 @receiver(post_save, sender=Flag)
-def _invalidate_on_save(sender, instance, **_):
+def _invalidate_on_save(sender, instance, **kwargs):
     invalidate_flag(instance.name)
 
 @receiver(post_delete, sender=Flag)
-def _invalidate_on_delete(sender, instance, **_):
+def _invalidate_on_delete(sender, instance, **kwargs):
     invalidate_flag(instance.name)
 
 @receiver(page_rendered)
-def _count_page_render(sender, file_path, **_):
+def _count_page_render(sender, file_path, **kwargs):
     record_render(_page_key(file_path))
 ```
 

--- a/examples/feature-flags/config/settings.py
+++ b/examples/feature-flags/config/settings.py
@@ -41,25 +41,22 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
 }
 
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "feature-flags",
-    },
+    }
 }
 
 LANGUAGE_CODE = "en-us"
@@ -84,16 +81,14 @@ NEXT_FRAMEWORK = {
             # `flags/panels/` tree.
             "DIRS": [str(BASE_DIR / "frame")],
             "PAGES_DIR": "panels",
-            "OPTIONS": {
-                "context_processors": [],
-            },
-        },
+            "OPTIONS": {"context_processors": []},
+        }
     ],
     "COMPONENT_BACKENDS": [
         {
             "BACKEND": "next.components.FileComponentsBackend",
             "DIRS": [str(SHARED_DIR / "_components")],
             "COMPONENTS_DIR": "_chunks",
-        },
+        }
     ],
 }

--- a/examples/feature-flags/config/urls.py
+++ b/examples/feature-flags/config/urls.py
@@ -1,6 +1,4 @@
 from django.urls import include, path
 
 
-urlpatterns = [
-    path("", include("next.urls")),
-]
+urlpatterns = [path("", include("next.urls"))]

--- a/examples/feature-flags/flags/panels/_chunks/feature_guard/component.py
+++ b/examples/feature-flags/flags/panels/_chunks/feature_guard/component.py
@@ -12,7 +12,7 @@ _BANNER = Template(
     ' font-medium text-emerald-900">live</span>'
     "</div>"
     '<p class="mt-1 text-sm text-emerald-800">{{ description }}</p>'
-    "</article>",
+    "</article>"
 )
 
 
@@ -26,6 +26,6 @@ def render(flag: DFlag[Flag]) -> str:
                 "flag": flag,
                 "label": flag.label or flag.name,
                 "description": flag.description or "No description provided.",
-            },
-        ),
+            }
+        )
     )

--- a/examples/feature-flags/flags/panels/admin/page.py
+++ b/examples/feature-flags/flags/panels/admin/page.py
@@ -12,8 +12,7 @@ from next.pages import context
 
 class BulkToggleForm(Form):
     enabled_names = forms.MultipleChoiceField(
-        required=False,
-        widget=forms.CheckboxSelectMultiple(attrs={"class": "hidden"}),
+        required=False, widget=forms.CheckboxSelectMultiple(attrs={"class": "hidden"})
     )
 
     class Meta:

--- a/examples/feature-flags/flags/panels/admin/page.py
+++ b/examples/feature-flags/flags/panels/admin/page.py
@@ -25,7 +25,7 @@ class BulkToggleForm(Form):
         if not flags.is_enabled(WRITE_GATE_FLAG):
             raise PermissionDenied
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         """Populate the choices from the current set of flag names."""
         super().__init__(*args, **kwargs)
         self.fields["enabled_names"].choices = [

--- a/examples/feature-flags/flags/receivers.py
+++ b/examples/feature-flags/flags/receivers.py
@@ -39,19 +39,19 @@ def _page_key(file_path: Path) -> str:
 
 
 @receiver(post_save, sender=Flag)
-def _invalidate_on_save(instance: Flag, **_: object) -> None:
+def _invalidate_on_save(instance: Flag, **kwargs) -> None:
     """Drop the cached entry so the next read reflects the updated row."""
     invalidate_flag(instance.name)
 
 
 @receiver(post_delete, sender=Flag)
-def _invalidate_on_delete(instance: Flag, **_: object) -> None:
+def _invalidate_on_delete(instance: Flag, **kwargs) -> None:
     """Drop the cached entry when the flag is removed from the database."""
     invalidate_flag(instance.name)
 
 
 @receiver(page_rendered)
-def _count_page_render(file_path: Path, **_: object) -> None:
+def _count_page_render(file_path: Path, **kwargs) -> None:
     """Count how many times each page rendered while the process is alive."""
     record_render(_page_key(file_path))
 
@@ -69,7 +69,7 @@ def _read(key: str) -> int:
 
 
 @receiver(component_rendered)
-def _count_feature_guard(info: object, **_: object) -> None:
+def _count_feature_guard(info: object, **kwargs) -> None:
     """Bump a counter every time the `feature_guard` component is rendered."""
     if getattr(info, "name", None) != "feature_guard":
         return
@@ -77,7 +77,7 @@ def _count_feature_guard(info: object, **_: object) -> None:
 
 
 @receiver(form_access_denied)
-def _count_access_denied(**_: object) -> None:
+def _count_access_denied(**kwargs) -> None:
     """Bump a counter whenever a form permission hook denies a request."""
     _bump(DENIED_COUNT_KEY, _denied_lock)
 

--- a/examples/feature-flags/tests/test_e2e.py
+++ b/examples/feature-flags/tests/test_e2e.py
@@ -219,8 +219,7 @@ class TestActiveNav:
     def test_admin_link_not_active_on_home(self, client) -> None:
         body = client.get("/").content.decode()
         assert_missing_class(
-            find_anchor(body, href="/admin/", text="Admin"),
-            "font-semibold",
+            find_anchor(body, href="/admin/", text="Admin"), "font-semibold"
         )
 
     def test_admin_subnav_metrics_active_only_on_metrics(self, client) -> None:
@@ -230,8 +229,7 @@ class TestActiveNav:
             "font-semibold",
         )
         assert_missing_class(
-            find_anchor(body, href="/admin/", text="Flags"),
-            "font-semibold",
+            find_anchor(body, href="/admin/", text="Flags"), "font-semibold"
         )
 
 

--- a/examples/kanban/config/settings.py
+++ b/examples/kanban/config/settings.py
@@ -41,25 +41,22 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
 }
 
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "kanban",
-    },
+    }
 }
 
 LANGUAGE_CODE = "en-us"
@@ -84,17 +81,15 @@ NEXT_FRAMEWORK = {
             # every board and settings screen.
             "DIRS": [str(BASE_DIR / "cockpit")],
             "PAGES_DIR": "boards",
-            "OPTIONS": {
-                "context_processors": [],
-            },
-        },
+            "OPTIONS": {"context_processors": []},
+        }
     ],
     "COMPONENT_BACKENDS": [
         {
             "BACKEND": "next.components.FileComponentsBackend",
             "DIRS": [str(SHARED_DIR / "_components")],
             "COMPONENTS_DIR": "_pieces",
-        },
+        }
     ],
     "STATIC_BACKENDS": [
         {
@@ -108,6 +103,6 @@ NEXT_FRAMEWORK = {
                     BASE_DIR / "kanban/static/kanban/dist/.vite/manifest.json"
                 ),
             },
-        },
+        }
     ],
 }

--- a/examples/kanban/config/urls.py
+++ b/examples/kanban/config/urls.py
@@ -1,6 +1,4 @@
 from django.urls import include, path
 
 
-urlpatterns = [
-    path("", include("next.urls")),
-]
+urlpatterns = [path("", include("next.urls"))]

--- a/examples/kanban/kanban/apps.py
+++ b/examples/kanban/kanban/apps.py
@@ -11,10 +11,7 @@ class KanbanConfig(AppConfig):
     def ready(self) -> None:
         """Register JSX kind, page stem, and connect signal handlers."""
         default_kinds.register(
-            "jsx",
-            extension=".jsx",
-            slot="scripts",
-            renderer="render_module_tag",
+            "jsx", extension=".jsx", slot="scripts", renderer="render_module_tag"
         )
         default_stems.register("template", "page")
 

--- a/examples/kanban/kanban/backends.py
+++ b/examples/kanban/kanban/backends.py
@@ -38,12 +38,7 @@ class ViteManifestBackend(StaticFilesBackend):
         self._manifest_data: dict[str, Any] | None = None
         self._manifest_missing_warned = False
 
-    def register_file(
-        self,
-        source_path: Path,
-        logical_name: str,
-        kind: str,
-    ) -> str:
+    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
         """Return the URL for a discovered asset file."""
         if kind != "jsx":
             return super().register_file(source_path, logical_name, kind)

--- a/examples/kanban/kanban/boards/board/[int:id]/page.py
+++ b/examples/kanban/kanban/boards/board/[int:id]/page.py
@@ -45,8 +45,7 @@ def moved_card(request: HttpRequest) -> Card | None:
 
 @context("board", inherit_context=True, serialize=True)
 def board_payload(
-    active_board: DBoard[Board],
-    request: HttpRequest,
+    active_board: DBoard[Board], request: HttpRequest
 ) -> dict[str, object]:
     """Expose the full board tree under the merged board JS context key.
 

--- a/examples/kanban/kanban/forms.py
+++ b/examples/kanban/kanban/forms.py
@@ -20,8 +20,7 @@ class MoveCardForm(Form):
     card_id = django_forms.IntegerField(widget=django_forms.HiddenInput)
     target_column_id = django_forms.IntegerField(widget=django_forms.HiddenInput)
     target_position = django_forms.IntegerField(
-        min_value=0,
-        widget=django_forms.HiddenInput,
+        min_value=0, widget=django_forms.HiddenInput
     )
 
     def clean(self) -> dict[str, object]:
@@ -78,13 +77,9 @@ class CreateCardForm(Form):
     """Create a card at the tail of a column subject to its WIP limit."""
 
     column_id = django_forms.IntegerField(widget=django_forms.HiddenInput)
-    title = django_forms.CharField(
-        max_length=200,
-        widget=ComponentWidget("input"),
-    )
+    title = django_forms.CharField(max_length=200, widget=ComponentWidget("input"))
     body = django_forms.CharField(
-        required=False,
-        widget=ComponentWidget("textarea", rows=4),
+        required=False, widget=ComponentWidget("textarea", rows=4)
     )
 
     def clean(self) -> dict[str, object]:
@@ -132,14 +127,9 @@ class CreateColumnForm(Form):
     # existing instance, so it carries the parent board_id as a hidden field
     # instead of resolving one row through instance_from_url.
     board_id = django_forms.IntegerField(widget=django_forms.HiddenInput)
-    title = django_forms.CharField(
-        max_length=120,
-        widget=ComponentWidget("input"),
-    )
+    title = django_forms.CharField(max_length=120, widget=ComponentWidget("input"))
     wip_limit = django_forms.IntegerField(
-        required=False,
-        min_value=1,
-        widget=ComponentWidget("input", type="number"),
+        required=False, min_value=1, widget=ComponentWidget("input", type="number")
     )
 
     def on_valid(

--- a/examples/kanban/kanban/models.py
+++ b/examples/kanban/kanban/models.py
@@ -24,11 +24,7 @@ class Board(models.Model):
 class Column(models.Model):
     """A vertical lane on a board where cards are stacked in display order."""
 
-    board = models.ForeignKey(
-        Board,
-        on_delete=models.CASCADE,
-        related_name="columns",
-    )
+    board = models.ForeignKey(Board, on_delete=models.CASCADE, related_name="columns")
     title = models.CharField(max_length=120)
     position = models.PositiveIntegerField(default=0)
     wip_limit = models.PositiveIntegerField(null=True, blank=True)
@@ -48,11 +44,7 @@ _EXCERPT_LIMIT = 100
 class Card(models.Model):
     """An individual task card that lives inside one column."""
 
-    column = models.ForeignKey(
-        Column,
-        on_delete=models.CASCADE,
-        related_name="cards",
-    )
+    column = models.ForeignKey(Column, on_delete=models.CASCADE, related_name="cards")
     title = models.CharField(max_length=200)
     body = models.TextField(blank=True)
     position = models.PositiveIntegerField(default=0)

--- a/examples/kanban/kanban/providers.py
+++ b/examples/kanban/kanban/providers.py
@@ -27,19 +27,11 @@ class BoardProvider(RegisteredParameterProvider):
     without re-fetching it inside the handler.
     """
 
-    def can_handle(
-        self,
-        param: inspect.Parameter,
-        _context: ResolutionContext,
-    ) -> bool:
+    def can_handle(self, param: inspect.Parameter, _context: ResolutionContext) -> bool:
         """Match parameters annotated as a ``DBoard[...]`` subscript."""
         return get_origin(param.annotation) is DBoard
 
-    def resolve(
-        self,
-        param: inspect.Parameter,
-        context: ResolutionContext,
-    ) -> object:
+    def resolve(self, param: inspect.Parameter, context: ResolutionContext) -> object:
         """Fetch the board matching the URL ``id`` or POST ``board_id``."""
         (model_cls,) = get_args(param.annotation)
         pk = context.url_kwargs.get("id")
@@ -58,11 +50,7 @@ class BoardProvider(RegisteredParameterProvider):
 class CardProvider(RegisteredParameterProvider):
     """Resolve ``DCard[Model]`` parameters from a POST ``card_id`` field."""
 
-    def can_handle(
-        self,
-        param: inspect.Parameter,
-        context: ResolutionContext,
-    ) -> bool:
+    def can_handle(self, param: inspect.Parameter, context: ResolutionContext) -> bool:
         """Match ``DCard[...]`` annotations when the request carries ``card_id``."""
         if get_origin(param.annotation) is not DCard:
             return False
@@ -71,11 +59,7 @@ class CardProvider(RegisteredParameterProvider):
             return False
         return bool(request.POST.get("card_id"))
 
-    def resolve(
-        self,
-        param: inspect.Parameter,
-        context: ResolutionContext,
-    ) -> object:
+    def resolve(self, param: inspect.Parameter, context: ResolutionContext) -> object:
         """Fetch the card matching POST ``card_id``, or raise ``Http404``."""
         (model_cls,) = get_args(param.annotation)
         pk = context.request.POST.get("card_id")

--- a/examples/kanban/kanban/signals.py
+++ b/examples/kanban/kanban/signals.py
@@ -12,7 +12,7 @@ def _has_module_assets(collector: object) -> bool:
     return any(asset.kind == "jsx" for asset in scripts)
 
 
-def inject_vite_dev_assets(sender: object, **_kwargs: object) -> None:
+def inject_vite_dev_assets(sender: object, **kwargs) -> None:
     """Prepend the React Refresh preamble and the Vite HMR client.
 
     Both assets are added as URL-form module scripts because the

--- a/examples/kanban/kanban/signals.py
+++ b/examples/kanban/kanban/signals.py
@@ -41,12 +41,10 @@ def inject_vite_dev_assets(sender: object, **_kwargs: object) -> None:
     # slot, so the resulting bucket order is preamble, then @vite/client,
     # then the regular module scripts.
     sender.add(  # type: ignore[attr-defined]
-        StaticAsset(url=preamble_url, kind="module"),
-        prepend=True,
+        StaticAsset(url=preamble_url, kind="module"), prepend=True
     )
     sender.add(  # type: ignore[attr-defined]
-        StaticAsset(url=f"{origin}/@vite/client", kind="module"),
-        prepend=True,
+        StaticAsset(url=f"{origin}/@vite/client", kind="module"), prepend=True
     )
 
 

--- a/examples/kanban/tests/test_e2e.py
+++ b/examples/kanban/tests/test_e2e.py
@@ -74,10 +74,7 @@ class TestBoardList:
     """The index page lists active boards and hides archived ones."""
 
     def test_renders_active_boards(
-        self,
-        client: NextClient,
-        board: Board,
-        archived_board: Board,
+        self, client: NextClient, board: Board, archived_board: Board
     ) -> None:
         del archived_board
         response = client.get("/")
@@ -85,11 +82,7 @@ class TestBoardList:
         assert response.status_code == 200
         assert board.title in body
 
-    def test_archived_hidden(
-        self,
-        client: NextClient,
-        archived_board: Board,
-    ) -> None:
+    def test_archived_hidden(self, client: NextClient, archived_board: Board) -> None:
         response = client.get("/")
         body = response.content.decode()
         assert response.status_code == 200
@@ -106,11 +99,7 @@ class TestBoardList:
 class TestBoardView:
     """The board detail page renders columns and the React mount point."""
 
-    def test_columns_and_cards_render(
-        self,
-        client: NextClient,
-        board: Board,
-    ) -> None:
+    def test_columns_and_cards_render(self, client: NextClient, board: Board) -> None:
         body = _board_html(client, board)
         assert "Backlog" in body
         assert "In Progress" in body
@@ -131,9 +120,7 @@ class TestBoardView:
         assert re.search(r'<script type="module"', body)
 
     def test_inherit_context_visible_in_settings(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         body = _settings_html(client, board)
         assert board.title in body
@@ -148,11 +135,7 @@ class TestSettings:
         assert "Add column" in body
         assert "Archive" in body
 
-    def test_rename_form_post_redirects(
-        self,
-        client: NextClient,
-        board: Board,
-    ) -> None:
+    def test_rename_form_post_redirects(self, client: NextClient, board: Board) -> None:
         response = client.post_action(
             "rename_board_form",
             {"title": "New title"},
@@ -162,11 +145,7 @@ class TestSettings:
         board.refresh_from_db()
         assert board.title == "New title"
 
-    def test_archive_form_toggles(
-        self,
-        client: NextClient,
-        board: Board,
-    ) -> None:
+    def test_archive_form_toggles(self, client: NextClient, board: Board) -> None:
         response = client.post_action(
             "archive_board_form",
             {"archived": "1"},
@@ -177,15 +156,12 @@ class TestSettings:
         assert board.archived is True
 
     def test_archive_unset_redirects_back_to_settings(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         board.archived = True
         board.save(update_fields=["archived"])
         response = client.post_action(
-            "archive_board_form",
-            origin=f"/board/{board.pk}/settings/",
+            "archive_board_form", origin=f"/board/{board.pk}/settings/"
         )
         assert response.status_code == 302
         assert response["Location"] == f"/board/{board.pk}/settings/"
@@ -193,14 +169,11 @@ class TestSettings:
         assert board.archived is False
 
     def test_invalid_then_fixed_resubmit_renames_in_place(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         rename = _rename_form_block(_settings_html(client, board))
         invalid = client.post(
-            _form_action_url(rename),
-            {**_hidden_fields(rename), "title": ""},
+            _form_action_url(rename), {**_hidden_fields(rename), "title": ""}
         )
         assert invalid.status_code == 200
         rerendered = _rename_form_block(invalid.content.decode())
@@ -208,8 +181,7 @@ class TestSettings:
         assert refields["_next_form_origin"] == f"/board/{board.pk}/settings/"
         before = Board.objects.count()
         fixed = client.post(
-            _form_action_url(rerendered),
-            {**refields, "title": "Fixed title"},
+            _form_action_url(rerendered), {**refields, "title": "Fixed title"}
         )
         assert fixed.status_code == 302
         assert fixed["Location"] == f"/board/{board.pk}/settings/"
@@ -217,11 +189,7 @@ class TestSettings:
         board.refresh_from_db()
         assert board.title == "Fixed title"
 
-    def test_add_column_form_post(
-        self,
-        client: NextClient,
-        board: Board,
-    ) -> None:
+    def test_add_column_form_post(self, client: NextClient, board: Board) -> None:
         before = board.columns.count()
         response = client.post_action(
             "create_column_form",
@@ -239,40 +207,26 @@ class TestMoveCard:
     """The move_card form action moves cards between columns."""
 
     def test_post_moves_card_between_columns(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         backlog = board.columns.get(title="Backlog")
         done = board.columns.get(title="Done")
         card = backlog.cards.first()
         response = client.post_action(
             "move_card_form",
-            {
-                "card_id": card.pk,
-                "target_column_id": done.pk,
-                "target_position": "0",
-            },
+            {"card_id": card.pk, "target_column_id": done.pk, "target_position": "0"},
         )
         assert response.status_code == 302
         card.refresh_from_db()
         assert card.column_id == done.pk
 
-    def test_post_normalises_positions(
-        self,
-        client: NextClient,
-        board: Board,
-    ) -> None:
+    def test_post_normalises_positions(self, client: NextClient, board: Board) -> None:
         backlog = board.columns.get(title="Backlog")
         done = board.columns.get(title="Done")
         card = backlog.cards.first()
         client.post_action(
             "move_card_form",
-            {
-                "card_id": card.pk,
-                "target_column_id": done.pk,
-                "target_position": "0",
-            },
+            {"card_id": card.pk, "target_column_id": done.pk, "target_position": "0"},
         )
         positions = list(
             done.cards.order_by("position").values_list("position", flat=True)
@@ -280,9 +234,7 @@ class TestMoveCard:
         assert positions == list(range(len(positions)))
 
     def test_cross_board_target_rejected(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         other_board = Board.objects.create(title="Other", slug="other")
         other_col = Column.objects.create(board=other_board, title="X", position=0)
@@ -299,21 +251,13 @@ class TestMoveCard:
         card.refresh_from_db()
         assert card.column.board_id == board.pk
 
-    def test_negative_position_rejected(
-        self,
-        client: NextClient,
-        board: Board,
-    ) -> None:
+    def test_negative_position_rejected(self, client: NextClient, board: Board) -> None:
         backlog = board.columns.get(title="Backlog")
         done = board.columns.get(title="Done")
         card = backlog.cards.first()
         response = client.post_action(
             "move_card_form",
-            {
-                "card_id": card.pk,
-                "target_column_id": done.pk,
-                "target_position": "-1",
-            },
+            {"card_id": card.pk, "target_column_id": done.pk, "target_position": "-1"},
         )
         assert response.status_code == 400
 
@@ -322,20 +266,14 @@ class TestPreviewComponent:
     """The preview composite renders after a successful move."""
 
     def test_preview_appears_with_moved_query(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         backlog = board.columns.get(title="Backlog")
         done = board.columns.get(title="Done")
         card = backlog.cards.first()
         client.post_action(
             "move_card_form",
-            {
-                "card_id": card.pk,
-                "target_column_id": done.pk,
-                "target_position": "0",
-            },
+            {"card_id": card.pk, "target_column_id": done.pk, "target_position": "0"},
         )
         response = client.get(f"/board/{board.pk}/?moved={card.pk}")
         body = response.content.decode()
@@ -343,17 +281,13 @@ class TestPreviewComponent:
         assert f'data-kanban-preview="{card.pk}"' in body
 
     def test_preview_hidden_without_moved_query(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         body = _board_html(client, board)
         assert "Move complete" not in body
 
     def test_preview_skips_unknown_card_id(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         response = client.get(f"/board/{board.pk}/?moved=99999")
         body = response.content.decode()
@@ -363,16 +297,11 @@ class TestPreviewComponent:
 class TestCreateCard:
     """The create_card form action appends cards and respects WIP limits."""
 
-    def test_post_appends_card_at_tail(
-        self,
-        client: NextClient,
-        board: Board,
-    ) -> None:
+    def test_post_appends_card_at_tail(self, client: NextClient, board: Board) -> None:
         backlog = board.columns.get(title="Backlog")
         before = backlog.cards.count()
         response = client.post_action(
-            "create_card_form",
-            {"column_id": backlog.pk, "title": "Extra"},
+            "create_card_form", {"column_id": backlog.pk, "title": "Extra"}
         )
         assert response.status_code == 302
         backlog.refresh_from_db()
@@ -381,30 +310,22 @@ class TestCreateCard:
         assert new.title == "Extra"
         assert new.position == before
 
-    def test_wip_limit_blocks_creation(
-        self,
-        client: NextClient,
-        board: Board,
-    ) -> None:
+    def test_wip_limit_blocks_creation(self, client: NextClient, board: Board) -> None:
         progress = board.columns.get(title="In Progress")
         Card.objects.create(column=progress, title="Second", position=1)
         response = client.post_action(
-            "create_card_form",
-            {"column_id": progress.pk, "title": "Over the limit"},
+            "create_card_form", {"column_id": progress.pk, "title": "Over the limit"}
         )
         assert response.status_code == 400
         assert progress.cards.filter(title="Over the limit").count() == 0
 
     def test_wip_limit_none_allows_unlimited(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         backlog = board.columns.get(title="Backlog")
         for index in range(5):
             response = client.post_action(
-                "create_card_form",
-                {"column_id": backlog.pk, "title": f"Card {index}"},
+                "create_card_form", {"column_id": backlog.pk, "title": f"Card {index}"}
             )
             assert response.status_code == 302
         assert backlog.cards.count() >= 5
@@ -414,20 +335,13 @@ class TestJsxBackend:
     """JSX files discovered alongside templates are injected as ES module scripts."""
 
     def test_page_jsx_rendered_as_module(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         body = _board_html(client, board)
-        assert re.search(
-            r'<script type="module" src="[^"]*page\.jsx">',
-            body,
-        )
+        assert re.search(r'<script type="module" src="[^"]*page\.jsx">', body)
 
     def test_no_text_babel_scripts_present(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         body = _board_html(client, board)
         assert 'type="text/babel"' not in body
@@ -437,9 +351,7 @@ class TestJsContext:
     """`Next._init({...})` carries deep-merged board state."""
 
     def test_next_init_call_contains_board(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         body = _board_html(client, board)
         payload = _next_init_payload(body)
@@ -447,11 +359,7 @@ class TestJsContext:
         assert payload["board"]["title"] == board.title
         assert "csrf" in payload["board"]
 
-    def test_deep_merge_columns_present(
-        self,
-        client: NextClient,
-        board: Board,
-    ) -> None:
+    def test_deep_merge_columns_present(self, client: NextClient, board: Board) -> None:
         body = _board_html(client, board)
         payload = _next_init_payload(body)
         cols = payload["board"]["columns"]
@@ -472,18 +380,12 @@ class TestInheritedHeaderCount:
         assert int(match.group(1)) >= 1
 
     def test_board_detail_inherits_count(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         body = _board_html(client, board)
         assert "active boards" in body
 
-    def test_settings_inherits_count(
-        self,
-        client: NextClient,
-        board: Board,
-    ) -> None:
+    def test_settings_inherits_count(self, client: NextClient, board: Board) -> None:
         body = _settings_html(client, board)
         assert "active boards" in body
 
@@ -492,9 +394,7 @@ class TestCdnCachePolicy:
     """Local script tags do not carry CDN cache-control attributes."""
 
     def test_local_script_has_no_cache_attrs(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         del board
         response = client.get("/")
@@ -510,9 +410,7 @@ class TestViteDevAssetsGuard:
     """`@vite/client` is injected only on pages that ship jsx scripts."""
 
     def test_index_page_skips_vite_client(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         del board
         response = client.get("/")
@@ -521,14 +419,11 @@ class TestViteDevAssetsGuard:
         assert 'src="data:text/javascript' not in body
 
     def test_board_page_includes_vite_client_and_preamble(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         body = _board_html(client, board)
         preamble_match = re.search(
-            r'<script type="module" src="data:text/javascript;base64,([^"]+)"',
-            body,
+            r'<script type="module" src="data:text/javascript;base64,([^"]+)"', body
         )
         assert preamble_match is not None, "React Refresh preamble not injected"
         decoded = base64.b64decode(preamble_match.group(1)).decode()
@@ -544,11 +439,7 @@ class TestViteDevAssetsGuard:
 class TestPayloadEnrichment:
     """Board JS payload carries excerpt and wip_limit for the React layer."""
 
-    def test_payload_includes_wip_limit(
-        self,
-        client: NextClient,
-        board: Board,
-    ) -> None:
+    def test_payload_includes_wip_limit(self, client: NextClient, board: Board) -> None:
         body = _board_html(client, board)
         payload = _next_init_payload(body)
         in_progress = next(
@@ -557,9 +448,7 @@ class TestPayloadEnrichment:
         assert in_progress["wip_limit"] == 2
 
     def test_payload_includes_card_excerpt(
-        self,
-        client: NextClient,
-        board: Board,
+        self, client: NextClient, board: Board
     ) -> None:
         backlog = board.columns.get(title="Backlog")
         long_card = backlog.cards.first()

--- a/examples/kanban/tests/test_unit.py
+++ b/examples/kanban/tests/test_unit.py
@@ -32,8 +32,7 @@ _PIECES = (
 
 def _load(relative: str):
     spec = importlib.util.spec_from_file_location(
-        f"_test_{relative.replace('/', '_').replace('.py', '')}",
-        _PIECES / relative,
+        f"_test_{relative.replace('/', '_').replace('.py', '')}", _PIECES / relative
     )
     mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
     spec.loader.exec_module(mod)  # type: ignore[union-attr]
@@ -208,8 +207,7 @@ class TestCardProvider:
         assert not provider.can_handle(param, ctx)
 
     def test_resolve_returns_card_for_post_id(
-        self,
-        two_columns: tuple[Column, Column],
+        self, two_columns: tuple[Column, Column]
     ) -> None:
         col_a, _ = two_columns
         card = Card.objects.create(column=col_a, title="Move me", position=0)
@@ -253,8 +251,7 @@ class TestCardProvider:
 
 class TestMoveCardFormClean:
     def test_cross_board_move_rejected(
-        self,
-        two_columns: tuple[Column, Column],
+        self, two_columns: tuple[Column, Column]
     ) -> None:
         col_a, _ = two_columns
         other_board = Board.objects.create(title="Other", slug="other")
@@ -266,7 +263,7 @@ class TestMoveCardFormClean:
                 "card_id": str(card.pk),
                 "target_column_id": str(other_col.pk),
                 "target_position": "0",
-            },
+            }
         )
         assert not form.is_valid()
         assert "across boards" in str(form.errors)
@@ -277,7 +274,7 @@ class TestMoveCardFormClean:
                 "card_id": "99999",
                 "target_column_id": "99999",
                 "target_position": "0",
-            },
+            }
         )
         assert not form.is_valid()
         assert "Unknown card" in str(form.errors)
@@ -290,24 +287,19 @@ class TestMoveCardFormClean:
 
 class TestCreateCardFormClean:
     def test_wip_limit_blocks_creation(
-        self,
-        two_columns: tuple[Column, Column],
+        self, two_columns: tuple[Column, Column]
     ) -> None:
         col_a, _ = two_columns
         col_a.wip_limit = 1
         col_a.save()
         Card.objects.create(column=col_a, title="One", position=0)
 
-        form = CreateCardForm(
-            data={"column_id": str(col_a.pk), "title": "Two"},
-        )
+        form = CreateCardForm(data={"column_id": str(col_a.pk), "title": "Two"})
         assert not form.is_valid()
         assert "WIP limit" in str(form.errors)
 
     def test_unknown_column_rejected(self) -> None:
-        form = CreateCardForm(
-            data={"column_id": "99999", "title": "Lost"},
-        )
+        form = CreateCardForm(data={"column_id": "99999", "title": "Lost"})
         assert not form.is_valid()
         assert "Unknown column" in str(form.errors)
 
@@ -358,9 +350,7 @@ class TestViteManifestBackendRegisterFile:
         assert out == "http://localhost:5173/page.jsx"
 
     def test_jsx_with_missing_manifest_file_falls_back(
-        self,
-        tmp_path: Path,
-        caplog: pytest.LogCaptureFixture,
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         manifest = tmp_path / "missing.json"  # never created
         backend = ViteManifestBackend(
@@ -485,8 +475,7 @@ class TestCreateCardHandlerRace:
     """Authoritative WIP check inside the handler rejects a racing post."""
 
     def test_handler_returns_400_when_limit_filled_after_clean(
-        self,
-        two_columns: tuple[Column, Column],
+        self, two_columns: tuple[Column, Column]
     ) -> None:
         col_a, _ = two_columns
         col_a.wip_limit = 2

--- a/examples/live-polls/README.md
+++ b/examples/live-polls/README.md
@@ -174,7 +174,7 @@ A naive `threading.Event` plus `clear()` looks attractive here but loses events 
 
 ```python
 @receiver(action_dispatched)
-def broadcast_vote(action_name="", form=None, request=None, **_):
+def broadcast_vote(action_name="", form=None, request=None, **kwargs):
     if action_name != VOTE_ACTION_NAME or form is None:
         return
     poll = form.cleaned_data.get("poll")

--- a/examples/live-polls/config/settings.py
+++ b/examples/live-polls/config/settings.py
@@ -59,25 +59,22 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
 }
 
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "live-polls",
-    },
+    }
 }
 
 LANGUAGE_CODE = "en-us"
@@ -102,17 +99,15 @@ NEXT_FRAMEWORK = {
             # around every poll list, detail, and stream surface.
             "DIRS": [str(BASE_DIR / "studio")],
             "PAGES_DIR": "screens",
-            "OPTIONS": {
-                "context_processors": [],
-            },
-        },
+            "OPTIONS": {"context_processors": []},
+        }
     ],
     "COMPONENT_BACKENDS": [
         {
             "BACKEND": "next.components.FileComponentsBackend",
             "DIRS": [str(SHARED_DIR / "_components")],
             "COMPONENTS_DIR": "_widgets",
-        },
+        }
     ],
     "STATIC_BACKENDS": [
         {
@@ -126,6 +121,6 @@ NEXT_FRAMEWORK = {
                     BASE_DIR / "polls/static/polls/dist/.vite/manifest.json"
                 ),
             },
-        },
+        }
     ],
 }

--- a/examples/live-polls/config/urls.py
+++ b/examples/live-polls/config/urls.py
@@ -1,6 +1,4 @@
 from django.urls import include, path
 
 
-urlpatterns = [
-    path("", include("next.urls")),
-]
+urlpatterns = [path("", include("next.urls"))]

--- a/examples/live-polls/polls/apps.py
+++ b/examples/live-polls/polls/apps.py
@@ -11,10 +11,7 @@ class PollsConfig(AppConfig):
     def ready(self) -> None:
         """Register the Vue asset kind, the page stem, and signal wiring."""
         default_kinds.register(
-            "vue",
-            extension=".vue",
-            slot="scripts",
-            renderer="render_module_tag",
+            "vue", extension=".vue", slot="scripts", renderer="render_module_tag"
         )
         default_stems.register("template", "page")
 

--- a/examples/live-polls/polls/backends.py
+++ b/examples/live-polls/polls/backends.py
@@ -33,12 +33,7 @@ class ViteManifestBackend(StaticFilesBackend):
         self._manifest_path: str = opts.get("MANIFEST_PATH", "")
         self._manifest_data: dict[str, Any] | None = None
 
-    def register_file(
-        self,
-        source_path: Path,
-        logical_name: str,
-        kind: str,
-    ) -> str:
+    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
         """Return the URL for a discovered asset file."""
         if kind != "vue":
             return super().register_file(source_path, logical_name, kind)

--- a/examples/live-polls/polls/broker.py
+++ b/examples/live-polls/polls/broker.py
@@ -124,10 +124,7 @@ class PollBroker:
             yield Change(snapshot=payload, request_id=self._request_ids.get(poll_id))
 
     def _wait_for_new_revision(
-        self,
-        poll_id: int,
-        condition: threading.Condition,
-        baseline: int,
+        self, poll_id: int, condition: threading.Condition, baseline: int
     ) -> int:
         """Block until the revision differs from `baseline` or the wake fires.
 

--- a/examples/live-polls/polls/forms.py
+++ b/examples/live-polls/polls/forms.py
@@ -22,7 +22,7 @@ class VoteForm(Form):
         queryset=Choice.objects.none(), widget=django_forms.HiddenInput
     )
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         """Narrow the choice queryset to the submitted poll on binding."""
         super().__init__(*args, **kwargs)
         poll_pk = self.data.get(self.add_prefix("poll"))

--- a/examples/live-polls/polls/forms.py
+++ b/examples/live-polls/polls/forms.py
@@ -16,12 +16,10 @@ class VoteForm(Form):
     """
 
     poll = django_forms.ModelChoiceField(
-        queryset=Poll.objects.all(),
-        widget=django_forms.HiddenInput,
+        queryset=Poll.objects.all(), widget=django_forms.HiddenInput
     )
     choice = django_forms.ModelChoiceField(
-        queryset=Choice.objects.none(),
-        widget=django_forms.HiddenInput,
+        queryset=Choice.objects.none(), widget=django_forms.HiddenInput
     )
 
     def __init__(self, *args: object, **kwargs: object) -> None:

--- a/examples/live-polls/polls/signals.py
+++ b/examples/live-polls/polls/signals.py
@@ -19,7 +19,7 @@ def broadcast_vote(
     action_name: str = "",
     form: django_forms.Form | None = None,
     request: HttpRequest | None = None,
-    **_: object,
+    **kwargs,
 ) -> None:
     """Publish a fresh snapshot for the poll that just received a vote.
 
@@ -28,8 +28,8 @@ def broadcast_vote(
     query, and the request to read the mutation's `X-Next-Request-Id`.
     Threading that id to `broker.publish` lets the stream echo it so the
     voter's own tab drops the fan-out update. Other payload fields are
-    absorbed by `**_` because this listener needs only the form and the
-    request.
+    absorbed by `**kwargs` because this listener needs only the form and
+    the request.
     """
     if action_name != VOTE_ACTION_NAME or form is None:
         return
@@ -46,7 +46,7 @@ def _has_module_assets(collector: StaticCollector) -> bool:
     return any(asset.kind == "vue" for asset in scripts)
 
 
-def inject_vite_dev_client(sender: StaticCollector, **_kwargs: object) -> None:
+def inject_vite_dev_client(sender: StaticCollector, **kwargs) -> None:
     """Prepend the Vite dev client so HMR can attach on pages with Vue assets.
 
     Vue does not need a React Refresh preamble. The single

--- a/examples/live-polls/polls/signals.py
+++ b/examples/live-polls/polls/signals.py
@@ -58,10 +58,7 @@ def inject_vite_dev_client(sender: StaticCollector, **_kwargs: object) -> None:
     if not _has_module_assets(sender):
         return
     origin = settings.VITE_DEV_ORIGIN
-    sender.add(
-        StaticAsset(url=f"{origin}/@vite/client", kind="module"),
-        prepend=True,
-    )
+    sender.add(StaticAsset(url=f"{origin}/@vite/client", kind="module"), prepend=True)
 
 
 # Wire the dev-client injector only when the developer opted into the

--- a/examples/live-polls/tests/test_e2e.py
+++ b/examples/live-polls/tests/test_e2e.py
@@ -222,9 +222,7 @@ class TestVoteAction:
         assert choice.votes == 1
 
     @pytest.mark.parametrize(
-        ("rounds", "expected"),
-        [(1, 1), (3, 3), (7, 7)],
-        ids=["once", "three", "seven"],
+        ("rounds", "expected"), [(1, 1), (3, 3), (7, 7)], ids=["once", "three", "seven"]
     )
     def test_repeated_votes_sum_correctly(
         self, client: NextClient, poll: Poll, rounds: int, expected: int
@@ -392,10 +390,7 @@ class TestBroadcastReceiver:
         assert snapshot["total_votes"] == 1
 
     def test_receiver_invokes_broker_publish_with_new_snapshot(
-        self,
-        client: NextClient,
-        poll: Poll,
-        monkeypatch: pytest.MonkeyPatch,
+        self, client: NextClient, poll: Poll, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A spy on `broker.publish` confirms the receiver is the publish source.
 

--- a/examples/live-polls/tests/test_unit.py
+++ b/examples/live-polls/tests/test_unit.py
@@ -8,12 +8,7 @@ from django.core.cache import cache
 from django.http import Http404
 from polls import broker as broker_module
 from polls.backends import ViteManifestBackend
-from polls.broker import (
-    SNAPSHOT_KEY,
-    PollBroker,
-    build_snapshot,
-    store_snapshot,
-)
+from polls.broker import SNAPSHOT_KEY, PollBroker, build_snapshot, store_snapshot
 from polls.forms import VoteForm
 from polls.models import Choice, Poll
 from polls.providers import DPoll
@@ -140,10 +135,7 @@ class TestManifestRouting:
         manifest_path = tmp_path / "manifest.json"
         manifest_path.write_text(json.dumps({manifest_key: {"file": built_file}}))
         backend = _backend(
-            {
-                "VITE_ROOT": str(configured_root),
-                "MANIFEST_PATH": str(manifest_path),
-            }
+            {"VITE_ROOT": str(configured_root), "MANIFEST_PATH": str(manifest_path)}
         )
         url = backend.register_file(asset_path, "component", "vue")
         assert f"polls/dist/{built_file}" in url

--- a/examples/markdown-blog/blog/markdown_template.py
+++ b/examples/markdown-blog/blog/markdown_template.py
@@ -19,10 +19,7 @@ def read_post_body(post_path: Path) -> str:
 def post_metadata(post_path: Path) -> dict[str, str]:
     """Return slug, URL name, and title extracted from the first `# …` line."""
     body = read_post_body(post_path)
-    heading = next(
-        (line for line in body.splitlines() if line.startswith("# ")),
-        "",
-    )
+    heading = next((line for line in body.splitlines() if line.startswith("# ")), "")
     slug = post_path.parent.name
     title = heading.removeprefix("# ").strip() or slug.replace("-", " ").title()
     return {

--- a/examples/markdown-blog/blog/receivers.py
+++ b/examples/markdown-blog/blog/receivers.py
@@ -34,7 +34,7 @@ def _detect_source(file_path: Path) -> str:
 
 
 @receiver(template_loaded)
-def _on_template_loaded(file_path: Path, **_kwargs: object) -> None:
+def _on_template_loaded(file_path: Path, **kwargs) -> None:
     """Record which source type won the loader race for `file_path`."""
     with _lock:
         _loader_hits[str(file_path)] = _detect_source(file_path)

--- a/examples/markdown-blog/config/settings.py
+++ b/examples/markdown-blog/config/settings.py
@@ -41,18 +41,15 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
 }
 
 LANGUAGE_CODE = "en-us"
@@ -82,9 +79,9 @@ NEXT_FRAMEWORK = {
                 "context_processors": [
                     "django.template.context_processors.request",
                     "blog.context_processors.site_nav",
-                ],
+                ]
             },
-        },
+        }
     ],
     "COMPONENT_BACKENDS": [
         {
@@ -98,7 +95,7 @@ NEXT_FRAMEWORK = {
                 str(BASE_DIR / "site" / "_parts"),
             ],
             "COMPONENTS_DIR": "_parts",
-        },
+        }
     ],
     "TEMPLATE_LOADERS": [
         "blog.loaders.MarkdownTemplateLoader",

--- a/examples/markdown-blog/config/urls.py
+++ b/examples/markdown-blog/config/urls.py
@@ -1,6 +1,4 @@
 from django.urls import include, path
 
 
-urlpatterns = [
-    path("", include("next.urls")),
-]
+urlpatterns = [path("", include("next.urls"))]

--- a/examples/markdown-blog/tests/test_e2e.py
+++ b/examples/markdown-blog/tests/test_e2e.py
@@ -78,8 +78,7 @@ class TestActiveNav:
         body = client.get("/").content.decode()
         assert_has_class(find_anchor(body, href="/", text="Home"), "font-semibold")
         assert_missing_class(
-            find_anchor(body, href="/about/", text="About"),
-            "font-semibold",
+            find_anchor(body, href="/about/", text="About"), "font-semibold"
         )
 
     def test_about_link_active_on_about(self, client) -> None:
@@ -87,7 +86,4 @@ class TestActiveNav:
         assert_has_class(
             find_anchor(body, href="/about/", text="About"), "font-semibold"
         )
-        assert_missing_class(
-            find_anchor(body, href="/", text="Home"),
-            "font-semibold",
-        )
+        assert_missing_class(find_anchor(body, href="/", text="Home"), "font-semibold")

--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -163,7 +163,7 @@ from .access import get_active_tenant
 
 
 @receiver(form_access_denied)
-def _on_form_access_denied(action_name, layer, reason, request, **_):
+def _on_form_access_denied(action_name, layer, reason, request, **kwargs):
     tenant = get_active_tenant(request)
     tenant_slug = getattr(tenant, "slug", "unknown")
     logger.warning(

--- a/examples/multi-tenant/config/settings.py
+++ b/examples/multi-tenant/config/settings.py
@@ -42,25 +42,22 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
 }
 
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "multi-tenant",
-    },
+    }
 }
 
 LANGUAGE_CODE = "en-us"
@@ -86,18 +83,16 @@ NEXT_FRAMEWORK = {
                 "context_processors": [
                     "django.template.context_processors.request",
                     "notes.context_processors.tenant_theme",
-                ],
+                ]
             },
-        },
+        }
     ],
     "COMPONENT_BACKENDS": [
         {
             "BACKEND": "next.components.FileComponentsBackend",
             "DIRS": [str(BASE_DIR / "root_blocks"), str(SHARED_DIR / "_components")],
             "COMPONENTS_DIR": "_blocks",
-        },
+        }
     ],
-    "STATIC_BACKENDS": [
-        {"BACKEND": "notes.backends.TenantPrefixStaticBackend"},
-    ],
+    "STATIC_BACKENDS": [{"BACKEND": "notes.backends.TenantPrefixStaticBackend"}],
 }

--- a/examples/multi-tenant/config/urls.py
+++ b/examples/multi-tenant/config/urls.py
@@ -3,11 +3,7 @@ from django.http import HttpRequest, HttpResponse
 from django.urls import include, path, re_path
 
 
-def serve_tenant_static(
-    request: HttpRequest,
-    slug: str,
-    path: str,
-) -> HttpResponse:
+def serve_tenant_static(request: HttpRequest, slug: str, path: str) -> HttpResponse:
     """Serve a co-located static asset under the per-tenant URL prefix.
 
     The custom `TenantPrefixStaticBackend` rewrites every asset URL to

--- a/examples/multi-tenant/notes/backends.py
+++ b/examples/multi-tenant/notes/backends.py
@@ -22,30 +22,15 @@ class TenantPrefixStaticBackend(StaticFilesBackend):
     commands behaving the same way as the default backend.
     """
 
-    def render_link_tag(
-        self,
-        url: str,
-        *,
-        request: HttpRequest | None = None,
-    ) -> str:
+    def render_link_tag(self, url: str, *, request: HttpRequest | None = None) -> str:
         """Return a CSS link tag with the per-tenant prefix injected."""
         return super().render_link_tag(_prefixed(url, request))
 
-    def render_script_tag(
-        self,
-        url: str,
-        *,
-        request: HttpRequest | None = None,
-    ) -> str:
+    def render_script_tag(self, url: str, *, request: HttpRequest | None = None) -> str:
         """Return a JS script tag with the per-tenant prefix injected."""
         return super().render_script_tag(_prefixed(url, request))
 
-    def render_module_tag(
-        self,
-        url: str,
-        *,
-        request: HttpRequest | None = None,
-    ) -> str:
+    def render_module_tag(self, url: str, *, request: HttpRequest | None = None) -> str:
         """Return a module script tag with the per-tenant prefix injected."""
         return super().render_module_tag(_prefixed(url, request))
 

--- a/examples/multi-tenant/notes/markdown_render.py
+++ b/examples/multi-tenant/notes/markdown_render.py
@@ -7,8 +7,7 @@ from django.utils.safestring import SafeString
 
 EMPTY_PREVIEW = "<p class='text-slate-400 italic'>Nothing to preview yet.</p>"
 UNSAFE_HREF = re.compile(
-    r'href="\s*(?:javascript|data|vbscript):[^"]*"',
-    flags=re.IGNORECASE,
+    r'href="\s*(?:javascript|data|vbscript):[^"]*"', flags=re.IGNORECASE
 )
 
 

--- a/examples/multi-tenant/notes/middleware.py
+++ b/examples/multi-tenant/notes/middleware.py
@@ -48,7 +48,7 @@ class TenantMiddleware:
             return HttpResponseBadRequest(
                 "Missing X-Tenant header.\n"
                 "Send a request with X-Tenant: <slug>. In DEBUG you may also "
-                "pass ?tenant=<slug> for a browser demo.",
+                "pass ?tenant=<slug> for a browser demo."
             )
 
         try:
@@ -61,21 +61,14 @@ class TenantMiddleware:
 
         if debug_query:
             response = HttpResponseRedirect(_strip_tenant_query(request))
-            response.set_cookie(
-                COOKIE_NAME,
-                slug,
-                httponly=True,
-                samesite="Lax",
-            )
+            response.set_cookie(COOKIE_NAME, slug, httponly=True, samesite="Lax")
             return response
 
         request.tenant = tenant  # type: ignore[attr-defined]
         return self._get_response(request)
 
 
-def _resolve_tenant_slug(
-    request: HttpRequest,
-) -> tuple[str | None, bool, bool]:
+def _resolve_tenant_slug(request: HttpRequest) -> tuple[str | None, bool, bool]:
     """Return (slug, came_from_query, came_from_cookie) for the request."""
     header_value = request.META.get(HEADER_NAME, "").strip()
     if header_value:

--- a/examples/multi-tenant/notes/models.py
+++ b/examples/multi-tenant/notes/models.py
@@ -17,11 +17,7 @@ class Tenant(models.Model):
 
 
 class Note(models.Model):
-    tenant = models.ForeignKey(
-        Tenant,
-        on_delete=models.CASCADE,
-        related_name="notes",
-    )
+    tenant = models.ForeignKey(Tenant, on_delete=models.CASCADE, related_name="notes")
     title = models.CharField(max_length=160)
     body = models.TextField(blank=True, default="")
     locked = models.BooleanField(default=False)

--- a/examples/multi-tenant/notes/providers.py
+++ b/examples/multi-tenant/notes/providers.py
@@ -15,11 +15,7 @@ class DTenant(DDependencyBase["Tenant"]):
 class TenantProvider(RegisteredParameterProvider):
     """Resolve `DTenant` parameters from `request.tenant`."""
 
-    def can_handle(
-        self,
-        param: inspect.Parameter,
-        context: ResolutionContext,
-    ) -> bool:
+    def can_handle(self, param: inspect.Parameter, context: ResolutionContext) -> bool:
         """Match the bare `DTenant` annotation when a request is attached."""
         if param.annotation is not DTenant:
             return False
@@ -28,10 +24,6 @@ class TenantProvider(RegisteredParameterProvider):
             return False
         return get_active_tenant(request) is not None
 
-    def resolve(
-        self,
-        _param: inspect.Parameter,
-        context: ResolutionContext,
-    ) -> Tenant:
+    def resolve(self, _param: inspect.Parameter, context: ResolutionContext) -> Tenant:
         """Return the `Tenant` previously stashed by `TenantMiddleware`."""
         return get_active_tenant(context.request)

--- a/examples/multi-tenant/notes/receivers.py
+++ b/examples/multi-tenant/notes/receivers.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("notes.access")
 
 @receiver(form_access_denied)
 def _on_form_access_denied(
-    action_name: str, layer: str, reason: str, request: HttpRequest, **_: object
+    action_name: str, layer: str, reason: str, request: HttpRequest, **kwargs
 ) -> None:
     """Log a permission-hook denial, naming the tenant when the request carries one."""
     tenant = get_active_tenant(request)

--- a/examples/multi-tenant/notes/receivers.py
+++ b/examples/multi-tenant/notes/receivers.py
@@ -13,11 +13,7 @@ logger = logging.getLogger("notes.access")
 
 @receiver(form_access_denied)
 def _on_form_access_denied(
-    action_name: str,
-    layer: str,
-    reason: str,
-    request: HttpRequest,
-    **_: object,
+    action_name: str, layer: str, reason: str, request: HttpRequest, **_: object
 ) -> None:
     """Log a permission-hook denial, naming the tenant when the request carries one."""
     tenant = get_active_tenant(request)

--- a/examples/multi-tenant/notes/workspaces/notes/[int:note_id]/edit/page.py
+++ b/examples/multi-tenant/notes/workspaces/notes/[int:note_id]/edit/page.py
@@ -46,9 +46,8 @@ class NoteEditForm(ModelForm):
         self.save()
         return HttpResponseRedirect(
             reverse(
-                "next:page_notes_int_note_id_edit",
-                kwargs={"note_id": self.instance.pk},
-            ),
+                "next:page_notes_int_note_id_edit", kwargs={"note_id": self.instance.pk}
+            )
         )
 
 

--- a/examples/multi-tenant/notes/workspaces/notes/new/page.py
+++ b/examples/multi-tenant/notes/workspaces/notes/new/page.py
@@ -12,8 +12,7 @@ from next.pages import context
 
 class NoteCreateForm(Form):
     title = django_forms.CharField(
-        max_length=160,
-        widget=ComponentWidget("input", placeholder="Note title"),
+        max_length=160, widget=ComponentWidget("input", placeholder="Note title")
     )
     body = django_forms.CharField(
         required=False,
@@ -30,10 +29,7 @@ class NoteCreateForm(Form):
             body=self.cleaned_data.get("body", ""),
         )
         return HttpResponseRedirect(
-            reverse(
-                "next:page_notes_int_note_id_edit",
-                kwargs={"note_id": note_obj.pk},
-            ),
+            reverse("next:page_notes_int_note_id_edit", kwargs={"note_id": note_obj.pk})
         )
 
 

--- a/examples/multi-tenant/tests/test_e2e.py
+++ b/examples/multi-tenant/tests/test_e2e.py
@@ -127,10 +127,7 @@ class TestNoteEditForm:
         note = _acme_note(acme)
         response = client.post_action(
             "note_edit_form",
-            {
-                "title": note.title,
-                "body": "edited body content",
-            },
+            {"title": note.title, "body": "edited body content"},
             origin=f"/notes/{note.pk}/edit/",
             HTTP_X_TENANT="acme",
         )
@@ -145,10 +142,7 @@ class TestNoteEditForm:
         note = _acme_note(acme)
         response = client.post_action(
             "note_edit_form",
-            {
-                "title": "hijack",
-                "body": "should not save",
-            },
+            {"title": "hijack", "body": "should not save"},
             origin=f"/notes/{note.pk}/edit/",
             HTTP_X_TENANT="globex",
         )
@@ -233,10 +227,7 @@ class TestNoteEditFormErrorRerender:
         note = _acme_note(acme)
         response = client.post_action(
             "note_edit_form",
-            {
-                "title": "",
-                "body": "x",
-            },
+            {"title": "", "body": "x"},
             origin=f"/notes/{note.pk}/edit/",
             HTTP_X_TENANT="acme",
         )
@@ -274,8 +265,8 @@ class TestNoteCreate:
         new_pk = next(
             iter(
                 set(Note.objects.filter(tenant=acme).values_list("pk", flat=True))
-                - existing,
-            ),
+                - existing
+            )
         )
         assert response.url == f"/notes/{new_pk}/edit/"
         created = Note.objects.get(pk=new_pk)
@@ -324,10 +315,7 @@ class TestNoteEditPage:
         self, client: NextClient, acme: Tenant
     ) -> None:
         note = _acme_note(acme)
-        response = client.get(
-            f"/notes/{note.pk}/edit/",
-            HTTP_X_TENANT="acme",
-        )
+        response = client.get(f"/notes/{note.pk}/edit/", HTTP_X_TENANT="acme")
         assert response.status_code == 200
         body = response.content.decode()
         assert note.title in body
@@ -338,10 +326,7 @@ class TestNoteEditPage:
         self, client: NextClient, acme: Tenant
     ) -> None:
         note = _acme_note(acme)
-        response = client.get(
-            f"/notes/{note.pk}/edit/",
-            HTTP_X_TENANT="acme",
-        )
+        response = client.get(f"/notes/{note.pk}/edit/", HTTP_X_TENANT="acme")
         body = response.content.decode()
         assert (
             '<script type="module" '

--- a/examples/multi-tenant/tests/test_unit.py
+++ b/examples/multi-tenant/tests/test_unit.py
@@ -30,8 +30,7 @@ def _load(path: Path, name: str) -> ModuleType:
 
 
 _note_card = _load(
-    PAGES_ROOT / "notes" / "_blocks" / "note_card" / "component.py",
-    "mt_note_card",
+    PAGES_ROOT / "notes" / "_blocks" / "note_card" / "component.py", "mt_note_card"
 )
 
 
@@ -73,9 +72,7 @@ class TestTenantMiddleware:
     @override_settings(DEBUG=False)
     def test_unknown_tenant_returns_404(self) -> None:
         middleware = TenantMiddleware(Mock())
-        response = middleware(
-            self._request(meta={"HTTP_X_TENANT": "nope"}),
-        )
+        response = middleware(self._request(meta={"HTTP_X_TENANT": "nope"}))
         assert response.status_code == 404
 
     @pytest.mark.django_db()
@@ -189,9 +186,7 @@ class TestTenantTheme:
     def test_returns_css_variables_for_known_tenant(self) -> None:
         request = HttpRequest()
         request.tenant = Tenant(  # type: ignore[attr-defined]
-            slug="acme",
-            name="Acme",
-            primary_color="#2563eb",
+            slug="acme", name="Acme", primary_color="#2563eb"
         )
         result = tenant_theme(request)
         assert result["tenant_theme"] == {"--tenant-accent": "#2563eb"}
@@ -211,10 +206,7 @@ class TestTenantPrefixStaticBackend:
         backend = TenantPrefixStaticBackend()
         request = HttpRequest()
         request.tenant = Tenant(slug="acme", name="Acme")  # type: ignore[attr-defined]
-        rendered = backend.render_script_tag(
-            "/static/next/a.js",
-            request=request,
-        )
+        rendered = backend.render_script_tag("/static/next/a.js", request=request)
         assert 'src="/_t/acme/static/next/a.js"' in rendered
 
     def test_module_tag_prepends_prefix(self) -> None:
@@ -222,8 +214,7 @@ class TestTenantPrefixStaticBackend:
         request = HttpRequest()
         request.tenant = Tenant(slug="acme", name="Acme")  # type: ignore[attr-defined]
         rendered = backend.render_module_tag(
-            "/static/next/components/markdown_preview.mjs",
-            request=request,
+            "/static/next/components/markdown_preview.mjs", request=request
         )
         assert 'type="module"' in rendered
         assert 'src="/_t/acme/static/next/components/markdown_preview.mjs"' in rendered
@@ -233,8 +224,7 @@ class TestTenantPrefixStaticBackend:
         request = HttpRequest()
         request.tenant = Tenant(slug="acme", name="Acme")  # type: ignore[attr-defined]
         rendered = backend.render_link_tag(
-            "https://cdn.example.com/x.css",
-            request=request,
+            "https://cdn.example.com/x.css", request=request
         )
         assert "https://cdn.example.com/x.css" in rendered
         assert "/_t/" not in rendered
@@ -316,7 +306,7 @@ class TestMarkdownRender:
         rendered = str(
             render_markdown(
                 "# Heading\n\n```py\nprint(1)\n```\n\n[ok](https://example.com)"
-            ),
+            )
         )
         assert "<h1>Heading</h1>" in rendered
         assert "<pre>" in rendered

--- a/examples/multi-tenant/tests/test_unit.py
+++ b/examples/multi-tenant/tests/test_unit.py
@@ -53,7 +53,7 @@ class TestTenantModelStr:
 class TestTenantMiddleware:
     """`TenantMiddleware` enforces the X-Tenant contract with a DEBUG affordance."""
 
-    def _request(self, **kwargs: object) -> HttpRequest:
+    def _request(self, **kwargs) -> HttpRequest:
         request = HttpRequest()
         request.method = "GET"
         request.path = kwargs.pop("path", "/notes/")

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -203,7 +203,7 @@ so the envelope carries the re-aggregated zone beside the custom verb with a pay
 ### 8. The flush command
 
 ```python
-def handle(self, *_args, **_options):
+def handle(self, *args, **options):
     rows = flush()
     if not rows:
         self.stdout.write("nothing to flush")

--- a/examples/observability/config/settings.py
+++ b/examples/observability/config/settings.py
@@ -41,25 +41,22 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
 }
 
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "next-example-observability",
-    },
+    }
 }
 
 LANGUAGE_CODE = "en-us"
@@ -91,25 +88,21 @@ NEXT_FRAMEWORK = {
             # every dashboard sees the same chrome.
             "DIRS": [str(BASE_DIR / "instrument")],
             "PAGES_DIR": "dashboards",
-            "OPTIONS": {
-                "context_processors": [],
-            },
-        },
+            "OPTIONS": {"context_processors": []},
+        }
     ],
     "COMPONENT_BACKENDS": [
         {
             "BACKEND": "obs.backends.CountingComponentsBackend",
             "DIRS": [str(SHARED_DIR / "_components")],
             "COMPONENTS_DIR": "_widgets",
-        },
+        }
     ],
     "STATIC_BACKENDS": [
         {
             "BACKEND": "obs.backends.BabelJsxBackend",
-            "OPTIONS": {
-                "DEDUP_STRATEGY": "obs.static_policies.InstrumentedDedup",
-            },
-        },
+            "OPTIONS": {"DEDUP_STRATEGY": "obs.static_policies.InstrumentedDedup"},
+        }
     ],
     "JS_CONTEXT_SERIALIZER": "obs.serializers.PydanticJsContextSerializer",
 }

--- a/examples/observability/config/urls.py
+++ b/examples/observability/config/urls.py
@@ -1,6 +1,4 @@
 from django.urls import include, path
 
 
-urlpatterns = [
-    path("", include("next.urls")),
-]
+urlpatterns = [path("", include("next.urls"))]

--- a/examples/observability/obs/apps.py
+++ b/examples/observability/obs/apps.py
@@ -14,10 +14,7 @@ class ObsConfig(AppConfig):
     def ready(self) -> None:
         """Register asset kinds, the custom patch verb, and signal receivers."""
         default_kinds.register(
-            "jsx",
-            extension=".jsx",
-            slot="scripts",
-            renderer="render_babel_script_tag",
+            "jsx", extension=".jsx", slot="scripts", renderer="render_babel_script_tag"
         )
         register_patch_op(METRIC_PULSE_OP)
         from obs import receivers  # noqa: F401, PLC0415

--- a/examples/observability/obs/backends.py
+++ b/examples/observability/obs/backends.py
@@ -18,11 +18,7 @@ if TYPE_CHECKING:
 class CountingComponentsBackend(FileComponentsBackend):
     """`FileComponentsBackend` that counts component resolutions."""
 
-    def get_component(
-        self,
-        name: str,
-        template_path: Path,
-    ) -> "ComponentInfo | None":
+    def get_component(self, name: str, template_path: Path) -> "ComponentInfo | None":
         """Return the component info and record one lookup event."""
         info = super().get_component(name, template_path)
         if info is not None:
@@ -50,10 +46,7 @@ class BabelJsxBackend(StaticFilesBackend):
         self._babel_tag = str(opts.get("babel_tag") or self._DEFAULT_BABEL_TAG)
 
     def render_babel_script_tag(
-        self,
-        url: str,
-        *,
-        request: HttpRequest | None = None,
+        self, url: str, *, request: HttpRequest | None = None
     ) -> str:
         """Return a `<script type="text/babel">` tag pointing at `url`."""
         return self._babel_tag.format(url=url)

--- a/examples/observability/obs/dashboards/_widgets/sparkline/component.py
+++ b/examples/observability/obs/dashboards/_widgets/sparkline/component.py
@@ -13,9 +13,7 @@ from next.components import component
 
 
 @component.context(
-    "totals_chart",
-    serialize=True,
-    serializer=WrappedJsContextSerializer(),
+    "totals_chart", serialize=True, serializer=WrappedJsContextSerializer()
 )
 def totals_chart(totals: dict[str, int]) -> dict[str, Any]:
     """Expose chart-ready data under `window.Next.context.totals_chart`.
@@ -26,5 +24,5 @@ def totals_chart(totals: dict[str, int]) -> dict[str, Any]:
     because the envelope is `{"v": 1, "data": ...}`.
     """
     return {
-        "bars": [{"name": name, "value": int(value)} for name, value in totals.items()],
+        "bars": [{"name": name, "value": int(value)} for name, value in totals.items()]
     }

--- a/examples/observability/obs/forms.py
+++ b/examples/observability/obs/forms.py
@@ -5,11 +5,7 @@ from next.forms import Form
 from next.partial import Patches, is_partial_request
 
 
-WINDOW_CHOICES = (
-    ("1m", "Last minute"),
-    ("5m", "Last 5 minutes"),
-    ("1h", "Last hour"),
-)
+WINDOW_CHOICES = (("1m", "Last minute"), ("5m", "Last 5 minutes"), ("1h", "Last hour"))
 DEFAULT_WINDOW = "5m"
 LIVE_TOTALS_ZONE = "live-totals"
 METRIC_PULSE_OP = "metric-pulse"
@@ -25,8 +21,8 @@ class WindowFilterForm(Form):
                 "class": (
                     "rounded-md border border-slate-300 bg-white px-3 py-2 "
                     "text-sm focus:outline-none focus:ring-2 focus:ring-slate-400"
-                ),
-            },
+                )
+            }
         ),
     )
 

--- a/examples/observability/obs/management/commands/flush_metrics.py
+++ b/examples/observability/obs/management/commands/flush_metrics.py
@@ -7,7 +7,7 @@ from obs.models import MetricSnapshot
 class Command(BaseCommand):
     help = "Persist cached counters into the MetricSnapshot table."
 
-    def handle(self, *_args: object, **_options: object) -> None:
+    def handle(self, *args, **options) -> None:
         """Drain every counter, persist the snapshot, and clear the cache."""
         rows = flush()
         if not rows:

--- a/examples/observability/obs/metrics.py
+++ b/examples/observability/obs/metrics.py
@@ -76,9 +76,7 @@ def incr(kind: str, key: str, by: int = 1) -> int:
     """
     cumulative = _atomic_bump(_full_key(kind, key), by)
     _atomic_bump(
-        _bucket_key(kind, key, _floor_minute(_now())),
-        by,
-        ttl=BUCKET_TTL_SECONDS,
+        _bucket_key(kind, key, _floor_minute(_now())), by, ttl=BUCKET_TTL_SECONDS
     )
     return cumulative
 

--- a/examples/observability/obs/receivers.py
+++ b/examples/observability/obs/receivers.py
@@ -13,11 +13,7 @@ from next.forms.signals import (
     action_registered,
     form_validation_failed,
 )
-from next.pages.signals import (
-    context_registered,
-    page_rendered,
-    template_loaded,
-)
+from next.pages.signals import context_registered, page_rendered, template_loaded
 from next.server.signals import watch_specs_ready
 from next.static.signals import (
     asset_registered,
@@ -56,9 +52,7 @@ def on_context_registered(file_path: object = None, **_kwargs: object) -> None:
 
 @receiver(page_rendered)
 def on_page_rendered(
-    file_path: object = None,
-    duration_ms: float | None = None,
-    **_kwargs: object,
+    file_path: object = None, duration_ms: float | None = None, **_kwargs: object
 ) -> None:
     """Pages group: count renders and accumulate render-time milliseconds."""
     incr("pages.rendered", str(file_path))

--- a/examples/observability/obs/receivers.py
+++ b/examples/observability/obs/receivers.py
@@ -27,32 +27,32 @@ from .metrics import incr
 
 
 @receiver(settings_reloaded)
-def on_settings_reloaded(**_kwargs: object) -> None:
+def on_settings_reloaded(**kwargs) -> None:
     """Conf group: bump on every framework settings reload."""
     incr("conf", "settings_reloaded")
 
 
 @receiver(provider_registered)
-def on_provider_registered(**_kwargs: object) -> None:
+def on_provider_registered(**kwargs) -> None:
     """Deps group: bump on every DI provider class definition."""
     incr("deps", "provider_registered")
 
 
 @receiver(template_loaded)
-def on_template_loaded(file_path: object = None, **_kwargs: object) -> None:
+def on_template_loaded(file_path: object = None, **kwargs) -> None:
     """Pages group: count distinct page templates loaded."""
     incr("pages.template", str(file_path))
 
 
 @receiver(context_registered)
-def on_context_registered(file_path: object = None, **_kwargs: object) -> None:
+def on_context_registered(file_path: object = None, **kwargs) -> None:
     """Pages group: count `@context` registrations."""
     incr("pages.context", str(file_path))
 
 
 @receiver(page_rendered)
 def on_page_rendered(
-    file_path: object = None, duration_ms: float | None = None, **_kwargs: object
+    file_path: object = None, duration_ms: float | None = None, **kwargs
 ) -> None:
     """Pages group: count renders and accumulate render-time milliseconds."""
     incr("pages.rendered", str(file_path))
@@ -61,26 +61,26 @@ def on_page_rendered(
 
 
 @receiver(route_registered)
-def on_route_registered(url_path: str | None = None, **_kwargs: object) -> None:
+def on_route_registered(url_path: str | None = None, **kwargs) -> None:
     """Urls group: count routes seen during file router scans."""
     incr("urls.route", str(url_path))
 
 
 @receiver(router_reloaded)
-def on_router_reloaded(**_kwargs: object) -> None:
+def on_router_reloaded(**kwargs) -> None:
     """Urls group: count router rebuilds."""
     incr("urls", "router_reloaded")
 
 
 @receiver(component_registered)
-def on_component_registered(info: object = None, **_kwargs: object) -> None:
+def on_component_registered(info: object = None, **kwargs) -> None:
     """Components group: count discovered components by name."""
     name = getattr(info, "name", "<unknown>")
     incr("components.registered", str(name))
 
 
 @receiver(components_registered)
-def on_components_registered(infos: tuple[object, ...] = (), **_kwargs: object) -> None:
+def on_components_registered(infos: tuple[object, ...] = (), **kwargs) -> None:
     """Components group: count bulk-registered components by name."""
     for info in infos:
         name = getattr(info, "name", "<unknown>")
@@ -88,52 +88,50 @@ def on_components_registered(infos: tuple[object, ...] = (), **_kwargs: object) 
 
 
 @receiver(component_backend_loaded)
-def on_component_backend_loaded(**_kwargs: object) -> None:
+def on_component_backend_loaded(**kwargs) -> None:
     """Components group: count built component backends."""
     incr("components", "backend_loaded")
 
 
 @receiver(component_rendered)
-def on_component_rendered(info: object = None, **_kwargs: object) -> None:
+def on_component_rendered(info: object = None, **kwargs) -> None:
     """Components group: count component render passes by name."""
     name = getattr(info, "name", "<unknown>")
     incr("components.rendered", str(name))
 
 
 @receiver(action_registered)
-def on_action_registered(action_name: str | None = None, **_kwargs: object) -> None:
+def on_action_registered(action_name: str | None = None, **kwargs) -> None:
     """Forms group: count action registrations."""
     incr("forms.action_registered", str(action_name))
 
 
 @receiver(action_dispatched)
-def on_action_dispatched(action_name: str | None = None, **_kwargs: object) -> None:
+def on_action_dispatched(action_name: str | None = None, **kwargs) -> None:
     """Forms group: count action dispatches."""
     incr("forms.action_dispatched", str(action_name))
 
 
 @receiver(form_validation_failed)
-def on_form_validation_failed(
-    action_name: str | None = None, **_kwargs: object
-) -> None:
+def on_form_validation_failed(action_name: str | None = None, **kwargs) -> None:
     """Forms group: count validation failures by action."""
     incr("forms.validation_failed", str(action_name))
 
 
 @receiver(asset_registered)
-def on_asset_registered(**_kwargs: object) -> None:
+def on_asset_registered(**kwargs) -> None:
     """Record one entry per static asset registration."""
     incr("static", "asset_registered")
 
 
 @receiver(collector_finalized)
-def on_collector_finalized(**_kwargs: object) -> None:
+def on_collector_finalized(**kwargs) -> None:
     """Record one entry per finalized static collector."""
     incr("static", "collector_finalized")
 
 
 @receiver(html_injected)
-def on_html_injected(injected_bytes: int | None = None, **_kwargs: object) -> None:
+def on_html_injected(injected_bytes: int | None = None, **kwargs) -> None:
     """Record HTML injection events and accumulate the byte total."""
     incr("static", "html_injected")
     if injected_bytes:
@@ -141,12 +139,12 @@ def on_html_injected(injected_bytes: int | None = None, **_kwargs: object) -> No
 
 
 @receiver(backend_loaded)
-def on_static_backend_loaded(**_kwargs: object) -> None:
+def on_static_backend_loaded(**kwargs) -> None:
     """Record one entry per built static backend."""
     incr("static", "backend_loaded")
 
 
 @receiver(watch_specs_ready)
-def on_watch_specs_ready(**_kwargs: object) -> None:
+def on_watch_specs_ready(**kwargs) -> None:
     """Server group: count watcher reload spec resolutions."""
     incr("server", "watch_specs_ready")

--- a/examples/observability/obs/serializers.py
+++ b/examples/observability/obs/serializers.py
@@ -1,8 +1,6 @@
 import json
 
-from next.static import (
-    PydanticJsContextSerializer as _FrameworkPydantic,
-)
+from next.static import PydanticJsContextSerializer as _FrameworkPydantic
 
 
 ENVELOPE_VERSION = 1

--- a/examples/observability/tests/test_e2e.py
+++ b/examples/observability/tests/test_e2e.py
@@ -43,12 +43,7 @@ GROUP_SAMPLES: dict[str, list] = {
         component_rendered,
     ],
     "forms": [action_registered, action_dispatched, form_validation_failed],
-    "static": [
-        asset_registered,
-        backend_loaded,
-        collector_finalized,
-        html_injected,
-    ],
+    "static": [asset_registered, backend_loaded, collector_finalized, html_injected],
     "server": [watch_specs_ready],
 }
 

--- a/examples/observability/tests/test_metrics_window.py
+++ b/examples/observability/tests/test_metrics_window.py
@@ -81,7 +81,7 @@ class TestReadWindowKindIsolation:
         with frozen_now(BASE):
             metrics.incr("pages.rendered", "/a/b:c/page.py", by=4)
             assert metrics.read_window("pages.rendered", minutes=5) == {
-                "/a/b:c/page.py": 4,
+                "/a/b:c/page.py": 4
             }
 
 

--- a/examples/observability/tests/test_unit.py
+++ b/examples/observability/tests/test_unit.py
@@ -203,10 +203,7 @@ class TestSerializerOverride:
         encoded = WrappedJsContextSerializer().dumps(
             _PydanticPayload(name="y", count=7)
         )
-        assert json.loads(encoded) == {
-            "v": 1,
-            "data": {"name": "y", "count": 7},
-        }
+        assert json.loads(encoded) == {"v": 1, "data": {"name": "y", "count": 7}}
 
 
 class TestInstrumentedDedup:
@@ -278,13 +275,7 @@ class TestReceiverDirectInvocation:
                 "/tmp/page.py",
                 1,
             ),
-            (
-                on_route_registered,
-                {"url_path": "/stats/"},
-                "urls.route",
-                "/stats/",
-                1,
-            ),
+            (on_route_registered, {"url_path": "/stats/"}, "urls.route", "/stats/", 1),
             (on_router_reloaded, {}, "urls", "router_reloaded", 1),
             (on_component_backend_loaded, {}, "components", "backend_loaded", 1),
             (
@@ -315,12 +306,7 @@ class TestReceiverDirectInvocation:
         ],
     )
     def test_receiver_increments_expected_counter(
-        self,
-        receiver,
-        kwargs,
-        expected_kind,
-        expected_key,
-        expected_value,
+        self, receiver, kwargs, expected_kind, expected_key, expected_value
     ) -> None:
         receiver(**kwargs)
         assert metrics.read_kind(expected_kind).get(expected_key) == expected_value

--- a/examples/search-catalog/catalog/context_processors.py
+++ b/examples/search-catalog/catalog/context_processors.py
@@ -29,32 +29,17 @@ def active_filters(request: HttpRequest) -> dict[str, Any]:
         chips.append(_chip(items, f"Search {f.q}", "q", f.q))
     chips.extend(_chip(items, f"Brand {brand}", "brand", brand) for brand in f.brands)
     if f.price_min is not None:
-        chips.append(
-            _chip(items, f"From {f.price_min}", "price_min", str(f.price_min)),
-        )
+        chips.append(_chip(items, f"From {f.price_min}", "price_min", str(f.price_min)))
     if f.price_max is not None:
-        chips.append(
-            _chip(items, f"To {f.price_max}", "price_max", str(f.price_max)),
-        )
+        chips.append(_chip(items, f"To {f.price_max}", "price_max", str(f.price_max)))
     if f.in_stock:
         chips.append(_chip(items, "In stock", "in_stock", "1"))
-    return {
-        "active_filters": chips,
-        "active_filters_count": len(chips),
-    }
+    return {"active_filters": chips, "active_filters_count": len(chips)}
 
 
 def _chip(
-    items: list[tuple[str, str]],
-    label: str,
-    key: str,
-    value: str,
+    items: list[tuple[str, str]], label: str, key: str, value: str
 ) -> dict[str, str]:
     """Return a single chip descriptor including the precomputed drop URL."""
     kept = [(k, v) for k, v in items if (k, v) != (key, value)]
-    return {
-        "label": label,
-        "key": key,
-        "value": value,
-        "drop_url": urlencode(kept),
-    }
+    return {"label": label, "key": key, "value": value, "drop_url": urlencode(kept)}

--- a/examples/search-catalog/catalog/forms.py
+++ b/examples/search-catalog/catalog/forms.py
@@ -28,8 +28,7 @@ class PresetFilterForm(Form):
     """
 
     preset = django_forms.ChoiceField(
-        choices=[(name, name) for name in PRESETS],
-        widget=django_forms.HiddenInput,
+        choices=[(name, name) for name in PRESETS], widget=django_forms.HiddenInput
     )
 
     def _target(self) -> str:

--- a/examples/search-catalog/catalog/models.py
+++ b/examples/search-catalog/catalog/models.py
@@ -23,9 +23,7 @@ class Category(models.Model):
 
 class Product(models.Model):
     category = models.ForeignKey(
-        Category,
-        on_delete=models.CASCADE,
-        related_name="products",
+        Category, on_delete=models.CASCADE, related_name="products"
     )
     slug = models.SlugField(max_length=80)
     name = models.CharField(max_length=200)
@@ -41,9 +39,8 @@ class Product(models.Model):
         ordering: ClassVar = ["-created_at"]
         constraints: ClassVar = [
             models.UniqueConstraint(
-                fields=["category", "slug"],
-                name="uniq_product_per_cat",
-            ),
+                fields=["category", "slug"], name="uniq_product_per_cat"
+            )
         ]
         indexes: ClassVar = [
             models.Index(fields=["category", "in_stock"]),

--- a/examples/search-catalog/catalog/providers.py
+++ b/examples/search-catalog/catalog/providers.py
@@ -32,7 +32,7 @@ class Filters:
             or self.price_min is not None
             or self.price_max is not None
             or self.in_stock
-            or self.sort != "newest",
+            or self.sort != "newest"
         )
 
 
@@ -82,21 +82,13 @@ def parse_filters(request: HttpRequest) -> Filters:
 class FiltersProvider(RegisteredParameterProvider):
     """Resolve `DFilters`-annotated parameters into a `Filters` snapshot."""
 
-    def can_handle(
-        self,
-        param: inspect.Parameter,
-        context: ResolutionContext,
-    ) -> bool:
+    def can_handle(self, param: inspect.Parameter, context: ResolutionContext) -> bool:
         """Match the bare `DFilters` annotation when a request is attached."""
         if param.annotation is not DFilters:
             return False
         return getattr(context, "request", None) is not None
 
-    def resolve(
-        self,
-        _param: inspect.Parameter,
-        context: ResolutionContext,
-    ) -> Filters:
+    def resolve(self, _param: inspect.Parameter, context: ResolutionContext) -> Filters:
         """Return a `Filters` snapshot derived from the current request."""
         return parse_filters(context.request)
 
@@ -104,20 +96,14 @@ class FiltersProvider(RegisteredParameterProvider):
 class PageProvider(RegisteredParameterProvider):
     """Resolve `DPage[T]`-annotated parameters into a `PageRequest`."""
 
-    def can_handle(
-        self,
-        param: inspect.Parameter,
-        context: ResolutionContext,
-    ) -> bool:
+    def can_handle(self, param: inspect.Parameter, context: ResolutionContext) -> bool:
         """Match `DPage` annotations when a request is attached."""
         if param.annotation is not DPage:
             return False
         return getattr(context, "request", None) is not None
 
     def resolve(
-        self,
-        _param: inspect.Parameter,
-        context: ResolutionContext,
+        self, _param: inspect.Parameter, context: ResolutionContext
     ) -> PageRequest:
         """Return a clamped `PageRequest` derived from `?page` and `?per_page`."""
         g = context.request.GET
@@ -129,7 +115,4 @@ class PageProvider(RegisteredParameterProvider):
             per_page = int(g.get("per_page") or DEFAULT_PER_PAGE)
         except ValueError:
             per_page = DEFAULT_PER_PAGE
-        return PageRequest(
-            number=number,
-            per_page=min(MAX_PER_PAGE, max(1, per_page)),
-        )
+        return PageRequest(number=number, per_page=min(MAX_PER_PAGE, max(1, per_page)))

--- a/examples/search-catalog/catalog/queries.py
+++ b/examples/search-catalog/catalog/queries.py
@@ -22,10 +22,7 @@ CACHE_TTL = 60
 
 
 def _cache_key(
-    filters: Filters,
-    page: int,
-    per_page: int,
-    category_pk: int | None,
+    filters: Filters, page: int, per_page: int, category_pk: int | None
 ) -> str:
     """Build a stable hash-based cache key for the given filter set."""
     payload: dict[str, Any] = {
@@ -44,11 +41,7 @@ def _cache_key(
 
 
 def cached_search(
-    filters: Filters,
-    page: int,
-    per_page: int,
-    *,
-    category: Category | None = None,
+    filters: Filters, page: int, per_page: int, *, category: Category | None = None
 ) -> dict[str, Any]:
     """Return a paginated search payload, reading from the cache when possible.
 

--- a/examples/search-catalog/catalog/storefront/catalog/[category]/[slug]/page.py
+++ b/examples/search-catalog/catalog/storefront/catalog/[category]/[slug]/page.py
@@ -9,8 +9,7 @@ def product(category: Category, slug: str) -> Product:
     """Return the product identified by the inherited category and the URL slug."""
     try:
         return Product.objects.select_related("category").get(
-            category=category,
-            slug=slug,
+            category=category, slug=slug
         )
     except Product.DoesNotExist as exc:
         raise Http404 from exc

--- a/examples/search-catalog/catalog/storefront/catalog/[category]/page.py
+++ b/examples/search-catalog/catalog/storefront/catalog/[category]/page.py
@@ -26,18 +26,9 @@ def category(category: object) -> Category:
 
 
 @context("page_obj")
-def page_obj(
-    category: Category,
-    filters: DFilters,
-    page: DPage,
-) -> dict:
+def page_obj(category: Category, filters: DFilters, page: DPage) -> dict:
     """Return the cached search payload scoped to the current category."""
-    return cached_search(
-        filters,
-        page.number,
-        page.per_page,
-        category=category,
-    )
+    return cached_search(filters, page.number, page.per_page, category=category)
 
 
 @context("all_brands")

--- a/examples/search-catalog/catalog/storefront/catalog/_cards/filter_panel/component.py
+++ b/examples/search-catalog/catalog/storefront/catalog/_cards/filter_panel/component.py
@@ -15,10 +15,7 @@ def submit_url(category: object = None) -> str:
     either a slug string or a resolved `Category` instance.
     """
     if isinstance(category, Category):
-        return reverse(
-            "next:page_catalog_category",
-            kwargs={"category": category.slug},
-        )
+        return reverse("next:page_catalog_category", kwargs={"category": category.slug})
     return reverse("next:page_catalog")
 
 

--- a/examples/search-catalog/catalog/storefront/page.py
+++ b/examples/search-catalog/catalog/storefront/page.py
@@ -20,7 +20,7 @@ def featured(show: DQuery[int] = DEFAULT_FEATURED) -> list[Product]:
     return list(
         Product.objects.filter(in_stock=True)
         .select_related("category")
-        .order_by("-created_at")[:count],
+        .order_by("-created_at")[:count]
     )
 
 

--- a/examples/search-catalog/catalog/templatetags/catalog_qs.py
+++ b/examples/search-catalog/catalog/templatetags/catalog_qs.py
@@ -10,7 +10,7 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def querystring(context: dict[str, Any], **overrides: object) -> str:
+def querystring(context: dict[str, Any], **overrides) -> str:
     """Return `request.GET` as a query string with the given overrides applied.
 
     Existing keys in `overrides` replace their values entirely. Other

--- a/examples/search-catalog/config/settings.py
+++ b/examples/search-catalog/config/settings.py
@@ -41,25 +41,22 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
 }
 
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "search-catalog",
-    },
+    }
 }
 
 LANGUAGE_CODE = "en-us"
@@ -85,17 +82,15 @@ NEXT_FRAMEWORK = {
             "DIRS": [str(BASE_DIR / "marketplace")],
             "PAGES_DIR": "storefront",
             "OPTIONS": {
-                "context_processors": [
-                    "catalog.context_processors.active_filters",
-                ],
+                "context_processors": ["catalog.context_processors.active_filters"]
             },
-        },
+        }
     ],
     "COMPONENT_BACKENDS": [
         {
             "BACKEND": "next.components.FileComponentsBackend",
             "DIRS": [str(SHARED_DIR / "_components")],
             "COMPONENTS_DIR": "_cards",
-        },
+        }
     ],
 }

--- a/examples/search-catalog/config/urls.py
+++ b/examples/search-catalog/config/urls.py
@@ -1,6 +1,4 @@
 from django.urls import include, path
 
 
-urlpatterns = [
-    path("", include("next.urls")),
-]
+urlpatterns = [path("", include("next.urls"))]

--- a/examples/search-catalog/tests/test_e2e.py
+++ b/examples/search-catalog/tests/test_e2e.py
@@ -39,32 +39,17 @@ class TestRouting:
         assert "Featured" in body
 
     @pytest.mark.parametrize(
-        ("show", "expected_count"),
-        [
-            (None, 3),
-            (1, 1),
-            (6, 6),
-            (999, 12),
-            (0, 1),
-        ],
+        ("show", "expected_count"), [(None, 3), (1, 1), (6, 6), (999, 12), (0, 1)]
     )
     def test_landing_show_query_param(
-        self,
-        client,
-        catalog_db,
-        show,
-        expected_count,
+        self, client, catalog_db, show, expected_count
     ) -> None:
         """Honour `?show=N` on the landing through `DQuery[int]`."""
         url = "/" if show is None else f"/?show={show}"
         body = client.get(url).content.decode()
         assert body.count("data-product-card") == expected_count
 
-    def test_landing_reuses_product_card_css(
-        self,
-        client,
-        catalog_db,
-    ) -> None:
+    def test_landing_reuses_product_card_css(self, client, catalog_db) -> None:
         """Render the shared `product_card.css` once on the landing too."""
         body = client.get("/").content.decode()
         assert body.count("data-product-card") == 3
@@ -135,16 +120,10 @@ class TestFilters:
         ],
     )
     def test_filter_by_brand_keeps_only_listed_brands(
-        self,
-        client,
-        catalog_db,
-        query,
-        expected_brands,
+        self, client, catalog_db, query, expected_brands
     ) -> None:
         """Restrict the listing to the requested brands across every wire format."""
-        cards = _product_card_section(
-            client.get(f"/catalog/{query}").content.decode(),
-        )
+        cards = _product_card_section(client.get(f"/catalog/{query}").content.decode())
         excluded = {"Acme", "Globex", "Initech", "Hooli"} - expected_brands
         for brand in excluded:
             assert brand not in cards
@@ -162,21 +141,13 @@ class TestFilters:
         assert r.status_code == 200
         assert "out of stock" not in _product_card_section(r.content.decode()).lower()
 
-    def test_search_query_matches_product_name(
-        self,
-        client,
-        catalog_db,
-    ) -> None:
+    def test_search_query_matches_product_name(self, client, catalog_db) -> None:
         """Match products whose name contains the search term."""
         r = client.get("/catalog/?q=iPhone")
         assert r.status_code == 200
         assert "iPhone 15" in r.content.decode()
 
-    def test_pagination_returns_distinct_pages(
-        self,
-        client,
-        catalog_db,
-    ) -> None:
+    def test_pagination_returns_distinct_pages(self, client, catalog_db) -> None:
         """Return non-overlapping product slugs for different page numbers."""
         slugs_page1 = _slug_set(client.get("/catalog/?page=1").content.decode())
         slugs_page2 = _slug_set(client.get("/catalog/?page=2").content.decode())
@@ -189,9 +160,7 @@ class TestActiveFilterChip:
     """Cover the active-filter chip rendered by the context processor."""
 
     def test_chip_renders_with_class_and_data_attribute(
-        self,
-        client,
-        catalog_db,
+        self, client, catalog_db
     ) -> None:
         """Render a chip with the active-filter class and a data attribute."""
         body = client.get("/catalog/?brand=Acme").content.decode()
@@ -199,11 +168,7 @@ class TestActiveFilterChip:
         assert 'data-active-filter="brand"' in body
         assert "Brand Acme" in body
 
-    def test_no_chip_on_default_sort(
-        self,
-        client,
-        catalog_db,
-    ) -> None:
+    def test_no_chip_on_default_sort(self, client, catalog_db) -> None:
         """Skip chip rendering when only the default sort key is present."""
         body = client.get("/catalog/?sort=newest").content.decode()
         assert "data-active-filter" not in body
@@ -212,11 +177,7 @@ class TestActiveFilterChip:
 class TestInheritContext:
     """Cover the `inherit_context=True` pathway."""
 
-    def test_product_detail_uses_inherited_category(
-        self,
-        client,
-        catalog_db,
-    ) -> None:
+    def test_product_detail_uses_inherited_category(self, client, catalog_db) -> None:
         """Surface the inherited Category instance on the product detail page."""
         body = client.get("/catalog/electronics/iphone-15/").content.decode()
         assert "Electronics" in body
@@ -227,20 +188,14 @@ class TestCacheHit:
     """Cover the LocMem cache hit path of `cached_search`."""
 
     def test_two_identical_requests_share_one_cache_key(
-        self,
-        client,
-        catalog_db,
+        self, client, catalog_db
     ) -> None:
         """Store one cache entry when the same filters arrive twice in a row."""
         client.get("/catalog/?brand=Acme")
         client.get("/catalog/?brand=Acme")
         assert len(_cache_keys()) == 1
 
-    def test_distinct_filters_produce_distinct_keys(
-        self,
-        client,
-        catalog_db,
-    ) -> None:
+    def test_distinct_filters_produce_distinct_keys(self, client, catalog_db) -> None:
         """Store one cache entry per distinct filter set."""
         client.get("/catalog/?brand=Acme")
         client.get("/catalog/?brand=Globex")
@@ -343,9 +298,7 @@ class TestInfiniteScrollAppend:
     ) -> None:
         first = client.get_zones("/catalog/", "catalog-results")
         second = client.get_zones(
-            "/catalog/?page=2",
-            "catalog-results",
-            HTTP_X_NEXT_MERGE="append",
+            "/catalog/?page=2", "catalog-results", HTTP_X_NEXT_MERGE="append"
         )
         keys_one = set(
             KEY_PATTERN.findall(envelope_of(first).html_for_zone("catalog-results"))

--- a/examples/search-catalog/tests/test_unit.py
+++ b/examples/search-catalog/tests/test_unit.py
@@ -16,9 +16,7 @@ from django.apps import apps as django_apps
 from django.test import RequestFactory
 
 
-_SEED_MIGRATION = importlib.import_module(
-    "catalog.migrations.0002_seed_catalog",
-)
+_SEED_MIGRATION = importlib.import_module("catalog.migrations.0002_seed_catalog")
 
 
 @pytest.fixture()
@@ -58,11 +56,7 @@ class TestModelStr:
         """Return the product name and brand from `__str__`."""
         cat = Category.objects.create(slug="x", name="Things")
         product = Product.objects.create(
-            category=cat,
-            slug="p",
-            name="Widget",
-            brand="Acme",
-            price=Decimal("1.00"),
+            category=cat, slug="p", name="Widget", brand="Acme", price=Decimal("1.00")
         )
         assert str(product) == "Widget (Acme)"
 

--- a/examples/shortener/config/settings.py
+++ b/examples/shortener/config/settings.py
@@ -41,25 +41,22 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
 }
 
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "shortener-clicks",
-    },
+    }
 }
 
 LANGUAGE_CODE = "en-us"
@@ -85,16 +82,14 @@ NEXT_FRAMEWORK = {
             # so per-app routes under `shortener/routes/` still apply.
             "DIRS": [str(BASE_DIR / "host")],
             "PAGES_DIR": "routes",
-            "OPTIONS": {
-                "context_processors": [],
-            },
-        },
+            "OPTIONS": {"context_processors": []},
+        }
     ],
     "COMPONENT_BACKENDS": [
         {
             "BACKEND": "next.components.FileComponentsBackend",
             "DIRS": [str(SHARED_DIR / "_components")],
             "COMPONENTS_DIR": "_widgets",
-        },
+        }
     ],
 }

--- a/examples/shortener/shortener/management/commands/flush_clicks.py
+++ b/examples/shortener/shortener/management/commands/flush_clicks.py
@@ -8,7 +8,7 @@ from shortener.cache import flush_clicks
 class Command(BaseCommand):
     help = "Persist cached click counters into the database."
 
-    def handle(self, *_args: object, **_options: object) -> None:
+    def handle(self, *args, **options) -> None:
         """Persist cached counters and print a summary line."""
         total = flush_clicks()
         self.stdout.write(self.style.SUCCESS(f"flushed {total} clicks"))

--- a/examples/shortener/shortener/receivers.py
+++ b/examples/shortener/shortener/receivers.py
@@ -28,7 +28,7 @@ def _remember(action_name: str) -> None:
 
 
 @receiver(action_dispatched)
-def _on_action_dispatched(action_name: str, **_kwargs: object) -> None:
+def _on_action_dispatched(action_name: str, **kwargs) -> None:
     """Bump the counter for `action_name` and track the name for readout."""
     key = _key(action_name)
     cache.add(key, 0)

--- a/examples/shortener/shortener/routes/admin/links/[slug]/page.py
+++ b/examples/shortener/shortener/routes/admin/links/[slug]/page.py
@@ -10,10 +10,7 @@ from next.partial import Patches
 
 @context
 def link_context(link: DLink[Link]) -> dict[str, object]:
-    return {
-        "link": link,
-        "cache_key": f"{CLICK_PREFIX}{link.slug}",
-    }
+    return {"link": link, "cache_key": f"{CLICK_PREFIX}{link.slug}"}
 
 
 @action("reset_clicks")

--- a/examples/shortener/shortener/routes/admin/stats/page.py
+++ b/examples/shortener/shortener/routes/admin/stats/page.py
@@ -9,8 +9,7 @@ from next.pages import context
 @context("totals")
 def totals() -> dict[str, int]:
     aggregate = Link.objects.aggregate(
-        link_count=Count("id"),
-        total_clicks=Sum("clicks"),
+        link_count=Count("id"), total_clicks=Sum("clicks")
     )
     return {
         "links": aggregate["link_count"],

--- a/examples/shortener/shortener/routes/page.py
+++ b/examples/shortener/shortener/routes/page.py
@@ -28,9 +28,7 @@ class CreateLinkForm(Form):
         max_length=2000,
         assume_scheme="https",
         widget=ComponentWidget(
-            "input",
-            type="url",
-            placeholder="https://example.com/very/long/path",
+            "input", type="url", placeholder="https://example.com/very/long/path"
         ),
     )
 
@@ -85,11 +83,7 @@ def _render_row(link: Link, request: HttpRequest) -> str:
     """
     return _ROW_TEMPLATE.render(
         Context(
-            {
-                "link": link,
-                "request": request,
-                "current_template_path": _TEMPLATE_PATH,
-            }
+            {"link": link, "request": request, "current_template_path": _TEMPLATE_PATH}
         )
     )
 

--- a/examples/shortener/tests/test_e2e.py
+++ b/examples/shortener/tests/test_e2e.py
@@ -28,18 +28,14 @@ class TestShorten:
 
     def test_success_message_flashes_on_home(self, client) -> None:
         response = client.post_action(
-            "create_link_form",
-            {"url": "https://example.com/a"},
-            follow=True,
+            "create_link_form", {"url": "https://example.com/a"}, follow=True
         )
         body = response.content.decode()
         assert "Short link created for https://example.com/a." in body
 
     def test_invalid_url_renders_form_with_errors(self, client) -> None:
         response = client.post_action(
-            "create_link_form",
-            {"url": "not-a-url"},
-            origin="/",
+            "create_link_form", {"url": "not-a-url"}, origin="/"
         )
         assert response.status_code == 200
         assert b"Enter a valid URL" in response.content
@@ -107,19 +103,16 @@ class TestActiveNav:
             find_anchor(body, href="/admin/", text="Links"), "font-semibold"
         )
         assert_missing_class(
-            find_anchor(body, href="/admin/stats/", text="Stats"),
-            "font-semibold",
+            find_anchor(body, href="/admin/stats/", text="Stats"), "font-semibold"
         )
 
     def test_admin_subnav_highlights_stats_when_on_stats(self, client) -> None:
         body = client.get("/admin/stats/").content.decode()
         assert_missing_class(
-            find_anchor(body, href="/admin/", text="Links"),
-            "font-semibold",
+            find_anchor(body, href="/admin/", text="Links"), "font-semibold"
         )
         assert_has_class(
-            find_anchor(body, href="/admin/stats/", text="Stats"),
-            "font-semibold",
+            find_anchor(body, href="/admin/stats/", text="Stats"), "font-semibold"
         )
 
     def test_root_admin_link_is_active_on_detail_page(self, client) -> None:
@@ -132,8 +125,7 @@ class TestActiveNav:
     def test_root_admin_link_not_active_on_home(self, client) -> None:
         body = client.get("/").content.decode()
         assert_missing_class(
-            find_anchor(body, href="/admin/", text="admin"),
-            "font-semibold",
+            find_anchor(body, href="/admin/", text="admin"), "font-semibold"
         )
 
 
@@ -205,9 +197,7 @@ class TestAdminInlineEdit:
     def test_inline_edit_invalid_keeps_the_link(self, client) -> None:
         Link.objects.create(slug="alpha", url="https://example.com/a")
         response = client.post_action(
-            "edit_link_form",
-            {"slug": "alpha", "url": "not-a-url"},
-            origin="/admin/",
+            "edit_link_form", {"slug": "alpha", "url": "not-a-url"}, origin="/admin/"
         )
         assert response.status_code == 200
         assert b"Enter a valid URL" in response.content
@@ -244,10 +234,7 @@ class TestDeleteRemovesRow:
         Link.objects.create(slug="alpha", url="https://example.com/a")
         Link.objects.create(slug="bravo", url="https://example.com/b")
         response = client.post_action(
-            "delete_link",
-            {"slug": "bravo"},
-            origin="/admin/",
-            partial=True,
+            "delete_link", {"slug": "bravo"}, origin="/admin/", partial=True
         )
         assert response.status_code == 200
         envelope = envelope_of(response)
@@ -310,10 +297,7 @@ class TestResetClicksMorphsForeignBadge:
         increment_clicks("hot")
         increment_clicks("cold")
         response = client.post_action(
-            "reset_clicks",
-            {},
-            origin=f"/admin/links/{link.slug}/",
-            partial=True,
+            "reset_clicks", {}, origin=f"/admin/links/{link.slug}/", partial=True
         )
         assert response.status_code == 200
         envelope = envelope_of(response)

--- a/examples/shortener/tests/test_unit.py
+++ b/examples/shortener/tests/test_unit.py
@@ -42,9 +42,7 @@ class TestFlushClicksDecrMissing:
         Link.objects.create(slug="gone", url="https://example.com/g")
         increment_clicks("gone")
         with mock.patch.object(
-            cache_module.cache,
-            "decr",
-            side_effect=ValueError("missing"),
+            cache_module.cache, "decr", side_effect=ValueError("missing")
         ):
             assert flush_clicks() == 1
         assert Link.objects.get(slug="gone").clicks == 1
@@ -69,14 +67,9 @@ class TestGenerateSlugIntegrityRetry:
         Link.objects.create(slug="fixed", url="https://example.com/s")
         total = SLUG_ATTEMPTS_PER_LENGTH * (SLUG_MAX_LENGTH - 6 + 1)
         with (
-            mock.patch(
-                "shortener.routes.page._random_slug",
-                return_value="fixed",
-            ),
+            mock.patch("shortener.routes.page._random_slug", return_value="fixed"),
             mock.patch.object(
-                Link.objects,
-                "create",
-                side_effect=IntegrityError("dup"),
+                Link.objects, "create", side_effect=IntegrityError("dup")
             ),
             pytest.raises(RuntimeError, match="Could not allocate"),
         ):

--- a/examples/wiki/config/settings.py
+++ b/examples/wiki/config/settings.py
@@ -41,25 +41,22 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
-            ],
+            ]
         },
-    },
+    }
 ]
 
 WSGI_APPLICATION = "config.wsgi.application"
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    },
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": BASE_DIR / "db.sqlite3"}
 }
 
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "LOCATION": "wiki",
-    },
+    }
 }
 
 LANGUAGE_CODE = "en-us"
@@ -86,17 +83,15 @@ NEXT_FRAMEWORK = {
             "DIRS": [str(BASE_DIR / "shell")],
             "PAGES_DIR": "routes",
             "OPTIONS": {
-                "context_processors": [
-                    "django.template.context_processors.request",
-                ],
+                "context_processors": ["django.template.context_processors.request"]
             },
-        },
+        }
     ],
     "COMPONENT_BACKENDS": [
         {
             "BACKEND": "next.components.FileComponentsBackend",
             "DIRS": [str(SHARED_DIR / "_components")],
             "COMPONENTS_DIR": "_blocks",
-        },
+        }
     ],
 }

--- a/examples/wiki/config/urls.py
+++ b/examples/wiki/config/urls.py
@@ -1,6 +1,4 @@
 from django.urls import include, path
 
 
-urlpatterns = [
-    path("", include("next.urls")),
-]
+urlpatterns = [path("", include("next.urls"))]

--- a/examples/wiki/tests/test_e2e.py
+++ b/examples/wiki/tests/test_e2e.py
@@ -320,9 +320,7 @@ class TestRouterReloadSignal:
     """`router_reloaded` fires once per article save and once per delete."""
 
     @pytest.mark.parametrize(
-        "trigger",
-        ["save", "delete"],
-        ids=["on-save", "on-delete"],
+        "trigger", ["save", "delete"], ids=["on-save", "on-delete"]
     )
     def test_router_reload_signal_fires(
         self, routing_doc: Article, trigger: str

--- a/examples/wiki/wiki/markdown_render.py
+++ b/examples/wiki/wiki/markdown_render.py
@@ -11,8 +11,7 @@ EMPTY_PREVIEW = format_html(
     "<p class='text-slate-400 italic'>{}</p>", "Nothing to preview yet."
 )
 UNSAFE_HREF = re.compile(
-    r'href="\s*(?:javascript|data|vbscript):[^"]*"',
-    flags=re.IGNORECASE,
+    r'href="\s*(?:javascript|data|vbscript):[^"]*"', flags=re.IGNORECASE
 )
 
 

--- a/examples/wiki/wiki/models.py
+++ b/examples/wiki/wiki/models.py
@@ -15,8 +15,7 @@ class Article(models.Model):
     """One DB-backed wiki article served at ``/wiki/<slug>/``."""
 
     SLUG_VALIDATOR = RegexValidator(
-        SLUG_RE,
-        message="Lowercase letters, digits, and dashes only.",
+        SLUG_RE, message="Lowercase letters, digits, and dashes only."
     )
     slug = models.SlugField(max_length=80, unique=True, validators=[SLUG_VALIDATOR])
     title = models.CharField(max_length=200)

--- a/examples/wiki/wiki/receivers.py
+++ b/examples/wiki/wiki/receivers.py
@@ -10,6 +10,6 @@ from .models import Article
 
 @receiver(post_save, sender=Article)
 @receiver(post_delete, sender=Article)
-def reload_router_on_article_change(**_kwargs: object) -> None:
+def reload_router_on_article_change(**kwargs) -> None:
     """Rebuild URL patterns whenever an article appears or disappears."""
     router_manager.reload()

--- a/examples/wiki/wiki/routes/articles/new/page.py
+++ b/examples/wiki/wiki/routes/articles/new/page.py
@@ -10,20 +10,15 @@ from next.pages import context
 
 class ArticleCreateForm(Form):
     slug = django_forms.SlugField(
-        max_length=80,
-        widget=ComponentWidget("input", placeholder="wiki-slug"),
+        max_length=80, widget=ComponentWidget("input", placeholder="wiki-slug")
     )
     title = django_forms.CharField(
-        max_length=200,
-        widget=ComponentWidget("input", placeholder="Article title"),
+        max_length=200, widget=ComponentWidget("input", placeholder="Article title")
     )
     body_md = django_forms.CharField(
         required=False,
         widget=ComponentWidget(
-            "textarea",
-            placeholder="# Markdown body",
-            rows=12,
-            markdown_source=True,
+            "textarea", placeholder="# Markdown body", rows=12, markdown_source=True
         ),
     )
 

--- a/next/apps/autoreload.py
+++ b/next/apps/autoreload.py
@@ -69,7 +69,7 @@ def uninstall() -> None:
         _state.watcher_connected = False
 
 
-def _watch_next_filesystem(sender: object, **_: object) -> None:
+def _watch_next_filesystem(sender: object, **kwargs) -> None:
     for path, glob in iter_all_autoreload_watch_specs():
         sender.watch_dir(path, glob)  # type: ignore[attr-defined]
 

--- a/next/apps/checks.py
+++ b/next/apps/checks.py
@@ -25,11 +25,12 @@ from django.core.checks import (
 from django.template import Library
 
 import next.templatetags
+from next.checks import NEXT
 
 from .templates import _BUILTIN_MODULES, _DJANGO_BACKEND
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_django_templates_backend_present(
     *_args: object,
     **_kwargs: object,
@@ -70,7 +71,7 @@ def _iter_tag_library_modules() -> list[str]:
     return found
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_builtin_tag_libraries_complete(
     *_args: object,
     **_kwargs: object,

--- a/next/apps/checks.py
+++ b/next/apps/checks.py
@@ -16,12 +16,7 @@ import pkgutil
 from importlib import import_module
 
 from django.conf import settings
-from django.core.checks import (
-    CheckMessage,
-    Tags,
-    Warning as DjangoWarning,
-    register,
-)
+from django.core.checks import CheckMessage, Tags, Warning as DjangoWarning, register
 from django.template import Library
 
 import next.templatetags
@@ -31,10 +26,7 @@ from .templates import _BUILTIN_MODULES, _DJANGO_BACKEND
 
 
 @register(Tags.templates, NEXT)
-def check_django_templates_backend_present(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_django_templates_backend_present(*args, **kwargs) -> list[CheckMessage]:
     """Warn when no DjangoTemplates engine carries the next-dj tags."""
     engines = getattr(settings, "TEMPLATES", [])
     if any(engine.get("BACKEND") == _DJANGO_BACKEND for engine in engines):
@@ -45,7 +37,7 @@ def check_django_templates_backend_present(
             "None is configured, so the {% %} tags will be unavailable.",
             obj=settings,
             id="next.W062",
-        ),
+        )
     ]
 
 
@@ -72,10 +64,7 @@ def _iter_tag_library_modules() -> list[str]:
 
 
 @register(Tags.templates, NEXT)
-def check_builtin_tag_libraries_complete(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_builtin_tag_libraries_complete(*args, **kwargs) -> list[CheckMessage]:
     """Warn when a tag library is not registered as a builtin (`next.W063`).
 
     The builtin registration list is the explicit `_BUILTIN_MODULES` tuple.

--- a/next/checks/__init__.py
+++ b/next/checks/__init__.py
@@ -34,8 +34,10 @@ if TYPE_CHECKING:
         check_context_processor_signature,
         check_layout_templates,
         check_page_functions,
+        check_page_module_imports,
         check_pages_structure,
         check_request_in_context,
+        check_single_keyless_context,
         check_template_loaders,
     )
     from next.pages.loaders import _load_python_module
@@ -62,8 +64,10 @@ _LAZY_SOURCES_BY_MODULE: dict[str, tuple[str, ...]] = {
         "check_context_processor_signature",
         "check_layout_templates",
         "check_page_functions",
+        "check_page_module_imports",
         "check_pages_structure",
         "check_request_in_context",
+        "check_single_keyless_context",
         "check_template_loaders",
     ),
     "next.pages.loaders": ("_load_python_module",),

--- a/next/checks/__init__.py
+++ b/next/checks/__init__.py
@@ -13,6 +13,12 @@ import importlib
 from typing import TYPE_CHECKING
 
 
+__all__ = ["NEXT", "register_all", "reset_check_caches"]
+
+NEXT: str = "next"
+"""Shared system-check tag that selects every `next-dj` check."""
+
+
 if TYPE_CHECKING:
     from next.components.checks import (
         check_component_py_no_pages_context,
@@ -83,12 +89,29 @@ def register_all() -> None:
         "next.urls.checks",
         "next.components.checks",
         "next.forms.checks",
-        "next.server.checks",
         "next.static.checks",
         "next.partial.checks",
         "next.apps.checks",
     ):
         importlib.import_module(module_name)
+
+
+def reset_check_caches() -> None:
+    """Drop every per-run check cache so the next run rebuilds from disk.
+
+    Tests and scripts that invoke checks directly and mutate the page or
+    component tree in place need this, since the caches otherwise freeze the
+    scanned state for the lifetime of the process. The module memo and context
+    registry are cleared together so a re-executed `page.py` repopulates the
+    registry from its current source instead of keeping a stale `@context`.
+    """
+    common = importlib.import_module("next.checks.common")
+    common.reset_router_manager_cache()
+    common.reset_components_manager_cache()
+    importlib.import_module("next.partial.checks").reset_composed_pages_memo()
+    importlib.import_module("next.urls.checks").reset_collected_patterns_cache()
+    importlib.import_module("next.pages.loaders").reset_module_memo()
+    importlib.import_module("next.pages.manager").reset_context_registry()
 
 
 def __getattr__(name: str) -> object:
@@ -102,4 +125,4 @@ def __getattr__(name: str) -> object:
 
 def __dir__() -> list[str]:
     """List the eager `register_all` plus every lazily resolved re-export."""
-    return ["register_all", *sorted(_LAZY_ATTRIBUTES)]
+    return ["NEXT", "register_all", "reset_check_caches", *sorted(_LAZY_ATTRIBUTES)]

--- a/next/checks/common.py
+++ b/next/checks/common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
+from weakref import WeakKeyDictionary
 
 from django.apps import apps
 from django.conf import settings
@@ -20,10 +21,7 @@ if TYPE_CHECKING:
 
 
 def errors_for_unknown_keys(
-    config: dict[str, Any],
-    *,
-    allowed: frozenset[str],
-    prefix: str,
+    config: dict[str, Any], *, allowed: frozenset[str], prefix: str
 ) -> list[CheckMessage]:
     """Return an `Error` list when `config` contains keys outside `allowed`."""
     unknown = sorted(k for k in config if k not in allowed)
@@ -36,26 +34,31 @@ def errors_for_unknown_keys(
             f"{prefix} has unknown keys {unknown_fmt}. Allowed keys are {allowed_fmt}.",
             obj=settings,
             id="next.E035",
-        ),
+        )
     ]
 
 
 # One manager per `manage.py check` run instead of rescanning the page and
 # component trees for every registered check.
 _ROUTER_MANAGER_CACHE: dict[
-    str,
-    tuple[RouterManager | None, list[CheckMessage]] | None,
+    str, tuple[RouterManager | None, list[CheckMessage]] | None
 ] = {"value": None}
 _COMPONENTS_MANAGER_CACHE: dict[str, ComponentsManager | None] = {"value": None}
 
-# Scan pairs materialised once per run and keyed by `id(router)`, which stays
-# unique because the manager cache above keeps every router alive for the run
-# and this slot is dropped before that manager is rebuilt.
-_SCANNED_PAIRS_CACHE: dict[str, dict[int, list[tuple[str, Path]]]] = {"value": {}}
+# Scan pairs keyed by the router object. A weak key ties each entry to its
+# router's lifetime, so a reused `id` can never alias a stale entry.
+_SCANNED_PAIRS_CACHE: WeakKeyDictionary[RouterBackend, list[tuple[str, Path]]] = (
+    WeakKeyDictionary()
+)
 
 
 def get_router_manager() -> tuple[RouterManager | None, list[CheckMessage]]:
-    """Return a per-run cached `RouterManager` or initialisation errors."""
+    """Return a per-run cached `RouterManager` or initialisation errors.
+
+    The cache is dropped only on `settings_reloaded` (a `NEXT_FRAMEWORK` change,
+    which `override_settings` triggers) or an explicit `reset_check_caches`, so
+    changes to other router inputs (for example `INSTALLED_APPS`) need a reset.
+    """
     cached = _ROUTER_MANAGER_CACHE["value"]
     if cached is not None:
         return cached
@@ -69,9 +72,7 @@ def get_router_manager() -> tuple[RouterManager | None, list[CheckMessage]]:
         router_manager.reload()
     except (ImportError, AttributeError) as e:
         error = Error(
-            f"Error initializing router manager: {e}",
-            obj=settings,
-            id="next.E007",
+            f"Error initializing router manager: {e}", obj=settings, id="next.E007"
         )
         result = (None, [error])
     else:
@@ -80,18 +81,21 @@ def get_router_manager() -> tuple[RouterManager | None, list[CheckMessage]]:
     return result
 
 
-def reset_router_manager_cache(**_kwargs: object) -> None:
+def reset_router_manager_cache(**kwargs) -> None:
     """Drop the cached `RouterManager` and its scan pairs for the next run.
 
     Scan pairs are meaningless without the manager that kept their routers
     alive, so both slots clear on the same reset contour.
     """
     _ROUTER_MANAGER_CACHE["value"] = None
-    _SCANNED_PAIRS_CACHE["value"] = {}
+    _SCANNED_PAIRS_CACHE.clear()
 
 
 def get_components_manager() -> ComponentsManager:
-    """Return a per-run cached `ComponentsManager` with its config loaded."""
+    """Return a per-run cached `ComponentsManager` with its config loaded.
+
+    Invalidated like `get_router_manager`.
+    """
     cached = _COMPONENTS_MANAGER_CACHE["value"]
     if cached is not None:
         return cached
@@ -105,7 +109,7 @@ def get_components_manager() -> ComponentsManager:
     return manager
 
 
-def reset_components_manager_cache(**_kwargs: object) -> None:
+def reset_components_manager_cache(**kwargs) -> None:
     """Drop the cached `ComponentsManager` so the next check run rebuilds it."""
     _COMPONENTS_MANAGER_CACHE["value"] = None
 
@@ -138,26 +142,23 @@ def get_pages_directory(router: RouterBackend) -> Path | None:
     file_router = cast("FileRouterBackend", router)
     if file_router.app_dirs:
         return get_first_app_pages_dir(file_router) or get_first_root_pages_path(
-            file_router,
+            file_router
         )
     p = Path(str(file_router.pages_dir))
     return get_first_root_pages_path(file_router) or (p if p.exists() else None)
 
 
-def iter_scanned_page_pairs(
-    router: RouterBackend,
-) -> Iterator[tuple[str, Path]]:
+def iter_scanned_page_pairs(router: RouterBackend) -> Iterator[tuple[str, Path]]:
     """Yield pairs from `_scan_pages_directory` when the router is scannable."""
     if not hasattr(router, "_scan_pages_directory"):
         return
     pages_dir = get_pages_directory(router)
     if not pages_dir:
         return
-    cache = _SCANNED_PAIRS_CACHE["value"]
-    pairs = cache.get(id(router))
+    pairs = _SCANNED_PAIRS_CACHE.get(router)
     if pairs is None:
         pairs = list(router._scan_pages_directory(pages_dir))
-        cache[id(router)] = pairs
+        _SCANNED_PAIRS_CACHE[router] = pairs
     yield from pairs
 
 

--- a/next/checks/common.py
+++ b/next/checks/common.py
@@ -9,10 +9,13 @@ from django.apps import apps
 from django.conf import settings
 from django.core.checks import CheckMessage, Error
 
+from next.conf.signals import settings_reloaded
+
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from next.components.manager import ComponentsManager
     from next.urls import FileRouterBackend, RouterBackend, RouterManager
 
 
@@ -37,12 +40,30 @@ def errors_for_unknown_keys(
     ]
 
 
+# One manager per `manage.py check` run instead of rescanning the page and
+# component trees for every registered check.
+_ROUTER_MANAGER_CACHE: dict[
+    str,
+    tuple[RouterManager | None, list[CheckMessage]] | None,
+] = {"value": None}
+_COMPONENTS_MANAGER_CACHE: dict[str, ComponentsManager | None] = {"value": None}
+
+# Scan pairs materialised once per run and keyed by `id(router)`, which stays
+# unique because the manager cache above keeps every router alive for the run
+# and this slot is dropped before that manager is rebuilt.
+_SCANNED_PAIRS_CACHE: dict[str, dict[int, list[tuple[str, Path]]]] = {"value": {}}
+
+
 def get_router_manager() -> tuple[RouterManager | None, list[CheckMessage]]:
-    """Return a fresh `RouterManager` or initialisation errors."""
+    """Return a per-run cached `RouterManager` or initialisation errors."""
+    cached = _ROUTER_MANAGER_CACHE["value"]
+    if cached is not None:
+        return cached
     # next.urls.checks imports next.checks.common, so the manager import is
     # deferred here to break the next.checks.common <-> next.urls cycle.
     from next.urls import RouterManager  # noqa: PLC0415
 
+    result: tuple[RouterManager | None, list[CheckMessage]]
     try:
         router_manager = RouterManager()
         router_manager.reload()
@@ -52,9 +73,45 @@ def get_router_manager() -> tuple[RouterManager | None, list[CheckMessage]]:
             obj=settings,
             id="next.E007",
         )
-        return None, [error]
+        result = (None, [error])
     else:
-        return router_manager, []
+        result = (router_manager, [])
+    _ROUTER_MANAGER_CACHE["value"] = result
+    return result
+
+
+def reset_router_manager_cache(**_kwargs: object) -> None:
+    """Drop the cached `RouterManager` and its scan pairs for the next run.
+
+    Scan pairs are meaningless without the manager that kept their routers
+    alive, so both slots clear on the same reset contour.
+    """
+    _ROUTER_MANAGER_CACHE["value"] = None
+    _SCANNED_PAIRS_CACHE["value"] = {}
+
+
+def get_components_manager() -> ComponentsManager:
+    """Return a per-run cached `ComponentsManager` with its config loaded."""
+    cached = _COMPONENTS_MANAGER_CACHE["value"]
+    if cached is not None:
+        return cached
+    # next.components imports next.conf, which imports next.checks.common during
+    # app setup, so the manager import is deferred here to break that cycle.
+    from next.components.manager import ComponentsManager  # noqa: PLC0415
+
+    manager = ComponentsManager()
+    manager._reload_config()
+    _COMPONENTS_MANAGER_CACHE["value"] = manager
+    return manager
+
+
+def reset_components_manager_cache(**_kwargs: object) -> None:
+    """Drop the cached `ComponentsManager` so the next check run rebuilds it."""
+    _COMPONENTS_MANAGER_CACHE["value"] = None
+
+
+settings_reloaded.connect(reset_router_manager_cache)
+settings_reloaded.connect(reset_components_manager_cache)
 
 
 def get_first_root_pages_path(file_router: FileRouterBackend) -> Path | None:
@@ -96,14 +153,22 @@ def iter_scanned_page_pairs(
     pages_dir = get_pages_directory(router)
     if not pages_dir:
         return
-    yield from router._scan_pages_directory(pages_dir)
+    cache = _SCANNED_PAIRS_CACHE["value"]
+    pairs = cache.get(id(router))
+    if pairs is None:
+        pairs = list(router._scan_pages_directory(pages_dir))
+        cache[id(router)] = pairs
+    yield from pairs
 
 
 __all__ = [
     "errors_for_unknown_keys",
+    "get_components_manager",
     "get_first_app_pages_dir",
     "get_first_root_pages_path",
     "get_pages_directory",
     "get_router_manager",
     "iter_scanned_page_pairs",
+    "reset_components_manager_cache",
+    "reset_router_manager_cache",
 ]

--- a/next/components/backends.py
+++ b/next/components/backends.py
@@ -31,17 +31,12 @@ class ComponentsBackend(ABC):
     """Pluggable source of component definitions (files, database, etc.)."""
 
     @abstractmethod
-    def get_component(
-        self,
-        name: str,
-        template_path: Path,
-    ) -> ComponentInfo | None:
+    def get_component(self, name: str, template_path: Path) -> ComponentInfo | None:
         """Return metadata for `name` from this backend, or `None`."""
 
     @abstractmethod
     def collect_visible_components(
-        self,
-        template_path: Path,
+        self, template_path: Path
     ) -> Mapping[str, ComponentInfo]:
         """Return a mapping of visible components for `template_path`."""
 
@@ -57,8 +52,7 @@ class FileComponentsBackend(ComponentsBackend):
         self._registry = ComponentRegistry()
         self._module_loader = ModuleLoader()
         self._scanner = ComponentScanner(
-            self.components_dir,
-            module_loader=self._module_loader,
+            self.components_dir, module_loader=self._module_loader
         )
         self._visibility_resolver = ComponentVisibilityResolver(self._registry)
 
@@ -92,11 +86,7 @@ class FileComponentsBackend(ComponentsBackend):
         self._registry.register_many(components)
 
     @override
-    def get_component(
-        self,
-        name: str,
-        template_path: Path,
-    ) -> ComponentInfo | None:
+    def get_component(self, name: str, template_path: Path) -> ComponentInfo | None:
         """Return the named component visible from `template_path`."""
         self._ensure_loaded()
         visible = self.collect_visible_components(template_path)
@@ -107,8 +97,7 @@ class FileComponentsBackend(ComponentsBackend):
 
     @override
     def collect_visible_components(
-        self,
-        template_path: Path,
+        self, template_path: Path
     ) -> Mapping[str, ComponentInfo]:
         """Return the full visibility map for `template_path`."""
         self._ensure_loaded()
@@ -124,18 +113,13 @@ class DummyBackend(ComponentsBackend):
         self.created = True
 
     @override
-    def get_component(
-        self,
-        _name: str,
-        _template_path: Path,
-    ) -> ComponentInfo | None:
+    def get_component(self, _name: str, _template_path: Path) -> ComponentInfo | None:
         """Return `None` to skip name resolution through this backend."""
         return None
 
     @override
     def collect_visible_components(
-        self,
-        _template_path: Path,
+        self, _template_path: Path
     ) -> Mapping[str, ComponentInfo]:
         """Return an empty mapping because this test double never registers."""
         return {}
@@ -151,18 +135,13 @@ class BoomBackend(ComponentsBackend):
         raise RuntimeError(msg)
 
     @override
-    def get_component(
-        self,
-        _name: str,
-        _template_path: Path,
-    ) -> ComponentInfo | None:
+    def get_component(self, _name: str, _template_path: Path) -> ComponentInfo | None:
         """Unreachable because construction always raises."""
         raise NotImplementedError
 
     @override
     def collect_visible_components(
-        self,
-        _template_path: Path,
+        self, _template_path: Path
     ) -> Mapping[str, ComponentInfo]:
         """Unreachable because construction always raises."""
         raise NotImplementedError
@@ -180,9 +159,7 @@ class ComponentsFactory:
 
 
 def register_components_folder_from_router_walk(
-    folder: Path,
-    pages_root: Path,
-    scope_relative: str,
+    folder: Path, pages_root: Path, scope_relative: str
 ) -> None:
     """Register components for one folder discovered during the URL tree walk."""
     # next.components.manager imports this backends module, so the manager

--- a/next/components/checks.py
+++ b/next/components/checks.py
@@ -21,27 +21,16 @@ if TYPE_CHECKING:
 
 _COMPONENT_BACKEND_SETTINGS_KEY = "COMPONENT_BACKENDS"
 
-_FILE_COMPONENT_BACKEND_CONFIG_KEYS = frozenset(
-    {
-        "BACKEND",
-        "COMPONENTS_DIR",
-        "DIRS",
-    },
-)
+_FILE_COMPONENT_BACKEND_CONFIG_KEYS = frozenset({"BACKEND", "COMPONENTS_DIR", "DIRS"})
 
 
 def _validate_single_component_backend(
-    config: dict[str, object],
-    index: int,
+    config: dict[str, object], index: int
 ) -> list[CheckMessage]:
     """Validate required keys and types for one merged component backend dict."""
     prefix = f"NEXT_FRAMEWORK['{_COMPONENT_BACKEND_SETTINGS_KEY}'][{index}]"
     errors: list[CheckMessage] = [
-        Error(
-            f"{prefix} must specify {key}.",
-            obj=settings,
-            id="next.E031",
-        )
+        Error(f"{prefix} must specify {key}.", obj=settings, id="next.E031")
         for key in ("BACKEND", "DIRS", "COMPONENTS_DIR")
         if key not in config
     ]
@@ -49,19 +38,11 @@ def _validate_single_component_backend(
         return errors
     if not isinstance(config["BACKEND"], str):
         errors.append(
-            Error(
-                f"{prefix}.BACKEND must be a string.",
-                obj=settings,
-                id="next.E032",
-            ),
+            Error(f"{prefix}.BACKEND must be a string.", obj=settings, id="next.E032")
         )
     if not isinstance(config["DIRS"], list):
         errors.append(
-            Error(
-                f"{prefix}.DIRS must be a list.",
-                obj=settings,
-                id="next.E032",
-            ),
+            Error(f"{prefix}.DIRS must be a list.", obj=settings, id="next.E032")
         )
     if not isinstance(config["COMPONENTS_DIR"], str):
         errors.append(
@@ -69,23 +50,18 @@ def _validate_single_component_backend(
                 f"{prefix}.COMPONENTS_DIR must be a string.",
                 obj=settings,
                 id="next.E027",
-            ),
+            )
         )
     errors.extend(
         errors_for_unknown_keys(
-            config,
-            allowed=_FILE_COMPONENT_BACKEND_CONFIG_KEYS,
-            prefix=prefix,
-        ),
+            config, allowed=_FILE_COMPONENT_BACKEND_CONFIG_KEYS, prefix=prefix
+        )
     )
     return errors
 
 
 @register(NEXT)
-def check_next_components_configuration(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_next_components_configuration(*args, **kwargs) -> list[CheckMessage]:
     """Validate `COMPONENT_BACKENDS` shape in merged `NEXT_FRAMEWORK`."""
     raw = getattr(settings, "NEXT_FRAMEWORK", None)
     if raw is not None and not isinstance(raw, dict):
@@ -99,7 +75,7 @@ def check_next_components_configuration(
                 "backend configuration dictionaries.",
                 obj=settings,
                 id="next.E023",
-            ),
+            )
         ]
 
     if len(backends) == 0:
@@ -109,7 +85,7 @@ def check_next_components_configuration(
                 "one component backend entry.",
                 obj=settings,
                 id="next.E033",
-            ),
+            )
         ]
 
     errors: list[CheckMessage] = []
@@ -121,7 +97,7 @@ def check_next_components_configuration(
                     "must be a dictionary.",
                     obj=settings,
                     id="next.E002",
-                ),
+                )
             )
             continue
         errors.extend(_validate_single_component_backend(config, i))
@@ -130,10 +106,7 @@ def check_next_components_configuration(
 
 
 @register(NEXT)
-def check_duplicate_component_names(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_duplicate_component_names(*args, **kwargs) -> list[CheckMessage]:
     """Check that no two components share the same name within the same scope."""
     errors: list[CheckMessage] = []
     configs = next_framework_settings.COMPONENT_BACKENDS
@@ -162,16 +135,13 @@ def check_duplicate_component_names(
                         f"within the same scope: {paths_str}",
                         obj=settings,
                         id="next.E020",
-                    ),
+                    )
                 )
     return errors
 
 
 @register(NEXT)
-def check_cross_root_component_name_conflicts(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_cross_root_component_name_conflicts(*args, **kwargs) -> list[CheckMessage]:
     """Reject one component name in the root route scope on more than one page tree."""
     errors: list[CheckMessage] = []
     configs = next_framework_settings.COMPONENT_BACKENDS
@@ -196,8 +166,7 @@ def check_cross_root_component_name_conflicts(
             details = ". ".join(
                 f"{root}: {path_str or '?'}"
                 for root, path_str in sorted(
-                    roots_map.items(),
-                    key=lambda item: str(item[0]),
+                    roots_map.items(), key=lambda item: str(item[0])
                 )
             )
             errors.append(
@@ -208,7 +177,7 @@ def check_cross_root_component_name_conflicts(
                     f"names at the root route scope. Locations: {details}.",
                     obj=settings,
                     id="next.E034",
-                ),
+                )
             )
     return errors
 
@@ -242,10 +211,7 @@ def _component_py_uses_pages_context(file_path: Path) -> bool:
 
 
 @register(NEXT)
-def check_component_py_no_pages_context(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_component_py_no_pages_context(*args, **kwargs) -> list[CheckMessage]:
     """Check that `component.py` files do not use `context` from `next.pages`."""
     errors: list[CheckMessage] = []
     configs = next_framework_settings.COMPONENT_BACKENDS
@@ -269,7 +235,7 @@ def check_component_py_no_pages_context(
                         "Use component context from next.components instead.",
                         obj=str(info.module_path),
                         id="next.E021",
-                    ),
+                    )
                 )
     return errors
 

--- a/next/components/checks.py
+++ b/next/components/checks.py
@@ -6,13 +6,13 @@ import ast
 from typing import TYPE_CHECKING
 
 from django.conf import settings
-from django.core.checks import CheckMessage, Error, Tags, register
+from django.core.checks import CheckMessage, Error, register
 
-from next.checks.common import errors_for_unknown_keys
+from next.checks import NEXT
+from next.checks.common import errors_for_unknown_keys, get_components_manager
 from next.conf import next_framework_settings
 
 from .backends import FileComponentsBackend
-from .manager import ComponentsManager
 
 
 if TYPE_CHECKING:
@@ -81,7 +81,7 @@ def _validate_single_component_backend(
     return errors
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_next_components_configuration(
     *_args: object,
     **_kwargs: object,
@@ -129,7 +129,7 @@ def check_next_components_configuration(
     return errors
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_duplicate_component_names(
     *_args: object,
     **_kwargs: object,
@@ -139,8 +139,7 @@ def check_duplicate_component_names(
     configs = next_framework_settings.COMPONENT_BACKENDS
     if not isinstance(configs, list) or not configs:
         return errors
-    manager = ComponentsManager()
-    manager._reload_config()
+    manager = get_components_manager()
     for backend in manager._backends:
         if not isinstance(backend, FileComponentsBackend):
             continue
@@ -168,7 +167,7 @@ def check_duplicate_component_names(
     return errors
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_cross_root_component_name_conflicts(
     *_args: object,
     **_kwargs: object,
@@ -178,8 +177,7 @@ def check_cross_root_component_name_conflicts(
     configs = next_framework_settings.COMPONENT_BACKENDS
     if not isinstance(configs, list) or not configs:
         return errors
-    manager = ComponentsManager()
-    manager._reload_config()
+    manager = get_components_manager()
     for backend in manager._backends:
         if not isinstance(backend, FileComponentsBackend):
             continue
@@ -243,7 +241,7 @@ def _component_py_uses_pages_context(file_path: Path) -> bool:
     return False
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_component_py_no_pages_context(
     *_args: object,
     **_kwargs: object,
@@ -253,8 +251,7 @@ def check_component_py_no_pages_context(
     configs = next_framework_settings.COMPONENT_BACKENDS
     if not isinstance(configs, list) or not configs:
         return errors
-    manager = ComponentsManager()
-    manager._reload_config()
+    manager = get_components_manager()
     for backend in manager._backends:
         if not isinstance(backend, FileComponentsBackend):
             continue

--- a/next/components/manager.py
+++ b/next/components/manager.py
@@ -90,9 +90,7 @@ class ComponentsManager:
                 )
                 continue
             component_backend_loaded.send(
-                sender=ComponentsManager,
-                backend=backend,
-                config=config,
+                sender=ComponentsManager, backend=backend, config=config
             )
             self._backends.append(backend)
 
@@ -112,11 +110,7 @@ class ComponentsManager:
         self._walk_registered_folders.add(key)
         return True
 
-    def get_component(
-        self,
-        name: str,
-        template_path: Path,
-    ) -> ComponentInfo | None:
+    def get_component(self, name: str, template_path: Path) -> ComponentInfo | None:
         """Return the first non-`None` match from configured backends."""
         self._ensure_backends()
         for backend in self._backends:
@@ -141,7 +135,7 @@ class ComponentsManager:
 components_manager = ComponentsManager()
 
 
-def _on_settings_reloaded(**_kwargs: object) -> None:
+def _on_settings_reloaded(**kwargs) -> None:
     """Rebuild component backends when framework settings reload."""
     components_manager._reload_config()
 

--- a/next/components/renderers.py
+++ b/next/components/renderers.py
@@ -59,8 +59,7 @@ def _render_template_string(template_str: str, context_dict: dict[str, Any]) -> 
 
 
 def _merge_csrf_context(
-    context_dict: dict[str, Any],
-    request: HttpRequest | None,
+    context_dict: dict[str, Any], request: HttpRequest | None
 ) -> None:
     """Add a lazy `csrf_token` matching the request context processor."""
     if request is None or "csrf_token" in context_dict:
@@ -70,9 +69,7 @@ def _merge_csrf_context(
 
 
 def _inject_component_context(
-    info: ComponentInfo,
-    context_data: dict[str, Any],
-    request: HttpRequest | None,
+    info: ComponentInfo, context_data: dict[str, Any], request: HttpRequest | None
 ) -> None:
     if info.module_path is None:
         return
@@ -161,9 +158,7 @@ class CompositeComponentRenderer:
     """Uses `render()` in `component.py` when present, otherwise the template."""
 
     def __init__(
-        self,
-        module_loader: ModuleLoader,
-        template_loader: ComponentTemplateLoader,
+        self, module_loader: ModuleLoader, template_loader: ComponentTemplateLoader
     ) -> None:
         """Bind the renderer to shared module and template loaders."""
         self._module_loader = module_loader
@@ -236,9 +231,7 @@ class CompositeComponentRenderer:
         return _render_template_string(template_str, context_dict)
 
     def _fallback_to_template(
-        self,
-        info: ComponentInfo,
-        context_data: Mapping[str, Any],
+        self, info: ComponentInfo, context_data: Mapping[str, Any]
     ) -> str:
         template_str = self._template_loader.load(info)
         if template_str is None:

--- a/next/components/scanner.py
+++ b/next/components/scanner.py
@@ -44,10 +44,7 @@ class ComponentScanner:
         self._module_loader = module_loader or ModuleLoader()
 
     def scan_directory(
-        self,
-        directory: Path,
-        scope_root: Path,
-        scope_relative: str,
+        self, directory: Path, scope_root: Path, scope_relative: str
     ) -> Sequence[ComponentInfo]:
         """Return a list of `ComponentInfo` found immediately inside `directory`."""
         components: list[ComponentInfo] = []
@@ -69,10 +66,7 @@ class ComponentScanner:
         return components
 
     def _create_simple_component(
-        self,
-        djx_file: Path,
-        scope_root: Path,
-        scope_relative: str,
+        self, djx_file: Path, scope_root: Path, scope_relative: str
     ) -> ComponentInfo:
         return ComponentInfo(
             name=djx_file.stem,
@@ -84,10 +78,7 @@ class ComponentScanner:
         )
 
     def _try_create_composite_component(
-        self,
-        directory: Path,
-        scope_root: Path,
-        scope_relative: str,
+        self, directory: Path, scope_root: Path, scope_relative: str
     ) -> ComponentInfo | None:
         comp_djx = directory / "component.djx"
         comp_py = directory / "component.py"

--- a/next/components/watch.py
+++ b/next/components/watch.py
@@ -27,9 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 def _collect_paths_for_one_pages_root(
-    scanner: ComponentScanner,
-    comp_name: str,
-    root: Path,
+    scanner: ComponentScanner, comp_name: str, root: Path
 ) -> set[Path]:
     """Gather component paths under one pages tree root."""
     result: set[Path] = set()
@@ -45,12 +43,7 @@ def _collect_paths_for_one_pages_root(
             for info in scanner.scan_directory(path, root, scope_relative):
                 result |= _paths_from_component_info(info)
     except OSError as e:
-        logger.debug(
-            "Cannot scan %s for component dirs %s: %s",
-            root,
-            comp_name,
-            e,
-        )
+        logger.debug("Cannot scan %s for component dirs %s: %s", root, comp_name, e)
     return result
 
 
@@ -71,8 +64,7 @@ def _collect_component_paths_under_page_trees() -> set[Path]:
             backend = RouterFactory.create_backend(config)
         except Exception:
             logger.exception(
-                "error creating page backend for component autoreload scan %s",
-                config,
+                "error creating page backend for component autoreload scan %s", config
             )
             continue
         if not RouterFactory.is_filesystem_discovery_router(backend):
@@ -110,20 +102,13 @@ def _collect_component_paths_from_backend_dirs() -> set[Path]:
             continue
         if not isinstance(backend, FileComponentsBackend):
             continue
-        scanner = ComponentScanner(
-            backend.components_dir,
-            module_loader=ModuleLoader(),
-        )
+        scanner = ComponentScanner(backend.components_dir, module_loader=ModuleLoader())
         for root in component_extra_roots_from_config(config):
             try:
                 for info in scanner.scan_directory(root, root, ""):
                     result |= _paths_from_component_info(info)
             except OSError as e:
-                logger.debug(
-                    "Cannot scan component root %s: %s",
-                    root,
-                    e,
-                )
+                logger.debug("Cannot scan component root %s: %s", root, e)
     return result
 
 

--- a/next/conf/checks.py
+++ b/next/conf/checks.py
@@ -12,20 +12,13 @@ from .settings import NextFrameworkSettings
 
 
 @register(NEXT)
-def check_next_framework_unknown_top_level_keys(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_next_framework_unknown_top_level_keys(*args, **kwargs) -> list[CheckMessage]:
     """Reject keys under `NEXT_FRAMEWORK` that are not defined in defaults."""
     raw = getattr(settings, "NEXT_FRAMEWORK", None)
     if raw is None or not isinstance(raw, dict):
         return []
     allowed = frozenset(NextFrameworkSettings.DEFAULTS.keys())
-    return errors_for_unknown_keys(
-        raw,
-        allowed=allowed,
-        prefix="NEXT_FRAMEWORK",
-    )
+    return errors_for_unknown_keys(raw, allowed=allowed, prefix="NEXT_FRAMEWORK")
 
 
 __all__ = ["check_next_framework_unknown_top_level_keys"]

--- a/next/conf/checks.py
+++ b/next/conf/checks.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 from django.conf import settings
-from django.core.checks import CheckMessage, Tags, register
+from django.core.checks import CheckMessage, register
 
+from next.checks import NEXT
 from next.checks.common import errors_for_unknown_keys
 
 from .settings import NextFrameworkSettings
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_next_framework_unknown_top_level_keys(
     *_args: object,
     **_kwargs: object,

--- a/next/conf/defaults.py
+++ b/next/conf/defaults.py
@@ -20,10 +20,8 @@ DEFAULTS: dict[str, Any] = {
             "DIRS": [],
             "APP_DIRS": True,
             "PAGES_DIR": "pages",
-            "OPTIONS": {
-                "context_processors": [],
-            },
-        },
+            "OPTIONS": {"context_processors": []},
+        }
     ],
     "URL_NAME_TEMPLATE": "page_{name}",
     "URL_RESOLVER": "next.urls.TrieURLResolver",
@@ -32,19 +30,11 @@ DEFAULTS: dict[str, Any] = {
             "BACKEND": "next.components.FileComponentsBackend",
             "DIRS": [],
             "COMPONENTS_DIR": "_components",
-        },
+        }
     ],
-    "STATIC_BACKENDS": [
-        {
-            "BACKEND": "next.static.StaticFilesBackend",
-            "OPTIONS": {},
-        },
-    ],
+    "STATIC_BACKENDS": [{"BACKEND": "next.static.StaticFilesBackend", "OPTIONS": {}}],
     "FORM_ACTION_BACKENDS": [
-        {
-            "BACKEND": "next.forms.RegistryFormActionBackend",
-            "OPTIONS": {},
-        },
+        {"BACKEND": "next.forms.RegistryFormActionBackend", "OPTIONS": {}}
     ],
     "PARTIAL_BACKENDS": [
         {
@@ -52,16 +42,11 @@ DEFAULTS: dict[str, Any] = {
             "OPTIONS": {
                 "VERSION": "manifest",
                 "PUSH_WIZARD_STEPS": False,
-                "SSE": {
-                    "HEARTBEAT_SECONDS": 25,
-                    "RETRY_MS": 3000,
-                },
+                "SSE": {"HEARTBEAT_SECONDS": 25, "RETRY_MS": 3000},
             },
-        },
+        }
     ],
-    "TEMPLATE_LOADERS": [
-        "next.pages.loaders.DjxTemplateLoader",
-    ],
+    "TEMPLATE_LOADERS": ["next.pages.loaders.DjxTemplateLoader"],
     "NEXT_JS_OPTIONS": {},
     "STRICT_CONTEXT": False,
     "LAZY_COMPONENT_MODULES": False,

--- a/next/conf/helpers.py
+++ b/next/conf/helpers.py
@@ -22,10 +22,7 @@ _BACKEND_LIST_KEYS = frozenset(
 
 
 def extend_default_backend(
-    key: str,
-    *,
-    index: int = 0,
-    **overrides: object,
+    key: str, *, index: int = 0, **overrides
 ) -> list[dict[str, Any]]:
     """Return a `NEXT_FRAMEWORK[key]` list with one backend entry patched.
 

--- a/next/conf/settings.py
+++ b/next/conf/settings.py
@@ -71,11 +71,7 @@ class NextFrameworkSettings:
         }
     )
     _BOOL_KEYS: ClassVar[frozenset[str]] = frozenset(
-        {
-            "STRICT_CONTEXT",
-            "LAZY_COMPONENT_MODULES",
-            "FORM_AUTODISCOVER",
-        }
+        {"STRICT_CONTEXT", "LAZY_COMPONENT_MODULES", "FORM_AUTODISCOVER"}
     )
 
     def _build_flat_merged(self, user: dict[str, Any] | None) -> dict[str, Any]:

--- a/next/conf/signals.py
+++ b/next/conf/signals.py
@@ -20,7 +20,7 @@ settings_reloaded: Signal = Signal()
 """Emitted when `NextFrameworkSettings` caches have been dropped."""
 
 
-def _on_setting_changed(*, setting: str, **_kwargs: object) -> None:
+def _on_setting_changed(*, setting: str, **kwargs) -> None:
     """Reload framework settings when Django reports a matching change."""
     if setting == USER_SETTING:
         next_framework_settings.reload()

--- a/next/deps/__init__.py
+++ b/next/deps/__init__.py
@@ -10,11 +10,7 @@ and the `RESERVED_KEYS` set. Deeper helpers live under
 from __future__ import annotations
 
 from . import signals
-from .cache import (
-    REQUEST_DEP_CACHE_ATTR,
-    DependencyCycleError,
-    get_request_dep_cache,
-)
+from .cache import REQUEST_DEP_CACHE_ATTR, DependencyCycleError, get_request_dep_cache
 from .context import RESERVED_KEYS, ResolutionContext
 from .markers import DDependencyBase, Depends
 from .providers import ParameterProvider, RegisteredParameterProvider

--- a/next/deps/__init__.py
+++ b/next/deps/__init__.py
@@ -9,7 +9,7 @@ and the `RESERVED_KEYS` set. Deeper helpers live under
 
 from __future__ import annotations
 
-from . import checks, signals
+from . import signals
 from .cache import (
     REQUEST_DEP_CACHE_ATTR,
     DependencyCycleError,
@@ -31,7 +31,6 @@ __all__ = [
     "ParameterProvider",
     "RegisteredParameterProvider",
     "ResolutionContext",
-    "checks",
     "get_request_dep_cache",
     "resolver",
     "signals",

--- a/next/deps/checks.py
+++ b/next/deps/checks.py
@@ -1,3 +1,0 @@
-"""System checks for the dependency-injection subsystem."""
-
-from __future__ import annotations

--- a/next/deps/providers.py
+++ b/next/deps/providers.py
@@ -45,7 +45,7 @@ class RegisteredParameterProvider(ABC):
     priority: ClassVar[int] = 100
 
     @override
-    def __init_subclass__(cls, **kwargs: object) -> None:
+    def __init_subclass__(cls, **kwargs) -> None:
         """Track concrete subclasses for lazy instantiation by the resolver."""
         super().__init_subclass__(**kwargs)
         RegisteredParameterProvider._registry.append(cls)

--- a/next/deps/resolver.py
+++ b/next/deps/resolver.py
@@ -167,8 +167,7 @@ class DependencyResolver:
         self._providers.append(provider)
 
     def register(
-        self,
-        provider: ParameterProvider | type[ParameterProvider],
+        self, provider: ParameterProvider | type[ParameterProvider]
     ) -> ParameterProvider | type[ParameterProvider]:
         """Register a provider, accepting either a class or an instance."""
         if isinstance(provider, type):
@@ -204,7 +203,7 @@ class DependencyResolver:
             self._resolve_call_stack.pop()
 
     def resolve_dependencies(
-        self, func: Callable[..., Any], **context: object
+        self, func: Callable[..., Any], **context
     ) -> dict[str, Any]:
         """Resolve `func` from a loose kwargs mapping and build a context object."""
         self._ensure_providers()

--- a/next/forms/backends.py
+++ b/next/forms/backends.py
@@ -55,12 +55,7 @@ class FormActionNotFoundError(LookupError):
         # failure.
         self._context: tuple[
             str, str | None, Callable[[], Iterable[str]] | Iterable[str], bool
-        ] = (
-            name,
-            page_path,
-            candidates,
-            registry_empty,
-        )
+        ] = (name, page_path, candidates, registry_empty)
         if message is None:
             super().__init__()
         else:
@@ -280,9 +275,7 @@ class FormActionBackend(ABC):
         """Run the handler for `uid`."""
 
     def get_meta(
-        self,
-        action_name: str,
-        page_path: str | None = None,
+        self, action_name: str, page_path: str | None = None
     ) -> "ActionMeta | None":
         """Return optional per-action metadata for subclasses."""
         del action_name, page_path
@@ -306,9 +299,7 @@ class FormActionBackend(ABC):
         return ""
 
     def shape_response(
-        self,
-        request: "HttpRequest",
-        outcome: ActionOutcome,
+        self, request: "HttpRequest", outcome: ActionOutcome
     ) -> "HttpResponse":
         """Turn one pipeline outcome into the HTTP response.
 
@@ -318,10 +309,7 @@ class FormActionBackend(ABC):
         """
         # Deferred to break the next.forms <-> next.partial import cycle:
         # partial shaping imports the form dispatch and origin helpers.
-        from next.partial import (  # noqa: PLC0415
-            is_partial_request,
-            shape_partial,
-        )
+        from next.partial import is_partial_request, shape_partial  # noqa: PLC0415
 
         if is_partial_request(request):
             return shape_partial(self, request, outcome)
@@ -338,7 +326,7 @@ def _make_uid_for_action(scope_key: str, name: str) -> str:
 _url_caching_backends: "WeakSet[RegistryFormActionBackend]" = WeakSet()
 
 
-def _on_setting_changed(*, setting: str, **_kwargs: object) -> None:
+def _on_setting_changed(*, setting: str, **kwargs) -> None:
     """Drop cached action URLs when the URLconf is swapped under override_settings."""
     if setting == "ROOT_URLCONF":
         for backend in _url_caching_backends:
@@ -528,9 +516,7 @@ class RegistryFormActionBackend(FormActionBackend):
 
     @override
     def get_meta(
-        self,
-        action_name: str,
-        page_path: str | None = None,
+        self, action_name: str, page_path: str | None = None
     ) -> "ActionMeta | None":
         """Return stored `ActionMeta` for the name, if any."""
         if page_path is not None:

--- a/next/forms/base.py
+++ b/next/forms/base.py
@@ -270,7 +270,7 @@ class _PermissionHooks:
     _has_object_permission: bool = False
 
     @override
-    def __init_subclass__(cls, **kwargs: object) -> None:
+    def __init_subclass__(cls, **kwargs) -> None:
         """Stamp the per-subclass hook-presence flags via __func__ identity."""
         super().__init_subclass__(**kwargs)
         cls._has_check_permissions = _stamp_hook_flag(
@@ -296,7 +296,7 @@ class BaseForm(_PermissionHooks, DjangoBaseForm):
     default_renderer = _div_form_renderer
 
     @override
-    def __init_subclass__(cls, **kwargs: object) -> None:
+    def __init_subclass__(cls, **kwargs) -> None:
         """Register subclass in form_action_manager automatically."""
         super().__init_subclass__(**kwargs)
         _auto_register_form_class(cls)
@@ -325,14 +325,14 @@ class BaseModelForm(_PermissionHooks, DjangoBaseModelForm):
     default_renderer = _div_form_renderer
 
     @override
-    def __init_subclass__(cls, **kwargs: object) -> None:
+    def __init_subclass__(cls, **kwargs) -> None:
         """Register subclass in form_action_manager automatically."""
         super().__init_subclass__(**kwargs)
         _auto_register_form_class(cls)
         _validate_instance_from_url(cls, is_model_form=True)
 
     @classmethod
-    def get_initial(cls, **url_kwargs: object) -> dict[str, Any] | Model:
+    def get_initial(cls, **url_kwargs) -> dict[str, Any] | Model:
         """Return a model instance loaded from the URL, or an empty dict."""
         spec = getattr(getattr(cls, "Meta", None), "instance_from_url", None)
         if not spec:

--- a/next/forms/checks.py
+++ b/next/forms/checks.py
@@ -7,12 +7,12 @@ from django.conf import settings
 from django.core.checks import (
     CheckMessage,
     Error,
-    Tags,
     Warning as DjangoWarning,
     register,
 )
 from django.forms import FileField, MultiValueField
 
+from next.checks import NEXT
 from next.components.facade import get_component
 from next.conf import import_class_cached, next_framework_settings
 
@@ -44,7 +44,7 @@ def _iter_registered_actions() -> "Iterator[ActionMeta]":
         yield from backend.iter_actions()
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_form_action_collisions(
     *_args: object,
     **_kwargs: object,
@@ -62,7 +62,7 @@ def check_form_action_collisions(
     ]
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_shared_action_name_collisions(
     *_args: object,
     **_kwargs: object,
@@ -83,7 +83,7 @@ def check_shared_action_name_collisions(
     ]
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_form_action_backends_configuration(
     *_args: object,
     **_kwargs: object,
@@ -147,7 +147,7 @@ def _validate_single_form_action_backend(
     return []
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_forms_outside_base_dir(
     *_args: object,
     **_kwargs: object,
@@ -163,7 +163,7 @@ def check_forms_outside_base_dir(
     ]
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_invalid_form_meta_scope(
     *_args: object,
     **_kwargs: object,
@@ -188,7 +188,7 @@ def check_invalid_form_meta_scope(
     return class_errors + action_errors
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_action_applied_to_class(
     *_args: object,
     **_kwargs: object,
@@ -204,7 +204,7 @@ def check_action_applied_to_class(
     ]
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_instance_from_url_unknown_field(
     *_args: object,
     **_kwargs: object,
@@ -224,7 +224,7 @@ def check_instance_from_url_unknown_field(
     ]
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_instance_from_url_on_non_model_form(
     *_args: object,
     **_kwargs: object,
@@ -240,7 +240,7 @@ def check_instance_from_url_on_non_model_form(
     ]
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_form_wizard_steps(
     *_args: object,
     **_kwargs: object,
@@ -256,7 +256,7 @@ def check_form_wizard_steps(
     ]
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_form_wizard_backend(
     *_args: object,
     **_kwargs: object,
@@ -313,7 +313,7 @@ def _validate_form_wizard_backend(config: object) -> list[CheckMessage]:
     return []
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_form_wizard_sessions(
     *_args: object,
     **_kwargs: object,
@@ -348,7 +348,7 @@ def check_form_wizard_sessions(
     ]
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_wizard_step_actions(
     *_args: object,
     **_kwargs: object,
@@ -391,7 +391,7 @@ def check_wizard_step_actions(
 _PAGE_MODULE_NAME = "page.py"
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_wizard_url_param_route(
     *_args: object,
     **_kwargs: object,
@@ -430,7 +430,7 @@ def check_wizard_url_param_route(
     return messages
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_wizard_step_file_fields(
     *_args: object,
     **_kwargs: object,
@@ -464,7 +464,7 @@ def check_wizard_step_file_fields(
     return messages
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_wizard_step_field_collisions(
     *_args: object,
     **_kwargs: object,
@@ -501,7 +501,7 @@ def check_wizard_step_field_collisions(
     return messages
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_form_anchor_files(
     *_args: object,
     **_kwargs: object,
@@ -535,7 +535,7 @@ def check_form_anchor_files(
     return []
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_action_guard_permissions(
     *_args: object,
     **_kwargs: object,
@@ -569,7 +569,7 @@ def _declares_success_message(target: object) -> bool:
     return bool(getattr(getattr(target, "Meta", None), "success_message", ""))
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_success_message_framework(
     *_args: object,
     **_kwargs: object,
@@ -594,7 +594,7 @@ def check_success_message_framework(
     ]
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_component_widget_components(
     *_args: object,
     **_kwargs: object,
@@ -630,7 +630,7 @@ def check_component_widget_components(
     return messages
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_component_widget_field_types(
     *_args: object,
     **_kwargs: object,

--- a/next/forms/checks.py
+++ b/next/forms/checks.py
@@ -4,12 +4,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from django.conf import settings
-from django.core.checks import (
-    CheckMessage,
-    Error,
-    Warning as DjangoWarning,
-    register,
-)
+from django.core.checks import CheckMessage, Error, Warning as DjangoWarning, register
 from django.forms import FileField, MultiValueField
 
 from next.checks import NEXT
@@ -20,11 +15,7 @@ from .backends import FormActionBackend
 from .diagnostics import registration_diagnostics
 from .manager import form_action_manager
 from .widgets import ComponentWidget
-from .wizard import (
-    CacheFormWizardBackend,
-    FormWizardBackend,
-    SessionFormWizardBackend,
-)
+from .wizard import CacheFormWizardBackend, FormWizardBackend, SessionFormWizardBackend
 
 
 if TYPE_CHECKING:
@@ -45,10 +36,7 @@ def _iter_registered_actions() -> "Iterator[ActionMeta]":
 
 
 @register(NEXT)
-def check_form_action_collisions(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_form_action_collisions(*args, **kwargs) -> list[CheckMessage]:
     """Flag two `@action` calls that share a name but come from different handlers."""
     return [
         Error(
@@ -63,10 +51,7 @@ def check_form_action_collisions(
 
 
 @register(NEXT)
-def check_shared_action_name_collisions(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_shared_action_name_collisions(*args, **kwargs) -> list[CheckMessage]:
     """Error when one shared action name is declared by two different modules."""
     return [
         Error(
@@ -84,10 +69,7 @@ def check_shared_action_name_collisions(
 
 
 @register(NEXT)
-def check_form_action_backends_configuration(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_form_action_backends_configuration(*args, **kwargs) -> list[CheckMessage]:
     """Validate `FORM_ACTION_BACKENDS` shape and import paths."""
     raw = getattr(settings, "NEXT_FRAMEWORK", None)
     if not isinstance(raw, dict):
@@ -99,10 +81,8 @@ def check_form_action_backends_configuration(
         key = _FORM_ACTION_BACKEND_SETTINGS_KEY
         return [
             Error(
-                f"NEXT_FRAMEWORK[{key!r}] must be a list.",
-                obj=settings,
-                id="next.E044",
-            ),
+                f"NEXT_FRAMEWORK[{key!r}] must be a list.", obj=settings, id="next.E044"
+            )
         ]
     errors: list[CheckMessage] = []
     for index, config in enumerate(configs):
@@ -112,19 +92,14 @@ def check_form_action_backends_configuration(
 
 
 def _validate_single_form_action_backend(
-    config: object,
-    prefix: str,
+    config: object, prefix: str
 ) -> list[CheckMessage]:
     if not isinstance(config, dict):
         return [Error(f"{prefix} must be a dict.", obj=settings, id="next.E044")]
     backend_path = config.get("BACKEND")
     if not isinstance(backend_path, str):
         return [
-            Error(
-                f"{prefix}.BACKEND must be a string.",
-                obj=settings,
-                id="next.E044",
-            ),
+            Error(f"{prefix}.BACKEND must be a string.", obj=settings, id="next.E044")
         ]
     try:
         cls = import_class_cached(backend_path)
@@ -134,7 +109,7 @@ def _validate_single_form_action_backend(
                 f"{prefix}.BACKEND {backend_path!r} cannot be imported: {exc}.",
                 obj=settings,
                 id="next.E044",
-            ),
+            )
         ]
     if not isinstance(cls, type) or not issubclass(cls, FormActionBackend):
         return [
@@ -142,16 +117,13 @@ def _validate_single_form_action_backend(
                 f"{prefix}.BACKEND {backend_path!r} must subclass FormActionBackend.",
                 obj=settings,
                 id="next.E045",
-            ),
+            )
         ]
     return []
 
 
 @register(NEXT)
-def check_forms_outside_base_dir(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_forms_outside_base_dir(*args, **kwargs) -> list[CheckMessage]:
     """Warn when form classes are declared outside BASE_DIR."""
     return [
         DjangoWarning(
@@ -164,10 +136,7 @@ def check_forms_outside_base_dir(
 
 
 @register(NEXT)
-def check_invalid_form_meta_scope(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_invalid_form_meta_scope(*args, **kwargs) -> list[CheckMessage]:
     """Error when a form class Meta.scope or an @action scope is invalid."""
     class_errors: list[CheckMessage] = [
         Error(
@@ -189,10 +158,7 @@ def check_invalid_form_meta_scope(
 
 
 @register(NEXT)
-def check_action_applied_to_class(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_action_applied_to_class(*args, **kwargs) -> list[CheckMessage]:
     """Error when @action decorator was applied to a class."""
     return [
         Error(
@@ -205,10 +171,7 @@ def check_action_applied_to_class(
 
 
 @register(NEXT)
-def check_instance_from_url_unknown_field(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_instance_from_url_unknown_field(*args, **kwargs) -> list[CheckMessage]:
     """Error when Meta.instance_from_url references a field absent on the model."""
     return [
         Error(
@@ -225,10 +188,7 @@ def check_instance_from_url_unknown_field(
 
 
 @register(NEXT)
-def check_instance_from_url_on_non_model_form(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_instance_from_url_on_non_model_form(*args, **kwargs) -> list[CheckMessage]:
     """Error when Meta.instance_from_url is set on a class that is not a ModelForm."""
     return [
         Error(
@@ -241,10 +201,7 @@ def check_instance_from_url_on_non_model_form(
 
 
 @register(NEXT)
-def check_form_wizard_steps(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_form_wizard_steps(*args, **kwargs) -> list[CheckMessage]:
     """Error when a FormWizard declares no steps."""
     return [
         Error(
@@ -257,10 +214,7 @@ def check_form_wizard_steps(
 
 
 @register(NEXT)
-def check_form_wizard_backend(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_form_wizard_backend(*args, **kwargs) -> list[CheckMessage]:
     """Validate `FORM_WIZARD_BACKEND` shape and import path."""
     raw = getattr(settings, "NEXT_FRAMEWORK", None)
     if not isinstance(raw, dict):
@@ -279,7 +233,7 @@ def _validate_form_wizard_backend(config: object) -> list[CheckMessage]:
                 f"NEXT_FRAMEWORK[{key!r}] must be a dict with a BACKEND key.",
                 obj=settings,
                 id="next.E051",
-            ),
+            )
         ]
     backend_path = config.get("BACKEND")
     if not isinstance(backend_path, str):
@@ -288,7 +242,7 @@ def _validate_form_wizard_backend(config: object) -> list[CheckMessage]:
                 f"NEXT_FRAMEWORK[{key!r}].BACKEND must be a string.",
                 obj=settings,
                 id="next.E051",
-            ),
+            )
         ]
     try:
         cls = import_class_cached(backend_path)
@@ -299,7 +253,7 @@ def _validate_form_wizard_backend(config: object) -> list[CheckMessage]:
                 f"imported: {exc}.",
                 obj=settings,
                 id="next.E051",
-            ),
+            )
         ]
     if not (isinstance(cls, type) and issubclass(cls, FormWizardBackend)):
         return [
@@ -308,16 +262,13 @@ def _validate_form_wizard_backend(config: object) -> list[CheckMessage]:
                 "FormWizardBackend.",
                 obj=settings,
                 id="next.E051",
-            ),
+            )
         ]
     return []
 
 
 @register(NEXT)
-def check_form_wizard_sessions(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_form_wizard_sessions(*args, **kwargs) -> list[CheckMessage]:
     """Warn when wizard storage needs sessions without django.contrib.sessions."""
     if "django.contrib.sessions" in settings.INSTALLED_APPS:
         return []
@@ -344,15 +295,12 @@ def check_form_wizard_sessions(
             "will raise ImproperlyConfigured at request time.",
             obj=settings,
             id="next.W056",
-        ),
+        )
     ]
 
 
 @register(NEXT)
-def check_wizard_step_actions(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_wizard_step_actions(*args, **kwargs) -> list[CheckMessage]:
     """Warn when a wizard step class is also a registered standalone action.
 
     Only static Meta.steps are inspected, `get_steps` dynamics are not visible.
@@ -392,10 +340,7 @@ _PAGE_MODULE_NAME = "page.py"
 
 
 @register(NEXT)
-def check_wizard_url_param_route(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_wizard_url_param_route(*args, **kwargs) -> list[CheckMessage]:
     """Error when a page-scoped wizard's page path lacks the url_param segment.
 
     Only wizards declared in a page module are inspected. The page file
@@ -431,10 +376,7 @@ def check_wizard_url_param_route(
 
 
 @register(NEXT)
-def check_wizard_step_file_fields(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_wizard_step_file_fields(*args, **kwargs) -> list[CheckMessage]:
     """Warn when a static wizard step declares a FileField or ImageField.
 
     Only static Meta.steps are inspected, `get_steps` dynamics are not visible.
@@ -465,10 +407,7 @@ def check_wizard_step_file_fields(
 
 
 @register(NEXT)
-def check_wizard_step_field_collisions(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_wizard_step_field_collisions(*args, **kwargs) -> list[CheckMessage]:
     """Warn when two static wizard steps declare the same field name.
 
     Only static Meta.steps are inspected, `get_steps` dynamics are not visible.
@@ -502,10 +441,7 @@ def check_wizard_step_field_collisions(
 
 
 @register(NEXT)
-def check_form_anchor_files(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_form_anchor_files(*args, **kwargs) -> list[CheckMessage]:
     """Validate that FORM_ANCHOR_FILES is None or a collection of strings."""
     raw = getattr(settings, "NEXT_FRAMEWORK", None)
     if not isinstance(raw, dict):
@@ -522,7 +458,7 @@ def check_form_anchor_files(
                 f"NEXT_FRAMEWORK[{key!r}] must be None or a list of strings.",
                 obj=settings,
                 id="next.E052",
-            ),
+            )
         ]
     if not all(isinstance(item, str) for item in value):
         return [
@@ -530,16 +466,13 @@ def check_form_anchor_files(
                 f"NEXT_FRAMEWORK[{key!r}] must contain only strings.",
                 obj=settings,
                 id="next.E052",
-            ),
+            )
         ]
     return []
 
 
 @register(NEXT)
-def check_action_guard_permissions(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_action_guard_permissions(*args, **kwargs) -> list[CheckMessage]:
     """Warn when permission_required is declared without django.contrib.auth.
 
     This inspects the static `ActionGuard` only. The dynamic `check_permissions`
@@ -570,10 +503,7 @@ def _declares_success_message(target: object) -> bool:
 
 
 @register(NEXT)
-def check_success_message_framework(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_success_message_framework(*args, **kwargs) -> list[CheckMessage]:
     """Warn when Meta.success_message is declared without the messages framework."""
     has_app = "django.contrib.messages" in settings.INSTALLED_APPS
     has_middleware = _MESSAGE_MIDDLEWARE in tuple(settings.MIDDLEWARE or ())
@@ -595,10 +525,7 @@ def check_success_message_framework(
 
 
 @register(NEXT)
-def check_component_widget_components(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_component_widget_components(*args, **kwargs) -> list[CheckMessage]:
     """Warn when a ComponentWidget names a component that does not resolve."""
     base = getattr(settings, "BASE_DIR", None)
     seen: set[str] = set()
@@ -631,10 +558,7 @@ def check_component_widget_components(
 
 
 @register(NEXT)
-def check_component_widget_field_types(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_component_widget_field_types(*args, **kwargs) -> list[CheckMessage]:
     """Warn when a ComponentWidget is attached to an unsupported field type."""
     messages: list[CheckMessage] = []
     for meta in _iter_registered_actions():

--- a/next/forms/decorators.py
+++ b/next/forms/decorators.py
@@ -39,9 +39,7 @@ class _HandlerSpec:
 
 
 def _register_handler(
-    func: Callable[..., Any],
-    file_path: str,
-    spec: _HandlerSpec,
+    func: Callable[..., Any], file_path: str, spec: _HandlerSpec
 ) -> None:
     """Validate the scope override and forward one registration to the manager."""
     if spec.scope is not None and spec.scope not in _VALID_SCOPES:
@@ -108,8 +106,7 @@ def action(
         raise TypeError(msg)
     action_name = name if isinstance(name, str) else None
     guard = build_action_guard(
-        login_required=login_required,
-        permission_required=permission_required,
+        login_required=login_required, permission_required=permission_required
     )
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/next/forms/dispatch.py
+++ b/next/forms/dispatch.py
@@ -26,10 +26,7 @@ from django.shortcuts import resolve_url
 from next.deps import REQUEST_DEP_CACHE_ATTR, resolver
 from next.deps.resolver import cached_signature
 
-from .origin import (
-    _url_kwargs_for_request,
-    resolve_origin,
-)
+from .origin import _url_kwargs_for_request, resolve_origin
 from .signals import (
     action_dispatched,
     form_access_denied,
@@ -99,8 +96,7 @@ def _redirect_to_login(next_url: str) -> HttpResponseRedirect:
 
 
 def _check_access(
-    request: "HttpRequest",
-    guard: "ActionGuard",
+    request: "HttpRequest", guard: "ActionGuard"
 ) -> HttpResponseRedirect | None:
     """Enforce the action guard with `AccessMixin` semantics.
 
@@ -117,9 +113,7 @@ def _check_access(
 
 
 def _send_success_message(
-    request: "HttpRequest",
-    source: object,
-    cleaned_data: dict[str, Any],
+    request: "HttpRequest", source: object, cleaned_data: dict[str, Any]
 ) -> None:
     """Flash the declared success message through django.contrib.messages."""
     if not hasattr(source, "get_success_message"):
@@ -208,11 +202,7 @@ def _resolve_and_call(
     """Resolve a hook's dependencies and call it, feeding url_kwargs to kwargs."""
     cache, stack = deps
     resolved = resolver.resolve_dependencies(
-        hook,
-        request=request,
-        _cache=cache,
-        _stack=stack,
-        **url_kwargs,
+        hook, request=request, _cache=cache, _stack=stack, **url_kwargs
     )
     if _accepts_var_keyword(hook):
         for key, value in url_kwargs.items():
@@ -292,10 +282,7 @@ def _enforce_permission_hook(
         return None
     try:
         raw = _resolve_and_call(
-            hook,
-            request,
-            state.url_kwargs,
-            deps=(state.dep_cache, state.dep_stack),
+            hook, request, state.url_kwargs, deps=(state.dep_cache, state.dep_stack)
         )
     except PermissionDenied:
         _emit_form_access_denied(
@@ -308,10 +295,7 @@ def _enforce_permission_hook(
 
 
 def _enforce_view_permissions(
-    form_class: type,
-    request: "HttpRequest",
-    action_name: str,
-    state: "_DispatchState",
+    form_class: type, request: "HttpRequest", action_name: str, state: "_DispatchState"
 ) -> "HttpResponse | None":
     """Run the view-level check_permissions hook, emitting on a denial."""
     present = getattr(form_class, "_has_check_permissions", False)
@@ -321,11 +305,7 @@ def _enforce_view_permissions(
         else None
     )
     return _enforce_permission_hook(
-        request,
-        action_name,
-        state,
-        hook=hook,
-        layer="view",
+        request, action_name, state, hook=hook, layer="view"
     )
 
 
@@ -364,11 +344,7 @@ def _enforce_object_permissions(
         cast("_ObjectPermissionHook", form).has_object_permission if present else None
     )
     return _enforce_permission_hook(
-        request,
-        action_name,
-        state,
-        hook=hook,
-        layer="object",
+        request, action_name, state, hook=hook, layer="object"
     )
 
 
@@ -382,10 +358,7 @@ def _form_action_context_callable(
         dep_cache: dict[str, Any] = {}
         dep_stack: list[str] = []
         resolved_form_class, init_kwargs = _resolve_form_class(
-            form_class,
-            request,
-            url_kwargs,
-            (dep_cache, dep_stack),
+            form_class, request, url_kwargs, (dep_cache, dep_stack)
         )
         if init_kwargs:
             form_instance = _form_from_initial_data(
@@ -439,11 +412,7 @@ def _resolve_form_class(
         raise TypeError(msg)
     cache, stack = deps if deps is not None else ({}, [])
     resolved = resolver.resolve_dependencies(
-        form_class,
-        request=request,
-        _cache=cache,
-        _stack=stack,
-        **url_kwargs,
+        form_class, request=request, _cache=cache, _stack=stack, **url_kwargs
     )
     produced = form_class(**resolved)
     if isinstance(produced, tuple) and len(produced) == _FACTORY_TUPLE_LEN:
@@ -561,10 +530,7 @@ class _DispatchState:
             )
 
     def emit_form_validation_failed(
-        self,
-        request: "HttpRequest",
-        action_name: str,
-        form: "django_forms.Form",
+        self, request: "HttpRequest", action_name: str, form: "django_forms.Form"
     ) -> None:
         """Send `form_validation_failed` when any receiver is connected."""
         if form_validation_failed.receivers:
@@ -604,10 +570,7 @@ class _DispatchState:
         """Send `wizard_completed` when any receiver is connected."""
         if wizard_completed.receivers:
             wizard_completed.send(
-                sender=wizard_class,
-                cleaned_data=merged,
-                uid=self.uid,
-                request=request,
+                sender=wizard_class, cleaned_data=merged, uid=self.uid, request=request
             )
 
 
@@ -689,11 +652,7 @@ class FormActionDispatch:
 
         if form_class is None and handler is not None:
             return FormActionDispatch._dispatch_handler_only(
-                backend,
-                handler,
-                request,
-                action_name,
-                state,
+                backend, handler, request, action_name, state
             )
 
         if form_class is not None:
@@ -980,9 +939,7 @@ class FormActionDispatch:
 
     @staticmethod
     def shape_response(
-        backend: "FormActionBackend",
-        request: "HttpRequest",
-        outcome: ActionOutcome,
+        backend: "FormActionBackend", request: "HttpRequest", outcome: ActionOutcome
     ) -> HttpResponse:
         """Build the default envelope for one pipeline outcome.
 
@@ -1017,9 +974,7 @@ class FormActionDispatch:
 
     @staticmethod
     def _origin_rerender_response(
-        backend: "FormActionBackend",
-        request: "HttpRequest",
-        action_name: str,
+        backend: "FormActionBackend", request: "HttpRequest", action_name: str
     ) -> HttpResponse:
         """Re-render the origin page after a valid submission's handler returned None.
 

--- a/next/forms/manager.py
+++ b/next/forms/manager.py
@@ -33,10 +33,7 @@ class FormActionManager:
     bypass the manager and hit a backend directly are not tracked, as
     they were never supported."""
 
-    def __init__(
-        self,
-        backends: "list[FormActionBackend] | None" = None,
-    ) -> None:
+    def __init__(self, backends: "list[FormActionBackend] | None" = None) -> None:
         """Initialise with explicit backends or defer loading to settings."""
         self._backends: list[FormActionBackend] = list(backends) if backends else []
 
@@ -55,8 +52,7 @@ class FormActionManager:
         self._version += 1
         self._backends = []
         configs = cast(
-            "list[Any]",
-            getattr(next_framework_settings, "FORM_ACTION_BACKENDS", []),
+            "list[Any]", getattr(next_framework_settings, "FORM_ACTION_BACKENDS", [])
         )
         for config in configs:
             if not isinstance(config, dict):
@@ -65,8 +61,7 @@ class FormActionManager:
                 self._backends.append(FormActionFactory.create_backend(config))
             except ImproperlyConfigured:
                 logger.exception(
-                    "Error creating form-action backend from config %s",
-                    config,
+                    "Error creating form-action backend from config %s", config
                 )
 
     def _ensure_backends(self) -> None:
@@ -116,10 +111,7 @@ class FormActionManager:
         )
 
     def get_action_meta(
-        self,
-        action_name: str,
-        *,
-        page_path: str | None = None,
+        self, action_name: str, *, page_path: str | None = None
     ) -> "ActionMeta | None":
         """Return the action meta from the first backend that knows the name."""
         self._ensure_backends()
@@ -130,10 +122,7 @@ class FormActionManager:
         return None
 
     def require_action_meta(
-        self,
-        action_name: str,
-        *,
-        page_path: str | None = None,
+        self, action_name: str, *, page_path: str | None = None
     ) -> "ActionMeta":
         """Return the action meta or raise with close matches when none exists."""
         meta = self.get_action_meta(action_name, page_path=page_path)
@@ -168,9 +157,7 @@ form_action_manager = FormActionManager()
 
 
 def build_form_namespace_for_action(
-    action_name: str,
-    request: "HttpRequest",
-    page_path: str | None = None,
+    action_name: str, request: "HttpRequest", page_path: str | None = None
 ) -> types.SimpleNamespace | None:
     """Build the form namespace used by the form template tag."""
     meta = form_action_manager.get_action_meta(action_name, page_path=page_path)
@@ -180,8 +167,7 @@ def build_form_namespace_for_action(
 
 
 def _build_form_namespace_from_meta(
-    meta: "ActionMeta",
-    request: "HttpRequest",
+    meta: "ActionMeta", request: "HttpRequest"
 ) -> types.SimpleNamespace | None:
     """Build the form namespace for already-resolved action meta."""
     wizard_class = meta.get("wizard_class")

--- a/next/forms/markers.py
+++ b/next/forms/markers.py
@@ -3,11 +3,7 @@
 import inspect
 from typing import get_args, get_origin, override
 
-from next.deps import (
-    DDependencyBase,
-    RegisteredParameterProvider,
-    ResolutionContext,
-)
+from next.deps import DDependencyBase, RegisteredParameterProvider, ResolutionContext
 
 
 class DForm[FormT](DDependencyBase[FormT]):

--- a/next/forms/origin.py
+++ b/next/forms/origin.py
@@ -44,10 +44,7 @@ def _page_path_from_view(view: object) -> "Path | None":
 
 
 def resolve_url_to_match(
-    url: str,
-    request: "HttpRequest",
-    *,
-    filter_reserved: bool = True,
+    url: str, request: "HttpRequest", *, filter_reserved: bool = True
 ) -> "OriginMatch | None":
     """Resolve a same-site URL against the URLconf to a page identity.
 

--- a/next/forms/rendering.py
+++ b/next/forms/rendering.py
@@ -81,10 +81,7 @@ def render_form_page_with_errors(
     context_data.update(overrides)
 
     rendered, _collector = page.render_with_static_assets(
-        file_path,
-        template,
-        context_data,
-        request=request,
+        file_path, template, context_data, request=request
     )
     return rendered
 

--- a/next/forms/uid.py
+++ b/next/forms/uid.py
@@ -42,8 +42,7 @@ def validated_origin_path(raw: object) -> str | None:
 
 
 def redirect_to_origin(
-    request: HttpRequest,
-    fallback: str = "/",
+    request: HttpRequest, fallback: str = "/"
 ) -> HttpResponseRedirect:
     """Redirect back to the page that rendered the form."""
     origin: str | None = None

--- a/next/forms/widgets.py
+++ b/next/forms/widgets.py
@@ -56,7 +56,7 @@ class ComponentWidget(django_forms.Widget):
         component_name: str,
         *,
         attrs: dict[str, Any] | None = None,
-        **component_kwargs: object,
+        **component_kwargs,
     ) -> None:
         """Store the target component name and its extra render kwargs."""
         self.component_name = component_name

--- a/next/forms/wizard.py
+++ b/next/forms/wizard.py
@@ -291,7 +291,7 @@ class WizardBackendManager:
 wizard_backend_manager = WizardBackendManager()
 
 
-def _on_settings_reloaded(**_kwargs: object) -> None:
+def _on_settings_reloaded(**kwargs) -> None:
     """Drop the cached backend so a reloaded config takes effect."""
     wizard_backend_manager.reset()
 
@@ -353,7 +353,7 @@ class FormWizard:
         url_param: str = "step"
 
     @override
-    def __init_subclass__(cls, **kwargs: object) -> None:
+    def __init_subclass__(cls, **kwargs) -> None:
         """Register the wizard subclass automatically and stamp the hook flag."""
         super().__init_subclass__(**kwargs)
         cls._has_check_permissions = _stamp_hook_flag(
@@ -566,11 +566,7 @@ class FormWizard:
         """Return the flash message sent after `done`, empty string for none."""
         return _format_success_message(type(self), cleaned_data)
 
-    def done(
-        self,
-        request: HttpRequest,
-        cleaned_data: dict[str, Any],
-    ) -> HttpResponse:
+    def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> HttpResponse:
         """Finalise the wizard after the last step. Subclasses must override."""
         msg = f"{type(self).__name__} must implement done(request, cleaned_data)."
         raise NotImplementedError(msg)

--- a/next/pages/__init__.py
+++ b/next/pages/__init__.py
@@ -12,12 +12,4 @@ from .context import Context, ContextResult
 from .manager import Page, context, page
 
 
-__all__ = [
-    "Context",
-    "ContextResult",
-    "Page",
-    "checks",
-    "context",
-    "page",
-    "signals",
-]
+__all__ = ["Context", "ContextResult", "Page", "checks", "context", "page", "signals"]

--- a/next/pages/checks.py
+++ b/next/pages/checks.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import ast
-import importlib.util
+import importlib
 import inspect
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, cast, get_origin
@@ -17,14 +16,19 @@ from django.core.checks import (
     register,
 )
 
+from next.checks import NEXT
 from next.checks.common import get_router_manager, iter_scanned_page_pairs
 from next.conf import import_class_cached, next_framework_settings
 
-from .loaders import TemplateLoader, _load_python_module, build_registered_loaders
+from .loaders import (
+    TemplateLoader,
+    _load_python_module_memo,
+    build_registered_loaders,
+)
+from .manager import page
 
 
 if TYPE_CHECKING:
-    import types
     from collections.abc import Callable
     from pathlib import Path
 
@@ -39,7 +43,7 @@ EXPECTED_PARAMETER_PARTS = 2
 _MIN_CONFLICTING_BODY_SOURCES = 2
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_request_in_context(
     *_args: object,
     **_kwargs: object,
@@ -73,7 +77,7 @@ def check_request_in_context(
     return errors
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_pages_structure(
     *_args: object,
     **_kwargs: object,
@@ -154,14 +158,15 @@ def _check_root_pages(
         warnings.extend(root_warnings)
 
 
-def _check_directory_syntax(pages_path: Path, context: str) -> list[CheckMessage]:
+def _check_directory_syntax(
+    directories: list[Path],
+    pages_path: Path,
+    context: str,
+) -> list[CheckMessage]:
     """Check directory names under `pages_path` for valid bracket syntax."""
     errors: list[CheckMessage] = []
 
-    for item in pages_path.rglob("*"):
-        if not item.is_dir():
-            continue
-
+    for item in directories:
         dir_name_str = item.name
         relative_path = item.relative_to(pages_path)
 
@@ -203,14 +208,15 @@ def _check_directory_syntax(pages_path: Path, context: str) -> list[CheckMessage
     return errors
 
 
-def _check_missing_page_files(pages_path: Path, context: str) -> list[CheckMessage]:
+def _check_missing_page_files(
+    directories: list[Path],
+    pages_path: Path,
+    context: str,
+) -> list[CheckMessage]:
     """Check for missing `page.py` files inside parameter directories."""
     errors: list[CheckMessage] = []
 
-    for item in pages_path.rglob("*"):
-        if not item.is_dir():
-            continue
-
+    for item in directories:
         dir_name_str = item.name
         if (dir_name_str.startswith("[") and dir_name_str.endswith("]")) or (
             dir_name_str.startswith("[[") and dir_name_str.endswith("]]")
@@ -254,8 +260,9 @@ def _check_pages_directory(
     errors: list[CheckMessage] = []
     warnings: list[CheckMessage] = []
 
-    errors.extend(_check_directory_syntax(pages_path, context))
-    errors.extend(_check_missing_page_files(pages_path, context))
+    directories = [item for item in pages_path.rglob("*") if item.is_dir()]
+    errors.extend(_check_directory_syntax(directories, pages_path, context))
+    errors.extend(_check_missing_page_files(directories, pages_path, context))
 
     return errors, warnings
 
@@ -286,7 +293,7 @@ def _is_valid_args_syntax(args_str: str) -> bool:
     return bool(content.strip())
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_page_functions(
     *_args: object,
     **_kwargs: object,
@@ -413,7 +420,7 @@ def _active_body_sources(page_file: Path) -> list[str]:
     declared under `NEXT_FRAMEWORK["TEMPLATE_LOADERS"]`. Each loader
     reports its file name via `TemplateLoader.source_name`.
     """
-    module = _load_python_module(page_file)
+    module = _load_python_module_memo(page_file)
     sources: list[str] = []
     if module is not None:
         if callable(getattr(module, "render", None)):
@@ -446,19 +453,15 @@ def _check_body_source_conflicts(page_file: Path) -> CheckMessage | None:
 
 
 def _load_render_function(file_path: Path) -> object:
-    """Load the `render` callable from a `page.py` file."""
-    try:
-        if (
-            spec := importlib.util.spec_from_file_location("page_module", file_path)
-        ) is None or spec.loader is None:
-            return None
+    """Return the `render` callable declared in a `page.py`, or `None`.
 
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-
-        return getattr(module, "render", None)
-    except (ImportError, AttributeError, OSError, SyntaxError):
+    A syntactically broken `page.py` loads as `None` and yields `None`
+    here, so the caller still reports `next.E012`.
+    """
+    module = _load_python_module_memo(file_path)
+    if module is None:
         return None
+    return getattr(module, "render", None)
 
 
 def _has_template_or_djx(file_path: Path) -> bool:
@@ -466,22 +469,11 @@ def _has_template_or_djx(file_path: Path) -> bool:
     if (file_path.parent / "layout.djx").exists():
         return True
 
-    try:
-        if (
-            spec := importlib.util.spec_from_file_location("page_module", file_path)
-        ) is None or spec.loader is None:
-            return False
+    module = _load_python_module_memo(file_path)
+    if module is not None and hasattr(module, "template"):
+        return True
 
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-
-        if hasattr(module, "template"):
-            return True
-
-        return any(loader.can_load(file_path) for loader in build_registered_loaders())
-
-    except (ImportError, AttributeError, OSError, SyntaxError):
-        return False
+    return any(loader.can_load(file_path) for loader in build_registered_loaders())
 
 
 def _check_layout_file(layout_file: Path) -> CheckMessage | None:
@@ -501,7 +493,7 @@ def _check_layout_file(layout_file: Path) -> CheckMessage | None:
     return None
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_layout_templates(
     *_args: object,
     **_kwargs: object,
@@ -524,21 +516,6 @@ def check_layout_templates(
                 warnings.append(warning)
 
     return warnings
-
-
-def _has_context_decorator_without_key(func: Callable[..., Any]) -> bool:
-    """Return True when `func` has the `@context` decorator applied without a key."""
-    try:
-        source = inspect.getsource(func)
-        tree = ast.parse(source)
-        for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef):
-                for decorator in node.decorator_list:
-                    if isinstance(decorator, ast.Name) and decorator.id == "context":
-                        return True
-    except (SyntaxError, OSError, UnicodeDecodeError):
-        pass
-    return False
 
 
 _DICT_ANNOTATION_NAMES = frozenset({"dict", "Dict", "Mapping", "MutableMapping"})
@@ -588,29 +565,30 @@ def _check_context_function(
     annotation_name = getattr(annotation, "__name__", None) or repr(annotation)
     return Error(
         f"Context function '{func_name}' in {page_path} "
-        "must return a dictionary "
-        f"when used with @context decorator (without key). "
-        f"Got return annotation {annotation_name} instead.",
+        "must return a dictionary when registered as a keyless context "
+        f"(got return annotation {annotation_name}). "
+        "Annotate it '-> dict' (or a TypedDict), or register it with a key "
+        "like @context('name').",
         obj=str(page_path),
         id="next.E029",
     )
 
 
-def _check_module_context_functions(
-    module: types.ModuleType,
-    page_path: Path,
-) -> list[CheckMessage]:
-    """Collect keyless `@context` functions declared in one page module."""
+def _check_registered_context_functions(page_path: Path) -> list[CheckMessage]:
+    """Return keyless `@context` errors recorded for `page_path` in the registry.
+
+    The registry keys on the caller's `__file__`, which is the same path the
+    check loads the module by, so a direct `page_path` lookup matches whatever
+    spelling the scanner used without resolving symlinks on either side.
+    """
     errors: list[CheckMessage] = []
-
-    for name, obj in inspect.getmembers(module, inspect.isfunction):
-        if not _has_context_decorator_without_key(obj):
+    registry = page._context_manager._context_registry.get(page_path, {})
+    for key, entry in registry.items():
+        if key is not None:
             continue
-
-        error = _check_context_function(name, obj, page_path)
-        if error:
+        error = _check_context_function(entry.func.__name__, entry.func, page_path)
+        if error is not None:
             errors.append(error)
-
     return errors
 
 
@@ -622,17 +600,15 @@ def _check_router_context_functions(router: RouterBackend) -> list[CheckMessage]
         if not page_path.exists():
             continue
 
-        module = _load_python_module(page_path)
-        if not module:
+        if _load_python_module_memo(page_path) is None:
             continue
 
-        module_errors = _check_module_context_functions(module, page_path)
-        errors.extend(module_errors)
+        errors.extend(_check_registered_context_functions(page_path))
 
     return errors
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_context_functions(
     *_args: object,
     **_kwargs: object,
@@ -650,7 +626,7 @@ def check_context_functions(
     return errors
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_context_processor_signature(
     *_args: object,
     **_kwargs: object,
@@ -710,7 +686,7 @@ def _check_processor_request_parameter(
     )
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_template_loaders(
     *_args: object,
     **_kwargs: object,

--- a/next/pages/checks.py
+++ b/next/pages/checks.py
@@ -20,19 +20,15 @@ from next.checks import NEXT
 from next.checks.common import get_router_manager, iter_scanned_page_pairs
 from next.conf import import_class_cached, next_framework_settings
 
-from .loaders import (
-    TemplateLoader,
-    _load_python_module_memo,
-    build_registered_loaders,
-)
+from .loaders import TemplateLoader, _load_python_module_memo, build_registered_loaders
 from .manager import page
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
     from pathlib import Path
 
-    from next.urls import FileRouterBackend, RouterBackend
+    from next.urls import FileRouterBackend, RouterBackend, RouterManager
 
 
 REQUEST_CONTEXT_PROCESSOR = "django.template.context_processors.request"
@@ -44,10 +40,7 @@ _MIN_CONFLICTING_BODY_SOURCES = 2
 
 
 @register(Tags.templates, NEXT)
-def check_request_in_context(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_request_in_context(*args, **kwargs) -> list[CheckMessage]:
     """Ensure `request` is in the template context (required for `{% form %}`)."""
     if "next" not in settings.INSTALLED_APPS:
         return []
@@ -67,21 +60,12 @@ def check_request_in_context(
                 "'django.template.context_processors.request' to "
                 "OPTIONS.context_processors."
             )
-            errors.append(
-                Error(
-                    msg,
-                    obj=settings,
-                    id="next.E019",
-                ),
-            )
+            errors.append(Error(msg, obj=settings, id="next.E019"))
     return errors
 
 
 @register(NEXT)
-def check_pages_structure(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_pages_structure(*args, **kwargs) -> list[CheckMessage]:
     """Check each router's pages tree for layouts, naming, and structure."""
     errors: list[CheckMessage] = []
     warnings: list[CheckMessage] = []
@@ -98,20 +82,14 @@ def check_pages_structure(
                 _check_root_pages(router, errors, warnings)
         except (AttributeError, OSError) as e:
             errors.append(
-                Error(
-                    f"Error checking router pages: {e}",
-                    obj=settings,
-                    id="next.E030",
-                ),
+                Error(f"Error checking router pages: {e}", obj=settings, id="next.E030")
             )
 
     return errors + warnings
 
 
 def _check_app_pages(
-    router: RouterBackend,
-    errors: list[CheckMessage],
-    warnings: list[CheckMessage],
+    router: RouterBackend, errors: list[CheckMessage], warnings: list[CheckMessage]
 ) -> None:
     """Check app pages for `router`."""
     if not hasattr(router, "_get_installed_apps"):
@@ -128,18 +106,14 @@ def _check_app_pages(
             continue
 
         app_errors, app_warnings = _check_pages_directory(
-            pages_path,
-            f"App '{app_name}'",
-            file_router.pages_dir,
+            pages_path, f"App '{app_name}'", file_router.pages_dir
         )
         errors.extend(app_errors)
         warnings.extend(app_warnings)
 
 
 def _check_root_pages(
-    router: RouterBackend,
-    errors: list[CheckMessage],
-    warnings: list[CheckMessage],
+    router: RouterBackend, errors: list[CheckMessage], warnings: list[CheckMessage]
 ) -> None:
     """Check root pages for `router` across all configured root paths."""
     if not hasattr(router, "_get_root_pages_paths"):
@@ -150,18 +124,14 @@ def _check_root_pages(
     for i, pages_path in enumerate(router._get_root_pages_paths()):
         context = "Root" if i == 0 else f"Root ({pages_path})"
         root_errors, root_warnings = _check_pages_directory(
-            pages_path,
-            context,
-            file_router.pages_dir,
+            pages_path, context, file_router.pages_dir
         )
         errors.extend(root_errors)
         warnings.extend(root_warnings)
 
 
 def _check_directory_syntax(
-    directories: list[Path],
-    pages_path: Path,
-    context: str,
+    directories: list[Path], pages_path: Path, context: str
 ) -> list[CheckMessage]:
     """Check directory names under `pages_path` for valid bracket syntax."""
     errors: list[CheckMessage] = []
@@ -179,7 +149,7 @@ def _check_directory_syntax(
                         f"Use [param] or [type:param] format.",
                         obj=settings,
                         id="next.E008",
-                    ),
+                    )
                 )
 
         elif dir_name_str.startswith("[[") and dir_name_str.endswith("]]"):
@@ -191,7 +161,7 @@ def _check_directory_syntax(
                         f"Use [[args]] format.",
                         obj=settings,
                         id="next.E009",
-                    ),
+                    )
                 )
 
         elif dir_name_str.startswith("["):
@@ -202,16 +172,14 @@ def _check_directory_syntax(
                     f"Use [[args]] format.",
                     obj=settings,
                     id="next.E009",
-                ),
+                )
             )
 
     return errors
 
 
 def _check_missing_page_files(
-    directories: list[Path],
-    pages_path: Path,
-    context: str,
+    directories: list[Path], pages_path: Path, context: str
 ) -> list[CheckMessage]:
     """Check for missing `page.py` files inside parameter directories."""
     errors: list[CheckMessage] = []
@@ -242,16 +210,14 @@ def _check_missing_page_files(
                         f'"{item.relative_to(pages_path)}" is missing page.py file.',
                         obj=settings,
                         id="next.E010",
-                    ),
+                    )
                 )
 
     return errors
 
 
 def _check_pages_directory(
-    pages_path: Path,
-    context: str,
-    _dir_name: str,
+    pages_path: Path, context: str, _dir_name: str
 ) -> tuple[list[CheckMessage], list[CheckMessage]]:
     """Check a specific pages directory for issues."""
     if not pages_path.exists():
@@ -294,10 +260,7 @@ def _is_valid_args_syntax(args_str: str) -> bool:
 
 
 @register(NEXT)
-def check_page_functions(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_page_functions(*args, **kwargs) -> list[CheckMessage]:
     """Validate each page module for `render` or `template`. Warn when empty."""
     errors: list[CheckMessage] = []
     warnings: list[CheckMessage] = []
@@ -315,19 +278,15 @@ def check_page_functions(
         except (AttributeError, OSError) as e:
             errors.append(
                 Error(
-                    f"Error checking page functions: {e}",
-                    obj=settings,
-                    id="next.E011",
-                ),
+                    f"Error checking page functions: {e}", obj=settings, id="next.E011"
+                )
             )
 
     return errors + warnings
 
 
 def _check_app_page_functions(
-    router: RouterBackend,
-    errors: list[CheckMessage],
-    warnings: list[CheckMessage],
+    router: RouterBackend, errors: list[CheckMessage], warnings: list[CheckMessage]
 ) -> None:
     """Check app page functions for `router`."""
     if not hasattr(router, "_get_installed_apps"):
@@ -343,18 +302,13 @@ def _check_app_page_functions(
         if not pages_path:
             continue
 
-        e, w = _check_page_functions_in_directory(
-            pages_path,
-            f"App '{app_name}'",
-        )
+        e, w = _check_page_functions_in_directory(pages_path, f"App '{app_name}'")
         errors.extend(e)
         warnings.extend(w)
 
 
 def _check_root_page_functions(
-    router: RouterBackend,
-    errors: list[CheckMessage],
-    warnings: list[CheckMessage],
+    router: RouterBackend, errors: list[CheckMessage], warnings: list[CheckMessage]
 ) -> None:
     """Check root page functions for `router` across all root paths."""
     if not hasattr(router, "_get_root_pages_paths"):
@@ -367,8 +321,7 @@ def _check_root_page_functions(
 
 
 def _check_page_functions_in_directory(
-    pages_path: Path,
-    context: str,
+    pages_path: Path, context: str
 ) -> tuple[list[CheckMessage], list[CheckMessage]]:
     """Check `page.py` files for render/template rules."""
     errors: list[CheckMessage] = []
@@ -390,7 +343,7 @@ def _check_page_functions_in_directory(
                     "attribute, a sibling template.djx, or a sibling layout.djx.",
                     obj=settings,
                     id="next.E012",
-                ),
+                )
             )
             hard_error = True
         elif render_func is not None and not callable(render_func):
@@ -400,7 +353,7 @@ def _check_page_functions_in_directory(
                     f"render attribute is not callable.",
                     obj=settings,
                     id="next.E013",
-                ),
+                )
             )
             hard_error = True
 
@@ -494,10 +447,7 @@ def _check_layout_file(layout_file: Path) -> CheckMessage | None:
 
 
 @register(Tags.templates, NEXT)
-def check_layout_templates(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_layout_templates(*args, **kwargs) -> list[CheckMessage]:
     """Check `layout.djx` files for the `{% block template %}` structure."""
     warnings: list[CheckMessage] = []
 
@@ -544,9 +494,7 @@ def _annotation_is_dict_like(annotation: object) -> bool:
 
 
 def _check_context_function(
-    func_name: str,
-    func: Callable[..., Any],
-    page_path: Path,
+    func_name: str, func: Callable[..., Any], page_path: Path
 ) -> CheckMessage | None:
     """Emit an error when keyless context callables are not annotated dict-like.
 
@@ -592,45 +540,88 @@ def _check_registered_context_functions(page_path: Path) -> list[CheckMessage]:
     return errors
 
 
-def _check_router_context_functions(router: RouterBackend) -> list[CheckMessage]:
-    """Return errors from `page.py` modules under one router's pages tree."""
-    errors: list[CheckMessage] = []
+def _iter_existing_scanned_pages(
+    router_manager: RouterManager, seen: set[Path]
+) -> Iterator[Path]:
+    """Yield each existing `page.py` once across routers, de-duplicated by `seen`.
 
-    for _url_path, page_path in iter_scanned_page_pairs(router):
-        if not page_path.exists():
-            continue
-
-        if _load_python_module_memo(page_path) is None:
-            continue
-
-        errors.extend(_check_registered_context_functions(page_path))
-
-    return errors
+    Virtual `template.djx`-only pages carry a non-existent path and are skipped.
+    """
+    for router in router_manager._backends:
+        for _url_path, page_path in iter_scanned_page_pairs(router):
+            if page_path in seen:
+                continue
+            seen.add(page_path)
+            if page_path.exists():
+                yield page_path
 
 
 @register(Tags.templates, NEXT)
-def check_context_functions(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_page_module_imports(*args, **kwargs) -> list[CheckMessage]:
+    """Report `page.py` files that raise while importing (`next.E017`)."""
+    router_manager, init_errors = get_router_manager()
+    if router_manager is None:
+        return init_errors
+    return [
+        Error(
+            f"page.py at {page_path} could not be imported. Fix the syntax or "
+            "import error so the framework stops skipping the module silently.",
+            obj=str(page_path),
+            id="next.E017",
+        )
+        for page_path in _iter_existing_scanned_pages(router_manager, set())
+        if _load_python_module_memo(page_path) is None
+    ]
+
+
+@register(Tags.templates, NEXT)
+def check_context_functions(*args, **kwargs) -> list[CheckMessage]:
     """Require keyless `@context` callables to return a dict when invoked."""
     router_manager, init_errors = get_router_manager()
     if router_manager is None:
         return init_errors
 
     errors: list[CheckMessage] = []
-    for router in router_manager._backends:
-        router_errors = _check_router_context_functions(router)
-        errors.extend(router_errors)
-
+    for page_path in _iter_existing_scanned_pages(router_manager, set()):
+        if _load_python_module_memo(page_path) is None:
+            continue
+        errors.extend(_check_registered_context_functions(page_path))
     return errors
 
 
 @register(Tags.templates, NEXT)
-def check_context_processor_signature(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_single_keyless_context(*args, **kwargs) -> list[CheckMessage]:
+    """Flag a `page.py` with more than one keyless `@context` (`next.E018`).
+
+    Keyless callables share one slot, so only the last survives and runs.
+    """
+    router_manager, init_errors = get_router_manager()
+    if router_manager is None:
+        return init_errors
+
+    errors: list[CheckMessage] = []
+    conflicts = page._context_manager._keyless_conflicts
+    for page_path in _iter_existing_scanned_pages(router_manager, set()):
+        if _load_python_module_memo(page_path) is None:
+            continue
+        names = conflicts.get(page_path)
+        if names:
+            joined = ", ".join(names)
+            errors.append(
+                Error(
+                    f"page.py at {page_path} registers multiple keyless @context "
+                    f"callables ({joined}). Only the last one runs, so the "
+                    "earlier ones are ignored. Give each a key like "
+                    "@context('name'), or merge them into a single callable.",
+                    obj=str(page_path),
+                    id="next.E018",
+                )
+            )
+    return errors
+
+
+@register(Tags.templates, NEXT)
+def check_context_processor_signature(*args, **kwargs) -> list[CheckMessage]:
     """Warn when a configured context processor has no `request` parameter."""
     errors: list[CheckMessage] = []
     for backend_index, backend in _iter_page_backend_configs():
@@ -660,8 +651,7 @@ def _iter_page_backend_configs() -> list[tuple[int, dict[str, Any]]]:
 
 
 def _check_processor_request_parameter(
-    processor_path: str,
-    location: str,
+    processor_path: str, location: str
 ) -> CheckMessage | None:
     """Return an error when the callable at `processor_path` lacks `request`."""
     try:
@@ -687,10 +677,7 @@ def _check_processor_request_parameter(
 
 
 @register(NEXT)
-def check_template_loaders(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_template_loaders(*args, **kwargs) -> list[CheckMessage]:
     """Validate every `NEXT_FRAMEWORK['TEMPLATE_LOADERS']` entry."""
     try:
         configured = next_framework_settings.TEMPLATE_LOADERS
@@ -706,7 +693,7 @@ def check_template_loaders(
                     f"path string, got {type(entry).__name__!r}.",
                     obj=settings,
                     id="next.E042",
-                ),
+                )
             )
             continue
         try:
@@ -718,7 +705,7 @@ def check_template_loaders(
                     f"cannot be imported: {exc}.",
                     obj=settings,
                     id="next.E043",
-                ),
+                )
             )
             continue
         if not isinstance(cls, type) or not issubclass(cls, TemplateLoader):
@@ -728,7 +715,7 @@ def check_template_loaders(
                     "not a TemplateLoader subclass.",
                     obj=settings,
                     id="next.E043",
-                ),
+                )
             )
     return messages
 
@@ -738,7 +725,9 @@ __all__ = [
     "check_context_processor_signature",
     "check_layout_templates",
     "check_page_functions",
+    "check_page_module_imports",
     "check_pages_structure",
     "check_request_in_context",
+    "check_single_keyless_context",
     "check_template_loaders",
 ]

--- a/next/pages/loaders.py
+++ b/next/pages/loaders.py
@@ -80,6 +80,16 @@ def _load_python_module_memo(file_path: Path) -> types.ModuleType | None:
     return module
 
 
+def reset_module_memo() -> None:
+    """Drop every memoised module so the next load re-executes from disk.
+
+    The memo keys by mtime, so a rewrite that lands on the same tick would
+    otherwise return a stale module. The check-cache reset clears this for
+    scripts that edit a `page.py` in place between runs.
+    """
+    _MODULE_MEMO.clear()
+
+
 # A single-slot holder mutated in place so cache invalidation never rebinds a
 # module global, which keeps the reset and read paths free of `global`.
 _ADDITIONAL_LAYOUTS_CACHE: dict[str, list[Path] | None] = {"value": None}

--- a/next/pages/loaders.py
+++ b/next/pages/loaders.py
@@ -95,7 +95,7 @@ def reset_module_memo() -> None:
 _ADDITIONAL_LAYOUTS_CACHE: dict[str, list[Path] | None] = {"value": None}
 
 
-def _reset_additional_layouts_cache(**_kwargs: object) -> None:
+def _reset_additional_layouts_cache(**kwargs) -> None:
     """Drop cached root-level `layout.djx` paths on settings reload."""
     _ADDITIONAL_LAYOUTS_CACHE["value"] = None
 
@@ -266,8 +266,7 @@ class LayoutTemplateLoader(TemplateLoader):
     def _get_pages_dirs_for_config(self, config: dict) -> list[Path]:
         """Return candidate roots from one router `DIRS` entry (paths only)."""
         path_roots, _ = classify_dirs_entries(
-            list(config.get("DIRS") or []),
-            resolve_base_dir(),
+            list(config.get("DIRS") or []), resolve_base_dir()
         )
         return list(path_roots)
 
@@ -284,9 +283,7 @@ class LayoutTemplateLoader(TemplateLoader):
         return "{% block template %}{% endblock template %}"
 
     def _compose_layout_hierarchy(
-        self,
-        template_content: str,
-        layout_files: list[Path],
+        self, template_content: str, layout_files: list[Path]
     ) -> str:
         """Return layouts wrapped outermost last, with the page in the first slot."""
         result = template_content
@@ -363,8 +360,7 @@ def build_registered_loaders() -> list[TemplateLoader]:
             continue
         if not isinstance(cls, type) or not issubclass(cls, TemplateLoader):
             logger.debug(
-                "TEMPLATE_LOADERS entry %r is not a TemplateLoader subclass",
-                entry,
+                "TEMPLATE_LOADERS entry %r is not a TemplateLoader subclass", entry
             )
             continue
         if cls in seen:
@@ -377,7 +373,7 @@ def build_registered_loaders() -> list[TemplateLoader]:
     return instances
 
 
-def _reset_registered_loaders_cache(**_kwargs: object) -> None:
+def _reset_registered_loaders_cache(**kwargs) -> None:
     """Drop cached loader instances on settings reload."""
     _REGISTERED_LOADERS_CACHE["value"] = None
 

--- a/next/pages/manager.py
+++ b/next/pages/manager.py
@@ -637,3 +637,12 @@ _ = inspect  # keep `inspect` import reachable for test-time patching
 
 page: Page = Page()
 context = page.context
+
+
+def reset_context_registry() -> None:
+    """Clear the shared page-context registry for a from-disk rebuild.
+
+    The check-cache reset pairs this with the module memo so a re-executed
+    `page.py` repopulates the registry from its current source.
+    """
+    page._context_manager.reset()

--- a/next/pages/manager.py
+++ b/next/pages/manager.py
@@ -24,11 +24,7 @@ from next.conf import next_framework_settings
 from next.deps import DependencyResolver, resolver
 from next.utils import caller_source_path
 
-from .loaders import (
-    LayoutManager,
-    _load_python_module_memo,
-    build_registered_loaders,
-)
+from .loaders import LayoutManager, _load_python_module_memo, build_registered_loaders
 from .processors import _get_context_processors
 from .registry import PageContextRegistry
 from .signals import page_rendered, template_loaded
@@ -52,7 +48,7 @@ class _RoutedPageView(Protocol):
 
     next_page_path: Path
 
-    def __call__(self, request: HttpRequest, **kwargs: object) -> HttpResponseBase: ...
+    def __call__(self, request: HttpRequest, **kwargs) -> HttpResponseBase: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -169,10 +165,7 @@ class Page:
         return decorator(func_or_key) if callable(func_or_key) else decorator
 
     def build_render_context(
-        self,
-        file_path: Path,
-        request: HttpRequest | None = None,
-        **kwargs: object,
+        self, file_path: Path, request: HttpRequest | None = None, **kwargs
     ) -> dict[str, object]:
         """Build the full render context dict used by `render`.
 
@@ -213,17 +206,13 @@ class Page:
                     if strict:
                         raise
                     logger.warning(
-                        "Error in context processor %s: %s",
-                        processor.__name__,
-                        e,
+                        "Error in context processor %s: %s", processor.__name__, e
                     )
 
         return context_data
 
     def _load_static_body(
-        self,
-        file_path: Path,
-        module: types.ModuleType | None,
+        self, file_path: Path, module: types.ModuleType | None
     ) -> str:
         """Return the static body for `file_path` without invoking `render()`.
 
@@ -249,7 +238,7 @@ class Page:
         file_path: Path,
         module: types.ModuleType | None,
         request: HttpRequest | None = None,
-        **kwargs: object,
+        **kwargs,
     ) -> _BodyResolution:
         """Resolve the page body per-request.
 
@@ -273,17 +262,13 @@ class Page:
         render_func: Callable[..., object],
         file_path: Path,
         request: HttpRequest | None = None,
-        **kwargs: object,
+        **kwargs,
     ) -> _BodyResolution:
         """Invoke `render_func` with DI-resolved arguments and classify the result."""
         dep_cache: dict[str, Any] = {}
         dep_stack: list[str] = []
         resolved = self._get_resolver().resolve_dependencies(
-            render_func,
-            request=request,
-            _cache=dep_cache,
-            _stack=dep_stack,
-            **kwargs,
+            render_func, request=request, _cache=dep_cache, _stack=dep_stack, **kwargs
         )
         result = render_func(**resolved)
         if isinstance(result, HttpResponseBase):
@@ -352,15 +337,12 @@ class Page:
         template: Template | str,
         start: float,
         request: HttpRequest | None = None,
-        **kwargs: object,
+        **kwargs,
     ) -> str:
         """Build context, render `template`, inject static assets, emit signal."""
         context_data = self.build_render_context(file_path, request, **kwargs)
         result, collector = self.render_with_static_assets(
-            file_path,
-            template,
-            context_data,
-            request=request,
+            file_path, template, context_data, request=request
         )
         if page_rendered.receivers:
             duration_ms = (time.perf_counter() - start) * 1000
@@ -375,11 +357,7 @@ class Page:
         return result
 
     def _render_composed(
-        self,
-        file_path: Path,
-        body: str,
-        request: HttpRequest | None = None,
-        **kwargs: object,
+        self, file_path: Path, body: str, request: HttpRequest | None = None, **kwargs
     ) -> str:
         """Compose `body` through layouts and render.
 
@@ -420,10 +398,7 @@ class Page:
         return compiled
 
     def render(
-        self,
-        file_path: Path,
-        request: HttpRequest | None = None,
-        **kwargs: object,
+        self, file_path: Path, request: HttpRequest | None = None, **kwargs
     ) -> str:
         """Render the page with Django `Template` and the static collector.
 
@@ -439,10 +414,7 @@ class Page:
         return self._render_template_str(file_path, template, start, request, **kwargs)
 
     def authorization_outcome(
-        self,
-        file_path: Path,
-        request: HttpRequest,
-        **kwargs: object,
+        self, file_path: Path, request: HttpRequest, **kwargs
     ) -> tuple[HttpResponseBase | None, bool]:
         """Re-run a page's body resolution once, reporting short-circuit and kind.
 
@@ -473,7 +445,7 @@ class Page:
         synthesised `page.py` location of virtual `template.djx` pages.
         """
 
-        def view(request: HttpRequest, **kwargs: object) -> HttpResponseBase:
+        def view(request: HttpRequest, **kwargs) -> HttpResponseBase:
             resolution = self._resolve_page_body(file_path, module, request, **kwargs)
             if resolution.http_response is not None:
                 return resolution.http_response
@@ -583,9 +555,7 @@ class Page:
         )
 
     def _page_has_body_source(
-        self,
-        file_path: Path,
-        module: types.ModuleType | None,
+        self, file_path: Path, module: types.ModuleType | None
     ) -> bool:
         """Return True when `file_path` can produce a body or layout body."""
         if module is not None:
@@ -598,10 +568,7 @@ class Page:
         return self._layout_manager._layout_loader.can_load(file_path)
 
     def create_url_pattern(
-        self,
-        url_path: str,
-        file_path: Path,
-        url_parser: URLPatternParser,
+        self, url_path: str, file_path: Path, url_parser: URLPatternParser
     ) -> URLPattern | None:
         """Return a `path()` pattern for a page, template, or virtual entry."""
         # The error class is reached through the parser because a top-level
@@ -611,24 +578,16 @@ class Page:
             django_pattern, parameters = url_parser.parse_url_pattern(url_path)
         except url_parser.duplicate_parameter_error as exc:
             raise url_parser.duplicate_parameter_error(
-                exc.param_name,
-                exc.url_path,
-                file_path=file_path,
+                exc.param_name, exc.url_path, file_path=file_path
             ) from exc
         clean_name = url_parser.prepare_url_name(url_path)
 
         if file_path.exists():
             return self._create_regular_page_pattern(
-                file_path,
-                django_pattern,
-                parameters,
-                clean_name,
+                file_path, django_pattern, parameters, clean_name
             )
         return self._create_virtual_page_pattern(
-            file_path,
-            django_pattern,
-            parameters,
-            clean_name,
+            file_path, django_pattern, parameters, clean_name
         )
 
 

--- a/next/pages/registry.py
+++ b/next/pages/registry.py
@@ -77,15 +77,12 @@ def get_template_djx_paths_for_watch() -> set[Path]:
 class PageContextRegistry:
     """Register per-`page.py` context callables and merge their output."""
 
-    def __init__(
-        self,
-        resolver: DependencyResolver | None = None,
-    ) -> None:
+    def __init__(self, resolver: DependencyResolver | None = None) -> None:
         """Initialise with an optional resolver and an empty registry."""
-        self._context_registry: dict[
-            Path,
-            dict[str | None, PageContextEntry],
-        ] = {}
+        self._context_registry: dict[Path, dict[str | None, PageContextEntry]] = {}
+        # Keyless callables share the `None` slot, so the registry keeps only
+        # the last. Retain the overwritten names for the `next.E018` diagnostic.
+        self._keyless_conflicts: dict[Path, list[str]] = {}
         self._resolver = resolver
 
     def _get_resolver(self) -> DependencyResolver:
@@ -101,6 +98,7 @@ class PageContextRegistry:
         a removed `@context` would otherwise leave a stale entry behind.
         """
         self._context_registry.clear()
+        self._keyless_conflicts.clear()
 
     def register_context(
         self,
@@ -113,7 +111,18 @@ class PageContextRegistry:
         serializer: JsContextSerializer | None = None,
     ) -> None:
         """Bind `func` to `file_path` with keyed or dict-merge semantics."""
-        self._context_registry.setdefault(file_path, {})[key] = PageContextEntry(
+        bucket = self._context_registry.setdefault(file_path, {})
+        existing = bucket.get(None)
+        # Compare by name so a re-executed module (same name) is not a conflict.
+        if (
+            key is None
+            and existing is not None
+            and existing.func.__name__ != func.__name__
+        ):
+            self._keyless_conflicts.setdefault(
+                file_path, [existing.func.__name__]
+            ).append(func.__name__)
+        bucket[key] = PageContextEntry(
             func=func,
             inherit_context=inherit_context,
             serialize=serialize,
@@ -124,10 +133,7 @@ class PageContextRegistry:
         )
 
     def collect_context(
-        self,
-        file_path: Path,
-        request: HttpRequest | None = None,
-        **kwargs: object,
+        self, file_path: Path, request: HttpRequest | None = None, **kwargs
     ) -> ContextResult:
         """Merge inherited ancestor page.py context with this file's context callables.
 
@@ -156,8 +162,7 @@ class PageContextRegistry:
 
         registry = self._context_registry.get(file_path, {})
         ordered = sorted(
-            registry.items(),
-            key=lambda item: (item[0] is not None, str(item[0] or "")),
+            registry.items(), key=lambda item: (item[0] is not None, str(item[0] or ""))
         )
         for key, entry in ordered:
             resolved = self._get_resolver().resolve_dependencies(
@@ -217,10 +222,7 @@ class PageContextRegistry:
             page_file = current_dir / "page.py"
 
             if page_file.exists():
-                for key, entry in self._context_registry.get(
-                    page_file,
-                    {},
-                ).items():
+                for key, entry in self._context_registry.get(page_file, {}).items():
                     if entry.inherit_context:
                         resolved = self._get_resolver().resolve_dependencies(
                             entry.func,

--- a/next/pages/registry.py
+++ b/next/pages/registry.py
@@ -94,6 +94,14 @@ class PageContextRegistry:
             return self._resolver
         return resolver
 
+    def reset(self) -> None:
+        """Drop every registered context so the next import repopulates it.
+
+        Re-executing a `page.py` only overwrites the keys it still declares, so
+        a removed `@context` would otherwise leave a stale entry behind.
+        """
+        self._context_registry.clear()
+
     def register_context(
         self,
         file_path: Path,

--- a/next/partial/backends.py
+++ b/next/partial/backends.py
@@ -41,11 +41,7 @@ class PartialProtocolBackend:
 
     def _dumps(self, envelope: "Envelope") -> str:
         """Serialise an envelope to a compact JSON string."""
-        return json.dumps(
-            envelope.as_dict(),
-            separators=(",", ":"),
-            ensure_ascii=False,
-        )
+        return json.dumps(envelope.as_dict(), separators=(",", ":"), ensure_ascii=False)
 
     def serialize_envelope(self, envelope: "Envelope") -> bytes:
         """Serialize one envelope for an HTTP response body."""

--- a/next/partial/checks.py
+++ b/next/partial/checks.py
@@ -128,7 +128,7 @@ def _collect_composed_pages(
         yield from _iter_router_pages(router, seen)
 
 
-def reset_composed_pages_memo(**_kwargs: object) -> None:
+def reset_composed_pages_memo(**kwargs) -> None:
     """Drop the memoised composed-page list for the next check run.
 
     Identity against the router manager already invalidates the memo when the
@@ -143,8 +143,7 @@ settings_reloaded.connect(reset_composed_pages_memo)
 
 
 def _iter_router_pages(
-    router: "RouterBackend",
-    seen: set[Path],
+    router: "RouterBackend", seen: set[Path]
 ) -> "Iterator[tuple[Path, Template]]":
     """Yield compiled composed templates for one router's scanned pages."""
     for _url_path, page_path in iter_scanned_page_pairs(router):
@@ -185,10 +184,7 @@ def _significant(nodelist: NodeList) -> list[Node]:
 
 
 @register(Tags.templates, NEXT)
-def check_composed_templates_compile(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_composed_templates_compile(*args, **kwargs) -> list[CheckMessage]:
     """Error when a composed page template fails to compile (`next.E072`).
 
     The zone checks skip a page whose composed template does not
@@ -225,10 +221,7 @@ def check_composed_templates_compile(
 
 
 @register(Tags.templates, NEXT)
-def check_duplicate_zone_names(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_duplicate_zone_names(*args, **kwargs) -> list[CheckMessage]:
     """Error when two zones in one composed page share a name (`next.E060`)."""
     messages: list[CheckMessage] = []
     for page_path, template in _iter_composed_pages():
@@ -252,10 +245,7 @@ def check_duplicate_zone_names(
 
 
 @register(Tags.templates, NEXT)
-def check_zone_name_is_slug(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_zone_name_is_slug(*args, **kwargs) -> list[CheckMessage]:
     """Error when a zone name is not an ASCII slug (`next.E061`)."""
     messages: list[CheckMessage] = []
     for page_path, template in _iter_composed_pages():
@@ -275,10 +265,7 @@ def check_zone_name_is_slug(
 
 
 @register(Tags.templates, NEXT)
-def check_zone_not_in_loop(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_zone_not_in_loop(*args, **kwargs) -> list[CheckMessage]:
     """Error when a zone sits inside a `{% for %}` loop (`next.E062`)."""
     return _ancestor_check(
         ancestor=ForNode,
@@ -292,10 +279,7 @@ def check_zone_not_in_loop(
 
 
 @register(Tags.templates, NEXT)
-def check_zone_not_in_if(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_zone_not_in_if(*args, **kwargs) -> list[CheckMessage]:
     """Error when a zone sits inside an `{% if %}` block (`next.E063`)."""
     return _ancestor_check(
         ancestor=IfNode,
@@ -309,10 +293,7 @@ def check_zone_not_in_if(
 
 
 def _ancestor_check(
-    *,
-    ancestor: type[Node],
-    check_id: str,
-    reason: str,
+    *, ancestor: type[Node], check_id: str, reason: str
 ) -> list[CheckMessage]:
     """Return errors for every zone nested under an `ancestor` node type."""
     messages: list[CheckMessage] = []
@@ -329,17 +310,11 @@ def _ancestor_check(
     return messages
 
 
-_TAG_LABELS: Final[dict[type[Node], str]] = {
-    ForNode: "{% for %}",
-    IfNode: "{% if %}",
-}
+_TAG_LABELS: Final[dict[type[Node], str]] = {ForNode: "{% for %}", IfNode: "{% if %}"}
 
 
 def _zones_under(
-    nodelist: NodeList,
-    ancestor: type[Node],
-    *,
-    inside: bool = False,
+    nodelist: NodeList, ancestor: type[Node], *, inside: bool = False
 ) -> "Iterator[str]":
     """Yield names of zones reached while an `ancestor` node is on the path."""
     for node in nodelist:
@@ -352,11 +327,7 @@ def _zones_under(
             yield from _zones_under(child, ancestor, inside=now_inside)
 
 
-def _forms_in_loop(
-    nodelist: NodeList,
-    *,
-    inside: bool = False,
-) -> "Iterator[FormNode]":
+def _forms_in_loop(nodelist: NodeList, *, inside: bool = False) -> "Iterator[FormNode]":
     """Yield each `{% form %}` node reached while a `{% for %}` is on the path."""
     for node in nodelist:
         if isinstance(node, FormNode) and inside:
@@ -372,10 +343,7 @@ def _form_has_partial_attr(node: FormNode, attr: str) -> bool:
 
 
 @register(Tags.templates, NEXT)
-def check_repeated_form_has_key(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_repeated_form_has_key(*args, **kwargs) -> list[CheckMessage]:
     """Warn when a looped `{% form %}` has no key or zone (`next.W070`)."""
     messages: list[CheckMessage] = []
     for page_path, template in _iter_composed_pages():
@@ -399,10 +367,7 @@ def check_repeated_form_has_key(
 
 
 @register(Tags.templates, NEXT)
-def check_lazy_zone_has_placeholder(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_lazy_zone_has_placeholder(*args, **kwargs) -> list[CheckMessage]:
     """Error when a lazy zone declares no `{% placeholder %}` (`next.E064`)."""
     messages: list[CheckMessage] = []
     for page_path, template in _iter_composed_pages():
@@ -422,10 +387,7 @@ def check_lazy_zone_has_placeholder(
 
 
 @register(Tags.templates, NEXT)
-def check_with_directly_over_zone(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_with_directly_over_zone(*args, **kwargs) -> list[CheckMessage]:
     """Warn when a `{% with %}` wraps a zone directly (`next.W067`)."""
     messages: list[CheckMessage] = []
     for page_path, template in _iter_composed_pages():
@@ -455,10 +417,7 @@ def _zones_directly_in_with(nodelist: NodeList) -> "Iterator[str]":
 
 
 @register(Tags.templates, NEXT)
-def check_no_zone_in_component(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_no_zone_in_component(*args, **kwargs) -> list[CheckMessage]:
     """Error when a component template declares a zone (`next.E065`)."""
     configs = next_framework_settings.COMPONENT_BACKENDS
     if not isinstance(configs, list) or not configs:
@@ -505,10 +464,7 @@ _OP_TOKEN = re.compile(r"\A[A-Za-z0-9_.-]+\Z")
 
 
 @register(Tags.templates, NEXT)
-def check_custom_patch_ops_well_formed(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_custom_patch_ops_well_formed(*args, **kwargs) -> list[CheckMessage]:
     """Error when a custom patch verb is malformed or shadows a built-in (`next.E066`).
 
     The runtime guard in `Patches.op()` rejects an unregistered verb on
@@ -542,10 +498,7 @@ def check_custom_patch_ops_well_formed(
 
 
 @register(NEXT)
-def check_form_backend_partial_aware(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_form_backend_partial_aware(*args, **kwargs) -> list[CheckMessage]:
     """Warn when partial rendering is on but a form backend is not aware (`next.W068`).
 
     The base `FormActionBackend.shape_response` routes partial requests
@@ -592,10 +545,7 @@ def _partial_backends_active() -> bool:
 
 
 @register(NEXT)
-def check_single_partial_backend(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_single_partial_backend(*args, **kwargs) -> list[CheckMessage]:
     """Warn when more than one partial protocol backend is configured (`next.W071`).
 
     Partial rendering uses a single protocol backend. Only the first valid
@@ -623,10 +573,7 @@ _STATICFILES_ALIAS: Final = "staticfiles"
 
 
 @register(NEXT)
-def check_partial_backend_names_a_path(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_partial_backend_names_a_path(*args, **kwargs) -> list[CheckMessage]:
     """Error when a PARTIAL_BACKENDS entry omits its BACKEND key (`next.E073`).
 
     The factory refuses such an entry with `ImproperlyConfigured` on the
@@ -649,10 +596,7 @@ def check_partial_backend_names_a_path(
 
 
 @register(NEXT)
-def check_manifest_version_has_manifest_storage(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_manifest_version_has_manifest_storage(*args, **kwargs) -> list[CheckMessage]:
     """Warn when manifest versioning has no manifest storage (`next.W069`).
 
     The `VERSION: "manifest"` option asks the version stamp to track the

--- a/next/partial/checks.py
+++ b/next/partial/checks.py
@@ -23,10 +23,15 @@ from django.template import TemplateDoesNotExist, TemplateSyntaxError
 from django.template.base import Node, NodeList, TextNode
 from django.template.defaulttags import ForNode, IfNode, WithNode
 
-from next.checks.common import get_router_manager, iter_scanned_page_pairs
+from next.checks import NEXT
+from next.checks.common import (
+    get_components_manager,
+    get_router_manager,
+    iter_scanned_page_pairs,
+)
 from next.components.backends import FileComponentsBackend
-from next.components.manager import ComponentsManager
 from next.conf import import_class_cached, next_framework_settings
+from next.conf.signals import settings_reloaded
 from next.forms.backends import FormActionBackend
 from next.forms.manager import form_action_manager
 from next.pages import page
@@ -41,7 +46,9 @@ if TYPE_CHECKING:
 
     from django.template.base import Template
 
-    from next.urls import RouterBackend
+    from next.urls import RouterBackend, RouterManager
+
+    _ComposedMemo = tuple[RouterManager, list[tuple[Path, Template]]] | None
 
 
 E_DUPLICATE_ZONE: Final = "next.E060"
@@ -86,20 +93,53 @@ CHECK_IDS: Final = (
 _ZONE_SLUG = re.compile(r"\A[A-Za-z0-9_-]+\Z")
 
 
+# One walk of the page tree shared by every zone check per run. Comparing the
+# stored manager by identity invalidates the memo when the manager is rebuilt.
+_COMPOSED_PAGES_MEMO: "dict[str, _ComposedMemo]" = {"value": None}
+
+
 def _iter_composed_pages() -> "Iterator[tuple[Path, Template]]":
     """Yield each page path with its compiled composed template.
 
     Pages whose body is produced dynamically by `render()` have no
     static composed template and are skipped. A page that fails to
     compile is skipped here and reported by
-    `check_composed_templates_compile`.
+    `check_composed_templates_compile`. The result is memoised per
+    router-manager instance so all zone checks share one walk.
     """
     router_manager, _errors = get_router_manager()
     if router_manager is None:
         return
+    memo = _COMPOSED_PAGES_MEMO["value"]
+    if memo is not None and memo[0] is router_manager:
+        yield from memo[1]
+        return
+    pages = list(_collect_composed_pages(router_manager))
+    _COMPOSED_PAGES_MEMO["value"] = (router_manager, pages)
+    yield from pages
+
+
+def _collect_composed_pages(
+    router_manager: "RouterManager",
+) -> "Iterator[tuple[Path, Template]]":
+    """Walk every router's scanned pages, de-duplicating by resolved path."""
     seen: set[Path] = set()
     for router in router_manager._backends:
         yield from _iter_router_pages(router, seen)
+
+
+def reset_composed_pages_memo(**_kwargs: object) -> None:
+    """Drop the memoised composed-page list for the next check run.
+
+    Identity against the router manager already invalidates the memo when the
+    manager is rebuilt. Call this explicitly after editing a `.djx` in place
+    under a live manager, since `settings_reloaded` only fires when
+    `NEXT_FRAMEWORK` itself changes.
+    """
+    _COMPOSED_PAGES_MEMO["value"] = None
+
+
+settings_reloaded.connect(reset_composed_pages_memo)
 
 
 def _iter_router_pages(
@@ -144,7 +184,7 @@ def _significant(nodelist: NodeList) -> list[Node]:
     return out
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_composed_templates_compile(
     *_args: object,
     **_kwargs: object,
@@ -184,7 +224,7 @@ def check_composed_templates_compile(
     return messages
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_duplicate_zone_names(
     *_args: object,
     **_kwargs: object,
@@ -211,7 +251,7 @@ def check_duplicate_zone_names(
     return messages
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_zone_name_is_slug(
     *_args: object,
     **_kwargs: object,
@@ -234,7 +274,7 @@ def check_zone_name_is_slug(
     return messages
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_zone_not_in_loop(
     *_args: object,
     **_kwargs: object,
@@ -251,7 +291,7 @@ def check_zone_not_in_loop(
     )
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_zone_not_in_if(
     *_args: object,
     **_kwargs: object,
@@ -331,7 +371,7 @@ def _form_has_partial_attr(node: FormNode, attr: str) -> bool:
     return any(name == attr for name, _expr in node.partial_attrs)
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_repeated_form_has_key(
     *_args: object,
     **_kwargs: object,
@@ -358,7 +398,7 @@ def check_repeated_form_has_key(
     return messages
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_lazy_zone_has_placeholder(
     *_args: object,
     **_kwargs: object,
@@ -381,7 +421,7 @@ def check_lazy_zone_has_placeholder(
     return messages
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_with_directly_over_zone(
     *_args: object,
     **_kwargs: object,
@@ -414,7 +454,7 @@ def _zones_directly_in_with(nodelist: NodeList) -> "Iterator[str]":
             yield from _zones_directly_in_with(child_list)
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_no_zone_in_component(
     *_args: object,
     **_kwargs: object,
@@ -424,8 +464,7 @@ def check_no_zone_in_component(
     if not isinstance(configs, list) or not configs:
         return []
     messages: list[CheckMessage] = []
-    manager = ComponentsManager()
-    manager._reload_config()
+    manager = get_components_manager()
     seen: set[Path] = set()
     for backend in manager._backends:
         if not isinstance(backend, FileComponentsBackend):
@@ -465,7 +504,7 @@ def _component_zone_errors(template_path: Path) -> list[CheckMessage]:
 _OP_TOKEN = re.compile(r"\A[A-Za-z0-9_.-]+\Z")
 
 
-@register(Tags.templates)
+@register(Tags.templates, NEXT)
 def check_custom_patch_ops_well_formed(
     *_args: object,
     **_kwargs: object,
@@ -502,7 +541,7 @@ def check_custom_patch_ops_well_formed(
     return messages
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_form_backend_partial_aware(
     *_args: object,
     **_kwargs: object,
@@ -552,7 +591,7 @@ def _partial_backends_active() -> bool:
     return any(isinstance(config, dict) for config in _partial_backend_configs())
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_single_partial_backend(
     *_args: object,
     **_kwargs: object,
@@ -583,7 +622,7 @@ _MANIFEST_VERSION: Final = "manifest"
 _STATICFILES_ALIAS: Final = "staticfiles"
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_partial_backend_names_a_path(
     *_args: object,
     **_kwargs: object,
@@ -609,7 +648,7 @@ def check_partial_backend_names_a_path(
     return messages
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_manifest_version_has_manifest_storage(
     *_args: object,
     **_kwargs: object,
@@ -711,4 +750,5 @@ __all__ = [
     "check_zone_name_is_slug",
     "check_zone_not_in_if",
     "check_zone_not_in_loop",
+    "reset_composed_pages_memo",
 ]

--- a/next/partial/manager.py
+++ b/next/partial/manager.py
@@ -4,10 +4,7 @@ import hashlib
 import json
 from typing import TYPE_CHECKING, Any, cast
 
-from django.contrib.staticfiles.storage import (
-    ManifestFilesMixin,
-    staticfiles_storage,
-)
+from django.contrib.staticfiles.storage import ManifestFilesMixin, staticfiles_storage
 from django.core.exceptions import ImproperlyConfigured
 
 from next.conf import import_class_cached, next_framework_settings
@@ -126,7 +123,7 @@ def _hash_mapping(hashed_files: "Mapping[str, str]") -> str:
     return digest[:_HASH_WIDTH]
 
 
-def _on_settings_reloaded(**_kwargs: object) -> None:
+def _on_settings_reloaded(**kwargs) -> None:
     """Drop the cached backend so a reloaded config takes effect."""
     partial_backend_manager.reset()
 
@@ -134,8 +131,4 @@ def _on_settings_reloaded(**_kwargs: object) -> None:
 settings_reloaded.connect(_on_settings_reloaded)
 
 
-__all__ = [
-    "PartialBackendManager",
-    "PartialProtocolFactory",
-    "partial_backend_manager",
-]
+__all__ = ["PartialBackendManager", "PartialProtocolFactory", "partial_backend_manager"]

--- a/next/partial/patches.py
+++ b/next/partial/patches.py
@@ -342,12 +342,7 @@ class Patches:
     paths that already hold the version and render their own HTML.
     """
 
-    def __init__(
-        self,
-        request: HttpRequest,
-        *,
-        echo_of: str | None = None,
-    ) -> None:
+    def __init__(self, request: HttpRequest, *, echo_of: str | None = None) -> None:
         """Start an empty builder bound to the request.
 
         Pass `echo_of` with the originating mutation's request id so the
@@ -371,10 +366,7 @@ class Patches:
         return builder
 
     def _init_state(
-        self,
-        request: HttpRequest | None,
-        version: str,
-        echo_of: str | None,
+        self, request: HttpRequest | None, version: str, echo_of: str | None
     ) -> None:
         """Set the builder state shared by both construction forms."""
         self._request = request
@@ -399,7 +391,7 @@ class Patches:
         html: str | None = None,
         *,
         extract: bool = False,
-        **select: object,
+        **select,
     ) -> "Patches":
         """Morph a target into HTML, the default verb.
 
@@ -413,9 +405,7 @@ class Patches:
         return self._dispatch_morph(html, select)
 
     def _dispatch_morph(
-        self,
-        html: str | None,
-        select: "Mapping[str, object]",
+        self, html: str | None, select: "Mapping[str, object]"
     ) -> "Patches":
         """Route a keyword-selected morph to its typed per-verb method."""
         zone = select.get("zone")
@@ -432,9 +422,7 @@ class Patches:
         raise TypeError(msg)
 
     def _dispatch_zone_morph(
-        self,
-        zone: str,
-        select: "Mapping[str, object]",
+        self, zone: str, select: "Mapping[str, object]"
     ) -> "Patches":
         """Route a zone-selected morph to its local or foreign per-verb method.
 
@@ -455,8 +443,7 @@ class Patches:
 
     @staticmethod
     def _reject_extra_morph_keys(
-        select: "Mapping[str, object]",
-        allowed: frozenset[str],
+        select: "Mapping[str, object]", allowed: frozenset[str]
     ) -> None:
         """Raise when the selector mapping carries keys the route does not own."""
         extra = sorted(select.keys() - allowed)
@@ -468,11 +455,7 @@ class Patches:
             raise TypeError(msg)
 
     def _append_morph(
-        self,
-        target: "Mapping[str, Any]",
-        html: str,
-        *,
-        extract: bool,
+        self, target: "Mapping[str, Any]", html: str, *, extract: bool
     ) -> "Patches":
         """Record one morph op with an optional extract flag."""
         extras = {"extract": True} if extract else {}
@@ -482,10 +465,7 @@ class Patches:
         return self
 
     def morph_zone(
-        self,
-        zone: str,
-        *,
-        overrides: "Mapping[str, Any] | None" = None,
+        self, zone: str, *, overrides: "Mapping[str, Any] | None" = None
     ) -> "Patches":
         """Render the named zone of the origin page and morph it in place."""
         result = self._render_zone(zone, overrides)
@@ -538,10 +518,7 @@ class Patches:
         return resolve_url_to_page(url, self._require_request())
 
     def _foreign_authorization(
-        self,
-        foreign_path: "Path",
-        request: HttpRequest,
-        url_kwargs: dict[str, Any],
+        self, foreign_path: "Path", request: HttpRequest, url_kwargs: dict[str, Any]
     ) -> "tuple[HttpResponseBase | None, bool]":
         """Re-run the foreign page's body resolution once for guard and kind.
 
@@ -575,42 +552,25 @@ class Patches:
         return self
 
     def append(
-        self,
-        target: "Mapping[str, Any]",
-        html: str,
-        *,
-        dedupe: DedupeMode = "key",
+        self, target: "Mapping[str, Any]", html: str, *, dedupe: DedupeMode = "key"
     ) -> "Patches":
         """Append children to the target, deduplicating by key or id."""
         return self._merge("append", target, html, dedupe)
 
     def prepend(
-        self,
-        target: "Mapping[str, Any]",
-        html: str,
-        *,
-        dedupe: DedupeMode = "key",
+        self, target: "Mapping[str, Any]", html: str, *, dedupe: DedupeMode = "key"
     ) -> "Patches":
         """Prepend children to the target, deduplicating by key or id."""
         return self._merge("prepend", target, html, dedupe)
 
     def _merge(
-        self,
-        op: str,
-        target: "Mapping[str, Any]",
-        html: str,
-        dedupe: DedupeMode,
+        self, op: str, target: "Mapping[str, Any]", html: str, dedupe: DedupeMode
     ) -> "Patches":
         """Record a merge op appending or prepending deduplicated children."""
         if dedupe not in _DEDUPE_MODES:
             raise UnknownDedupeError(dedupe)
         self._ops.append(
-            Patch(
-                op=op,
-                target=dict(target),
-                html=html,
-                extras={"dedupe": dedupe},
-            )
+            Patch(op=op, target=dict(target), html=html, extras={"dedupe": dedupe})
         )
         return self
 
@@ -624,7 +584,7 @@ class Patches:
         self._ops.append(Patch(op="refresh", extras={keys.ZONE: zone}))
         return self
 
-    def context(self, **names: object) -> "Patches":
+    def context(self, **names) -> "Patches":
         """Merge named serialize provider values into the client context.
 
         Only the names of registered `serialize=True` providers on the
@@ -651,10 +611,7 @@ class Patches:
         return self
 
     def layer_open(
-        self,
-        *,
-        zone: str | None = None,
-        href: str | None = None,
+        self, *, zone: str | None = None, href: str | None = None
     ) -> "Patches":
         """Open a server-initiated layer, optionally seeding a zone or href.
 
@@ -673,10 +630,7 @@ class Patches:
         return self
 
     def layer_close(
-        self,
-        *,
-        result: object = None,
-        dismiss: str | None = None,
+        self, *, result: object = None, dismiss: str | None = None
     ) -> "Patches":
         """Close the top layer with an accept result or a dismissal.
 
@@ -745,7 +699,7 @@ class Patches:
             )
         return self
 
-    def op(self, name: str, **payload: object) -> "Patches":
+    def op(self, name: str, **payload) -> "Patches":
         """Emit a custom verb registered through `register_patch_op`.
 
         A built-in verb is refused so it travels only through its typed
@@ -868,9 +822,7 @@ class Patches:
         return dict(self._render_context)
 
     def _render_zone(
-        self,
-        zone: str,
-        overrides: "Mapping[str, Any] | None",
+        self, zone: str, overrides: "Mapping[str, Any] | None"
     ) -> "ZoneRenderResult":
         """Render the named zone of the origin page with optional overrides."""
         return render_zone(

--- a/next/partial/registry.py
+++ b/next/partial/registry.py
@@ -113,9 +113,7 @@ def _zones_from_template(template: "Template") -> dict[str, ZoneInfo]:
     nodes = cast("list[ZoneNode]", template.nodelist.get_nodes_by_type(ZoneNode))
     for node in nodes:
         zones[node.name] = ZoneInfo(
-            name=node.name,
-            partial=node.partial,
-            options=node.options,
+            name=node.name, partial=node.partial, options=node.options
         )
     return zones
 

--- a/next/partial/render.py
+++ b/next/partial/render.py
@@ -132,8 +132,7 @@ def render_zone(
 
 
 def _renderable_zone_names(
-    zone_names: tuple[str, ...],
-    zones: "Mapping[str, ZoneInfo]",
+    zone_names: tuple[str, ...], zones: "Mapping[str, ZoneInfo]"
 ) -> tuple[str, ...]:
     """Return the declared names of a batch, deduplicated in request order.
 
@@ -149,8 +148,7 @@ def _renderable_zone_names(
 
 
 def _seed_collector(
-    page_path: "Path",
-    context_data: dict[str, object],
+    page_path: "Path", context_data: dict[str, object]
 ) -> "StaticCollector":
     """Seed a fresh collector and bind it to the context like the page path.
 
@@ -174,10 +172,7 @@ def _seed_collector(
 
 
 def _emit_rendered(
-    page_path: "Path",
-    zone_names: tuple[str, ...],
-    request: "HttpRequest",
-    start: float,
+    page_path: "Path", zone_names: tuple[str, ...], request: "HttpRequest", start: float
 ) -> None:
     """Announce each rendered zone when the signal has receivers."""
     if not zone_rendered.receivers:

--- a/next/partial/shaping.py
+++ b/next/partial/shaping.py
@@ -63,9 +63,7 @@ class ActionRef:
 
 
 def shape_partial(
-    backend: "FormActionBackend",
-    request: "HttpRequest",
-    outcome: ActionOutcome,
+    backend: "FormActionBackend", request: "HttpRequest", outcome: ActionOutcome
 ) -> HttpResponse:
     """Shape one action outcome as a patch envelope for a partial request.
 
@@ -115,11 +113,7 @@ def shape_validate(
         patches.morph(zone=zone, overrides=overrides)
     else:
         html = backend.render_invalid_page(
-            request,
-            action.action_name,
-            form,
-            page_path,
-            url_kwargs,
+            request, action.action_name, form, page_path, url_kwargs
         )
         patches.morph({keys.FORM_SELECTOR: uid}, html, extract=True)
     patches.set_form(_form_meta(uid, form))
@@ -165,11 +159,7 @@ def _shape_invalid(
         patches.morph(zone=zone, overrides=_form_overrides(outcome))
     else:
         html = backend.render_invalid_page(
-            request,
-            outcome.action_name,
-            form,
-            outcome.page_path,
-            outcome.url_kwargs,
+            request, outcome.action_name, form, outcome.page_path, outcome.url_kwargs
         )
         patches.morph({keys.FORM_SELECTOR: uid}, html, extract=True)
     if form is not None:
@@ -217,9 +207,7 @@ def _shape_advance(
         return response
     page_path, url_kwargs = target
     next_wizard = type(wizard)(
-        request=request,
-        url_kwargs=url_kwargs,
-        base_path=redirect_to,
+        request=request, url_kwargs=url_kwargs, base_path=redirect_to
     )
     form = next_wizard.current_form()
     patches = Patches(request)
@@ -296,10 +284,7 @@ def _shape_result(
 
 
 def _redirect_as_visit(
-    request: "HttpRequest",
-    redirect: HttpResponseRedirect,
-    *,
-    rotated: bool,
+    request: "HttpRequest", redirect: HttpResponseRedirect, *, rotated: bool
 ) -> HttpResponse:
     """Pack a handler redirect into a `visit`, full-navigating external hosts.
 
@@ -312,9 +297,7 @@ def _redirect_as_visit(
     """
     href = redirect["Location"]
     internal = url_has_allowed_host_and_scheme(
-        href,
-        allowed_hosts={request.get_host()},
-        require_https=request.is_secure(),
+        href, allowed_hosts={request.get_host()}, require_https=request.is_secure()
     )
     patches = Patches(request)
     patches.redirect(href, external=not internal)
@@ -337,20 +320,14 @@ def _success_funnel(
         patches.morph(zone=zone)
     else:
         html = backend.render_invalid_page(
-            request,
-            outcome.action_name,
-            None,
-            page_path,
-            url_kwargs,
+            request, outcome.action_name, None, page_path, url_kwargs
         )
         patches.morph({keys.FORM_SELECTOR: uid}, html, extract=True)
     drain_messages(request, patches)
     return _envelope_response(patches, request=request, rotated=rotated)
 
 
-def _origin_target(
-    request: "HttpRequest",
-) -> "tuple[Path | None, dict[str, object]]":
+def _origin_target(request: "HttpRequest") -> "tuple[Path | None, dict[str, object]]":
     """Resolve the request origin to its page path and URL kwargs.
 
     Both the validate pass and the success funnel re-render the origin
@@ -399,17 +376,14 @@ def _form_overrides(outcome: ActionOutcome) -> dict[str, object]:
 
 
 def _bound_form_overrides(
-    form: "BaseForm | BaseFormSet",
-    action_name: str,
+    form: "BaseForm | BaseFormSet", action_name: str
 ) -> dict[str, object]:
     """Return the overrides binding an already-bound form into the zone."""
     return {"form": form, action_name: form}
 
 
 def _wizard_overrides(
-    form: object,
-    wizard: "FormWizard",
-    action_name: str,
+    form: object, wizard: "FormWizard", action_name: str
 ) -> dict[str, object]:
     """Return the overrides binding the next step's unbound form into the zone."""
     namespace = types.SimpleNamespace(form=form, wizard=wizard)
@@ -417,8 +391,7 @@ def _wizard_overrides(
 
 
 def _resolve_step_target(
-    request: "HttpRequest",
-    href: str,
+    request: "HttpRequest", href: str
 ) -> "tuple[Path, dict[str, object]] | None":
     """Resolve the next step URL to its page identity and URL kwargs.
 
@@ -442,8 +415,7 @@ def _should_push_steps(wizard: "FormWizard") -> bool:
 
 
 def _validate_targets(
-    form: "BaseForm | BaseFormSet",
-    validate_fields: tuple[str, ...],
+    form: "BaseForm | BaseFormSet", validate_fields: tuple[str, ...]
 ) -> frozenset[str]:
     """Return the requested field names with file fields removed.
 
@@ -473,10 +445,7 @@ def _form_file_fields(form: "BaseForm") -> frozenset[str]:
     )
 
 
-def _scrub_errors(
-    form: "BaseForm | BaseFormSet",
-    requested: frozenset[str],
-) -> None:
+def _scrub_errors(form: "BaseForm | BaseFormSet", requested: frozenset[str]) -> None:
     """Drop every error the validate request did not ask to surface.
 
     Only errors of the requested fields survive. The cross-field non-field
@@ -533,12 +502,7 @@ def _csrf_rotated(request: "HttpRequest") -> bool:
     return bool(meta.get(_CSRF_ROTATED_FLAG))
 
 
-def _stamp_csrf(
-    request: "HttpRequest",
-    patches: Patches,
-    *,
-    rotated: bool,
-) -> None:
+def _stamp_csrf(request: "HttpRequest", patches: Patches, *, rotated: bool) -> None:
     """Attach the rotated CSRF payload when the request rotated its token."""
     if rotated:
         patches.set_csrf(csrf_payload(request))
@@ -571,10 +535,7 @@ def _error_count(form: "BaseForm | BaseFormSet") -> int:
 
 
 def _envelope_response(
-    patches: Patches,
-    *,
-    request: "HttpRequest | None" = None,
-    rotated: bool = False,
+    patches: Patches, *, request: "HttpRequest | None" = None, rotated: bool = False
 ) -> PatchResponse:
     """Serialise the builder's envelope into a partial response.
 

--- a/next/partial/sse.py
+++ b/next/partial/sse.py
@@ -16,12 +16,7 @@ from .signals import sse_stream_closed, sse_stream_opened
 
 
 if TYPE_CHECKING:
-    from collections.abc import (
-        AsyncIterator,
-        Callable,
-        Iterable,
-        Iterator,
-    )
+    from collections.abc import AsyncIterator, Callable, Iterable, Iterator
 
     from django.http import HttpRequest
 
@@ -90,8 +85,7 @@ class PatchEventStream(StreamingHttpResponse):
             sse_stream_opened.send(sender=type(self), request=request)
 
     def _guard_source_kind(
-        self,
-        source: "Iterable[Patches] | AsyncIterable[Patches]",
+        self, source: "Iterable[Patches] | AsyncIterable[Patches]"
     ) -> None:
         """Refuse a source kind the request's server kind would buffer.
 
@@ -119,8 +113,7 @@ class PatchEventStream(StreamingHttpResponse):
             raise ImproperlyConfigured(msg)
 
     def _build_content(
-        self,
-        source: "Iterable[Patches] | AsyncIterable[Patches]",
+        self, source: "Iterable[Patches] | AsyncIterable[Patches]"
     ) -> "Iterator[bytes] | AsyncIterator[bytes]":
         """Return a sync or async byte stream matching the source kind."""
         if isinstance(source, AsyncIterable):
@@ -160,8 +153,7 @@ class PatchEventStream(StreamingHttpResponse):
             close()
 
     async def _async_stream(
-        self,
-        source: "AsyncIterable[Patches]",
+        self, source: "AsyncIterable[Patches]"
     ) -> "AsyncIterator[bytes]":
         """Yield SSE bytes for an async source, interleaving heartbeats.
 
@@ -200,9 +192,7 @@ class PatchEventStream(StreamingHttpResponse):
             self._announce_closed(sent)
 
     async def _cleanup_async(
-        self,
-        task: "asyncio.Future[Patches] | None",
-        iterator: "AsyncIterator[Patches]",
+        self, task: "asyncio.Future[Patches] | None", iterator: "AsyncIterator[Patches]"
     ) -> None:
         """Cancel an in-flight pull and close the source generator.
 

--- a/next/partial/view.py
+++ b/next/partial/view.py
@@ -67,9 +67,7 @@ def _version_conflict(intent: "PartialIntent", version: str) -> bool:
 
 
 def _build_envelope(
-    result: "ZoneRenderResult",
-    intent: "PartialIntent",
-    version: str,
+    result: "ZoneRenderResult", intent: "PartialIntent", version: str
 ) -> Envelope:
     """Assemble one envelope patching every rendered zone with its assets.
 
@@ -89,10 +87,7 @@ def _build_envelope(
 
 
 def _patch_zone(
-    patches: Patches,
-    name: str,
-    result: "ZoneRenderResult",
-    merge: "MergeMode | None",
+    patches: Patches, name: str, result: "ZoneRenderResult", merge: "MergeMode | None"
 ) -> None:
     """Patch one zone in place, morphing it or merging deduplicated children.
 

--- a/next/partial/zone.py
+++ b/next/partial/zone.py
@@ -82,10 +82,7 @@ class ZoneOptions:
 
 
 def render_zone_body(
-    partial: "ZonePartial",
-    name: str,
-    options: ZoneOptions,
-    context: "Context",
+    partial: "ZonePartial", name: str, options: ZoneOptions, context: "Context"
 ) -> tuple[SafeString, SafeString]:
     """Render one zone body and its addressable wrapper element.
 
@@ -100,10 +97,7 @@ def render_zone_body(
 
 
 def render_zone_standalone(
-    partial: "ZonePartial",
-    name: str,
-    options: ZoneOptions,
-    context: "Context",
+    partial: "ZonePartial", name: str, options: ZoneOptions, context: "Context"
 ) -> SafeString:
     """Render one zone body wrapped in its addressable element.
 
@@ -125,11 +119,7 @@ class ZonePartial:
     """
 
     def __init__(
-        self,
-        nodelist: NodeList,
-        name: str,
-        origin: "Origin | None",
-        engine: Engine,
+        self, nodelist: NodeList, name: str, origin: "Origin | None", engine: Engine
     ) -> None:
         """Store the body node list and the template identity it stands for."""
         self.nodelist = nodelist
@@ -300,16 +290,10 @@ def do_zone(parser: "Parser", token: "Token") -> ZoneNode:
         )
         raise TemplateSyntaxError(msg)
     partial = ZonePartial(
-        nodelist=body,
-        name=name,
-        origin=parser.origin,
-        engine=Engine.get_default(),
+        nodelist=body, name=name, origin=parser.origin, engine=Engine.get_default()
     )
     return ZoneNode(
-        name=name,
-        partial=partial,
-        options=options,
-        placeholder=placeholder,
+        name=name, partial=partial, options=options, placeholder=placeholder
     )
 
 

--- a/next/server/__init__.py
+++ b/next/server/__init__.py
@@ -8,7 +8,7 @@ paths.
 
 from __future__ import annotations
 
-from . import checks, signals
+from . import signals
 from .autoreload import NextStatReloader
 from .roots import get_framework_filesystem_roots_for_linking
 from .watcher import (
@@ -21,7 +21,6 @@ from .watcher import (
 __all__ = [
     "FilesystemWatchContributor",
     "NextStatReloader",
-    "checks",
     "get_framework_filesystem_roots_for_linking",
     "iter_all_autoreload_watch_specs",
     "register_autoreload_watch_spec",

--- a/next/server/checks.py
+++ b/next/server/checks.py
@@ -1,3 +1,0 @@
-"""System checks for the development server subsystem."""
-
-from __future__ import annotations

--- a/next/server/watcher.py
+++ b/next/server/watcher.py
@@ -50,9 +50,7 @@ def register_autoreload_watch_spec(path: Path, glob: str) -> None:
     _registered_extra_watch_specs.append((path, glob))
 
 
-def _dedupe_watch_specs(
-    specs: Iterable[tuple[Path, str]],
-) -> list[tuple[Path, str]]:
+def _dedupe_watch_specs(specs: Iterable[tuple[Path, str]]) -> list[tuple[Path, str]]:
     """Drop duplicate `(path, glob)` pairs keyed on resolved path."""
     seen: set[tuple[Path, str]] = set()
     out: list[tuple[Path, str]] = []

--- a/next/signals.py
+++ b/next/signals.py
@@ -23,11 +23,7 @@ from next.forms.signals import (
     wizard_completed,
     wizard_step_submitted,
 )
-from next.pages.signals import (
-    context_registered,
-    page_rendered,
-    template_loaded,
-)
+from next.pages.signals import context_registered, page_rendered, template_loaded
 from next.partial.signals import (
     field_validated,
     patch_op_registered,

--- a/next/static/assets.py
+++ b/next/static/assets.py
@@ -78,10 +78,7 @@ class KindRegistry:
     Example::
 
         default_kinds.register(
-            "css",
-            extension=".css",
-            slot="styles",
-            renderer="render_link_tag",
+            "css", extension=".css", slot="styles", renderer="render_link_tag"
         )
     """
 

--- a/next/static/backends.py
+++ b/next/static/backends.py
@@ -65,12 +65,7 @@ class StaticBackend(ABC):
         return self._config
 
     @abstractmethod
-    def register_file(
-        self,
-        source_path: Path,
-        logical_name: str,
-        kind: str,
-    ) -> str:
+    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
         """Register a co-located asset file and return its public URL.
 
         The `source_path` argument is the absolute path to the source
@@ -114,12 +109,7 @@ class StaticFilesBackend(StaticBackend):
         return f"{StaticNamespace.NEXT}/{logical_name}{suffix}"
 
     @override
-    def register_file(
-        self,
-        source_path: Path,
-        logical_name: str,
-        kind: str,
-    ) -> str:
+    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
         """Return the staticfiles URL for `next/<logical_name><suffix>`.
 
         The suffix is taken from `source_path.suffix`, so a single kind
@@ -149,12 +139,7 @@ class StaticFilesBackend(StaticBackend):
         self._url_cache[cache_key] = url
         return url
 
-    def render_link_tag(
-        self,
-        url: str,
-        *,
-        request: HttpRequest | None = None,
-    ) -> str:
+    def render_link_tag(self, url: str, *, request: HttpRequest | None = None) -> str:
         """Return a link tag built from the configured css_tag template.
 
         The `request` argument is accepted for contract compatibility
@@ -163,12 +148,7 @@ class StaticFilesBackend(StaticBackend):
         del request
         return self._css_tag.format(url=url)
 
-    def render_script_tag(
-        self,
-        url: str,
-        *,
-        request: HttpRequest | None = None,
-    ) -> str:
+    def render_script_tag(self, url: str, *, request: HttpRequest | None = None) -> str:
         """Return a script tag built from the configured js_tag template.
 
         The `request` argument is accepted for contract compatibility
@@ -177,12 +157,7 @@ class StaticFilesBackend(StaticBackend):
         del request
         return self._js_tag.format(url=url)
 
-    def render_module_tag(
-        self,
-        url: str,
-        *,
-        request: HttpRequest | None = None,
-    ) -> str:
+    def render_module_tag(self, url: str, *, request: HttpRequest | None = None) -> str:
         """Return a module script tag built from the configured module_tag template.
 
         The `request` argument is accepted for contract compatibility

--- a/next/static/checks.py
+++ b/next/static/checks.py
@@ -24,12 +24,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
-from django.core.checks import (
-    CheckMessage,
-    Error,
-    Warning as DjangoWarning,
-    register,
-)
+from django.core.checks import CheckMessage, Error, Warning as DjangoWarning, register
 
 from next.checks import NEXT
 from next.conf import import_class_cached, next_framework_settings
@@ -43,9 +38,7 @@ if TYPE_CHECKING:
 
 
 def _validate_tag_template(
-    tag_name: str,
-    value: object,
-    backend_index: int,
+    tag_name: str, value: object, backend_index: int
 ) -> CheckMessage | None:
     if not isinstance(value, str):
         return None
@@ -63,9 +56,7 @@ def _validate_tag_template(
 
 
 def _check_single_backend(
-    config: object,
-    index: int,
-    seen: set[str],
+    config: object, index: int, seen: set[str]
 ) -> Iterable[CheckMessage]:
     messages: list[CheckMessage] = []
     if not isinstance(config, dict):
@@ -133,18 +124,14 @@ def _check_single_backend(
 
 
 @register(NEXT)
-def check_static_backends(**_kwargs: object) -> list[CheckMessage]:
+def check_static_backends(**kwargs) -> list[CheckMessage]:
     """Validate the structure of `NEXT_FRAMEWORK['STATIC_BACKENDS']`."""
     messages: list[CheckMessage] = []
     try:
         configs = next_framework_settings.STATIC_BACKENDS
     except (AttributeError, ImportError) as e:  # pragma: no cover
         return [
-            Error(
-                f"Unable to read STATIC_BACKENDS: {e}",
-                obj=settings,
-                id="next.E036",
-            )
+            Error(f"Unable to read STATIC_BACKENDS: {e}", obj=settings, id="next.E036")
         ]
 
     if not isinstance(configs, list) or len(configs) == 0:
@@ -170,10 +157,7 @@ def _w042(message: str) -> CheckMessage:
 
 
 @register(NEXT)
-def check_js_context_serializer(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_js_context_serializer(*args, **kwargs) -> list[CheckMessage]:
     """Validate that `JS_CONTEXT_SERIALIZER` resolves to a protocol implementation."""
     message = _js_context_serializer_message()
     return [message] if message is not None else []

--- a/next/static/checks.py
+++ b/next/static/checks.py
@@ -27,11 +27,11 @@ from django.conf import settings
 from django.core.checks import (
     CheckMessage,
     Error,
-    Tags,
     Warning as DjangoWarning,
     register,
 )
 
+from next.checks import NEXT
 from next.conf import import_class_cached, next_framework_settings
 
 from .backends import StaticBackend
@@ -132,7 +132,7 @@ def _check_single_backend(
     return messages
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_static_backends(**_kwargs: object) -> list[CheckMessage]:
     """Validate the structure of `NEXT_FRAMEWORK['STATIC_BACKENDS']`."""
     messages: list[CheckMessage] = []
@@ -169,7 +169,7 @@ def _w042(message: str) -> CheckMessage:
     return DjangoWarning(message, obj=settings, id="next.W042")
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_js_context_serializer(
     *_args: object,
     **_kwargs: object,

--- a/next/static/collector.py
+++ b/next/static/collector.py
@@ -123,10 +123,7 @@ class JsContextPolicy(Protocol):
     """Merge strategy for the collector JS context."""
 
     def merge(
-        self,
-        existing: dict[str, Any],
-        key: str,
-        value: object,
+        self, existing: dict[str, Any], key: str, value: object
     ) -> dict[str, Any]:
         """Merge a new entry into the existing mapping and return it."""
         raise NotImplementedError
@@ -140,10 +137,7 @@ class FirstWinsPolicy:
     """
 
     def merge(
-        self,
-        existing: dict[str, Any],
-        key: str,
-        value: object,
+        self, existing: dict[str, Any], key: str, value: object
     ) -> dict[str, Any]:
         """Write the value only when the key is absent from existing."""
         if key not in existing:
@@ -155,10 +149,7 @@ class LastWinsPolicy:
     """Overwrite the previous value with the latest registration."""
 
     def merge(
-        self,
-        existing: dict[str, Any],
-        key: str,
-        value: object,
+        self, existing: dict[str, Any], key: str, value: object
     ) -> dict[str, Any]:
         """Assign the value under the key, overwriting any existing entry."""
         existing[key] = value
@@ -169,10 +160,7 @@ class RaiseOnConflictPolicy:
     """Raise `KeyError` when the same key is registered twice."""
 
     def merge(
-        self,
-        existing: dict[str, Any],
-        key: str,
-        value: object,
+        self, existing: dict[str, Any], key: str, value: object
     ) -> dict[str, Any]:
         """Assign the value or raise when the key already exists."""
         if key in existing:
@@ -186,10 +174,7 @@ class DeepMergePolicy:
     """Recursively merge dict values and override scalars with the latest value."""
 
     def merge(
-        self,
-        existing: dict[str, Any],
-        key: str,
-        value: object,
+        self, existing: dict[str, Any], key: str, value: object
     ) -> dict[str, Any]:
         """Recursively merge dict values or assign the new one otherwise."""
         current = existing.get(key)
@@ -200,11 +185,7 @@ class DeepMergePolicy:
         return existing
 
     @classmethod
-    def _deep_merge(
-        cls,
-        a: dict[str, Any],
-        b: dict[str, Any],
-    ) -> dict[str, Any]:
+    def _deep_merge(cls, a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
         out = dict(a)
         for k, v in b.items():
             cur = out.get(k)
@@ -363,11 +344,7 @@ class StaticCollector:
         return self._js_serializer
 
     def add_js_context(
-        self,
-        key: str,
-        value: object,
-        *,
-        serializer: JsContextSerializer | None = None,
+        self, key: str, value: object, *, serializer: JsContextSerializer | None = None
     ) -> None:
         """Merge the value under the key through the JS-context policy.
 
@@ -409,10 +386,7 @@ class StaticCollector:
         return self._js_context_serializers
 
     def _encoded_fragment(
-        self,
-        key: str,
-        value: object,
-        default: JsContextSerializer,
+        self, key: str, value: object, default: JsContextSerializer
     ) -> str:
         """Return the cached JSON fragment for a key or re-encode on miss.
 

--- a/next/static/defaults.py
+++ b/next/static/defaults.py
@@ -40,10 +40,7 @@ def register_defaults() -> None:
         inline_tag="script",
     )
     default_kinds.register(
-        "module",
-        extension=".mjs",
-        slot="scripts",
-        renderer="render_module_tag",
+        "module", extension=".mjs", slot="scripts", renderer="render_module_tag"
     )
 
 

--- a/next/static/discovery.py
+++ b/next/static/discovery.py
@@ -159,10 +159,7 @@ class PathResolver:
     provider callable returns already resolved absolute page roots.
     """
 
-    def __init__(
-        self,
-        page_roots_provider: Callable[[], tuple[Path, ...]],
-    ) -> None:
+    def __init__(self, page_roots_provider: Callable[[], tuple[Path, ...]]) -> None:
         """Store the page-roots provider callable consulted on every lookup."""
         self._provider = page_roots_provider
         self._find_page_root_cache: dict[Path, Path | None] = {}
@@ -185,9 +182,7 @@ class PathResolver:
         return None
 
     def logical_name_for_template(
-        self,
-        template_dir: Path,
-        page_root: Path | None,
+        self, template_dir: Path, page_root: Path | None
     ) -> str:
         """Return the logical URL name for a page template directory.
 
@@ -201,11 +196,7 @@ class PathResolver:
             return self._fallback(template_dir)
         return rel or "index"
 
-    def logical_name_for_layout(
-        self,
-        layout_dir: Path,
-        page_root: Path | None,
-    ) -> str:
+    def logical_name_for_layout(self, layout_dir: Path, page_root: Path | None) -> str:
         """Return the logical URL name for a layout directory.
 
         The caller is expected to pass a resolved `layout_dir` and a
@@ -247,11 +238,7 @@ class AssetDiscovery:
         self._module_list_cache: OrderedDict[Path, dict[str, list[str]]] = OrderedDict()
         self._layout_dir_cache: OrderedDict[Path, list[Path]] = OrderedDict()
 
-    def discover_page_assets(
-        self,
-        file_path: Path,
-        collector: StaticCollector,
-    ) -> None:
+    def discover_page_assets(self, file_path: Path, collector: StaticCollector) -> None:
         """Collect layout, template, and module-level assets for a page file.
 
         Assets are added from the outermost layout inward, then from
@@ -283,9 +270,7 @@ class AssetDiscovery:
             self._collect_module_lists(resolved, collector)
 
     def discover_component_assets(
-        self,
-        info: ComponentInfo,
-        collector: StaticCollector,
+        self, info: ComponentInfo, collector: StaticCollector
     ) -> None:
         """Collect co-located CSS, JS, and module asset lists for a component."""
         component_dir = self._component_directory(info)
@@ -324,9 +309,7 @@ class AssetDiscovery:
                     self._register_file(candidate, logical_name, kind, collector)
 
     def _collect_module_lists(
-        self,
-        module_path: Path,
-        collector: StaticCollector,
+        self, module_path: Path, collector: StaticCollector
     ) -> None:
         """Read URL list variables matching every registered placeholder slot.
 
@@ -363,10 +346,7 @@ class AssetDiscovery:
                 self._register_module_url(url, slot_name, collector)
 
     def _register_module_url(
-        self,
-        url: str,
-        slot_name: str,
-        collector: StaticCollector,
+        self, url: str, slot_name: str, collector: StaticCollector
     ) -> None:
         """Resolve a module-level URL to a kind and add it to the collector.
 
@@ -421,11 +401,7 @@ class AssetDiscovery:
             return
         asset = StaticAsset(url=url, kind=kind, source_path=source_path.resolve())
         collector.add(asset)
-        asset_registered.send(
-            sender=asset,
-            collector=collector,
-            backend=backend,
-        )
+        asset_registered.send(sender=asset, collector=collector, backend=backend)
 
     def _component_directory(self, info: ComponentInfo) -> Path | None:
         """Return the directory that holds a composite component, or None."""
@@ -438,9 +414,7 @@ class AssetDiscovery:
         return None  # pragma: no cover
 
     def _find_layout_directories(
-        self,
-        file_path: Path,
-        page_root: Path | None,
+        self, file_path: Path, page_root: Path | None
     ) -> list[Path]:
         """Walk up from the page directory and return layout dirs outermost first.
 

--- a/next/static/finders.py
+++ b/next/static/finders.py
@@ -172,10 +172,7 @@ class NextStaticFilesFinder(BaseFinder):
 
     @override
     def find(
-        self,
-        path: str,
-        find_all: bool = False,
-        **kwargs: bool,
+        self, path: str, find_all: bool = False, **kwargs: bool
     ) -> str | list[str] | None:
         """Resolve the logical path to an absolute filesystem path or list."""
         # Django's BaseFinder.find dictates a positional bool and a deprecated
@@ -190,8 +187,7 @@ class NextStaticFilesFinder(BaseFinder):
 
     @override
     def list(
-        self,
-        ignore_patterns: Iterable[str] | None,
+        self, ignore_patterns: Iterable[str] | None
     ) -> Iterator[tuple[str, Storage]]:
         """Yield logical-path and storage pairs for `collectstatic`."""
         patterns = list(ignore_patterns) if ignore_patterns is not None else []

--- a/next/static/manager.py
+++ b/next/static/manager.py
@@ -93,24 +93,17 @@ class StaticManager:
         """Return the shared asset discovery instance."""
         if self._discovery is None:
             self._discovery = AssetDiscovery(
-                self,
-                resolver=PathResolver(self.page_roots),
+                self, resolver=PathResolver(self.page_roots)
             )
         return self._discovery
 
-    def discover_page_assets(
-        self,
-        file_path: Path,
-        collector: StaticCollector,
-    ) -> None:
+    def discover_page_assets(self, file_path: Path, collector: StaticCollector) -> None:
         """Forward page asset discovery to the shared discovery instance."""
         self._ensure_backends()
         self.discovery.discover_page_assets(file_path, collector)
 
     def discover_component_assets(
-        self,
-        info: ComponentInfo,
-        collector: StaticCollector,
+        self, info: ComponentInfo, collector: StaticCollector
     ) -> None:
         """Forward component asset discovery to the shared discovery instance."""
         self._ensure_backends()
@@ -192,11 +185,7 @@ class StaticManager:
         return user_tags
 
     def _wrap_with_runtime(
-        self,
-        user_tags: str,
-        collector: StaticCollector,
-        *,
-        request: HttpRequest | None,
+        self, user_tags: str, collector: StaticCollector, *, request: HttpRequest | None
     ) -> str:
         builder = self._next_script_builder()
         if builder.policy is ScriptInjectionPolicy.AUTO:
@@ -231,10 +220,7 @@ class StaticManager:
         return "\n".join(self._render_one(asset, backend, request) for asset in assets)
 
     def _render_one(
-        self,
-        asset: StaticAsset,
-        backend: StaticBackend,
-        request: HttpRequest | None,
+        self, asset: StaticAsset, backend: StaticBackend, request: HttpRequest | None
     ) -> str:
         if asset.inline is not None:
             tag = default_kinds.inline_tag(asset.kind)
@@ -331,8 +317,7 @@ default_manager: DefaultStaticManager = DefaultStaticManager()
 
 
 def collect_component_assets(
-    info: ComponentInfo,
-    collector: StaticCollector | None,
+    info: ComponentInfo, collector: StaticCollector | None
 ) -> None:
     """Discover a composite component's co-located assets into the collector.
 
@@ -355,7 +340,7 @@ def reset_default_manager() -> None:
     default_manager._wrapped = empty  # type: ignore[assignment]
 
 
-def _on_settings_reloaded(**_kwargs: object) -> None:
+def _on_settings_reloaded(**kwargs) -> None:
     """Reset the default static manager when framework settings reload."""
     reset_default_manager()
 

--- a/next/static/scripts.py
+++ b/next/static/scripts.py
@@ -186,9 +186,7 @@ class NextScriptBuilder:
 
     @classmethod
     def from_options(
-        cls,
-        next_js_url: str,
-        options: Mapping[str, Any] | None = None,
+        cls, next_js_url: str, options: Mapping[str, Any] | None = None
     ) -> NextScriptBuilder:
         """Build a script builder from an options mapping.
 

--- a/next/templatetags/components.py
+++ b/next/templatetags/components.py
@@ -60,9 +60,7 @@ def _strip_quotes(raw: str) -> str:
 
 
 def _parse_props(
-    parser: Parser,
-    bits: list[str],
-    start: int,
+    parser: Parser, bits: list[str], start: int
 ) -> dict[str, FilterExpression]:
     """Parse ``key=expr`` pairs from tag bits starting at *start*.
 
@@ -92,9 +90,7 @@ class _NamedBlockSpec:
 
 
 def _parse_one_named_block(
-    parser: Parser,
-    token: Token,
-    spec: _NamedBlockSpec,
+    parser: Parser, token: Token, spec: _NamedBlockSpec
 ) -> tuple[str, NodeList]:
     """Parse ``tag "name"`` … ``/end`` into a name and inner node list."""
     bits = token.split_contents()
@@ -130,10 +126,7 @@ class ComponentNode(Node):
     """Looks up the component, gathers slots and free children, then renders HTML."""
 
     def __init__(
-        self,
-        name: str,
-        props: dict[str, FilterExpression],
-        nodelist: NodeList,
+        self, name: str, props: dict[str, FilterExpression], nodelist: NodeList
     ) -> None:
         """Store component name, prop expressions, and nested nodes."""
         self.name = name
@@ -199,10 +192,7 @@ class ComponentNode(Node):
         parent_flat = dict(cast("dict[str, Any]", context.flatten()))
         for key in _INTERNAL_CONTEXT_KEYS:
             parent_flat.pop(key, None)
-        render_ctx: dict[str, Any] = {
-            **parent_flat,
-            **self._resolved_props(context),
-        }
+        render_ctx: dict[str, Any] = {**parent_flat, **self._resolved_props(context)}
         render_ctx["current_template_path"] = path
         render_ctx["children"] = "".join(child_chunks)
 

--- a/next/templatetags/forms.py
+++ b/next/templatetags/forms.py
@@ -98,9 +98,7 @@ def action_url(context: template.Context, action_name: str) -> str:
 
 
 def _parse_form_attr(
-    parser: template.base.Parser,
-    tag_name: str,
-    bit: str,
+    parser: template.base.Parser, tag_name: str, bit: str
 ) -> "tuple[str, FilterExpression]":
     """Parse one `key="value"` tag argument into an attribute name and value."""
     name, eq, value = bit.partition("=")

--- a/next/testing/actions.py
+++ b/next/testing/actions.py
@@ -22,9 +22,7 @@ def resolve_action_url(action_name: str) -> str:
 
 
 def build_form_for(
-    action_name: str,
-    data: dict[str, Any] | None = None,
-    **form_kwargs: object,
+    action_name: str, data: dict[str, Any] | None = None, **form_kwargs
 ) -> django_forms.Form:
     """Instantiate the form class registered for `action_name`.
 
@@ -43,8 +41,7 @@ def build_form_for(
             f"({action_name!r}) with the test client instead."
         )
         raise LookupError(msg)
-    kwargs = cast("dict[str, Any]", form_kwargs)
-    return cast("django_forms.Form", form_class(data=data, **kwargs))
+    return cast("django_forms.Form", form_class(data=data, **form_kwargs))
 
 
 __all__ = ["build_form_for", "resolve_action_url"]

--- a/next/testing/client.py
+++ b/next/testing/client.py
@@ -124,7 +124,7 @@ class NextClient(Client):
         partial: bool = False,
         zones: str | tuple[str, ...] | None = None,
         version: str | None = None,
-        **extra: object,
+        **extra,
     ) -> HttpResponse:
         """Resolve `action_name` and POST `data` to the resulting URL.
 
@@ -158,7 +158,7 @@ class NextClient(Client):
         zones: str | tuple[str, ...],
         *,
         version: str | None = None,
-        **extra: object,
+        **extra,
     ) -> HttpResponse:
         """GET `url` as a partial request for the named zones.
 

--- a/next/testing/deps.py
+++ b/next/testing/deps.py
@@ -55,10 +55,7 @@ def resolve_call(
     loose keyword arguments as `make_resolution_context`.
     """
     context = make_resolution_context(
-        request=request,
-        form=form,
-        url_kwargs=url_kwargs,
-        context_data=context_data,
+        request=request, form=form, url_kwargs=url_kwargs, context_data=context_data
     )
     return resolver.resolve(func, context)
 

--- a/next/testing/html.py
+++ b/next/testing/html.py
@@ -72,12 +72,7 @@ def _inner_text(fragment: str) -> str:
     return "".join(parser.parts).strip()
 
 
-def find_anchor(
-    html: str,
-    *,
-    href: str | None = None,
-    text: str | None = None,
-) -> str:
+def find_anchor(html: str, *, href: str | None = None, text: str | None = None) -> str:
     """Return the first `<a>...</a>` substring that matches the filters.
 
     `href` is compared for exact equality with the anchor's `href`

--- a/next/testing/patching.py
+++ b/next/testing/patching.py
@@ -33,7 +33,7 @@ _MISSING: Any = object()
 
 
 @contextlib.contextmanager
-def override_next_settings(**overrides: object) -> Iterator[None]:
+def override_next_settings(**overrides) -> Iterator[None]:
     """Merge `overrides` into `NEXT_FRAMEWORK` for the duration of the block.
 
     The merge is shallow: top-level keys supplied as kwargs replace any
@@ -144,9 +144,7 @@ class StaticCollectorProxy:
 
 @contextlib.contextmanager
 def patch_static_collector(
-    factory: Callable[[], StaticCollector] | None = None,
-    *,
-    capture: bool = False,
+    factory: Callable[[], StaticCollector] | None = None, *, capture: bool = False
 ) -> Iterator[StaticCollectorProxy | None]:
     """Replace `default_manager.create_collector` for the block.
 

--- a/next/testing/rendering.py
+++ b/next/testing/rendering.py
@@ -24,10 +24,7 @@ if TYPE_CHECKING:
 
 
 def render_page(
-    file_path: Path | str,
-    request: HttpRequest | None = None,
-    /,
-    **url_kwargs: object,
+    file_path: Path | str, request: HttpRequest | None = None, /, **url_kwargs
 ) -> str:
     """Render the page at `file_path` and return its HTML string.
 

--- a/next/testing/signals.py
+++ b/next/testing/signals.py
@@ -63,12 +63,7 @@ class SignalRecorder:
             signal.disconnect(self._receiver)
         self._started = False
 
-    def _receiver(
-        self,
-        sender: object,
-        signal: Signal,
-        **kwargs: object,
-    ) -> None:
+    def _receiver(self, sender: object, signal: Signal, **kwargs) -> None:
         self.events.append(
             SignalEvent(signal=signal, sender=sender, kwargs=dict(kwargs))
         )

--- a/next/urls/backends.py
+++ b/next/urls/backends.py
@@ -145,7 +145,7 @@ class FileRouterBackend(RouterBackend):
                 tuple(sorted(self._skip_dir_names)),
                 self._components_folder_name,
                 cp_t,
-            ),
+            )
         )
 
     @override
@@ -225,35 +225,27 @@ class FileRouterBackend(RouterBackend):
             return self._patterns_cache[app_name]
         if pages_path := self._get_app_pages_path(app_name):
             patterns: list[URLPattern | URLResolver] = list(
-                self._generate_patterns_from_directory(pages_path),
+                self._generate_patterns_from_directory(pages_path)
             )
             self._patterns_cache[app_name] = patterns
             return patterns
         return []
 
     def _generate_patterns_from_directory(
-        self,
-        pages_path: Path,
+        self, pages_path: Path
     ) -> Generator[URLPattern, None, None]:
         """Yield one `URLPattern` per discovered page under `pages_path`."""
         for url_path, file_path in self._scan_pages_directory(pages_path):
             if pattern := page.create_url_pattern(
-                url_path,
-                file_path,
-                self._url_parser,
+                url_path, file_path, self._url_parser
             ):
                 route_registered.send(
-                    sender=FileRouterBackend,
-                    url_path=url_path,
-                    file_path=file_path,
+                    sender=FileRouterBackend, url_path=url_path, file_path=file_path
                 )
                 yield pattern
 
     def _scan_pages_directory(
-        self,
-        pages_path: Path,
-        *,
-        register_components: bool = True,
+        self, pages_path: Path, *, register_components: bool = True
     ) -> Generator[tuple[str, Path], None, None]:
         """Yield `(url_path, page_file)` pairs discovered under `pages_path`."""
         dispatcher = FilesystemTreeDispatcher(
@@ -268,7 +260,7 @@ class RouterFactory:
     """Build `RouterBackend` instances from `PAGE_BACKENDS`-style dicts."""
 
     _backends: ClassVar[dict[str, type[RouterBackend]]] = {
-        "next.urls.FileRouterBackend": FileRouterBackend,
+        "next.urls.FileRouterBackend": FileRouterBackend
     }
 
     @classmethod
@@ -329,8 +321,7 @@ class RouterFactory:
                 raise ValueError(msg) from e
 
         if not isinstance(backend_class, type) or not issubclass(
-            backend_class,
-            RouterBackend,
+            backend_class, RouterBackend
         ):
             msg = f"Backend {backend_name!r} is not a RouterBackend subclass"
             raise TypeError(msg)
@@ -359,8 +350,4 @@ class RouterFactory:
         return backend_class()
 
 
-__all__ = [
-    "FileRouterBackend",
-    "RouterBackend",
-    "RouterFactory",
-]
+__all__ = ["FileRouterBackend", "RouterBackend", "RouterFactory"]

--- a/next/urls/checks.py
+++ b/next/urls/checks.py
@@ -8,11 +8,13 @@ from django.conf import settings
 from django.core.checks import CheckMessage, Error, Tags, register
 from django.utils.module_loading import import_string
 
+from next.checks import NEXT
 from next.checks.common import (
     errors_for_unknown_keys,
     get_router_manager,
 )
 from next.conf import next_framework_settings
+from next.conf.signals import settings_reloaded
 
 from .backends import FileRouterBackend, RouterBackend, RouterFactory
 from .dispatcher import scan_pages_tree
@@ -282,7 +284,7 @@ def _validate_config_fields(
     return errors
 
 
-@register(Tags.compatibility)
+@register(NEXT)
 def check_next_pages_configuration(
     *_args: object,
     **_kwargs: object,
@@ -328,7 +330,7 @@ def check_next_pages_configuration(
     return errors
 
 
-@register(Tags.urls)
+@register(Tags.urls, NEXT)
 def check_url_patterns(
     *_args: object,
     **_kwargs: object,
@@ -356,7 +358,7 @@ def check_url_patterns(
     return errors + warnings
 
 
-@register(Tags.urls)
+@register(Tags.urls, NEXT)
 def check_reverse_name_collisions(
     *_args: object,
     **_kwargs: object,
@@ -404,7 +406,37 @@ def check_reverse_name_collisions(
     return errors
 
 
+# One collection walk shared by the two URL checks in a run. The stored
+# manager is compared by identity, and holding a reference to it keeps it alive
+# so its `id` can never be reused by a later manager while the memo is live.
+_COLLECTED_PATTERNS_CACHE: dict[
+    str,
+    tuple[RouterManager, list[_CollectedPattern], list[CheckMessage]] | None,
+] = {"value": None}
+
+
+def reset_collected_patterns_cache(**_kwargs: object) -> None:
+    """Drop memoised collected patterns so the next check run recollects."""
+    _COLLECTED_PATTERNS_CACHE["value"] = None
+
+
+settings_reloaded.connect(reset_collected_patterns_cache)
+
+
 def _collect_all_patterns(
+    router_manager: RouterManager,
+) -> tuple[list[_CollectedPattern], list[CheckMessage]]:
+    """Return per-run memoised patterns as fresh lists callers may mutate."""
+    cached = _COLLECTED_PATTERNS_CACHE["value"]
+    if cached is not None and cached[0] is router_manager:
+        _, patterns, errors = cached
+    else:
+        patterns, errors = _collect_all_patterns_uncached(router_manager)
+        _COLLECTED_PATTERNS_CACHE["value"] = (router_manager, patterns, errors)
+    return list(patterns), list(errors)
+
+
+def _collect_all_patterns_uncached(
     router_manager: RouterManager,
 ) -> tuple[list[_CollectedPattern], list[CheckMessage]]:
     """Collect one `_CollectedPattern` per route from every router backend."""
@@ -551,4 +583,5 @@ __all__ = [
     "check_next_pages_configuration",
     "check_reverse_name_collisions",
     "check_url_patterns",
+    "reset_collected_patterns_cache",
 ]

--- a/next/urls/checks.py
+++ b/next/urls/checks.py
@@ -9,10 +9,7 @@ from django.core.checks import CheckMessage, Error, Tags, register
 from django.utils.module_loading import import_string
 
 from next.checks import NEXT
-from next.checks.common import (
-    errors_for_unknown_keys,
-    get_router_manager,
-)
+from next.checks.common import errors_for_unknown_keys, get_router_manager
 from next.conf import next_framework_settings
 from next.conf.signals import settings_reloaded
 
@@ -33,13 +30,7 @@ FILE_ROUTER_BACKEND = "next.urls.FileRouterBackend"
 _PAGE_BACKEND_SETTINGS_KEY = "PAGE_BACKENDS"
 
 _FILE_ROUTER_PAGE_CONFIG_KEYS = frozenset(
-    {
-        "BACKEND",
-        "APP_DIRS",
-        "DIRS",
-        "OPTIONS",
-        "PAGES_DIR",
-    },
+    {"BACKEND", "APP_DIRS", "DIRS", "OPTIONS", "PAGES_DIR"}
 )
 
 _NON_FILE_ROUTER_PAGE_CONFIG_KEYS = frozenset({"BACKEND"})
@@ -59,10 +50,7 @@ def _router_backend_path_is_valid(backend_path: str) -> bool:
     return isinstance(resolved, type) and issubclass(resolved, RouterBackend)
 
 
-def _validate_config_structure(
-    config: object,
-    index: int,
-) -> list[CheckMessage]:
+def _validate_config_structure(config: object, index: int) -> list[CheckMessage]:
     """Validate required keys and types for one `PAGE_BACKENDS` entry."""
     errors: list[CheckMessage] = []
 
@@ -73,7 +61,7 @@ def _validate_config_structure(
                 "must be a dictionary.",
                 obj=settings,
                 id="next.E002",
-            ),
+            )
         )
         return errors
 
@@ -84,15 +72,14 @@ def _validate_config_structure(
                 "must specify a BACKEND.",
                 obj=settings,
                 id="next.E003",
-            ),
+            )
         )
 
     return errors
 
 
 def _validate_file_router_backend_fields(
-    config: dict[str, Any],
-    index: int,
+    config: dict[str, Any], index: int
 ) -> list[CheckMessage]:
     """Validate `DIRS`, `PAGES_DIR`, `APP_DIRS`, `OPTIONS` for the file router."""
     rf_routers = f"NEXT_FRAMEWORK['{_PAGE_BACKEND_SETTINGS_KEY}'][{index}]"
@@ -103,10 +90,8 @@ def _validate_file_router_backend_fields(
     errors.extend(_validate_options_field(config, rf_routers))
     errors.extend(
         errors_for_unknown_keys(
-            config,
-            allowed=_FILE_ROUTER_PAGE_CONFIG_KEYS,
-            prefix=rf_routers,
-        ),
+            config, allowed=_FILE_ROUTER_PAGE_CONFIG_KEYS, prefix=rf_routers
+        )
     )
     return errors
 
@@ -119,8 +104,7 @@ def _validate_dirs_field(config: dict[str, Any], prefix: str) -> list[CheckMessa
 
 
 def _validate_pages_dir_field(
-    config: dict[str, Any],
-    prefix: str,
+    config: dict[str, Any], prefix: str
 ) -> list[CheckMessage]:
     """Validate that `PAGES_DIR` is present and a string."""
     if "PAGES_DIR" not in config:
@@ -129,23 +113,16 @@ def _validate_pages_dir_field(
                 f"{prefix} must specify PAGES_DIR when using FileRouterBackend.",
                 obj=settings,
                 id="next.E024",
-            ),
+            )
         ]
     if not isinstance(config["PAGES_DIR"], str):
         return [
-            Error(
-                f"{prefix}.PAGES_DIR must be a string.",
-                obj=settings,
-                id="next.E027",
-            ),
+            Error(f"{prefix}.PAGES_DIR must be a string.", obj=settings, id="next.E027")
         ]
     return []
 
 
-def _validate_app_dirs_field(
-    config: dict[str, Any],
-    prefix: str,
-) -> list[CheckMessage]:
+def _validate_app_dirs_field(config: dict[str, Any], prefix: str) -> list[CheckMessage]:
     """Validate that `APP_DIRS` is present and a boolean."""
     if "APP_DIRS" not in config:
         return [
@@ -153,23 +130,16 @@ def _validate_app_dirs_field(
                 f"{prefix} must specify APP_DIRS when using FileRouterBackend.",
                 obj=settings,
                 id="next.E025",
-            ),
+            )
         ]
     if not isinstance(config["APP_DIRS"], bool):
         return [
-            Error(
-                f"{prefix}.APP_DIRS must be a boolean.",
-                obj=settings,
-                id="next.E005",
-            ),
+            Error(f"{prefix}.APP_DIRS must be a boolean.", obj=settings, id="next.E005")
         ]
     return []
 
 
-def _validate_options_field(
-    config: dict[str, Any],
-    prefix: str,
-) -> list[CheckMessage]:
+def _validate_options_field(config: dict[str, Any], prefix: str) -> list[CheckMessage]:
     """Validate that `OPTIONS` is present, a dict, and only names known keys."""
     if "OPTIONS" not in config:
         return [
@@ -177,13 +147,13 @@ def _validate_options_field(
                 f"{prefix} must specify OPTIONS when using FileRouterBackend.",
                 obj=settings,
                 id="next.E026",
-            ),
+            )
         ]
     if not isinstance(config["OPTIONS"], dict):
         return [
             Error(
                 f"{prefix}.OPTIONS must be a dictionary.", obj=settings, id="next.E006"
-            ),
+            )
         ]
     opts = config["OPTIONS"]
     errors = _validate_context_processors(opts, prefix)
@@ -192,8 +162,7 @@ def _validate_options_field(
 
 
 def _validate_context_processors(
-    opts: dict[str, Any],
-    prefix: str,
+    opts: dict[str, Any], prefix: str
 ) -> list[CheckMessage]:
     """Validate the `context_processors` option as a list of strings."""
     cp = opts.get("context_processors")
@@ -203,7 +172,7 @@ def _validate_context_processors(
                 f"{prefix}.OPTIONS['context_processors'] must be a list.",
                 obj=settings,
                 id="next.E006",
-            ),
+            )
         ]
     if isinstance(cp, list) and any(not isinstance(item, str) for item in cp):
         return [
@@ -211,14 +180,13 @@ def _validate_context_processors(
                 f"{prefix}.OPTIONS['context_processors'] must contain only strings.",
                 obj=settings,
                 id="next.E006",
-            ),
+            )
         ]
     return []
 
 
 def _validate_options_unknown_keys(
-    opts: dict[str, Any],
-    prefix: str,
+    opts: dict[str, Any], prefix: str
 ) -> list[CheckMessage]:
     """Report the first `OPTIONS` key that is not `context_processors`."""
     unknown = next((key for key in opts if key != "context_processors"), None)
@@ -231,14 +199,11 @@ def _validate_options_unknown_keys(
             "Use top-level DIRS for extra page roots.",
             obj=settings,
             id="next.E006",
-        ),
+        )
     ]
 
 
-def _validate_config_fields(
-    config: dict[str, Any],
-    index: int,
-) -> list[CheckMessage]:
+def _validate_config_fields(config: dict[str, Any], index: int) -> list[CheckMessage]:
     """Validate specific fields of a single page-backend configuration."""
     errors: list[CheckMessage] = []
 
@@ -250,7 +215,7 @@ def _validate_config_fields(
                 f'unknown backend "{backend}".',
                 obj=settings,
                 id="next.E004",
-            ),
+            )
         )
 
     is_file_router = False
@@ -275,29 +240,20 @@ def _validate_config_fields(
         rf = f"NEXT_FRAMEWORK['{_PAGE_BACKEND_SETTINGS_KEY}'][{index}]"
         errors.extend(
             errors_for_unknown_keys(
-                config,
-                allowed=_NON_FILE_ROUTER_PAGE_CONFIG_KEYS,
-                prefix=rf,
-            ),
+                config, allowed=_NON_FILE_ROUTER_PAGE_CONFIG_KEYS, prefix=rf
+            )
         )
 
     return errors
 
 
 @register(NEXT)
-def check_next_pages_configuration(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_next_pages_configuration(*args, **kwargs) -> list[CheckMessage]:
     """Validate `PAGE_BACKENDS` inside merged `NEXT_FRAMEWORK`."""
     raw = getattr(settings, "NEXT_FRAMEWORK", None)
     if raw is not None and not isinstance(raw, dict):
         return [
-            Error(
-                "NEXT_FRAMEWORK must be a dictionary.",
-                obj=settings,
-                id="next.E001",
-            ),
+            Error("NEXT_FRAMEWORK must be a dictionary.", obj=settings, id="next.E001")
         ]
 
     next_pages = next_framework_settings.PAGE_BACKENDS
@@ -308,7 +264,7 @@ def check_next_pages_configuration(
                 "configuration dictionaries.",
                 obj=settings,
                 id="next.E001",
-            ),
+            )
         ]
 
     if len(next_pages) == 0:
@@ -318,7 +274,7 @@ def check_next_pages_configuration(
                 "router entry (configure the file router or another backend).",
                 obj=settings,
                 id="next.E022",
-            ),
+            )
         ]
 
     errors: list[CheckMessage] = []
@@ -331,10 +287,7 @@ def check_next_pages_configuration(
 
 
 @register(Tags.urls, NEXT)
-def check_url_patterns(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_url_patterns(*args, **kwargs) -> list[CheckMessage]:
     """Collect patterns from routers and flag duplicate Django path strings."""
     warnings: list[CheckMessage] = []
 
@@ -348,21 +301,14 @@ def check_url_patterns(
         _check_url_conflicts(all_patterns, errors, warnings)
     except (ValueError, TypeError) as e:
         errors.append(
-            Error(
-                f"Error checking URL conflicts: {e}",
-                obj=settings,
-                id="next.E014",
-            ),
+            Error(f"Error checking URL conflicts: {e}", obj=settings, id="next.E014")
         )
 
     return errors + warnings
 
 
 @register(Tags.urls, NEXT)
-def check_reverse_name_collisions(
-    *_args: object,
-    **_kwargs: object,
-) -> list[CheckMessage]:
+def check_reverse_name_collisions(*args, **kwargs) -> list[CheckMessage]:
     """Fail when two distinct routes collapse to the same reverse URL name."""
     errors: list[CheckMessage] = []
 
@@ -379,12 +325,11 @@ def check_reverse_name_collisions(
     grouped: dict[tuple[str, frozenset[str]], dict[str, list[str]]] = {}
     for _pattern, url_path, source, parameters in all_patterns:
         full_name = next_framework_settings.URL_NAME_TEMPLATE.format(
-            name=default_url_parser.prepare_url_name(url_path),
+            name=default_url_parser.prepare_url_name(url_path)
         )
-        grouped.setdefault((full_name, parameters), {}).setdefault(
-            url_path,
-            [],
-        ).append(source)
+        grouped.setdefault((full_name, parameters), {}).setdefault(url_path, []).append(
+            source
+        )
 
     for (full_name, _signature), routes in grouped.items():
         # One trail from several trees is an E015 path conflict, not this.
@@ -400,7 +345,7 @@ def check_reverse_name_collisions(
                 "them. Rename the conflicting directories.",
                 obj=settings,
                 id="next.E039",
-            ),
+            )
         )
 
     return errors
@@ -410,12 +355,11 @@ def check_reverse_name_collisions(
 # manager is compared by identity, and holding a reference to it keeps it alive
 # so its `id` can never be reused by a later manager while the memo is live.
 _COLLECTED_PATTERNS_CACHE: dict[
-    str,
-    tuple[RouterManager, list[_CollectedPattern], list[CheckMessage]] | None,
+    str, tuple[RouterManager, list[_CollectedPattern], list[CheckMessage]] | None
 ] = {"value": None}
 
 
-def reset_collected_patterns_cache(**_kwargs: object) -> None:
+def reset_collected_patterns_cache(**kwargs) -> None:
     """Drop memoised collected patterns so the next check run recollects."""
     _COLLECTED_PATTERNS_CACHE["value"] = None
 
@@ -454,7 +398,7 @@ def _collect_all_patterns_uncached(
                     f"Error collecting patterns from router: {e}",
                     obj=settings,
                     id="next.E016",
-                ),
+                )
             )
 
     return all_patterns, errors
@@ -528,7 +472,7 @@ def _check_url_conflicts(
                     f"multiple locations: {', '.join(sources)}",
                     obj=settings,
                     id="next.E015",
-                ),
+                )
             )
 
 
@@ -550,14 +494,12 @@ def _collect_url_patterns(
 
     for url_path, page_file in scan_pages_tree(pages_path, skip_dir_names):
         try:
-            django_pattern, parameters = default_url_parser.parse_url_pattern(
-                url_path,
-            )
+            django_pattern, parameters = default_url_parser.parse_url_pattern(url_path)
         except DuplicateURLParameterError as exc:
             # Two wildcards with distinct names raise without a name
             # duplicate, so fall back to the name the parser flagged.
             names = default_url_parser.duplicate_parameter_names(url_path) or [
-                exc.param_name,
+                exc.param_name
             ]
             errors.append(
                 Error(
@@ -566,15 +508,13 @@ def _collect_url_patterns(
                     "Each parameter must have a unique name.",
                     obj=str(page_file),
                     id="next.E028",
-                ),
+                )
             )
         except (ValueError, TypeError):
             continue
         else:
             source = f"{context}: {page_file.relative_to(pages_path)}"
-            patterns.append(
-                (django_pattern, url_path, source, frozenset(parameters)),
-            )
+            patterns.append((django_pattern, url_path, source, frozenset(parameters)))
 
     return patterns
 

--- a/next/urls/dispatcher.py
+++ b/next/urls/dispatcher.py
@@ -42,10 +42,7 @@ class FilesystemTreeDispatcher:
         yield from self._visit(pages_path, pages_path, "")
 
     def _visit(
-        self,
-        current_path: Path,
-        tree_root: Path,
-        url_path: str,
+        self, current_path: Path, tree_root: Path, url_path: str
     ) -> Generator[tuple[str, Path], None, None]:
         try:
             items = list(current_path.iterdir())

--- a/next/urls/manager.py
+++ b/next/urls/manager.py
@@ -104,7 +104,7 @@ class RouterManager:
 router_manager = RouterManager()
 
 
-def _on_settings_reloaded(**_kwargs: object) -> None:
+def _on_settings_reloaded(**kwargs) -> None:
     """Rebuild router backends and the URL resolver on settings reload.
 
     The resolver is swapped in place so `urlpatterns` keeps its identity
@@ -148,11 +148,7 @@ class _LazyUrlPatterns(Sequence["URLPattern | URLResolver"]):
         ]
         # Versions are read after the build because expanding pages can
         # register form actions and bump the forms version mid-build.
-        self._cache = (
-            router_manager._version,
-            form_action_manager._version,
-            patterns,
-        )
+        self._cache = (router_manager._version, form_action_manager._version, patterns)
         return patterns
 
     @override
@@ -214,9 +210,4 @@ app_name = "next"
 urlpatterns = [_build_url_resolver()]
 
 
-__all__ = [
-    "RouterManager",
-    "app_name",
-    "router_manager",
-    "urlpatterns",
-]
+__all__ = ["RouterManager", "app_name", "router_manager", "urlpatterns"]

--- a/next/urls/markers.py
+++ b/next/urls/markers.py
@@ -191,22 +191,14 @@ class QueryParamProvider(RegisteredParameterProvider):
     priority = 80
 
     @override
-    def can_handle(
-        self,
-        param: inspect.Parameter,
-        context: ResolutionContext,
-    ) -> bool:
+    def can_handle(self, param: inspect.Parameter, context: ResolutionContext) -> bool:
         """Return True for `DQuery[...]` annotations when a request is present."""
         if get_origin(param.annotation) is not DQuery:
             return False
         return getattr(context, "request", None) is not None
 
     @override
-    def resolve(
-        self,
-        param: inspect.Parameter,
-        context: ResolutionContext,
-    ) -> object:
+    def resolve(self, param: inspect.Parameter, context: ResolutionContext) -> object:
         """Pull the value from `request.GET` and coerce it to the annotated type."""
         request = context.request
         if request is None:
@@ -227,9 +219,7 @@ def _missing(param: inspect.Parameter) -> object:
 
 
 def _resolve_multi(
-    request: HttpRequest,
-    param: inspect.Parameter,
-    hint: object,
+    request: HttpRequest, param: inspect.Parameter, hint: object
 ) -> object:
     """Resolve a `DQuery[list[T]]` parameter from repeated query-string keys.
 
@@ -250,11 +240,7 @@ def _resolve_multi(
     return [_coerce_url_value(v, inner_type) for v in raw_list]
 
 
-def _expand_multi_value(
-    request: HttpRequest,
-    name: str,
-    plain: list[str],
-) -> list[str]:
+def _expand_multi_value(request: HttpRequest, name: str, plain: list[str]) -> list[str]:
     """Return values for `name` after considering bracket and comma forms.
 
     `plain` holds whatever `request.GET.getlist(name)` returned and is

--- a/next/urls/parser.py
+++ b/next/urls/parser.py
@@ -60,10 +60,7 @@ class DuplicateURLParameterError(ValueError):
     """
 
     def __init__(
-        self,
-        param_name: str,
-        url_path: str,
-        file_path: Path | None = None,
+        self, param_name: str, url_path: str, file_path: Path | None = None
     ) -> None:
         """Build the message from the conflicting name and the source path."""
         self.param_name = param_name
@@ -96,7 +93,7 @@ class URLPatternParser:
     # The wildcard alternative must come first so `[[x]]` never matches
     # the single-bracket branch with a `[` inside the captured name.
     _bracket_pattern: ClassVar[re.Pattern[str]] = re.compile(
-        r"\[\[(?P<wild>[^\[\]]+)\]\]|\[(?P<param>[^\[\]]+)\]",
+        r"\[\[(?P<wild>[^\[\]]+)\]\]|\[(?P<param>[^\[\]]+)\]"
     )
 
     def parse_url_pattern(self, url_path: str) -> tuple[str, dict[str, str]]:
@@ -115,7 +112,7 @@ class URLPatternParser:
                 parameters[name] = name
                 return f"<path:{name}>"
             param_name, param_type = self._parse_param_name_and_type(
-                match.group("param"),
+                match.group("param")
             )
             name = param_name.replace("-", "_")
             if name in parameters:

--- a/next/urls/resolver.py
+++ b/next/urls/resolver.py
@@ -47,10 +47,7 @@ class _TrieNode:
 
 
 def _collect(
-    node: _TrieNode,
-    segments: list[str],
-    depth: int,
-    found: list[_Candidate],
+    node: _TrieNode, segments: list[str], depth: int, found: list[_Candidate]
 ) -> None:
     found.extend(node.tail_terminals)
     if depth == len(segments):

--- a/next/urls/reverse.py
+++ b/next/urls/reverse.py
@@ -14,10 +14,7 @@ from .parser import default_url_parser
 
 
 def page_reverse(
-    path_template: str = "",
-    *,
-    namespace: str = app_name,
-    **kwargs: object,
+    path_template: str = "", *, namespace: str = app_name, **kwargs
 ) -> str:
     """Reverse a file-router page URL from its directory-tree template."""
     clean_name = default_url_parser.prepare_url_name(path_template)
@@ -30,7 +27,7 @@ def page_reverse(
 page_reverse_lazy = lazy(page_reverse, str)
 
 
-def with_query(base: str, **overrides: object) -> str:
+def with_query(base: str, **overrides) -> str:
     """Return `base` with its query string updated by `overrides`.
 
     `None` values drop their key from the result. Multi-valued keys can be
@@ -50,7 +47,7 @@ def with_query(base: str, **overrides: object) -> str:
             pairs.append((key, str(value)))
     new_query = urlencode(pairs, doseq=False)
     return urlunsplit(
-        (parts.scheme, parts.netloc, parts.path, new_query, parts.fragment),
+        (parts.scheme, parts.netloc, parts.path, new_query, parts.fragment)
     )
 
 

--- a/next/utils.py
+++ b/next/utils.py
@@ -24,8 +24,7 @@ def resolve_base_dir() -> Path | None:
 
 
 def _classify_one_dir_entry(
-    item: Path,
-    base_dir: Path | None,
+    item: Path, base_dir: Path | None
 ) -> tuple[str, Path | str | None]:
     if item.is_absolute():
         if item.exists() and item.is_dir():
@@ -49,8 +48,7 @@ def _classify_one_dir_entry(
 
 
 def classify_dirs_entries(
-    entries: list[Any] | tuple[Any, ...] | None,
-    base_dir: Path | None,
+    entries: list[Any] | tuple[Any, ...] | None, base_dir: Path | None
 ) -> tuple[list[Path], frozenset[str]]:
     """Split ``DIRS`` into directory roots and URL segment names (file router)."""
     path_roots: list[Path] = []
@@ -123,9 +121,7 @@ def _walk_back(frame: FrameType | None, back_count: int) -> FrameType | None:
 
 
 def _scan_by_suffix(
-    frame: FrameType | None,
-    suffixes: tuple[str, ...],
-    max_walk: int,
+    frame: FrameType | None, suffixes: tuple[str, ...], max_walk: int
 ) -> Path:
     """Return the first caller frame whose ``__file__`` is not a framework suffix."""
     for _ in range(max_walk):
@@ -142,9 +138,7 @@ def _scan_by_suffix(
 
 
 def _scan_framework_file(
-    frame: FrameType | None,
-    skip_framework_file: tuple[str, str],
-    max_walk: int,
+    frame: FrameType | None, skip_framework_file: tuple[str, str], max_walk: int
 ) -> Path:
     """Return the first caller frame outside the named framework module file."""
     base, parent = skip_framework_file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,8 @@ select = ["ALL"]
 ignore = [
     # Framework-specific ignores
     "SLF001", # private member access (framework code needs this)
+    "ANN002", # missing type annotation for *args
+    "ANN003", # missing type annotation for **kwargs
 
     # Docstring rule conflicts - choose one of each conflicting pair
     "D203",   # incorrect-blank-line-before-class (conflicts with D211)
@@ -237,7 +239,7 @@ known-first-party = ["next"]
 force-single-line = false
 lines-after-imports = 2
 combine-as-imports = true
-split-on-trailing-comma = true
+split-on-trailing-comma = false
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10
@@ -257,6 +259,11 @@ multiline-quotes = "double"
 allow-star-arg-any = false
 ignore-fully-untyped = false
 
+[tool.ruff.lint.flake8-unused-arguments]
+# *args/**kwargs a callback must accept but never reads are not dead code, so
+# they need no `_` prefix to mark them unused.
+ignore-variadic-names = true
+
 [tool.ruff.lint.flake8-pytest-style]
 mark-parentheses = true
 fixture-parentheses = true
@@ -267,7 +274,7 @@ extend-immutable-calls = ["next.deps.Depends"]
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
-skip-magic-trailing-comma = false
+skip-magic-trailing-comma = true
 docstring-code-format = true
 docstring-code-line-length = "dynamic"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,8 +148,6 @@ omit = [
     "*/next/urls/checks.py",
     "*/next/components/checks.py",
     "*/next/forms/checks.py",
-    "*/next/deps/checks.py",
-    "*/next/server/checks.py",
     "*/next/partial/checks.py",
     "*/next/apps/checks.py",
 ]

--- a/tests/apps/test_checks.py
+++ b/tests/apps/test_checks.py
@@ -42,10 +42,7 @@ class TestDjangoTemplatesBackendCheck:
 
     def test_mixed_engines_with_django_backend_pass(self) -> None:
         with override_settings(
-            TEMPLATES=[
-                {"BACKEND": _JINJA_BACKEND},
-                {"BACKEND": _DJANGO_BACKEND},
-            ],
+            TEMPLATES=[{"BACKEND": _JINJA_BACKEND}, {"BACKEND": _DJANGO_BACKEND}]
         ):
             messages = check_django_templates_backend_present(app_configs=None)
         assert messages == []

--- a/tests/apps/test_config.py
+++ b/tests/apps/test_config.py
@@ -155,9 +155,7 @@ class TestComponentsInstall:
         marker = tmp_path / "imported.txt"
         config = _component_backend_config(tmp_path, "widget", marker)
         try:
-            with override_settings(
-                NEXT_FRAMEWORK={"COMPONENT_BACKENDS": [config]},
-            ):
+            with override_settings(NEXT_FRAMEWORK={"COMPONENT_BACKENDS": [config]}):
                 next_components.install()
                 backend = components_manager._backends[0]
                 assert isinstance(backend, FileComponentsBackend)
@@ -175,7 +173,7 @@ class TestComponentsInstall:
                 NEXT_FRAMEWORK={
                     "COMPONENT_BACKENDS": [config],
                     "LAZY_COMPONENT_MODULES": True,
-                },
+                }
             ):
                 next_components.install()
                 backend = components_manager._backends[0]

--- a/tests/benchmarks/components/test_bench_facade.py
+++ b/tests/benchmarks/components/test_bench_facade.py
@@ -17,9 +17,7 @@ if TYPE_CHECKING:
 
 
 def _send_component_rendered(
-    signal: Signal,
-    sender: object,
-    info: ComponentInfo,
+    signal: Signal, sender: object, info: ComponentInfo
 ) -> None:
     signal.send(sender=sender, info=info, template_path=info.template_path)
 
@@ -37,11 +35,6 @@ class TestBenchComponentRenderedSignal:
         info = build_component_info(tmp_path)
         component_rendered.connect(noop_signal_receiver)
         try:
-            benchmark(
-                _send_component_rendered,
-                component_rendered,
-                object(),
-                info,
-            )
+            benchmark(_send_component_rendered, component_rendered, object(), info)
         finally:
             component_rendered.disconnect(noop_signal_receiver)

--- a/tests/benchmarks/components/test_bench_registry.py
+++ b/tests/benchmarks/components/test_bench_registry.py
@@ -4,10 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from next.components.registry import (
-    ComponentRegistry,
-    ComponentVisibilityResolver,
-)
+from next.components.registry import ComponentRegistry, ComponentVisibilityResolver
 from tests.benchmarks.factories import build_component_info_list
 
 
@@ -31,18 +28,14 @@ class TestBenchComponentRegistry:
 
     @pytest.mark.benchmark(group="components.registry")
     def test_lookup_by_name_hit(
-        self,
-        populated_component_registry: tuple[ComponentRegistry, Path],
-        benchmark,
+        self, populated_component_registry: tuple[ComponentRegistry, Path], benchmark
     ) -> None:
         registry, _root = populated_component_registry
         benchmark(registry.__contains__, "c_250")
 
     @pytest.mark.benchmark(group="components.registry")
     def test_lookup_miss(
-        self,
-        populated_component_registry: tuple[ComponentRegistry, Path],
-        benchmark,
+        self, populated_component_registry: tuple[ComponentRegistry, Path], benchmark
     ) -> None:
         registry, _root = populated_component_registry
         benchmark(registry.__contains__, "not_registered")
@@ -51,9 +44,7 @@ class TestBenchComponentRegistry:
 class TestBenchComponentVisibility:
     @pytest.mark.benchmark(group="components.visibility")
     def test_visibility_resolve_cold(
-        self,
-        populated_component_registry: tuple[ComponentRegistry, Path],
-        benchmark,
+        self, populated_component_registry: tuple[ComponentRegistry, Path], benchmark
     ) -> None:
         registry, tmp_path = populated_component_registry
         template_path = tmp_path / "leaf" / "page.djx"
@@ -68,9 +59,7 @@ class TestBenchComponentVisibility:
 
     @pytest.mark.benchmark(group="components.visibility")
     def test_visibility_resolve_cached(
-        self,
-        populated_component_registry: tuple[ComponentRegistry, Path],
-        benchmark,
+        self, populated_component_registry: tuple[ComponentRegistry, Path], benchmark
     ) -> None:
         registry, tmp_path = populated_component_registry
         template_path = tmp_path / "leaf" / "page.djx"
@@ -82,9 +71,7 @@ class TestBenchComponentVisibility:
 
     @pytest.mark.benchmark(group="components.visibility")
     def test_version_bump_invalidation(
-        self,
-        populated_component_registry: tuple[ComponentRegistry, Path],
-        benchmark,
+        self, populated_component_registry: tuple[ComponentRegistry, Path], benchmark
     ) -> None:
         registry, tmp_path = populated_component_registry
         template_path = tmp_path / "leaf" / "page.djx"

--- a/tests/benchmarks/conf/test_bench_helpers.py
+++ b/tests/benchmarks/conf/test_bench_helpers.py
@@ -8,11 +8,7 @@ from next.conf.helpers import extend_default_backend
 class TestBenchExtendDefaultBackend:
     @pytest.mark.benchmark(group="conf.helpers")
     def test_extend_single_override(self, benchmark) -> None:
-        benchmark(
-            extend_default_backend,
-            "PAGE_BACKENDS",
-            PAGES_DIR="routes",
-        )
+        benchmark(extend_default_backend, "PAGE_BACKENDS", PAGES_DIR="routes")
 
     @pytest.mark.benchmark(group="conf.helpers")
     def test_extend_nested_options_merge(self, benchmark) -> None:

--- a/tests/benchmarks/conf/test_bench_settings.py
+++ b/tests/benchmarks/conf/test_bench_settings.py
@@ -48,7 +48,7 @@ class TestBenchSettingsMerge:
             "FORM_ACTION_BACKENDS": [
                 {"BACKEND": "myapp.backends.AuditedBackend", "OPTIONS": {}},
                 {"BACKEND": "myapp.backends.MetricsBackend", "OPTIONS": {}},
-            ],
+            ]
         }
         settings = NextFrameworkSettings()
         benchmark(settings._build_flat_merged, user_dict)

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -35,9 +35,7 @@ def populated_form_backend() -> RegistryFormActionBackend:
 
 
 @pytest.fixture()
-def populated_component_registry(
-    tmp_path: Path,
-) -> tuple[ComponentRegistry, Path]:
+def populated_component_registry(tmp_path: Path) -> tuple[ComponentRegistry, Path]:
     """``ComponentRegistry`` with 500 components rooted at ``tmp_path``."""
     registry = ComponentRegistry()
     registry.mark_as_root(tmp_path)

--- a/tests/benchmarks/deps/test_bench_resolver.py
+++ b/tests/benchmarks/deps/test_bench_resolver.py
@@ -15,20 +15,14 @@ def _handler_simple(request: object, name: str = "default") -> str:
 
 
 def _handler_five(
-    request: object,
-    a: int = 1,
-    b: int = 2,
-    c: int = 3,
-    d: int = 4,
+    request: object, a: int = 1, b: int = 2, c: int = 3, d: int = 4
 ) -> int:
     del request
     return a + b + c + d
 
 
 def _handler_mixed(
-    request: object,
-    cached: str = Depends("theme"),
-    value: int = Context("page_value"),
+    request: object, cached: str = Depends("theme"), value: int = Context("page_value")
 ) -> str:
     del request
     return f"{cached}:{value}"
@@ -40,22 +34,14 @@ class TestBenchDependencyResolver:
         """Signature walk with one positional-only ``request`` + default kwarg."""
         resolver = DependencyResolver()
         request = MagicMock()
-        benchmark(
-            resolver.resolve_dependencies,
-            _handler_simple,
-            request=request,
-        )
+        benchmark(resolver.resolve_dependencies, _handler_simple, request=request)
 
     @pytest.mark.benchmark(group="deps.resolver")
     def test_resolve_five_params(self, benchmark) -> None:
         """Five-parameter function — measures per-arg overhead."""
         resolver = DependencyResolver()
         request = MagicMock()
-        benchmark(
-            resolver.resolve_dependencies,
-            _handler_five,
-            request=request,
-        )
+        benchmark(resolver.resolve_dependencies, _handler_five, request=request)
 
     @pytest.mark.benchmark(group="deps.resolver")
     def test_resolve_mixed_markers(self, benchmark) -> None:

--- a/tests/benchmarks/factories.py
+++ b/tests/benchmarks/factories.py
@@ -27,13 +27,7 @@ def build_pages_tree(
     for i in range(fanout):
         child = root / f"n_{i}"
         child.mkdir()
-        build_pages_tree(
-            child,
-            depth - 1,
-            fanout,
-            leaf=leaf,
-            leaf_body=leaf_body,
-        )
+        build_pages_tree(child, depth - 1, fanout, leaf=leaf, leaf_body=leaf_body)
 
 
 def build_component_djx_dir(root: Path, count: int) -> None:
@@ -42,11 +36,11 @@ def build_component_djx_dir(root: Path, count: int) -> None:
         (root / f"comp_{i}.djx").write_text(f"<div>c{i}</div>")
 
 
-def noop_form_handler(**_: object) -> None:  # pragma: no cover - bench stub
+def noop_form_handler(**kwargs) -> None:  # pragma: no cover - bench stub
     """Stub action handler for form-action benchmarks."""
 
 
-def noop_signal_receiver(sender: object, **_: object) -> None:  # pragma: no cover
+def noop_signal_receiver(sender: object, **kwargs) -> None:  # pragma: no cover
     """No-op Django signal receiver for signal-overhead benchmarks."""
     del sender
 

--- a/tests/benchmarks/forms/test_bench_checks.py
+++ b/tests/benchmarks/forms/test_bench_checks.py
@@ -10,16 +10,12 @@ _VALID_TWO_ENTRY = {
     "FORM_ACTION_BACKENDS": [
         {"BACKEND": "next.forms.RegistryFormActionBackend"},
         {"BACKEND": "next.forms.RegistryFormActionBackend", "OPTIONS": {}},
-    ],
+    ]
 }
 
-_INVALID_BACKEND_PATH = {
-    "FORM_ACTION_BACKENDS": [{"BACKEND": "no.such.Module"}],
-}
+_INVALID_BACKEND_PATH = {"FORM_ACTION_BACKENDS": [{"BACKEND": "no.such.Module"}]}
 
-_WRONG_SUBCLASS = {
-    "FORM_ACTION_BACKENDS": [{"BACKEND": "django.http.HttpResponse"}],
-}
+_WRONG_SUBCLASS = {"FORM_ACTION_BACKENDS": [{"BACKEND": "django.http.HttpResponse"}]}
 
 
 class TestBenchFormActionBackendsCheck:

--- a/tests/benchmarks/forms/test_bench_dispatch.py
+++ b/tests/benchmarks/forms/test_bench_dispatch.py
@@ -8,10 +8,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 
 from next.forms import Form
 from next.forms.backends import ActionRegistration, RegistryFormActionBackend
-from next.forms.dispatch import (
-    FormActionDispatch,
-    _normalize_handler_response,
-)
+from next.forms.dispatch import FormActionDispatch, _normalize_handler_response
 from next.forms.origin import (
     _ORIGIN_MATCH_ATTR,
     _filter_reserved_url_kwargs,
@@ -89,7 +86,7 @@ class _BenchForm(Form):
     name = forms.CharField(max_length=32)
 
 
-def _ok_handler(**_kwargs: object) -> HttpResponseRedirect:
+def _ok_handler(**kwargs) -> HttpResponseRedirect:
     return HttpResponseRedirect("/")
 
 
@@ -112,13 +109,7 @@ class TestBenchDispatchEndToEnd:
         post = MagicMock()
         post.items.return_value = [("name", "bench")]
         request = build_mock_http_request(method="POST", POST=post, FILES=None)
-        benchmark(
-            FormActionDispatch.dispatch,
-            backend,
-            request,
-            "bench_action",
-            meta,
-        )
+        benchmark(FormActionDispatch.dispatch, backend, request, "bench_action", meta)
 
     @pytest.mark.benchmark(group="forms.dispatch")
     def test_dispatch_invalid_form(self, benchmark) -> None:
@@ -139,13 +130,7 @@ class TestBenchDispatchEndToEnd:
         post = MagicMock()
         post.items.return_value = []
         request = build_mock_http_request(method="POST", POST=post, FILES=None)
-        benchmark(
-            FormActionDispatch.dispatch,
-            backend,
-            request,
-            "bench_action",
-            meta,
-        )
+        benchmark(FormActionDispatch.dispatch, backend, request, "bench_action", meta)
 
     @pytest.mark.benchmark(group="forms.dispatch")
     def test_dispatch_unguarded_form_no_hook_overhead(self, benchmark) -> None:
@@ -172,13 +157,7 @@ class TestBenchDispatchEndToEnd:
         post = MagicMock()
         post.items.return_value = [("name", "bench")]
         request = build_mock_http_request(method="POST", POST=post, FILES=None)
-        benchmark(
-            FormActionDispatch.dispatch,
-            backend,
-            request,
-            "bench_action",
-            meta,
-        )
+        benchmark(FormActionDispatch.dispatch, backend, request, "bench_action", meta)
 
     @pytest.mark.benchmark(group="forms.dispatch")
     def test_dispatch_through_subclassed_backend(self, benchmark) -> None:
@@ -209,10 +188,4 @@ class TestBenchDispatchEndToEnd:
         post = MagicMock()
         post.items.return_value = [("name", "bench")]
         request = build_mock_http_request(method="POST", POST=post, FILES=None)
-        benchmark(
-            FormActionDispatch.dispatch,
-            backend,
-            request,
-            "bench_action",
-            meta,
-        )
+        benchmark(FormActionDispatch.dispatch, backend, request, "bench_action", meta)

--- a/tests/benchmarks/forms/test_bench_factory.py
+++ b/tests/benchmarks/forms/test_bench_factory.py
@@ -33,10 +33,7 @@ class TestBenchFormActionFactory:
 
         try:
             benchmark.pedantic(
-                FormActionFactory.create_backend,
-                setup=setup,
-                rounds=200,
-                iterations=1,
+                FormActionFactory.create_backend, setup=setup, rounds=200, iterations=1
             )
         finally:
             FormActionFactory.create_backend(_REGISTRY_CONFIG)

--- a/tests/benchmarks/forms/test_bench_manager.py
+++ b/tests/benchmarks/forms/test_bench_manager.py
@@ -147,8 +147,5 @@ class TestBenchClearRegistries:
             return (), {}
 
         benchmark.pedantic(
-            manager.clear_registries,
-            setup=setup,
-            rounds=200,
-            iterations=1,
+            manager.clear_registries, setup=setup, rounds=200, iterations=1
         )

--- a/tests/benchmarks/forms/test_bench_rendering.py
+++ b/tests/benchmarks/forms/test_bench_rendering.py
@@ -73,9 +73,7 @@ class TestBenchRenderInvalidPage:
 
     @pytest.mark.benchmark(group="forms.rendering")
     def test_render_invalid_page_with_errors(
-        self,
-        error_render_setup: tuple[RegistryFormActionBackend, Path],
-        benchmark,
+        self, error_render_setup: tuple[RegistryFormActionBackend, Path], benchmark
     ) -> None:
         backend, page_file = error_render_setup
         request = build_mock_http_request(method="GET")
@@ -84,10 +82,7 @@ class TestBenchRenderInvalidPage:
 
         def run() -> str:
             return backend.render_invalid_page(
-                request,
-                _INVALID_PAGE_ACTION,
-                form,
-                page_file_path=page_file,
+                request, _INVALID_PAGE_ACTION, form, page_file_path=page_file
             )
 
         benchmark(run)
@@ -101,8 +96,7 @@ class TestBenchErrorRerenderWithLayouts:
         self, tmp_path: Path
     ) -> tuple[RegistryFormActionBackend, Path]:
         page_file = _build_layered_page(
-            tmp_path,
-            "<main>{{ form.title }}{{ form.body }}{{ form.errors }}</main>",
+            tmp_path, "<main>{{ form.title }}{{ form.body }}{{ form.errors }}</main>"
         )
         backend = RegistryFormActionBackend()
         backend.register_action(
@@ -117,9 +111,7 @@ class TestBenchErrorRerenderWithLayouts:
 
     @pytest.mark.benchmark(group="forms.rendering.page")
     def test_error_rerender_with_layouts(
-        self,
-        layered_error_setup: tuple[RegistryFormActionBackend, Path],
-        benchmark,
+        self, layered_error_setup: tuple[RegistryFormActionBackend, Path], benchmark
     ) -> None:
         backend, page_file = layered_error_setup
         request = build_mock_http_request(method="GET")
@@ -128,10 +120,7 @@ class TestBenchErrorRerenderWithLayouts:
 
         def run() -> str:
             return backend.render_invalid_page(
-                request,
-                _LAYERED_ACTION,
-                form,
-                page_file_path=page_file,
+                request, _LAYERED_ACTION, form, page_file_path=page_file
             )
 
         benchmark(run)
@@ -198,12 +187,7 @@ class TestBenchFormTag:
 
         def run() -> str:
             return template.render(
-                Context(
-                    {
-                        "request": csrf_request,
-                        "current_page_module_path": __file__,
-                    }
-                )
+                Context({"request": csrf_request, "current_page_module_path": __file__})
             )
 
         benchmark(run)

--- a/tests/benchmarks/forms/test_bench_wizard.py
+++ b/tests/benchmarks/forms/test_bench_wizard.py
@@ -98,8 +98,7 @@ class TestBenchWizardDispatch:
         meta = backend.get_meta("bench_dispatch_wizard")
         assert meta is not None
         request = RequestFactory().post(
-            "/form/action/",
-            {"_next_form_origin": "/request/one/", "name": "Ada"},
+            "/form/action/", {"_next_form_origin": "/request/one/", "name": "Ada"}
         )
         request.session = SessionStore()
 

--- a/tests/benchmarks/forms/urls_bench.py
+++ b/tests/benchmarks/forms/urls_bench.py
@@ -2,7 +2,7 @@ from django.http import HttpRequest, HttpResponse
 from django.urls import path
 
 
-def _items_page(_request: HttpRequest, **_kwargs: object) -> HttpResponse:
+def _items_page(_request: HttpRequest, **kwargs) -> HttpResponse:
     """Stand-in item page view carrying a string `next_page_path`."""
     return HttpResponse("item")
 
@@ -10,6 +10,4 @@ def _items_page(_request: HttpRequest, **_kwargs: object) -> HttpResponse:
 _items_page.next_page_path = "/items/pages/page.py"
 
 
-urlpatterns = [
-    path("items/<int:id>/", _items_page, name="items_page"),
-]
+urlpatterns = [path("items/<int:id>/", _items_page, name="items_page")]

--- a/tests/benchmarks/pages/test_bench_loaders.py
+++ b/tests/benchmarks/pages/test_bench_loaders.py
@@ -42,10 +42,7 @@ class TestBenchPythonModuleLoader:
 
     @pytest.mark.benchmark(group="pages.loaders")
     def test_python_template_loader_can_load(
-        self,
-        tmp_path: Path,
-        python_template_loader: PythonTemplateLoader,
-        benchmark,
+        self, tmp_path: Path, python_template_loader: PythonTemplateLoader, benchmark
     ) -> None:
         page_path = tmp_path / "page.py"
         page_path.write_text(_PY_SRC)

--- a/tests/benchmarks/partial/test_bench_envelope.py
+++ b/tests/benchmarks/partial/test_bench_envelope.py
@@ -84,9 +84,7 @@ class TestBenchShapeInvalid:
 
     @pytest.mark.benchmark(group="partial.shaping")
     def test_shape_invalid_outcome(
-        self,
-        invalid_setup: tuple[RegistryFormActionBackend, ActionOutcome],
-        benchmark,
+        self, invalid_setup: tuple[RegistryFormActionBackend, ActionOutcome], benchmark
     ) -> None:
         backend, outcome = invalid_setup
         request = RequestFactory().post(

--- a/tests/benchmarks/server/test_bench_autoreload.py
+++ b/tests/benchmarks/server/test_bench_autoreload.py
@@ -14,9 +14,7 @@ if TYPE_CHECKING:
 
 class TestBenchTreeSignature:
     @pytest.mark.parametrize(
-        ("depth", "fanout"),
-        [(3, 3), (4, 5)],
-        ids=["small", "large"],
+        ("depth", "fanout"), [(3, 3), (4, 5)], ids=["small", "large"]
     )
     @pytest.mark.benchmark(group="server.autoreload")
     def test_signature(
@@ -33,8 +31,7 @@ class TestBenchCollectRoutes:
     ) -> None:
         build_pages_tree(tmp_path, depth=3, fanout=4, leaf="page.py")
         monkeypatch.setattr(
-            "next.server.autoreload.get_pages_directories_for_watch",
-            lambda: [tmp_path],
+            "next.server.autoreload.get_pages_directories_for_watch", lambda: [tmp_path]
         )
         reloader = NextStatReloader()
         reloader._collect_routes()  # warm
@@ -44,8 +41,7 @@ class TestBenchCollectRoutes:
     def test_collect_routes_fresh(self, tmp_path: Path, monkeypatch, benchmark) -> None:
         build_pages_tree(tmp_path, depth=3, fanout=4, leaf="page.py")
         monkeypatch.setattr(
-            "next.server.autoreload.get_pages_directories_for_watch",
-            lambda: [tmp_path],
+            "next.server.autoreload.get_pages_directories_for_watch", lambda: [tmp_path]
         )
 
         def run() -> None:

--- a/tests/benchmarks/testing/test_bench_isolation.py
+++ b/tests/benchmarks/testing/test_bench_isolation.py
@@ -30,9 +30,4 @@ class TestBenchResetFormActions:
                 )
             return (), {}
 
-        benchmark.pedantic(
-            reset_form_actions,
-            setup=setup,
-            rounds=200,
-            iterations=1,
-        )
+        benchmark.pedantic(reset_form_actions, setup=setup, rounds=200, iterations=1)

--- a/tests/benchmarks/urls/test_bench_resolver.py
+++ b/tests/benchmarks/urls/test_bench_resolver.py
@@ -19,7 +19,7 @@ _SECTIONS = 10
 _PAGES = 12
 
 
-def _bench_view(_request, **_kwargs: object) -> HttpResponse:
+def _bench_view(_request, **kwargs) -> HttpResponse:
     return HttpResponse(b"bench")
 
 

--- a/tests/checks/test_common.py
+++ b/tests/checks/test_common.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from django.core.checks import run_checks
+from django.core.checks.registry import registry
+from django.test import override_settings
+
+from next.checks import NEXT, register_all
+from next.checks.common import (
+    get_components_manager,
+    get_router_manager,
+    iter_scanned_page_pairs,
+    reset_components_manager_cache,
+    reset_router_manager_cache,
+)
+from next.conf.signals import settings_reloaded
+from next.urls import checks as urls_checks
+from next.urls.checks import (
+    check_reverse_name_collisions,
+    check_url_patterns,
+)
+from next.urls.dispatcher import scan_pages_tree
+from tests.support import patch_checks_router_manager_with_routers
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _clean_manager_caches() -> Iterator[None]:
+    reset_router_manager_cache()
+    reset_components_manager_cache()
+    urls_checks.reset_collected_patterns_cache()
+    yield
+    reset_router_manager_cache()
+    reset_components_manager_cache()
+    urls_checks.reset_collected_patterns_cache()
+
+
+def _write_page(tree: Path, route: str) -> Path:
+    directory = tree / route
+    directory.mkdir(parents=True, exist_ok=True)
+    page_file = directory / "page.py"
+    page_file.write_text('template = "ok"\n')
+    return page_file
+
+
+class _ScanSpyRouter:
+    """Root router that walks a real tree and counts each scan call."""
+
+    app_dirs = False
+
+    def __init__(self, tree: Path) -> None:
+        self.pages_dir = str(tree)
+        self._tree = tree
+        self.scan_calls = 0
+
+    def _get_root_pages_paths(self) -> list[Path]:
+        return [self._tree]
+
+    def _scan_pages_directory(self, pages_dir: Path) -> Iterator[tuple[str, Path]]:
+        self.scan_calls += 1
+        yield from scan_pages_tree(pages_dir)
+
+
+class _RootTreeRouter:
+    """Root router exposing several page trees for URL pattern collection."""
+
+    app_dirs = False
+    _skip_dir_names: frozenset[str] = frozenset()
+
+    def __init__(self, root_trees: list[Path]) -> None:
+        self._root_trees = list(root_trees)
+
+    def _get_root_pages_paths(self) -> list[Path]:
+        return list(self._root_trees)
+
+
+class TestRouterManagerCache:
+    """`get_router_manager` reuses one manager per check run."""
+
+    def test_built_once_across_repeated_calls(self) -> None:
+        with patch("next.urls.RouterManager") as mock_cls:
+            first = get_router_manager()
+            second = get_router_manager()
+            third = get_router_manager()
+        assert first is second is third
+        assert mock_cls.call_count == 1
+        assert mock_cls.return_value.reload.call_count == 1
+
+    def test_explicit_reset_forces_rebuild(self) -> None:
+        with patch("next.urls.RouterManager") as mock_cls:
+            get_router_manager()
+            reset_router_manager_cache()
+            get_router_manager()
+        assert mock_cls.call_count == 2
+        assert mock_cls.return_value.reload.call_count == 2
+
+    def test_settings_reloaded_signal_resets_cache(self) -> None:
+        with patch("next.urls.RouterManager") as mock_cls:
+            get_router_manager()
+            settings_reloaded.send(sender=None)
+            get_router_manager()
+        assert mock_cls.call_count == 2
+
+    def test_init_error_result_is_cached(self) -> None:
+        with patch("next.urls.RouterManager", side_effect=ImportError("boom")):
+            manager, errors = get_router_manager()
+            second_manager, second_errors = get_router_manager()
+        assert manager is None
+        assert second_manager is None
+        assert errors is second_errors
+        assert errors[0].id == "next.E007"
+
+
+class TestComponentsManagerCache:
+    """`get_components_manager` reuses one manager per check run."""
+
+    def test_built_once_across_repeated_calls(self) -> None:
+        with patch("next.components.manager.ComponentsManager") as mock_cls:
+            first = get_components_manager()
+            second = get_components_manager()
+            third = get_components_manager()
+        assert first is second is third
+        assert mock_cls.call_count == 1
+        assert mock_cls.return_value._reload_config.call_count == 1
+
+    def test_explicit_reset_forces_rebuild(self) -> None:
+        with patch("next.components.manager.ComponentsManager") as mock_cls:
+            get_components_manager()
+            reset_components_manager_cache()
+            get_components_manager()
+        assert mock_cls.call_count == 2
+        assert mock_cls.return_value._reload_config.call_count == 2
+
+    def test_settings_reloaded_signal_resets_cache(self) -> None:
+        with patch("next.components.manager.ComponentsManager") as mock_cls:
+            get_components_manager()
+            settings_reloaded.send(sender=None)
+            get_components_manager()
+        assert mock_cls.call_count == 2
+
+
+class TestScannedPairsCache:
+    """`iter_scanned_page_pairs` materialises one scan per router per run."""
+
+    def test_two_consumptions_scan_once(self, tmp_path: Path) -> None:
+        _write_page(tmp_path, "blog")
+        router = _ScanSpyRouter(tmp_path)
+
+        first = list(iter_scanned_page_pairs(router))
+        second = list(iter_scanned_page_pairs(router))
+
+        assert first == second
+        assert router.scan_calls == 1
+
+    def test_cached_pairs_match_direct_scan(self, tmp_path: Path) -> None:
+        _write_page(tmp_path, "blog")
+        _write_page(tmp_path, "docs/guide")
+        router = _ScanSpyRouter(tmp_path)
+
+        cached = list(iter_scanned_page_pairs(router))
+        direct = list(scan_pages_tree(tmp_path))
+
+        assert cached == direct
+
+    def test_distinct_routers_cache_independently(self, tmp_path: Path) -> None:
+        tree_a = tmp_path / "a"
+        tree_b = tmp_path / "b"
+        _write_page(tree_a, "one")
+        _write_page(tree_b, "two")
+        router_a = _ScanSpyRouter(tree_a)
+        router_b = _ScanSpyRouter(tree_b)
+
+        pairs_a = list(iter_scanned_page_pairs(router_a))
+        list(iter_scanned_page_pairs(router_a))
+        pairs_b = list(iter_scanned_page_pairs(router_b))
+        list(iter_scanned_page_pairs(router_b))
+
+        assert router_a.scan_calls == 1
+        assert router_b.scan_calls == 1
+        assert pairs_a != pairs_b
+
+    def test_explicit_reset_rescans(self, tmp_path: Path) -> None:
+        _write_page(tmp_path, "blog")
+        router = _ScanSpyRouter(tmp_path)
+
+        list(iter_scanned_page_pairs(router))
+        reset_router_manager_cache()
+        list(iter_scanned_page_pairs(router))
+
+        assert router.scan_calls == 2
+
+    def test_settings_reloaded_signal_rescans(self, tmp_path: Path) -> None:
+        _write_page(tmp_path, "blog")
+        router = _ScanSpyRouter(tmp_path)
+
+        list(iter_scanned_page_pairs(router))
+        settings_reloaded.send(sender=None)
+        list(iter_scanned_page_pairs(router))
+
+        assert router.scan_calls == 2
+
+    def test_new_pages_visible_only_after_reset(self, tmp_path: Path) -> None:
+        _write_page(tmp_path, "blog")
+        router = _ScanSpyRouter(tmp_path)
+
+        before = list(iter_scanned_page_pairs(router))
+        _write_page(tmp_path, "about")
+        frozen = list(iter_scanned_page_pairs(router))
+        reset_router_manager_cache()
+        after = list(iter_scanned_page_pairs(router))
+
+        assert frozen == before
+        assert len(after) == len(before) + 1
+
+
+class TestCollectAllPatternsDedup:
+    """The two URL checks share one collection walk within a run."""
+
+    def test_two_url_checks_collect_once_with_stable_messages(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        tree_a = tmp_path / "a"
+        tree_b = tmp_path / "b"
+        _write_page(tree_a, "blog")
+        _write_page(tree_b, "blog")
+        router = _RootTreeRouter(root_trees=[tree_a, tree_b])
+
+        with (
+            patch_checks_router_manager_with_routers(routers=[router]),
+            patch(
+                "next.urls.checks._collect_all_patterns_uncached",
+                wraps=urls_checks._collect_all_patterns_uncached,
+            ) as spy,
+        ):
+            memo_url = check_url_patterns(None)
+            memo_rev = check_reverse_name_collisions(None)
+
+        assert spy.call_count == 1
+        assert any(m.id == "next.E015" for m in memo_url)
+
+        urls_checks.reset_collected_patterns_cache()
+        with patch_checks_router_manager_with_routers(routers=[router]):
+            control_url = check_url_patterns(None)
+            urls_checks.reset_collected_patterns_cache()
+            control_rev = check_reverse_name_collisions(None)
+
+        assert [(m.id, m.msg) for m in memo_url] == [(m.id, m.msg) for m in control_url]
+        assert [(m.id, m.msg) for m in memo_rev] == [(m.id, m.msg) for m in control_rev]
+
+
+class TestRegisterAll:
+    """`register_all` keeps the registered check set stable without server checks."""
+
+    def test_register_all_registers_same_check_set(self) -> None:
+        before = {
+            getattr(check, "__name__", None) for check in registry.registered_checks
+        }
+        register_all()
+        after = {
+            getattr(check, "__name__", None) for check in registry.registered_checks
+        }
+        assert after == before
+        assert len(after) == len(before)
+
+
+class TestNextTag:
+    """The `next` tag selects only `next-dj` checks for `manage.py check`."""
+
+    def test_next_tag_runs_next_checks(self) -> None:
+        register_all()
+        with override_settings(NEXT_FRAMEWORK={"__unknown_top_level__": True}):
+            messages = run_checks(tags=[NEXT])
+        assert messages
+        assert any(message.id == "next.E035" for message in messages)
+        assert all(message.id.startswith("next.") for message in messages)
+
+    def test_unregistered_tag_runs_nothing(self) -> None:
+        register_all()
+        assert run_checks(tags=["__not_a_real_tag__"]) == []
+
+    def test_no_next_check_carries_compatibility_tag(self) -> None:
+        register_all()
+        next_checks = [
+            check
+            for check in registry.registered_checks
+            if getattr(check, "__module__", "").startswith("next.")
+        ]
+        assert next_checks
+        assert all("compatibility" not in check.tags for check in next_checks)

--- a/tests/checks/test_common.py
+++ b/tests/checks/test_common.py
@@ -18,10 +18,7 @@ from next.checks.common import (
 )
 from next.conf.signals import settings_reloaded
 from next.urls import checks as urls_checks
-from next.urls.checks import (
-    check_reverse_name_collisions,
-    check_url_patterns,
-)
+from next.urls.checks import check_reverse_name_collisions, check_url_patterns
 from next.urls.dispatcher import scan_pages_tree
 from tests.support import patch_checks_router_manager_with_routers
 
@@ -224,8 +221,7 @@ class TestCollectAllPatternsDedup:
     """The two URL checks share one collection walk within a run."""
 
     def test_two_url_checks_collect_once_with_stable_messages(
-        self,
-        tmp_path: Path,
+        self, tmp_path: Path
     ) -> None:
         tree_a = tmp_path / "a"
         tree_b = tmp_path / "b"

--- a/tests/compat/test_allauth.py
+++ b/tests/compat/test_allauth.py
@@ -35,7 +35,7 @@ def django_db_setup(django_db_setup, django_db_blocker):
             MIDDLEWARE=[
                 *settings.MIDDLEWARE,
                 "allauth.account.middleware.AccountMiddleware",
-            ],
+            ]
         ),
         override_settings(INSTALLED_APPS=[*settings.INSTALLED_APPS, *_ALLAUTH_APPS]),
     ):
@@ -69,9 +69,7 @@ def factory_actions(allauth_env):
     account_utils = pytest.importorskip("allauth.account.utils")
     account_settings = pytest.importorskip("allauth.account.app_settings")
 
-    def login_form_factory(
-        request: HttpRequest,
-    ) -> tuple[type, dict[str, HttpRequest]]:
+    def login_form_factory(request: HttpRequest) -> tuple[type, dict[str, HttpRequest]]:
         return account_forms.LoginForm, {"request": request}
 
     @action("compat_allauth_login", form_class=login_form_factory)
@@ -103,12 +101,7 @@ def subclass_action(allauth_env):
     class CompatAllauthLoginSub(Form, account_forms.LoginForm):
         """Login subclass that recovers the request from the allauth context."""
 
-        def __init__(
-            self,
-            *args: object,
-            request: HttpRequest | None = None,
-            **kwargs: object,
-        ) -> None:
+        def __init__(self, *args, request: HttpRequest | None = None, **kwargs) -> None:
             if request is None:
                 request = allauth_core_context.request
             super().__init__(*args, request=request, **kwargs)

--- a/tests/compat/test_crispy_forms.py
+++ b/tests/compat/test_crispy_forms.py
@@ -112,10 +112,7 @@ class TestCrispyFilter:
         form = CompatCrispyFilterForm(data={"name": "Ada", "email": "nope"})
         assert not form.is_valid()
         html = form_action_manager.default_backend.render_invalid_page(
-            csrf_request,
-            "compat_crispy_filter_form",
-            form,
-            page_file_path=page_file,
+            csrf_request, "compat_crispy_filter_form", form, page_file_path=page_file
         )
         assert "is-invalid" in html
         assert 'value="Ada"' in html

--- a/tests/compat/test_django_htmx.py
+++ b/tests/compat/test_django_htmx.py
@@ -36,7 +36,7 @@ HX_SOURCE = (
 def htmx_env():
     """Append HtmxMiddleware to the middleware chain for one test."""
     with override_settings(
-        MIDDLEWARE=[*settings.MIDDLEWARE, "django_htmx.middleware.HtmxMiddleware"],
+        MIDDLEWARE=[*settings.MIDDLEWARE, "django_htmx.middleware.HtmxMiddleware"]
     ):
         yield
 
@@ -96,9 +96,7 @@ class TestHtmxMiddlewareDispatch:
 
     def test_plain_post_sees_falsy_htmx(self, htmx_env, next_client):
         resp = next_client.post_action(
-            "compat_htmx_form",
-            {"name": "Ada", "email": "ada@example.com"},
-            origin="/",
+            "compat_htmx_form", {"name": "Ada", "email": "ada@example.com"}, origin="/"
         )
         assert resp.status_code == 302
         assert resp["Location"] == "/plain-submit/"

--- a/tests/compat/test_widget_tweaks.py
+++ b/tests/compat/test_widget_tweaks.py
@@ -34,9 +34,7 @@ TWEAKS_SOURCE = (
 @pytest.fixture()
 def tweaks_env():
     """Enable the widget_tweaks template library for one test."""
-    with override_settings(
-        INSTALLED_APPS=[*settings.INSTALLED_APPS, "widget_tweaks"],
-    ):
+    with override_settings(INSTALLED_APPS=[*settings.INSTALLED_APPS, "widget_tweaks"]):
         yield
 
 

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -56,7 +56,7 @@ def capture_component_registered() -> Generator[list[dict[str, Any]], None, None
     """Capture ``component_registered`` signal events."""
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     component_registered.connect(_listener)
@@ -71,7 +71,7 @@ def capture_components_registered() -> Generator[list[dict[str, Any]], None, Non
     """Capture ``components_registered`` (plural) signal events."""
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     components_registered.connect(_listener)
@@ -86,7 +86,7 @@ def capture_component_backend_loaded() -> Generator[list[dict[str, Any]], None, 
     """Capture ``component_backend_loaded`` signal events."""
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     component_backend_loaded.connect(_listener)
@@ -101,7 +101,7 @@ def capture_component_rendered() -> Generator[list[dict[str, Any]], None, None]:
     """Capture ``component_rendered`` signal events."""
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     component_rendered.connect(_listener)

--- a/tests/components/test_backends.py
+++ b/tests/components/test_backends.py
@@ -106,7 +106,7 @@ class TestFileComponentsBackend:
         """Root component dir: .djx files are discovered as simple components."""
         (tmp_path / "header.djx").write_text("<header>Hi</header>")
         backend = FileComponentsBackend(
-            {**min_component_config, "DIRS": [str(tmp_path)]},
+            {**min_component_config, "DIRS": [str(tmp_path)]}
         )
         backend._ensure_loaded()
         assert len(backend._registry) == 1
@@ -125,7 +125,7 @@ class TestFileComponentsBackend:
         (tmp_path / "profile").mkdir()
         (tmp_path / "profile" / "component.djx").write_text("<div>profile</div>")
         backend = FileComponentsBackend(
-            {**min_component_config, "DIRS": [str(tmp_path)]},
+            {**min_component_config, "DIRS": [str(tmp_path)]}
         )
         backend._ensure_loaded()
         assert len(backend._registry) == 1
@@ -226,7 +226,7 @@ class TestFileComponentsBackend:
 
         with patch.object(ModuleLoader, "_load_from_disk", tracking_load_from_disk):
             backend = FileComponentsBackend(
-                {**min_component_config, "DIRS": [str(tmp_path)]},
+                {**min_component_config, "DIRS": [str(tmp_path)]}
             )
             backend._ensure_loaded()
             backend.import_all_component_modules()
@@ -275,10 +275,7 @@ class TestComponentsFactoryManager:
     def test_create_backend_imports_class_and_passes_config(self) -> None:
         """Backend is loaded by dotted path and receives the full config dict."""
         b = ComponentsFactory.create_backend(
-            {
-                "BACKEND": "next.components.DummyBackend",
-                "OPTIONS": {"marker": 7},
-            },
+            {"BACKEND": "next.components.DummyBackend", "OPTIONS": {"marker": 7}}
         )
         assert isinstance(b, DummyBackend)
         assert b.config["OPTIONS"]["marker"] == 7
@@ -306,7 +303,7 @@ class TestComponentsFactoryManager:
                     "DIRS": [],
                     "COMPONENTS_DIR": "_components",
                 },
-            ],
+            ]
         )
         with patch("next.components.manager.next_framework_settings", mock_ns2):
             mgr2._reload_config()
@@ -321,8 +318,8 @@ class TestComponentsFactoryManager:
                     "BACKEND": "next.components.BoomBackend",
                     "DIRS": [],
                     "COMPONENTS_DIR": "_components",
-                },
-            ],
+                }
+            ]
         )
         with patch("next.components.manager.next_framework_settings", mock_ns):
             mgr._reload_config()

--- a/tests/components/test_checks.py
+++ b/tests/components/test_checks.py
@@ -1,10 +1,13 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from next.checks import (
     check_component_py_no_pages_context,
     check_cross_root_component_name_conflicts,
     check_duplicate_component_names,
+    reset_check_caches,
 )
 from next.components import (
     ComponentInfo,
@@ -14,6 +17,13 @@ from tests.support import (
     next_framework_settings_for_checks_backends_value as _next_framework_settings_for_checks_backends_value,
     patch_checks_components_manager,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_check_caches():
+    reset_check_caches()
+    yield
+    reset_check_caches()
 
 
 class TestChecks:

--- a/tests/components/test_checks.py
+++ b/tests/components/test_checks.py
@@ -9,10 +9,7 @@ from next.checks import (
     check_duplicate_component_names,
     reset_check_caches,
 )
-from next.components import (
-    ComponentInfo,
-    FileComponentsBackend,
-)
+from next.components import ComponentInfo, FileComponentsBackend
 from tests.support import (
     next_framework_settings_for_checks_backends_value as _next_framework_settings_for_checks_backends_value,
     patch_checks_components_manager,
@@ -126,14 +123,7 @@ class TestChecks:
         fake_backend = FileComponentsBackend(dict(min_component_config))
 
         fake_backend._registry.register(
-            ComponentInfo(
-                "bad",
-                tmp_path,
-                "",
-                None,
-                tmp_path / "component.py",
-                False,
-            )
+            ComponentInfo("bad", tmp_path, "", None, tmp_path / "component.py", False)
         )
         fake_backend._loaded = True
 

--- a/tests/components/test_context.py
+++ b/tests/components/test_context.py
@@ -49,9 +49,7 @@ class TestComponentContextManager:
         (tmp_path / "k" / "component.djx").write_text("<span>{{ count }}</span>")
         (tmp_path / "k" / "component.py").write_text("# empty\n")
         component._registry.register(
-            tmp_path / "k" / "component.py",
-            "count",
-            lambda: 42,
+            tmp_path / "k" / "component.py", "count", lambda: 42
         )
         info = ComponentInfo(
             name="k",
@@ -244,10 +242,7 @@ class TestComponentContextManagerFrames:
     def test_get_caller_path_raises_when_no_python_file_in_chain(self) -> None:
         """Walk stops if no frame exposes a ``.py`` __file__."""
         inner = types.SimpleNamespace(f_back=None, f_globals={"__file__": "/x.txt"})
-        start = types.SimpleNamespace(
-            f_back=inner,
-            f_globals={"__file__": "/y.txt"},
-        )
+        start = types.SimpleNamespace(f_back=inner, f_globals={"__file__": "/y.txt"})
         mgr = ComponentContextManager()
         with (
             patch("next.utils.inspect.currentframe", return_value=start),
@@ -480,11 +475,7 @@ class TestComponentContextSerializerOverride:
         mgr, info, module_path = self._setup(tmp_path)
         marker = self._MarkerSerializer()
         mgr._registry.register(
-            module_path,
-            "feed",
-            lambda: "payload",
-            serialize=True,
-            serializer=marker,
+            module_path, "feed", lambda: "payload", serialize=True, serializer=marker
         )
 
         collector = StaticCollector()

--- a/tests/components/test_manager.py
+++ b/tests/components/test_manager.py
@@ -51,9 +51,7 @@ class TestComponentsManager:
     def test_reload_config_swallows_backend_creation_error(self) -> None:
         """When create_backend raises, _reload_config logs and continues."""
         mock_ns = _next_framework_settings_component_backends_list(
-            [
-                {"BACKEND": "next.components.NonexistentBackend", "OPTIONS": {}},
-            ],
+            [{"BACKEND": "next.components.NonexistentBackend", "OPTIONS": {}}]
         )
         with patch("next.components.manager.next_framework_settings", mock_ns):
             manager = ComponentsManager()
@@ -116,9 +114,7 @@ class TestRegisterComponentsFolderFromRouterWalk:
         (comp_dir / "component.djx").write_text("<span>news</span>")
         (comp_dir / "component.py").write_text("# module for news\n")
         register_components_folder_from_router_walk(
-            tmp_path / "_components",
-            tmp_path,
-            "",
+            tmp_path / "_components", tmp_path, ""
         )
         infos = [i for i in backend._registry.get_all() if i.name == "news"]
         assert len(infos) == 1
@@ -161,7 +157,7 @@ class TestRegisterComponentsFolderFromRouterWalk:
             NEXT_FRAMEWORK={
                 "COMPONENT_BACKENDS": [config],
                 "LAZY_COMPONENT_MODULES": True,
-            },
+            }
         ):
             backend = FileComponentsBackend(config)
             with patch.object(
@@ -240,12 +236,8 @@ class TestRenderComponent:
     ) -> None:
         """Composite with component.djx and component.py without render uses template."""
         (tmp_path / "profile").mkdir()
-        (tmp_path / "profile" / "component.djx").write_text(
-            "<div>{{ username }}</div>",
-        )
-        (tmp_path / "profile" / "component.py").write_text(
-            "other = 1\n",
-        )
+        (tmp_path / "profile" / "component.djx").write_text("<div>{{ username }}</div>")
+        (tmp_path / "profile" / "component.py").write_text("other = 1\n")
         info = ComponentInfo(
             name="profile",
             scope_root=tmp_path,
@@ -261,7 +253,7 @@ class TestRenderComponent:
         """load_component_template returns module.component when no .djx."""
         (tmp_path / "mod").mkdir()
         (tmp_path / "mod" / "component.py").write_text(
-            'component = "<div>{{ x }}</div>"\n',
+            'component = "<div>{{ x }}</div>"\n'
         )
         info = ComponentInfo(
             name="mod",
@@ -294,7 +286,7 @@ class TestRenderComponent:
         """Composite with render() in component.py uses it and returns string."""
         (tmp_path / "custom").mkdir()
         (tmp_path / "custom" / "component.py").write_text(
-            "def render(x=''):\n    return f'<div>{x}</div>'\n",
+            "def render(x=''):\n    return f'<div>{x}</div>'\n"
         )
         info = ComponentInfo(
             name="custom",
@@ -333,14 +325,7 @@ class TestComponentRenderers:
         loader = ModuleLoader()
         tl = ComponentTemplateLoader(loader)
         r = CompositeComponentRenderer(loader, tl)
-        info = ComponentInfo(
-            "x",
-            Path("/"),
-            "",
-            Path("/t.djx"),
-            None,
-            False,
-        )
+        info = ComponentInfo("x", Path("/"), "", Path("/t.djx"), None, False)
         assert r.render(info, {}, None) == ""
 
     def test_composite_render_returns_httpresponse_content(
@@ -352,16 +337,9 @@ class TestComponentRenderers:
         (d / "component.py").write_text(
             "from django.http import HttpResponse\n"
             "def render():\n"
-            "    return HttpResponse(b'<em>ok</em>')\n",
+            "    return HttpResponse(b'<em>ok</em>')\n"
         )
-        info = ComponentInfo(
-            "hr",
-            tmp_path,
-            "",
-            None,
-            d / "component.py",
-            False,
-        )
+        info = ComponentInfo("hr", tmp_path, "", None, d / "component.py", False)
         out = render_component(info, {})
         assert "ok" in out
 
@@ -372,12 +350,7 @@ class TestComponentRenderers:
         (d / "component.djx").write_text("<i>{{ request.path }}</i>")
         (d / "component.py").write_text("# no render\n")
         info = ComponentInfo(
-            "rq",
-            tmp_path,
-            "",
-            d / "component.djx",
-            d / "component.py",
-            False,
+            "rq", tmp_path, "", d / "component.djx", d / "component.py", False
         )
         req = RequestFactory().get("/hello")
         html = render_component(info, {}, request=req)
@@ -392,12 +365,7 @@ class TestComponentRenderers:
         (d / "component.djx").write_text("{% csrf_token %}")
         (d / "component.py").write_text("# no render\n")
         info = ComponentInfo(
-            "csrf",
-            tmp_path,
-            "",
-            d / "component.djx",
-            d / "component.py",
-            False,
+            "csrf", tmp_path, "", d / "component.djx", d / "component.py", False
         )
         req = RequestFactory().get("/")
         html = render_component(info, {}, request=req)
@@ -426,12 +394,7 @@ class TestComponentRenderers:
         (d / "component.djx").write_text("<p>x</p>")
         (d / "component.py").write_text("# template path via djx. no render()\n")
         info = ComponentInfo(
-            "nt",
-            tmp_path,
-            "",
-            d / "component.djx",
-            d / "component.py",
-            False,
+            "nt", tmp_path, "", d / "component.djx", d / "component.py", False
         )
         loader = ModuleLoader()
         tl = ComponentTemplateLoader(loader)
@@ -444,14 +407,7 @@ class TestComponentRenderers:
         d = tmp_path / "nf"
         d.mkdir()
         (d / "component.py").write_text("syntax error (\n")
-        info = ComponentInfo(
-            "nf",
-            tmp_path,
-            "",
-            None,
-            d / "component.py",
-            False,
-        )
+        info = ComponentInfo("nf", tmp_path, "", None, d / "component.py", False)
         r = CompositeComponentRenderer(
             ModuleLoader(), ComponentTemplateLoader(ModuleLoader())
         )
@@ -488,8 +444,7 @@ class TestGetComponentPathsForWatch:
     def test_empty_when_backend_settings_not_lists(self) -> None:
         """Return empty sets when ``*_BACKENDS`` settings are not lists."""
         mock_nf = SimpleNamespace(
-            PAGE_BACKENDS="not-a-list",
-            COMPONENT_BACKENDS="not-a-list",
+            PAGE_BACKENDS="not-a-list", COMPONENT_BACKENDS="not-a-list"
         )
         with patch("next.components.watch.next_framework_settings", mock_nf):
             assert get_component_paths_for_watch() == set()
@@ -509,16 +464,16 @@ class TestGetComponentPathsForWatch:
                         "APP_DIRS": False,
                         "DIRS": [str(pages_root)],
                         "OPTIONS": {},
-                    },
+                    }
                 ],
                 "COMPONENT_BACKENDS": [
                     {
                         "BACKEND": "next.components.FileComponentsBackend",
                         "DIRS": [],
                         "COMPONENTS_DIR": "_components",
-                    },
+                    }
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             paths = get_component_paths_for_watch()
@@ -540,16 +495,16 @@ class TestGetComponentPathsForWatch:
                         "APP_DIRS": False,
                         "DIRS": [str(pages_root)],
                         "OPTIONS": {},
-                    },
+                    }
                 ],
                 "COMPONENT_BACKENDS": [
                     {
                         "BACKEND": "next.components.FileComponentsBackend",
                         "DIRS": [],
                         "COMPONENTS_DIR": "_components",
-                    },
+                    }
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             paths = get_component_paths_for_watch()
@@ -559,10 +514,7 @@ class TestGetComponentPathsForWatch:
     def test_skips_non_dict_page_config(self) -> None:
         """Non-dict ``PAGE_BACKENDS`` entries are ignored."""
         with override_settings(
-            NEXT_FRAMEWORK={
-                "PAGE_BACKENDS": ["not-dict"],
-                "COMPONENT_BACKENDS": [],
-            },
+            NEXT_FRAMEWORK={"PAGE_BACKENDS": ["not-dict"], "COMPONENT_BACKENDS": []}
         ):
             next_framework_settings.reload()
             assert get_component_paths_for_watch() == set()
@@ -571,10 +523,7 @@ class TestGetComponentPathsForWatch:
     def test_skips_non_dict_component_config(self) -> None:
         """Non-dict ``COMPONENT_BACKENDS`` entries are ignored."""
         with override_settings(
-            NEXT_FRAMEWORK={
-                "PAGE_BACKENDS": [],
-                "COMPONENT_BACKENDS": ["bad"],
-            },
+            NEXT_FRAMEWORK={"PAGE_BACKENDS": [], "COMPONENT_BACKENDS": ["bad"]}
         ):
             next_framework_settings.reload()
             assert get_component_paths_for_watch() == set()
@@ -593,9 +542,9 @@ class TestGetComponentPathsForWatch:
                         "BACKEND": "next.components.FileComponentsBackend",
                         "DIRS": [str(root)],
                         "COMPONENTS_DIR": "_components",
-                    },
+                    }
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             paths = get_component_paths_for_watch()
@@ -615,10 +564,10 @@ class TestGetComponentPathsForWatch:
                         "APP_DIRS": False,
                         "DIRS": [str(pages_root)],
                         "OPTIONS": {},
-                    },
+                    }
                 ],
                 "COMPONENT_BACKENDS": [],
-            },
+            }
         ):
             next_framework_settings.reload()
             with patch(
@@ -641,16 +590,16 @@ class TestGetComponentPathsForWatch:
                         "APP_DIRS": False,
                         "DIRS": [str(pages_root)],
                         "OPTIONS": {},
-                    },
+                    }
                 ],
                 "COMPONENT_BACKENDS": [
                     {
                         "BACKEND": "next.components.FileComponentsBackend",
                         "DIRS": [],
                         "COMPONENTS_DIR": "_components",
-                    },
+                    }
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             with patch.object(Path, "glob", side_effect=OSError("glob fail")):
@@ -672,16 +621,16 @@ class TestGetComponentPathsForWatch:
                         "APP_DIRS": False,
                         "DIRS": [str(pages_root)],
                         "OPTIONS": {},
-                    },
+                    }
                 ],
                 "COMPONENT_BACKENDS": [
                     {
                         "BACKEND": "next.components.FileComponentsBackend",
                         "DIRS": [],
                         "COMPONENTS_DIR": "_components",
-                    },
+                    }
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             with patch.object(Path, "relative_to", side_effect=ValueError("outside")):
@@ -698,9 +647,9 @@ class TestGetComponentPathsForWatch:
                         "BACKEND": "next.components.FileComponentsBackend",
                         "DIRS": [],
                         "COMPONENTS_DIR": "_components",
-                    },
+                    }
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             with patch(
@@ -720,9 +669,9 @@ class TestGetComponentPathsForWatch:
                         "BACKEND": "next.components.DummyBackend",
                         "DIRS": [],
                         "COMPONENTS_DIR": "_components",
-                    },
+                    }
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             assert get_component_paths_for_watch() == set()
@@ -740,9 +689,9 @@ class TestGetComponentPathsForWatch:
                         "BACKEND": "next.components.FileComponentsBackend",
                         "DIRS": [str(root)],
                         "COMPONENTS_DIR": "_components",
-                    },
+                    }
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             with patch.object(Path, "iterdir", side_effect=OSError("read")):
@@ -762,16 +711,16 @@ class TestGetComponentPathsForWatch:
                         "APP_DIRS": False,
                         "DIRS": [str(pages_root)],
                         "OPTIONS": {},
-                    },
+                    }
                 ],
                 "COMPONENT_BACKENDS": [
                     {
                         "BACKEND": "next.components.FileComponentsBackend",
                         "DIRS": [],
                         "COMPONENTS_DIR": "_components",
-                    },
+                    }
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             with patch(
@@ -796,16 +745,16 @@ class TestGetComponentPathsForWatch:
                         "APP_DIRS": False,
                         "DIRS": [str(pages_root)],
                         "OPTIONS": {},
-                    },
+                    }
                 ],
                 "COMPONENT_BACKENDS": [
                     {
                         "BACKEND": "next.components.FileComponentsBackend",
                         "DIRS": [],
                         "COMPONENTS_DIR": "_components",
-                    },
+                    }
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             assert get_component_paths_for_watch() == set()
@@ -823,15 +772,13 @@ class TestGetComponentPathsForWatch:
                         "BACKEND": "next.components.FileComponentsBackend",
                         "DIRS": [str(root)],
                         "COMPONENTS_DIR": "_components",
-                    },
+                    }
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             with patch.object(
-                ComponentScanner,
-                "scan_directory",
-                side_effect=OSError("scan"),
+                ComponentScanner, "scan_directory", side_effect=OSError("scan")
             ):
                 assert get_component_paths_for_watch() == set()
         next_framework_settings.reload()

--- a/tests/components/test_registry.py
+++ b/tests/components/test_registry.py
@@ -39,14 +39,7 @@ class TestComponentRegistry:
 
         broken_root = MagicMock(spec=Path)
         broken_root.resolve.side_effect = OSError
-        info2 = ComponentInfo(
-            "n",
-            broken_root,
-            "",
-            tmp_path / "n.djx",
-            None,
-            True,
-        )
+        info2 = ComponentInfo("n", broken_root, "", tmp_path / "n.djx", None, True)
         assert info2.resolved_scope_root is broken_root
 
     def test_contains_is_indexed_by_name(self, tmp_path: Path) -> None:
@@ -55,7 +48,7 @@ class TestComponentRegistry:
         root = tmp_path.resolve()
         for i in range(50):
             reg.register(
-                ComponentInfo(f"c{i}", root, "", tmp_path / f"{i}.djx", None, True),
+                ComponentInfo(f"c{i}", root, "", tmp_path / f"{i}.djx", None, True)
             )
         assert "c49" in reg
         assert "missing" not in reg
@@ -107,13 +100,13 @@ class TestComponentExtraRootsFromConfig:
         r1 = component_extra_roots_from_config({"DIRS": (a, b)})
         assert len(r1) == 2
         r2 = component_extra_roots_from_config(
-            {"DIRS": [str(b.resolve()), Path(str(a))]},
+            {"DIRS": [str(b.resolve()), Path(str(a))]}
         )
         assert {Path(p).resolve() for p in r2} == {a.resolve(), b.resolve()}
         missing = tmp_path / "nope"
         assert not missing.exists()
         r3 = component_extra_roots_from_config(
-            {"DIRS": [str(a.resolve()), str(missing)]},
+            {"DIRS": [str(a.resolve()), str(missing)]}
         )
         assert r3 == [a.resolve()]
 
@@ -132,14 +125,7 @@ class TestComponentVisibilityResolver:
         (comp_dir / "c.djx").write_text("x")
         reg = ComponentRegistry()
         reg.register(
-            ComponentInfo(
-                "c",
-                pages.resolve(),
-                "about",
-                comp_dir / "c.djx",
-                None,
-                True,
-            )
+            ComponentInfo("c", pages.resolve(), "about", comp_dir / "c.djx", None, True)
         )
         resolver = ComponentVisibilityResolver(reg)
         outside = tmp_path / "elsewhere" / "t.djx"
@@ -155,12 +141,7 @@ class TestComponentVisibilityResolver:
         reg = ComponentRegistry()
         reg.register(
             ComponentInfo(
-                "c",
-                pages.resolve(),
-                "",
-                pages / "_components" / "c.djx",
-                None,
-                True,
+                "c", pages.resolve(), "", pages / "_components" / "c.djx", None, True
             )
         )
         (pages / "_components").mkdir()
@@ -182,14 +163,7 @@ class TestComponentVisibilityResolver:
         (comp_dir / "c.djx").write_text("x")
         reg = ComponentRegistry()
         reg.register(
-            ComponentInfo(
-                "c",
-                pages.resolve(),
-                "about",
-                comp_dir / "c.djx",
-                None,
-                True,
-            )
+            ComponentInfo("c", pages.resolve(), "about", comp_dir / "c.djx", None, True)
         )
         res = ComponentVisibilityResolver(reg)
         t1 = pages / "about" / "a.djx"
@@ -209,14 +183,7 @@ class TestComponentVisibilityResolver:
         reg = ComponentRegistry()
         reg.mark_as_root(root.resolve())
         reg.register(
-            ComponentInfo(
-                "x",
-                root.resolve(),
-                "onlyhere",
-                root / "x.djx",
-                None,
-                True,
-            )
+            ComponentInfo("x", root.resolve(), "onlyhere", root / "x.djx", None, True)
         )
         res = ComponentVisibilityResolver(reg)
         outsider = tmp_path / "else" / "t.djx"
@@ -228,10 +195,7 @@ class TestComponentVisibilityResolver:
         reg = ComponentRegistry()
         res = ComponentVisibilityResolver(reg)
         assert (
-            res._compute_relative_parts(
-                tmp_path / "a" / "t.djx",
-                tmp_path / "b",
-            )
+            res._compute_relative_parts(tmp_path / "a" / "t.djx", tmp_path / "b")
             is None
         )
 
@@ -262,10 +226,10 @@ class TestComponentVisibilityResolver:
         # call queries `_get_relative_parts_cached` twice for that key: the second
         # lookup hits the cache and exercises `move_to_end`.
         reg.register(
-            ComponentInfo("c1", scope_root, "area", sub / "c1.djx", None, True),
+            ComponentInfo("c1", scope_root, "area", sub / "c1.djx", None, True)
         )
         reg.register(
-            ComponentInfo("c2", scope_root, "area", sub / "c2.djx", None, True),
+            ComponentInfo("c2", scope_root, "area", sub / "c2.djx", None, True)
         )
 
         res = ComponentVisibilityResolver(reg)
@@ -322,12 +286,7 @@ class TestComponentVisibilityResolver:
         reg.mark_as_root(dirs_root)
         reg.register(
             ComponentInfo(
-                "button",
-                pages,
-                "",
-                pages / "_components" / "button.djx",
-                None,
-                True,
+                "button", pages, "", pages / "_components" / "button.djx", None, True
             )
         )
         return reg, pages, dirs_root

--- a/tests/components/test_signals.py
+++ b/tests/components/test_signals.py
@@ -40,20 +40,15 @@ class TestComponentRegisteredSignal:
     """``component_registered`` wiring."""
 
     def test_listener_receives_manual_send(
-        self,
-        capture_component_registered: list[dict[str, Any]],
+        self, capture_component_registered: list[dict[str, Any]]
     ) -> None:
         """A connected listener receives kwargs from ``.send``."""
-        component_registered.send(
-            sender=object,
-            name="card",
-        )
+        component_registered.send(sender=object, name="card")
         assert len(capture_component_registered) == 1
         assert capture_component_registered[0]["name"] == "card"
 
     def test_sender_is_preserved(
-        self,
-        capture_component_registered: list[dict[str, Any]],
+        self, capture_component_registered: list[dict[str, Any]]
     ) -> None:
         """``sender`` passed to ``.send`` is captured in the event dict."""
 
@@ -64,8 +59,7 @@ class TestComponentRegisteredSignal:
         assert capture_component_registered[0]["sender"] is _Fake
 
     def test_disconnect_stops_receiving(
-        self,
-        capture_component_registered: list[dict[str, Any]],
+        self, capture_component_registered: list[dict[str, Any]]
     ) -> None:
         """After fixture teardown the listener is removed (no cross-test bleed)."""
         component_registered.send(sender=object, name="x")
@@ -116,8 +110,7 @@ class TestComponentsRegisteredSignal:
         ]
 
     def test_listener_receives_manual_send(
-        self,
-        capture_components_registered: list[dict[str, Any]],
+        self, capture_components_registered: list[dict[str, Any]]
     ) -> None:
         """A connected listener receives `infos` from `.send`."""
         components_registered.send(sender=object, infos=())
@@ -137,8 +130,7 @@ class TestComponentsRegisteredSignal:
         assert event["infos"] == tuple(items)
 
     def test_registry_register_many_empty_does_not_fire(
-        self,
-        capture_components_registered: list[dict[str, Any]],
+        self, capture_components_registered: list[dict[str, Any]]
     ) -> None:
         """An empty bulk call stays silent."""
         ComponentRegistry().register_many([])
@@ -160,20 +152,17 @@ class TestComponentBackendLoadedSignal:
     """``component_backend_loaded`` wiring."""
 
     def test_listener_receives_manual_send(
-        self,
-        capture_component_backend_loaded: list[dict[str, Any]],
+        self, capture_component_backend_loaded: list[dict[str, Any]]
     ) -> None:
         """A connected listener receives kwargs from ``.send``."""
         component_backend_loaded.send(
-            sender=object,
-            config={"BACKEND": "next.components.FileComponentsBackend"},
+            sender=object, config={"BACKEND": "next.components.FileComponentsBackend"}
         )
         assert len(capture_component_backend_loaded) == 1
         assert "config" in capture_component_backend_loaded[0]
 
     def test_sender_is_preserved(
-        self,
-        capture_component_backend_loaded: list[dict[str, Any]],
+        self, capture_component_backend_loaded: list[dict[str, Any]]
     ) -> None:
         """``sender`` is echoed back from the event."""
 
@@ -184,15 +173,11 @@ class TestComponentBackendLoadedSignal:
         assert capture_component_backend_loaded[0]["sender"] is _Backend
 
     def test_manager_reload_config_emits_per_backend(
-        self,
-        capture_component_backend_loaded: list[dict[str, Any]],
+        self, capture_component_backend_loaded: list[dict[str, Any]]
     ) -> None:
         """`ComponentsManager._reload_config` fires once per built backend."""
         sentinel: ComponentsBackend = ComponentsFactory.create_backend(
-            {
-                "BACKEND": "next.components.DummyBackend",
-                "COMPONENTS_DIR": "_widgets",
-            }
+            {"BACKEND": "next.components.DummyBackend", "COMPONENTS_DIR": "_widgets"}
         )
 
         class _StubFactory:
@@ -210,9 +195,7 @@ class TestComponentBackendLoadedSignal:
         ]
 
         with (
-            patch(
-                "next.components.manager.next_framework_settings",
-            ) as fake_settings,
+            patch("next.components.manager.next_framework_settings") as fake_settings,
             patch.object(
                 ComponentsFactory, "create_backend", _StubFactory.create_backend
             ),
@@ -232,21 +215,15 @@ class TestComponentRenderedSignal:
     """``component_rendered`` wiring."""
 
     def test_listener_receives_manual_send(
-        self,
-        capture_component_rendered: list[dict[str, Any]],
+        self, capture_component_rendered: list[dict[str, Any]]
     ) -> None:
         """A connected listener receives kwargs from ``.send``."""
-        component_rendered.send(
-            sender=object,
-            name="card",
-            html="<div>card</div>",
-        )
+        component_rendered.send(sender=object, name="card", html="<div>card</div>")
         assert len(capture_component_rendered) == 1
         assert capture_component_rendered[0]["html"] == "<div>card</div>"
 
     def test_sender_is_preserved(
-        self,
-        capture_component_rendered: list[dict[str, Any]],
+        self, capture_component_rendered: list[dict[str, Any]]
     ) -> None:
         """``sender`` is echoed back from the event."""
 
@@ -257,8 +234,7 @@ class TestComponentRenderedSignal:
         assert capture_component_rendered[0]["sender"] is _Renderer
 
     def test_multiple_listeners_all_notified(
-        self,
-        capture_component_rendered: list[dict[str, Any]],
+        self, capture_component_rendered: list[dict[str, Any]]
     ) -> None:
         """Two calls produce two events."""
         component_rendered.send(sender=object, html="<a/>")
@@ -266,9 +242,7 @@ class TestComponentRenderedSignal:
         assert len(capture_component_rendered) == 2
 
     def test_render_component_emits_when_listener_connected(
-        self,
-        tmp_path: Path,
-        capture_component_rendered: list[dict[str, Any]],
+        self, tmp_path: Path, capture_component_rendered: list[dict[str, Any]]
     ) -> None:
         """``render_component`` fires ``component_rendered`` when a listener exists."""
         template_path = tmp_path / "card.djx"
@@ -288,8 +262,7 @@ class TestComponentRenderedSignal:
         assert event["template_path"] == template_path
 
     def test_render_component_skips_send_without_listeners(
-        self,
-        tmp_path: Path,
+        self, tmp_path: Path
     ) -> None:
         """``render_component`` does not dispatch when no listener is connected."""
         template_path = tmp_path / "card.djx"

--- a/tests/components/test_tags.py
+++ b/tests/components/test_tags.py
@@ -55,7 +55,7 @@ class TestComponentTag:
         t = Template('{% load components %}{% component "nonexistent" %}')
         with patch("next.templatetags.components.get_component", return_value=None):
             result = t.render(
-                Context({"current_template_path": "/app/pages/home/template.djx"}),
+                Context({"current_template_path": "/app/pages/home/template.djx"})
             )
         assert result == ""
 
@@ -76,7 +76,7 @@ class TestComponentTag:
         ):
             t = Template('{% load components %}{% component "card" title="Hello" %}')
             result = t.render(
-                Context({"current_template_path": str(tmp_path / "template.djx")}),
+                Context({"current_template_path": str(tmp_path / "template.djx")})
             )
         assert 'class="card"' in result
         assert "Hello" in result
@@ -106,8 +106,8 @@ class TestComponentTag:
                     {
                         "current_template_path": str(tmp_path / "template.djx"),
                         "page_var": "from_parent_page",
-                    },
-                ),
+                    }
+                )
             )
         assert "from_parent_page" in result
 
@@ -136,19 +136,15 @@ class TestComponentTag:
                     {
                         "current_template_path": str(tmp_path / "t.djx"),
                         "title": "from_parent",
-                    },
-                ),
+                    }
+                )
             )
         assert "from_prop" in result
         assert "from_parent" not in result
 
     def test_component_tag_accepts_path_object_in_context(self, tmp_path: Path) -> None:
         """current_template_path in context can be a Path object."""
-        with patch.object(
-            components_manager,
-            "get_component",
-            return_value=None,
-        ):
+        with patch.object(components_manager, "get_component", return_value=None):
             t = Template('{% load components %}{% component "c" %}')
             t.render(Context({"current_template_path": tmp_path / "t.djx"}))
 
@@ -178,8 +174,8 @@ class TestComponentTag:
                     {
                         "current_template_path": str(tmp_path / "template.djx"),
                         "_static_collector": collector,
-                    },
-                ),
+                    }
+                )
             )
         spy.assert_called_once()
         (called_info, called_collector) = spy.call_args.args
@@ -227,7 +223,7 @@ class TestComponentTag:
         (tmp_path / "card.djx").write_text(
             "<article>"
             '{% #set_slot "description" %}<i>fallback</i>{% /set_slot %}'
-            "</article>",
+            "</article>"
         )
         info = ComponentInfo(
             name="card",
@@ -240,7 +236,7 @@ class TestComponentTag:
         with patch.object(components_manager, "get_component", return_value=info):
             t = Template("{% load components %}" + call_site)
             result = t.render(
-                Context({"current_template_path": str(tmp_path / "page.djx")}),
+                Context({"current_template_path": str(tmp_path / "page.djx")})
             )
         assert expected_substring in result
         for forbidden in forbidden_substrings:
@@ -322,7 +318,7 @@ class TestComponentTag:
     ) -> None:
         """When #component body has #slot, content is passed to component."""
         (tmp_path / "box.djx").write_text(
-            '<div class="box">{{ slot_image }} {{ children }}</div>',
+            '<div class="box">{{ slot_image }} {{ children }}</div>'
         )
         with patch.object(
             components_manager,
@@ -344,7 +340,7 @@ class TestComponentTag:
                 "{% /component %}"
             )
             result = t.render(
-                Context({"current_template_path": str(tmp_path / "template.djx")}),
+                Context({"current_template_path": str(tmp_path / "template.djx")})
             )
         assert "slot_image" in result or "<img" in result
         assert "kids" in result
@@ -366,7 +362,7 @@ class TestComponentTag:
         ):
             t = Template('{% load components %}{% component "card" title="My Title" %}')
             result = t.render(
-                Context({"current_template_path": str(tmp_path / "t.djx")}),
+                Context({"current_template_path": str(tmp_path / "t.djx")})
             )
         assert "My Title" in result
 
@@ -389,7 +385,7 @@ class TestComponentTag:
                 '{% load components %}{% component "card" orphan title="Kept" %}'
             )
             result = t.render(
-                Context({"current_template_path": str(tmp_path / "t.djx")}),
+                Context({"current_template_path": str(tmp_path / "t.djx")})
             )
         assert "Kept" in result
 
@@ -414,7 +410,7 @@ class TestComponentTag:
                         "current_template_path": str(tmp_path / "t.djx"),
                         "page_title": "From Context",
                     }
-                ),
+                )
             )
         assert "From Context" in result
         assert "page_title" not in result
@@ -440,7 +436,7 @@ class TestComponentTag:
                         "current_template_path": str(tmp_path / "t.djx"),
                         "user": {"name": "Ada"},
                     }
-                ),
+                )
             )
         assert "Ada" in result
 
@@ -458,7 +454,7 @@ class TestComponentTag:
         with patch.object(components_manager, "get_component", return_value=info):
             t = Template('{% load components %}{% component "card" count=42 %}')
             result = t.render(
-                Context({"current_template_path": str(tmp_path / "t.djx")}),
+                Context({"current_template_path": str(tmp_path / "t.djx")})
             )
         assert "42" in result
 
@@ -482,7 +478,7 @@ class TestComponentTag:
                         "current_template_path": str(tmp_path / "t.djx"),
                         "payload": marker,
                     }
-                ),
+                )
             )
         assert "YES" in result
 
@@ -501,23 +497,16 @@ class TestComponentTag:
             t = Template('{% load components %}{% component "card" title=name|upper %}')
             result = t.render(
                 Context(
-                    {
-                        "current_template_path": str(tmp_path / "t.djx"),
-                        "name": "ada",
-                    }
-                ),
+                    {"current_template_path": str(tmp_path / "t.djx"), "name": "ada"}
+                )
             )
         assert "ADA" in result
 
     def test_nested_components_three_levels(self, tmp_path: Path) -> None:
         """{% #component %} inside component.djx resolves nested names."""
         (tmp_path / "inner.djx").write_text("<i>inner</i>")
-        (tmp_path / "mid.djx").write_text(
-            '{% #component "inner" %}{% /component %}',
-        )
-        (tmp_path / "outer.djx").write_text(
-            '{% #component "mid" %}{% /component %}',
-        )
+        (tmp_path / "mid.djx").write_text('{% #component "inner" %}{% /component %}')
+        (tmp_path / "outer.djx").write_text('{% #component "mid" %}{% /component %}')
 
         def fake_get(name: str, _: Path) -> ComponentInfo | None:
             mapping = {
@@ -539,10 +528,10 @@ class TestComponentTag:
 
         with patch.object(components_manager, "get_component", side_effect=fake_get):
             t = Template(
-                "{% load components %}{% #component 'outer' %}{% /component %}",
+                "{% load components %}{% #component 'outer' %}{% /component %}"
             )
             result = t.render(
-                Context({"current_template_path": str(tmp_path / "page.djx")}),
+                Context({"current_template_path": str(tmp_path / "page.djx")})
             )
         assert "<i>inner</i>" in result
 
@@ -660,9 +649,7 @@ class TestSetSlotTag:
     def test_short_set_slot_requires_exactly_one_name(self) -> None:
         """{% set_slot %} short form with two names raises."""
         with pytest.raises(TemplateSyntaxError, match="exactly one"):
-            Template(
-                '{% load components %}{% set_slot "a" "b" %}',
-            )
+            Template('{% load components %}{% set_slot "a" "b" %}')
 
     def test_short_set_slot_empty_name_raises(self) -> None:
         """{% set_slot "" %} raises."""
@@ -676,11 +663,7 @@ class TestSetSlotTag:
             # must not shadow the default body. Earlier versions fell back
             # to the unprefixed ``<name>`` key, which leaked props into
             # the slot lookup.
-            (
-                {"description": "prop value"},
-                "<span>default</span>",
-                ("prop value",),
-            ),
+            ({"description": "prop value"}, "<span>default</span>", ("prop value",)),
             # Both slot_<name> and a same-named prop are present: the
             # caller-injected slot wins over both the prop and the
             # default fallback body.
@@ -701,7 +684,7 @@ class TestSetSlotTag:
         """Slot lookup honours ``slot_<name>`` only and never falls back to props."""
         t = Template(
             "{% load components %}"
-            '{% #set_slot "description" %}<span>default</span>{% /set_slot %}',
+            '{% #set_slot "description" %}<span>default</span>{% /set_slot %}'
         )
         result = t.render(Context(context_data))
         assert expected_substring in result
@@ -716,7 +699,7 @@ class TestSetSlotTag:
         that case — the caller asked for the slot to render empty.
         """
         t = Template(
-            '{% load components %}{% #set_slot "label" %}fallback{% /set_slot %}',
+            '{% load components %}{% #set_slot "label" %}fallback{% /set_slot %}'
         )
         result = t.render(Context({"slot_label": ""}))
         assert result == ""

--- a/tests/conf/test_helpers.py
+++ b/tests/conf/test_helpers.py
@@ -9,8 +9,7 @@ class TestExtendDefaultBackend:
 
     def test_replaces_single_top_level_key(self) -> None:
         patched = extend_default_backend(
-            "COMPONENT_BACKENDS",
-            COMPONENTS_DIR="_widgets",
+            "COMPONENT_BACKENDS", COMPONENTS_DIR="_widgets"
         )
         assert patched[0]["COMPONENTS_DIR"] == "_widgets"
         assert patched[0]["BACKEND"] == "next.components.FileComponentsBackend"
@@ -21,14 +20,11 @@ class TestExtendDefaultBackend:
             OPTIONS={"DEDUP_STRATEGY": "next.static.collector.HashContentDedup"},
         )
         assert patched[0]["OPTIONS"] == {
-            "DEDUP_STRATEGY": "next.static.collector.HashContentDedup",
+            "DEDUP_STRATEGY": "next.static.collector.HashContentDedup"
         }
 
     def test_preserves_unrelated_entries(self) -> None:
-        patched = extend_default_backend(
-            "PAGE_BACKENDS",
-            PAGES_DIR="routes",
-        )
+        patched = extend_default_backend("PAGE_BACKENDS", PAGES_DIR="routes")
         assert patched[0]["APP_DIRS"] is True
         assert patched[0]["DIRS"] == []
         assert patched[0]["PAGES_DIR"] == "routes"
@@ -42,8 +38,7 @@ class TestExtendDefaultBackend:
 
     def test_patches_form_action_backends(self) -> None:
         patched = extend_default_backend(
-            "FORM_ACTION_BACKENDS",
-            OPTIONS={"strict": True},
+            "FORM_ACTION_BACKENDS", OPTIONS={"strict": True}
         )
         assert patched[0]["BACKEND"] == "next.forms.RegistryFormActionBackend"
         assert patched[0]["OPTIONS"] == {"strict": True}

--- a/tests/conf/test_settings.py
+++ b/tests/conf/test_settings.py
@@ -27,17 +27,9 @@ class TestLazyFixtureWiring:
 class TestNextFrameworkSettingsDjangoIntegration:
     """Global next_framework_settings with override_settings(NEXT_FRAMEWORK=...)."""
 
-    @pytest.mark.parametrize(
-        "next_framework",
-        [
-            {},
-            42,
-        ],
-        ids=["empty_dict", "non_dict"],
-    )
+    @pytest.mark.parametrize("next_framework", [{}, 42], ids=["empty_dict", "non_dict"])
     def test_falls_back_to_default_page_router_backend(
-        self,
-        next_framework: object,
+        self, next_framework: object
     ) -> None:
         """Empty or invalid NEXT_FRAMEWORK keeps the default file router backend."""
         with override_settings(NEXT_FRAMEWORK=next_framework):  # type: ignore[arg-type]
@@ -55,7 +47,7 @@ class TestNextFrameworkSettingsDjangoIntegration:
                 "APP_DIRS": False,
                 "DIRS": [],
                 "OPTIONS": {},
-            },
+            }
         ]
         with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": custom}):
             next_framework_settings.reload()
@@ -73,15 +65,13 @@ class TestNextFrameworkSettingsDjangoIntegration:
                         "BACKEND": "next.components.FileComponentsBackend",
                         "DIRS": ["/tmp/x"],
                         "COMPONENTS_DIR": "_components",
-                    },
-                ],
-            },
+                    }
+                ]
+            }
         ):
             next_framework_settings.reload()
             assert next_framework_settings.PAGE_BACKENDS[0]["PAGES_DIR"] == "pages"
-            assert next_framework_settings.COMPONENT_BACKENDS[0]["DIRS"] == [
-                "/tmp/x",
-            ]
+            assert next_framework_settings.COMPONENT_BACKENDS[0]["DIRS"] == ["/tmp/x"]
 
     @pytest.mark.parametrize(
         "bad_attr",
@@ -95,9 +85,7 @@ class TestNextFrameworkSettingsDjangoIntegration:
 
     def test_only_url_name_template_overridden(self) -> None:
         """Setting only URL_NAME_TEMPLATE keeps default page backends."""
-        with override_settings(
-            NEXT_FRAMEWORK={"URL_NAME_TEMPLATE": "view_{name}"},
-        ):
+        with override_settings(NEXT_FRAMEWORK={"URL_NAME_TEMPLATE": "view_{name}"}):
             next_framework_settings.reload()
             assert next_framework_settings.URL_NAME_TEMPLATE == "view_{name}"
             assert (
@@ -114,9 +102,7 @@ class TestNextFrameworkSettingsDjangoIntegration:
         ids=["invalid_routers_type", "invalid_url_name_template"],
     )
     def test_invalid_setting_type_keeps_default(
-        self,
-        next_framework: dict[str, Any],
-        setting_name: str,
+        self, next_framework: dict[str, Any], setting_name: str
     ) -> None:
         """Wrong type for a key is ignored and the default value is kept."""
         with override_settings(NEXT_FRAMEWORK=next_framework):  # type: ignore[arg-type, dict-item]
@@ -131,11 +117,7 @@ class TestNextFrameworkSettingsFlatMerge:
 
     @pytest.mark.parametrize(
         ("user", "expected_routers_len"),
-        [
-            (None, 1),
-            ({}, 1),
-            ({"PAGE_BACKENDS": []}, 0),
-        ],
+        [(None, 1), ({}, 1), ({"PAGE_BACKENDS": []}, 0)],
         ids=["none_user", "empty_user_dict", "explicit_empty_routers"],
     )
     def test_build_flat_merged_routers_length(
@@ -149,8 +131,7 @@ class TestNextFrameworkSettingsFlatMerge:
         assert len(merged["PAGE_BACKENDS"]) == expected_routers_len
 
     def test_build_flat_merge_empty_component_backends(
-        self,
-        fresh_next_framework_settings: NextFrameworkSettings,
+        self, fresh_next_framework_settings: NextFrameworkSettings
     ) -> None:
         """Explicit empty COMPONENT_BACKENDS is preserved."""
         user = {"COMPONENT_BACKENDS": []}
@@ -199,7 +180,7 @@ class TestUrlResolverSetting:
     def test_string_override_reaches_merged_settings(self) -> None:
         """A dotted-path string lands in next_framework_settings unchanged."""
         with override_settings(
-            NEXT_FRAMEWORK={"URL_RESOLVER": "django.urls.resolvers.URLResolver"},
+            NEXT_FRAMEWORK={"URL_RESOLVER": "django.urls.resolvers.URLResolver"}
         ):
             next_framework_settings.reload()
             assert (
@@ -208,9 +189,7 @@ class TestUrlResolverSetting:
             )
 
     @pytest.mark.parametrize(
-        "raw",
-        [123, None, ["next.urls.TrieURLResolver"]],
-        ids=["int", "none", "list"],
+        "raw", [123, None, ["next.urls.TrieURLResolver"]], ids=["int", "none", "list"]
     )
     def test_non_string_override_keeps_default(self, raw: object) -> None:
         """A non-string value is ignored by the merge and the default stays."""
@@ -221,7 +200,7 @@ class TestUrlResolverSetting:
     def test_key_passes_unknown_key_check(self) -> None:
         """System checks accept URL_RESOLVER as a known top-level key."""
         with override_settings(
-            NEXT_FRAMEWORK={"URL_RESOLVER": "next.urls.TrieURLResolver"},
+            NEXT_FRAMEWORK={"URL_RESOLVER": "next.urls.TrieURLResolver"}
         ):
             next_framework_settings.reload()
             errors = check_next_framework_unknown_top_level_keys()
@@ -242,10 +221,10 @@ class TestNextFrameworkChecksUnknownKeys:
                         "APP_DIRS": True,
                         "DIRS": [],
                         "OPTIONS": {},
-                    },
+                    }
                 ],
                 "NOT_A_FRAMEWORK_KEY": True,
-            },
+            }
         ):
             next_framework_settings.reload()
             errors = check_next_framework_unknown_top_level_keys()
@@ -262,8 +241,7 @@ class TestNextFrameworkChecksUnknownKeys:
         ],
     )
     def test_next_framework_rejects_legacy_prefixed_keys(
-        self,
-        renamed_key: str,
+        self, renamed_key: str
     ) -> None:
         """Pre-rename keys with the dropped prefix are reported as unknown."""
         with override_settings(NEXT_FRAMEWORK={f"DEFAULT_{renamed_key}": []}):
@@ -283,9 +261,9 @@ class TestNextFrameworkChecksUnknownKeys:
                         "DIRS": [],
                         "OPTIONS": {},
                         "made_up_option": True,
-                    },
-                ],
-            },
+                    }
+                ]
+            }
         ):
             next_framework_settings.reload()
             errors = check_next_pages_configuration()
@@ -303,9 +281,9 @@ class TestNextFrameworkChecksUnknownKeys:
                         "DIRS": [],
                         "OPTIONS": {},
                         "COMPONENTS_DIR": "_components",
-                    },
-                ],
-            },
+                    }
+                ]
+            }
         ):
             next_framework_settings.reload()
             errors = check_next_pages_configuration()
@@ -321,9 +299,9 @@ class TestNextFrameworkChecksUnknownKeys:
                         "DIRS": [],
                         "COMPONENTS_DIR": "_components",
                         "extra_key": 1,
-                    },
-                ],
-            },
+                    }
+                ]
+            }
         ):
             next_framework_settings.reload()
             errors = check_next_components_configuration()
@@ -341,13 +319,8 @@ class TestNextFrameworkChecksUnknownKeys:
         try:
             with override_settings(
                 NEXT_FRAMEWORK={
-                    "PAGE_BACKENDS": [
-                        {
-                            "BACKEND": backend_path,
-                            "PAGES_DIR": "pages",
-                        },
-                    ],
-                },
+                    "PAGE_BACKENDS": [{"BACKEND": backend_path, "PAGES_DIR": "pages"}]
+                }
             ):
                 next_framework_settings.reload()
                 errors = check_next_pages_configuration()

--- a/tests/conf/test_signals.py
+++ b/tests/conf/test_signals.py
@@ -12,7 +12,7 @@ from next.conf.signals import settings_reloaded
 def capture_settings_reloaded() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender, **kwargs: object) -> None:
+    def _listener(sender, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     settings_reloaded.connect(_listener)

--- a/tests/deps/test_markers.py
+++ b/tests/deps/test_markers.py
@@ -1,16 +1,8 @@
 from django.http import HttpRequest
 
-from next.deps import (
-    DependencyResolver,
-    Depends,
-    resolver,
-)
+from next.deps import DependencyResolver, Depends, resolver
 from next.deps.markers import DependsProvider
-from tests.support import (
-    _ctx,
-    _minimal_resolver,
-    inspect_parameter,
-)
+from tests.support import _ctx, _minimal_resolver, inspect_parameter
 
 
 class TestRegisterDependency:

--- a/tests/deps/test_providers.py
+++ b/tests/deps/test_providers.py
@@ -174,10 +174,7 @@ class TestUrlKwargsProvider:
 
     @pytest.mark.parametrize(
         ("url_kwargs", "expected"),
-        [
-            ({"id": 42}, True),
-            ({}, False),
-        ],
+        [({"id": 42}, True), ({}, False)],
         ids=["name_in_kwargs", "name_missing"],
     )
     def test_can_handle(self, url_kwargs, expected) -> None:
@@ -214,10 +211,7 @@ class TestUrlByAnnotationProvider:
 
     @pytest.mark.parametrize(
         ("annotation", "expected"),
-        [
-            (DUrl[int], True),
-            (int, False),
-        ],
+        [(DUrl[int], True), (int, False)],
         ids=["durl", "plain_int"],
     )
     def test_can_handle(self, annotation, expected) -> None:
@@ -245,11 +239,7 @@ class TestFormProvider:
 
     @pytest.mark.parametrize(
         ("param_name", "form_kind", "expected"),
-        [
-            ("form", "mock", True),
-            ("form", "none", False),
-            ("other", "mock", False),
-        ],
+        [("form", "mock", True), ("form", "none", False), ("other", "mock", False)],
         ids=["name_form_with_instance", "form_none", "wrong_name"],
     )
     def test_can_handle_basic(self, param_name, form_kind, expected) -> None:

--- a/tests/deps/test_query.py
+++ b/tests/deps/test_query.py
@@ -5,10 +5,7 @@ from django.http import HttpRequest, QueryDict
 
 from next.deps import DependencyResolver
 from next.urls import DQuery, QueryParamProvider, get_multi_values
-from tests.support import (
-    _ctx,
-    inspect_parameter,
-)
+from tests.support import _ctx, inspect_parameter
 
 
 @pytest.fixture()
@@ -55,12 +52,7 @@ class TestQueryParamProviderCanHandle:
         ],
     )
     def test_can_handle_matrix(
-        self,
-        provider,
-        make_request,
-        annotation,
-        request_present,
-        expected,
+        self, provider, make_request, annotation, request_present, expected
     ) -> None:
         """Match `DQuery[...]` annotations only when a request is attached."""
         request = make_request() if request_present else None
@@ -88,12 +80,7 @@ class TestQueryParamProviderResolveScalar:
         ],
     )
     def test_scalar_value(
-        self,
-        provider,
-        request_ctx,
-        query,
-        annotation,
-        expected,
+        self, provider, request_ctx, query, annotation, expected
     ) -> None:
         """Return a coerced value when the key is present in the query string."""
         ctx = request_ctx(query)
@@ -126,20 +113,14 @@ class TestQueryParamProviderResolveScalar:
         assert provider.resolve(param, ctx) is None
 
     def test_unparametrised_dquery_falls_back_to_string(
-        self,
-        provider,
-        request_ctx,
+        self, provider, request_ctx
     ) -> None:
         """Treat a bare `DQuery` annotation as `DQuery[str]`."""
         ctx = request_ctx("q=hello")
         param = inspect_parameter("q", DQuery)
         assert provider.resolve(param, ctx) == "hello"
 
-    def test_non_type_inner_hint_treated_as_string(
-        self,
-        provider,
-        request_ctx,
-    ) -> None:
+    def test_non_type_inner_hint_treated_as_string(self, provider, request_ctx) -> None:
         """Coerce as `str` when the inner hint is a string literal rather than a type."""
         ctx = request_ctx("q=hello")
         param = inspect_parameter("q", DQuery["ignored"])
@@ -163,32 +144,21 @@ class TestQueryParamProviderResolveMultiValue:
         ],
     )
     def test_multi_value(
-        self,
-        provider,
-        request_ctx,
-        query,
-        annotation,
-        expected,
+        self, provider, request_ctx, query, annotation, expected
     ) -> None:
         """Collect repeated keys from plain, bracket, and comma-delimited forms."""
         ctx = request_ctx(query)
         param = inspect_parameter(query.split("=", 1)[0].rstrip("[]"), annotation)
         assert provider.resolve(param, ctx) == expected
 
-    def test_repeated_plain_form_skips_comma_split(
-        self,
-        provider,
-        request_ctx,
-    ) -> None:
+    def test_repeated_plain_form_skips_comma_split(self, provider, request_ctx) -> None:
         """Treat each repeated value as atomic when the plain form has multiple entries."""
         ctx = request_ctx("brand=Acme,Inc&brand=Globex")
         param = inspect_parameter("brand", DQuery[list[str]])
         assert provider.resolve(param, ctx) == ["Acme,Inc", "Globex"]
 
     def test_plain_single_value_with_bracket_present(
-        self,
-        provider,
-        request_ctx,
+        self, provider, request_ctx
     ) -> None:
         """Keep the bracket form when the plain form has a single entry that is empty."""
         ctx = request_ctx("brand=&brand[]=Acme&brand[]=Globex")
@@ -196,43 +166,27 @@ class TestQueryParamProviderResolveMultiValue:
         assert provider.resolve(param, ctx) == ["Acme", "Globex"]
 
     def test_comma_split_only_when_single_plain_value(
-        self,
-        provider,
-        request_ctx,
+        self, provider, request_ctx
     ) -> None:
         """Split on commas only when exactly one plain value is present."""
         ctx = request_ctx("brand=Acme,Globex")
         param = inspect_parameter("brand", DQuery[list[str]])
         assert provider.resolve(param, ctx) == ["Acme", "Globex"]
 
-    def test_empty_list_when_key_absent_no_default(
-        self,
-        provider,
-        request_ctx,
-    ) -> None:
+    def test_empty_list_when_key_absent_no_default(self, provider, request_ctx) -> None:
         """Return an empty list when neither plain nor bracket key is present."""
         ctx = request_ctx()
         param = inspect_parameter("brand", DQuery[list[str]])
         assert provider.resolve(param, ctx) == []
 
-    def test_empty_returns_default_when_provided(
-        self,
-        provider,
-        request_ctx,
-    ) -> None:
+    def test_empty_returns_default_when_provided(self, provider, request_ctx) -> None:
         """Return the declared default when the multi-value key is absent."""
         ctx = request_ctx()
-        param = inspect_parameter(
-            "brand",
-            DQuery[list[str]],
-            default=("fallback",),
-        )
+        param = inspect_parameter("brand", DQuery[list[str]], default=("fallback",))
         assert provider.resolve(param, ctx) == ("fallback",)
 
     def test_nested_list_hint_falls_back_to_string_coercion(
-        self,
-        provider,
-        request_ctx,
+        self, provider, request_ctx
     ) -> None:
         """Coerce list elements as strings when the inner hint is a generic alias."""
         ctx = request_ctx("brand=Acme&brand=Globex")
@@ -249,9 +203,7 @@ class TestQueryParamProviderEndToEnd:
         request = make_request("q=hello&page=2&brand=Acme&brand=Globex")
 
         def view(
-            q: DQuery[str] = "",
-            page: DQuery[int] = 1,
-            brand: DQuery[list[str]] = (),
+            q: DQuery[str] = "", page: DQuery[int] = 1, brand: DQuery[list[str]] = ()
         ) -> tuple[str, int, list[str]]:
             return q, page, list(brand)
 

--- a/tests/deps/test_resolver.py
+++ b/tests/deps/test_resolver.py
@@ -13,11 +13,7 @@ from next.deps import (
 )
 from next.deps.cache import _IN_PROGRESS, DependencyCache
 from next.urls import HttpRequestProvider, UrlKwargsProvider
-from tests.support import (
-    _ctx,
-    _minimal_resolver,
-    _resolver_with_form,
-)
+from tests.support import _ctx, _minimal_resolver, _resolver_with_form
 
 
 _IN_PROGRESS_SENTINEL = _IN_PROGRESS
@@ -99,9 +95,7 @@ class TestDependencyResolver:
         assert "cls" not in result
         assert result == {"request": request, "obj_id": 1}
 
-    def test_resolve_dependencies_unknown_param_without_default_gets_none(
-        self,
-    ) -> None:
+    def test_resolve_dependencies_unknown_param_without_default_gets_none(self) -> None:
         """Params with no provider and no context value get None."""
 
         def fn(unknown: str) -> None:
@@ -112,12 +106,11 @@ class TestDependencyResolver:
         assert result == {"unknown": None}
 
     def test_resolve_dependencies_skips_var_positional_and_var_keyword(
-        self,
-        mock_http_request,
+        self, mock_http_request
     ) -> None:
         """*args and **kwargs are not included in resolved dict."""
 
-        def fn(request: HttpRequest, *args: object, **kwargs: object) -> None:
+        def fn(request: HttpRequest, *args, **kwargs) -> None:
             pass
 
         r = _minimal_resolver()
@@ -326,11 +319,7 @@ class TestResolveWithTemplateContext:
 
         r = DependencyResolver()
         result = r.resolve_with_template_context(
-            fn,
-            request=None,
-            template_context={"form": form},
-            _cache={},
-            _stack=[],
+            fn, request=None, template_context={"form": form}, _cache={}, _stack=[]
         )
         assert result["form"] is form
 

--- a/tests/deps/test_signals.py
+++ b/tests/deps/test_signals.py
@@ -11,7 +11,7 @@ from next.deps.signals import provider_registered
 def capture_provider_registered() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     provider_registered.connect(_listener)

--- a/tests/django_setup.py
+++ b/tests/django_setup.py
@@ -20,10 +20,7 @@ def _build_test_settings() -> dict[str, object]:
     return {
         "DEBUG": True,
         "DATABASES": {
-            "default": {
-                "ENGINE": "django.db.backends.sqlite3",
-                "NAME": ":memory:",
-            },
+            "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
         },
         "TEMPLATES": [
             {
@@ -31,11 +28,9 @@ def _build_test_settings() -> dict[str, object]:
                 "DIRS": [],
                 "APP_DIRS": True,
                 "OPTIONS": {
-                    "context_processors": [
-                        "django.template.context_processors.request",
-                    ],
+                    "context_processors": ["django.template.context_processors.request"]
                 },
-            },
+            }
         ],
         "INSTALLED_APPS": [
             "django.contrib.auth",
@@ -61,7 +56,7 @@ def _build_test_settings() -> dict[str, object]:
         "STORAGES": {
             "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
             "staticfiles": {
-                "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+                "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
             },
         },
         "USE_TZ": True,
@@ -74,8 +69,8 @@ def _build_test_settings() -> dict[str, object]:
                     "APP_DIRS": False,
                     "DIRS": [str(PROJECT_ROOT / "tests" / "site_pages")],
                     "OPTIONS": {},
-                },
-            ],
+                }
+            ]
         },
     }
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -160,7 +160,6 @@ def checks_router_patch(request, tmp_path):
     """Indirect: ``request.param`` is ``list[tuple[str, Path]]`` routes for page checks mocks."""
     routes = request.param
     with patch_checks_router_manager(
-        pages_directory=tmp_path,
-        scan_routes=routes,
+        pages_directory=tmp_path, scan_routes=routes
     ) as ctx:
         yield ctx

--- a/tests/forms/test_autodiscover.py
+++ b/tests/forms/test_autodiscover.py
@@ -93,7 +93,7 @@ def test_second_call_does_not_reregister(settings, tmp_path, monkeypatch) -> Non
 
     events: list[object] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append(kwargs.get("action_name"))
 
     action_registered.connect(_listener)
@@ -117,7 +117,7 @@ def test_disabled_setting_skips_import(tmp_path, monkeypatch) -> None:
 
 
 def test_disabled_setting_skips_discovery_entirely(monkeypatch) -> None:
-    def _boom(*_args: str) -> None:
+    def _boom(*args: str) -> None:
         pytest.fail("discovery attempted while disabled")
 
     monkeypatch.setattr(autodiscover, "autodiscover_modules", _boom)

--- a/tests/forms/test_backends.py
+++ b/tests/forms/test_backends.py
@@ -94,9 +94,7 @@ class TestFormActionNotFoundError:
     def test_reduce_round_trip_keeps_message(self) -> None:
         """Pickle and deepcopy carry the rendered message and drop the source."""
         exc = FormActionNotFoundError(
-            name="vote",
-            page_path="/app/page.py",
-            candidates=lambda: ["votes"],
+            name="vote", page_path="/app/page.py", candidates=lambda: ["votes"]
         )
         revived = copy.deepcopy(exc)
         assert isinstance(revived, FormActionNotFoundError)
@@ -190,10 +188,10 @@ class TestFormActionManager:
         """Skip backends whose get_meta yields None and ask the next one."""
 
         class NoMetaBackend(FormActionBackend):
-            def register_action(self, *args: object, **kwargs: object) -> None:
+            def register_action(self, *args, **kwargs) -> None:
                 pass
 
-            def get_action_url(self, action_name: str, **kwargs: object) -> str:
+            def get_action_url(self, action_name: str, **kwargs) -> str:
                 return ""
 
             def generate_urls(self) -> list:
@@ -358,10 +356,7 @@ class TestRegistryFormActionBackend:
 
         backend.register_action(
             ActionRegistration(
-                name="page_action",
-                file_path=page_file,
-                scope="page",
-                handler=handler,
+                name="page_action", file_path=page_file, scope="page", handler=handler
             )
         )
         meta = backend.get_meta("page_action", page_file)
@@ -373,18 +368,12 @@ class TestRegistryFormActionBackend:
         backend = RegistryFormActionBackend()
         backend.register_action(
             ActionRegistration(
-                name="alpha",
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=lambda: None,
+                name="alpha", file_path=_FAKE_FILE, scope="shared", handler=lambda: None
             )
         )
         first_uid = next(iter(backend._uid_to_name))
         with (
-            patch(
-                "next.forms.backends._make_uid_for_action",
-                return_value=first_uid,
-            ),
+            patch("next.forms.backends._make_uid_for_action", return_value=first_uid),
             pytest.raises(ImproperlyConfigured, match="UID collision"),
         ):
             backend.register_action(
@@ -401,18 +390,12 @@ class TestRegistryFormActionBackend:
         backend = RegistryFormActionBackend()
         backend.register_action(
             ActionRegistration(
-                name="alpha",
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=lambda: None,
+                name="alpha", file_path=_FAKE_FILE, scope="shared", handler=lambda: None
             )
         )
         backend.register_action(
             ActionRegistration(
-                name="alpha",
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=lambda: None,
+                name="alpha", file_path=_FAKE_FILE, scope="shared", handler=lambda: None
             )
         )
         assert backend.get_meta("alpha") is not None
@@ -426,10 +409,7 @@ class TestRegistryFormActionBackend:
 
         backend.register_action(
             ActionRegistration(
-                name="tuple_test",
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=h,
+                name="tuple_test", file_path=_FAKE_FILE, scope="shared", handler=h
             )
         )
         keys = list(backend._registry.keys())
@@ -444,10 +424,7 @@ class TestRegistryFormActionBackend:
 
         backend.register_action(
             ActionRegistration(
-                name="uid_tuple_test",
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=h,
+                name="uid_tuple_test", file_path=_FAKE_FILE, scope="shared", handler=h
             )
         )
         values = list(backend._uid_to_name.values())
@@ -463,10 +440,7 @@ class TestRegistryFormActionBackend:
 
         backend.register_action(
             ActionRegistration(
-                name="page_meta_test",
-                file_path=page_path,
-                scope="page",
-                handler=h,
+                name="page_meta_test", file_path=page_path, scope="page", handler=h
             )
         )
         meta = backend.get_meta("page_meta_test", page_path)
@@ -482,10 +456,7 @@ class TestRegistryFormActionBackend:
 
         backend.register_action(
             ActionRegistration(
-                name="any_scope_test",
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=h,
+                name="any_scope_test", file_path=_FAKE_FILE, scope="shared", handler=h
             )
         )
         meta = backend.get_meta("any_scope_test")
@@ -538,10 +509,7 @@ class TestNameIndexScopeFilter:
     ) -> None:
         backend.register_action(
             ActionRegistration(
-                name=name,
-                file_path=file_path,
-                scope=scope,
-                handler=lambda: None,
+                name=name, file_path=file_path, scope=scope, handler=lambda: None
             )
         )
 
@@ -599,10 +567,7 @@ class TestUnknownActionSuggestions:
     def _register(backend: RegistryFormActionBackend, name: str) -> None:
         backend.register_action(
             ActionRegistration(
-                name=name,
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=lambda: None,
+                name=name, file_path=_FAKE_FILE, scope="shared", handler=lambda: None
             )
         )
 
@@ -624,10 +589,7 @@ class TestUnknownActionSuggestions:
         ],
     )
     def test_backend_suggestions(
-        self,
-        lookup_name: str,
-        expected_suggestions: tuple[str, ...],
-        message_tail: str,
+        self, lookup_name: str, expected_suggestions: tuple[str, ...], message_tail: str
     ) -> None:
         """The lookup error carries close matches and renders them last."""
         backend = RegistryFormActionBackend()
@@ -658,10 +620,7 @@ class TestEmptyRegistryDiagnosis:
     def _register(backend: RegistryFormActionBackend, name: str) -> None:
         backend.register_action(
             ActionRegistration(
-                name=name,
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=lambda: None,
+                name=name, file_path=_FAKE_FILE, scope="shared", handler=lambda: None
             )
         )
 
@@ -710,10 +669,10 @@ class TestFormActionBackendAbstract:
         """Abstract backend get_meta returns None."""
 
         class StubBackend(FormActionBackend):
-            def register_action(self, *args: object, **kwargs: object) -> None:
+            def register_action(self, *args, **kwargs) -> None:
                 pass
 
-            def get_action_url(self, action_name: str, **kwargs: object) -> str:
+            def get_action_url(self, action_name: str, **kwargs) -> str:
                 return ""
 
             def generate_urls(self) -> list:
@@ -729,10 +688,10 @@ class TestFormActionBackendAbstract:
         """Abstract backend render_invalid_page returns empty string."""
 
         class StubBackend(FormActionBackend):
-            def register_action(self, *args: object, **kwargs: object) -> None:
+            def register_action(self, *args, **kwargs) -> None:
                 pass
 
-            def get_action_url(self, action_name: str, **kwargs: object) -> str:
+            def get_action_url(self, action_name: str, **kwargs) -> str:
                 return ""
 
             def generate_urls(self) -> list:
@@ -749,10 +708,10 @@ class TestFormActionBackendAbstract:
         """The base hooks keep the plain parameter names subclasses override."""
 
         class StubBackend(FormActionBackend):
-            def register_action(self, *args: object, **kwargs: object) -> None:
+            def register_action(self, *args, **kwargs) -> None:
                 pass
 
-            def get_action_url(self, action_name: str, **kwargs: object) -> str:
+            def get_action_url(self, action_name: str, **kwargs) -> str:
                 return ""
 
             def generate_urls(self) -> list:
@@ -777,10 +736,10 @@ class TestFormActionBackendAbstract:
         """Abstract backend shape_response delegates to the default envelope."""
 
         class StubBackend(FormActionBackend):
-            def register_action(self, *args: object, **kwargs: object) -> None:
+            def register_action(self, *args, **kwargs) -> None:
                 pass
 
-            def get_action_url(self, action_name: str, **kwargs: object) -> str:
+            def get_action_url(self, action_name: str, **kwargs) -> str:
                 return ""
 
             def generate_urls(self) -> list:
@@ -835,10 +794,7 @@ class TestIterActions:
                 )
             )
         metas = list(backend.iter_actions())
-        assert [meta.get("name") for meta in metas] == [
-            "first_action",
-            "second_action",
-        ]
+        assert [meta.get("name") for meta in metas] == ["first_action", "second_action"]
         assert all(meta.get("uid") for meta in metas)
 
     def test_empty_registry_backend_yields_nothing(self) -> None:
@@ -860,8 +816,8 @@ class TestManagerBackendsAccessor:
         """An unprimed manager builds its backends from settings."""
         settings.NEXT_FRAMEWORK = {
             "FORM_ACTION_BACKENDS": [
-                {"BACKEND": "next.forms.RegistryFormActionBackend"},
-            ],
+                {"BACKEND": "next.forms.RegistryFormActionBackend"}
+            ]
         }
         manager = FormActionManager()
         backends = manager.backends
@@ -884,7 +840,7 @@ class TestFormActionManagerReloadConfig:
             "FORM_ACTION_BACKENDS": [
                 "not-a-dict",
                 {"BACKEND": "next.forms.RegistryFormActionBackend"},
-            ],
+            ]
         }
         manager = FormActionManager()
         manager._reload_config()
@@ -895,8 +851,8 @@ class TestFormActionManagerReloadConfig:
         """If a backend constructor raises ImproperlyConfigured, the entry is skipped and logged."""
         settings.NEXT_FRAMEWORK = {
             "FORM_ACTION_BACKENDS": [
-                {"BACKEND": "next.forms.RegistryFormActionBackend"},
-            ],
+                {"BACKEND": "next.forms.RegistryFormActionBackend"}
+            ]
         }
 
         def boom(_config: dict) -> None:
@@ -919,7 +875,7 @@ class TestFormActionFactory:
     def test_explicit_backend_path(self) -> None:
         """Explicit `BACKEND` path is honoured."""
         backend = FormActionFactory.create_backend(
-            {"BACKEND": "next.forms.RegistryFormActionBackend"},
+            {"BACKEND": "next.forms.RegistryFormActionBackend"}
         )
         assert isinstance(backend, RegistryFormActionBackend)
 
@@ -942,16 +898,13 @@ class TestGetActionUrlNoReverseMatchFallback:
 
         backend.register_action(
             ActionRegistration(
-                name="fallback_action",
-                file_path=page_path,
-                scope="page",
-                handler=h,
+                name="fallback_action", file_path=page_path, scope="page", handler=h
             )
         )
 
         original_reverse = __import__("django.urls", fromlist=["reverse"]).reverse
 
-        def mock_reverse(name: str, **kwargs: object) -> str:
+        def mock_reverse(name: str, **kwargs) -> str:
             if name == "next:form_action":
                 msg = "no such url"
                 raise NoReverseMatch(msg)
@@ -1072,8 +1025,8 @@ class TestFormActionManagerVersion:
         """_reload_config increments the version alongside the backend rebuild."""
         settings.NEXT_FRAMEWORK = {
             "FORM_ACTION_BACKENDS": [
-                {"BACKEND": "next.forms.RegistryFormActionBackend"},
-            ],
+                {"BACKEND": "next.forms.RegistryFormActionBackend"}
+            ]
         }
         manager = FormActionManager()
         before = manager._version
@@ -1165,10 +1118,7 @@ def _register(backend: RegistryFormActionBackend, name: str) -> None:
 
     backend.register_action(
         ActionRegistration(
-            name=name,
-            file_path=_FAKE_FILE,
-            scope="shared",
-            handler=handler,
+            name=name, file_path=_FAKE_FILE, scope="shared", handler=handler
         )
     )
 

--- a/tests/forms/test_base.py
+++ b/tests/forms/test_base.py
@@ -236,18 +236,12 @@ class TestAutoRegistration:
 
         form_action_manager.register_action(
             ActionRegistration(
-                name="dup_test",
-                file_path=fake_path,
-                scope="shared",
-                handler=handler_v1,
+                name="dup_test", file_path=fake_path, scope="shared", handler=handler_v1
             )
         )
         form_action_manager.register_action(
             ActionRegistration(
-                name="dup_test",
-                file_path=fake_path,
-                scope="shared",
-                handler=handler_v2,
+                name="dup_test", file_path=fake_path, scope="shared", handler=handler_v2
             )
         )
 

--- a/tests/forms/test_checks.py
+++ b/tests/forms/test_checks.py
@@ -55,10 +55,7 @@ class TestFormActionCollisions:
         backend = RegistryFormActionBackend()
         backend.register_action(
             ActionRegistration(
-                name="solo",
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=lambda: None,
+                name="solo", file_path=_FAKE_FILE, scope="shared", handler=lambda: None
             )
         )
         assert check_form_action_collisions() == []
@@ -92,18 +89,12 @@ class TestFormActionCollisions:
         same = _distinct_handler("stable")
         backend.register_action(
             ActionRegistration(
-                name="reload_me",
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=same,
+                name="reload_me", file_path=_FAKE_FILE, scope="shared", handler=same
             )
         )
         backend.register_action(
             ActionRegistration(
-                name="reload_me",
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=same,
+                name="reload_me", file_path=_FAKE_FILE, scope="shared", handler=same
             )
         )
         assert check_form_action_collisions() == []
@@ -152,10 +143,7 @@ class TestSharedActionNameCollisions:
     ) -> None:
         backend.register_action(
             ActionRegistration(
-                name=name,
-                file_path=file_path,
-                scope=scope,
-                handler=lambda: None,
+                name=name, file_path=file_path, scope=scope, handler=lambda: None
             )
         )
 
@@ -251,7 +239,7 @@ class TestFormActionBackendsConfigurationCheck:
     def test_unimportable_backend_is_e044(self, settings) -> None:
         """A path that fails to import surfaces the original error."""
         settings.NEXT_FRAMEWORK = {
-            "FORM_ACTION_BACKENDS": [{"BACKEND": "no.such.Module"}],
+            "FORM_ACTION_BACKENDS": [{"BACKEND": "no.such.Module"}]
         }
         errors = check_form_action_backends_configuration()
         assert any(
@@ -261,7 +249,7 @@ class TestFormActionBackendsConfigurationCheck:
     def test_wrong_type_backend_is_e045(self, settings) -> None:
         """A class that is not a `FormActionBackend` subclass triggers E045."""
         settings.NEXT_FRAMEWORK = {
-            "FORM_ACTION_BACKENDS": [{"BACKEND": "django.http.HttpResponse"}],
+            "FORM_ACTION_BACKENDS": [{"BACKEND": "django.http.HttpResponse"}]
         }
         errors = check_form_action_backends_configuration()
         assert any(e.id == "next.E045" for e in errors)
@@ -270,8 +258,8 @@ class TestFormActionBackendsConfigurationCheck:
         """Default backend path passes the check without errors."""
         settings.NEXT_FRAMEWORK = {
             "FORM_ACTION_BACKENDS": [
-                {"BACKEND": "next.forms.RegistryFormActionBackend"},
-            ],
+                {"BACKEND": "next.forms.RegistryFormActionBackend"}
+            ]
         }
         assert check_form_action_backends_configuration() == []
 
@@ -692,10 +680,7 @@ def _isolated_backend_with(
 
 def _wizard_registration(name: str, wizard_class: type) -> ActionRegistration:
     return ActionRegistration(
-        name=name,
-        file_path=_FAKE_FILE,
-        scope="shared",
-        wizard_class=wizard_class,
+        name=name, file_path=_FAKE_FILE, scope="shared", wizard_class=wizard_class
     )
 
 
@@ -843,10 +828,7 @@ def _page_wizard_registration(
     name: str, wizard_class: type, file_path: str
 ) -> ActionRegistration:
     return ActionRegistration(
-        name=name,
-        file_path=file_path,
-        scope="page",
-        wizard_class=wizard_class,
+        name=name, file_path=file_path, scope="page", wizard_class=wizard_class
     )
 
 

--- a/tests/forms/test_decorators.py
+++ b/tests/forms/test_decorators.py
@@ -6,11 +6,7 @@ import pytest
 from django import forms, forms as django_forms
 from django.http import HttpRequest, HttpResponseRedirect
 
-from next.forms import (
-    BaseModelForm,
-    Form,
-    ModelForm,
-)
+from next.forms import BaseModelForm, Form, ModelForm
 from next.forms.base import _is_self_registered
 from next.forms.decorators import action as action_decorator
 from next.forms.diagnostics import registration_diagnostics
@@ -343,7 +339,7 @@ class TestBaseFormGetInitial:
             name = forms.CharField(max_length=100)
 
             @classmethod
-            def get_initial(cls, request: HttpRequest, **kwargs: object) -> dict:
+            def get_initial(cls, request: HttpRequest, **kwargs) -> dict:
                 return {"name": f"from-{kwargs['id']}"}
 
         request = HttpRequest()

--- a/tests/forms/test_dispatch.py
+++ b/tests/forms/test_dispatch.py
@@ -70,10 +70,7 @@ class DispatchWizard(FormWizard):
     class Meta:
         """Two ordered steps routed through the wizard backend."""
 
-        steps: ClassVar = [
-            ("identity", WizardIdentityStep),
-            ("scope", WizardScopeStep),
-        ]
+        steps: ClassVar = [("identity", WizardIdentityStep), ("scope", WizardScopeStep)]
 
     done_payloads: ClassVar[list] = []
 
@@ -89,10 +86,7 @@ class ConditionalDispatchWizard(FormWizard):
     class Meta:
         """Two declared steps that a get_steps override can expand."""
 
-        steps: ClassVar = [
-            ("identity", WizardIdentityStep),
-            ("scope", WizardScopeStep),
-        ]
+        steps: ClassVar = [("identity", WizardIdentityStep), ("scope", WizardScopeStep)]
 
     done_payloads: ClassVar[list] = []
 
@@ -228,12 +222,7 @@ class TestDispatchViaClient:
         """Invalid POST returns 200 with validation errors when the origin resolves."""
         url = form_action_manager.get_action_url("simple_form")
         resp = client_no_csrf.post(
-            url,
-            data={
-                "name": "",
-                "_next_form_origin": "/",
-            },
-            follow=False,
+            url, data={"name": "", "_next_form_origin": "/"}, follow=False
         )
         assert resp.status_code == 200
         c = resp.content
@@ -254,9 +243,7 @@ class TestDispatchViaClient:
         """Invalid POST whose origin matches no route returns 400."""
         url = form_action_manager.get_action_url("simple_form")
         resp = client_no_csrf.post(
-            url,
-            data={"name": "", "_next_form_origin": "/no/such/route/"},
-            follow=False,
+            url, data={"name": "", "_next_form_origin": "/no/such/route/"}, follow=False
         )
         assert resp.status_code == 400
 
@@ -265,11 +252,7 @@ class TestDispatchViaClient:
         url = form_action_manager.get_action_url("simple_form")
         resp = client_no_csrf.post(
             url,
-            data={
-                "name": "Alice",
-                "email": "",
-                "_next_form_origin": "/",
-            },
+            data={"name": "Alice", "email": "", "_next_form_origin": "/"},
             follow=False,
         )
         # SimpleForm.on_valid returns None, so the dispatcher re-renders the
@@ -282,11 +265,7 @@ class TestDispatchViaClient:
     def test_redirect_action_returns_redirect(self, client_no_csrf) -> None:
         """Redirect action returns 302 redirect."""
         url = form_action_manager.get_action_url("simple_form_redirect")
-        resp = client_no_csrf.post(
-            url,
-            data={"name": "Bob"},
-            follow=False,
-        )
+        resp = client_no_csrf.post(url, data={"name": "Bob"}, follow=False)
         assert resp.status_code == 302
         assert resp.url == "/done/"
 
@@ -313,19 +292,13 @@ class TestFormDispatchRenderInvalidPageBranches:
 
         backend.register_action(
             ActionRegistration(
-                name="only",
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=h,
+                name="only", file_path=_FAKE_FILE, scope="shared", handler=h
             )
         )
         req = mock_http_request(method="GET")
         form = F()
         html = backend.render_invalid_page(
-            req,
-            "missing_action",
-            form,
-            PAGE_MODULE_FOR_FORM_TESTS,
+            req, "missing_action", form, PAGE_MODULE_FOR_FORM_TESTS
         )
         assert html == form.render(form.template_name_p)
 
@@ -343,10 +316,7 @@ class TestFormDispatchRenderInvalidPageBranches:
 
         backend.register_action(
             ActionRegistration(
-                name="frag",
-                file_path=_FAKE_FILE,
-                scope="shared",
-                handler=h,
+                name="frag", file_path=_FAKE_FILE, scope="shared", handler=h
             )
         )
         req = mock_http_request(method="GET")
@@ -354,12 +324,7 @@ class TestFormDispatchRenderInvalidPageBranches:
         blank_page = tmp_path / "page.py"
         blank_page.write_text("")
 
-        html = backend.render_invalid_page(
-            req,
-            "frag",
-            form,
-            blank_page,
-        )
+        html = backend.render_invalid_page(req, "frag", form, blank_page)
         assert html == form.render(form.template_name_p)
 
     def test_dispatch_with_modelform_returning_instance(
@@ -387,7 +352,7 @@ class TestFormDispatchRenderInvalidPageBranches:
                 return mock_instance
 
         def handler(
-            request: HttpRequest, form: TestModelForm, **_kwargs: object
+            request: HttpRequest, form: TestModelForm, **kwargs
         ) -> HttpResponseRedirect:
             return HttpResponseRedirect("/")
 
@@ -441,10 +406,7 @@ class TestFormDispatchRenderInvalidPageBranches:
         try:
             form = TestForm(initial={"name": "test"})
             html = backend.render_invalid_page(
-                request,
-                "test_action",
-                form,
-                page_file_path=file_path,
+                request, "test_action", form, page_file_path=file_path
             )
             assert isinstance(html, str)
         finally:
@@ -761,11 +723,7 @@ class TestResolveFormClass:
             return F
 
         request = mock_http_request(method="POST")
-        cls, init_kwargs = _resolve_form_class(
-            factory,
-            request,
-            {"model_name": "tag"},
-        )
+        cls, init_kwargs = _resolve_form_class(factory, request, {"model_name": "tag"})
         assert cls is F
         assert init_kwargs == {}
         assert seen["model_name"] == "tag"
@@ -827,12 +785,7 @@ class _CustomInitForm(django_forms.Form):
 
     name = django_forms.CharField(max_length=10, required=False)
 
-    def __init__(
-        self,
-        *args: object,
-        label_suffix: str = "",
-        **kwargs: object,
-    ) -> None:
+    def __init__(self, *args, label_suffix: str = "", **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.label_suffix = label_suffix
 
@@ -841,9 +794,7 @@ class TestFormClassInitKwargs:
     """Factory returning `(cls, init_kwargs)` bypasses get_initial."""
 
     @pytest.mark.parametrize(
-        ("bound", "suffix"),
-        [(False, "?"), (True, "!")],
-        ids=("unbound", "bound"),
+        ("bound", "suffix"), [(False, "?"), (True, "!")], ids=("unbound", "bound")
     )
     def test_form_built_with_init_kwargs(
         self, mock_http_request, bound, suffix
@@ -875,9 +826,7 @@ class TestFormClassInitKwargs:
     def test_dispatch_uses_init_kwargs_and_skips_get_initial(
         self, mock_http_request
     ) -> None:
-        def factory(
-            request: HttpRequest,
-        ) -> tuple[type[django_forms.Form], dict]:
+        def factory(request: HttpRequest) -> tuple[type[django_forms.Form], dict]:
             return _CustomInitForm, {"label_suffix": "$"}
 
         captured: dict[str, object] = {}
@@ -899,11 +848,7 @@ class TestFormClassInitKwargs:
 
         post = QueryDict(mutable=True)
         post["name"] = "x"
-        request = mock_http_request(
-            method="POST",
-            POST=post,
-            FILES=QueryDict(),
-        )
+        request = mock_http_request(method="POST", POST=post, FILES=QueryDict())
         meta = backend.get_meta("init_kwargs_action")
         assert meta is not None
         response = FormActionDispatch.dispatch(
@@ -968,7 +913,7 @@ class TestDispatchSharedDepCache:
 
         seen: dict[str, object] = {}
 
-        def receiver(**kwargs: object) -> None:
+        def receiver(**kwargs) -> None:
             seen.update(kwargs)
 
         action_dispatched.connect(receiver)
@@ -1021,10 +966,7 @@ class TestDispatchSharedDepCache:
             cls, _ = _resolve_form_class(factory, request, {}, (dep_cache, dep_stack))
             assert cls is WForm
             resolved = resolver.resolve_dependencies(
-                handler_like,
-                request=request,
-                _cache=dep_cache,
-                _stack=dep_stack,
+                handler_like, request=request, _cache=dep_cache, _stack=dep_stack
             )
         finally:
             resolver._dependency_callables.pop("widget", None)
@@ -1172,20 +1114,14 @@ class TestWizardDispatchViaClient:
 
         url = form_action_manager.get_action_url("empty_dispatch_wizard")
         resp = client_no_csrf.post(
-            url,
-            data={"_next_form_origin": "/request/ghost/"},
-            follow=False,
+            url, data={"_next_form_origin": "/request/ghost/"}, follow=False
         )
         assert resp.status_code == 400
 
     def test_missing_origin_returns_bad_request(self, client_no_csrf) -> None:
         """A wizard POST without a valid _next_form_origin returns 400."""
         url = form_action_manager.get_action_url("dispatch_wizard")
-        resp = client_no_csrf.post(
-            url,
-            data={"name": "Ada"},
-            follow=False,
-        )
+        resp = client_no_csrf.post(url, data={"name": "Ada"}, follow=False)
         assert resp.status_code == 400
 
     def test_done_error_response_preserves_draft(
@@ -1233,7 +1169,7 @@ class TestWizardDispatchViaClient:
 
         completed: list[dict] = []
 
-        def on_completed(sender, **kwargs: object) -> None:
+        def on_completed(sender, **kwargs) -> None:
             completed.append(kwargs)
 
         wizard_completed.connect(on_completed)
@@ -1309,10 +1245,7 @@ class PlainStepsWizard(FormWizard):
     class Meta:
         """Two bare Django form steps."""
 
-        steps: ClassVar = [
-            ("identity", PlainIdentityStep),
-            ("scope", PlainScopeStep),
-        ]
+        steps: ClassVar = [("identity", PlainIdentityStep), ("scope", PlainScopeStep)]
 
     done_payloads: ClassVar[list] = []
 
@@ -1374,18 +1307,12 @@ class InjectedDoneWizard(FormWizard):
     class Meta:
         """Two ordered steps routed through the wizard backend."""
 
-        steps: ClassVar = [
-            ("identity", WizardIdentityStep),
-            ("scope", WizardScopeStep),
-        ]
+        steps: ClassVar = [("identity", WizardIdentityStep), ("scope", WizardScopeStep)]
 
     seen: ClassVar[list] = []
 
     def done(
-        self,
-        request: HttpRequest,
-        cleaned_data: dict,
-        token: str = Depends("token"),
+        self, request: HttpRequest, cleaned_data: dict, token: str = Depends("token")
     ) -> HttpResponseRedirect:
         """Record the resolved arguments and redirect."""
         type(self).seen.append((request is not None, dict(cleaned_data), token))
@@ -1465,10 +1392,7 @@ class TestWizardDoneInjection:
             del cleaned_data, slug
 
         resolved = resolver.resolve_dependencies(
-            func,
-            request=None,
-            cleaned_data={"a": 1},
-            slug="x",
+            func, request=None, cleaned_data={"a": 1}, slug="x"
         )
         assert resolved == {"cleaned_data": {"a": 1}, "slug": "x"}
 

--- a/tests/forms/test_field_components.py
+++ b/tests/forms/test_field_components.py
@@ -87,10 +87,7 @@ def _register_form(
     """Register a page-scoped form action through the default backend."""
     form_action_manager.default_backend.register_action(
         ActionRegistration(
-            name=name,
-            file_path=file_path,
-            scope="page",
-            form_class=form_class,
+            name=name, file_path=file_path, scope="page", form_class=form_class
         )
     )
 
@@ -310,10 +307,7 @@ class TestComponentWidgetAssetCollection:
     """`render` discovers co-located component assets when a collector is bound."""
 
     def _render_with_collector(
-        self,
-        component_name: str,
-        anchor: Path,
-        collector: StaticCollector | None,
+        self, component_name: str, anchor: Path, collector: StaticCollector | None
     ) -> None:
         widget = ComponentWidget(component_name)
         widget._template_path = anchor
@@ -408,10 +402,7 @@ class TestBindComponentWidgets:
         request = object()
         collector = StaticCollector()
         bind_component_widgets(
-            formset,
-            template_path=echo_component,
-            request=request,
-            collector=collector,
+            formset, template_path=echo_component, request=request, collector=collector
         )
         assert len(formset.forms) == 2
         for member in formset.forms:
@@ -480,7 +471,7 @@ class TestCheckComponentWidgetComponents:
                 name="formless",
                 file_path="/fake/page.py",
                 scope="page",
-                handler=lambda *_: None,
+                handler=lambda *args: None,
             )
         )
         assert check_component_widget_components() == []
@@ -489,10 +480,10 @@ class TestCheckComponentWidgetComponents:
         # A from-scratch backend keeping the iter_actions default must not
         # raise: the check sees an empty iterator and reports nothing.
         class _BareBackend(FormActionBackend):
-            def register_action(self, *args: object, **kwargs: object) -> None:
+            def register_action(self, *args, **kwargs) -> None:
                 pass
 
-            def get_action_url(self, action_name: str, **kwargs: object) -> str:
+            def get_action_url(self, action_name: str, **kwargs) -> str:
                 return ""
 
             def generate_urls(self) -> list:
@@ -564,7 +555,7 @@ class TestCheckComponentWidgetFieldTypes:
                 name="formless_types",
                 file_path="/fake/page.py",
                 scope="page",
-                handler=lambda *_: None,
+                handler=lambda *args: None,
             )
         )
         assert check_component_widget_field_types() == []

--- a/tests/forms/test_guards.py
+++ b/tests/forms/test_guards.py
@@ -475,7 +475,7 @@ class TestCallCheckPermissions:
 
         class _Form(BaseForm):
             @classmethod
-            def check_permissions(cls, **url_kwargs: object) -> PermissionOutcome:
+            def check_permissions(cls, **url_kwargs) -> PermissionOutcome:
                 seen.update(url_kwargs)
                 return None
 
@@ -514,7 +514,7 @@ class TestCallHasObjectPermission:
         class _Form(Form):
             name = django_forms.CharField(max_length=10, required=False)
 
-            def has_object_permission(self, **url_kwargs: object) -> PermissionOutcome:
+            def has_object_permission(self, **url_kwargs) -> PermissionOutcome:
                 seen.update(url_kwargs)
                 return None
 
@@ -533,7 +533,7 @@ class TestEmitFormAccessDenied:
     def test_emits_when_receiver_present(self, mock_http_request) -> None:
         seen: list[dict[str, object]] = []
 
-        def receiver(**kwargs: object) -> None:
+        def receiver(**kwargs) -> None:
             seen.append(kwargs)
 
         request = mock_http_request(method="POST")
@@ -693,9 +693,7 @@ class TestPermissionHookReturnContract:
         "layer", _HOOK_LAYERS, ids=[layer.id for layer in _HOOK_LAYERS]
     )
     @pytest.mark.parametrize(
-        "case",
-        PERMISSION_OUTCOME_CASES,
-        ids=[c.id for c in PERMISSION_OUTCOME_CASES],
+        "case", PERMISSION_OUTCOME_CASES, ids=[c.id for c in PERMISSION_OUTCOME_CASES]
     )
     def test_matrix_via_dispatch(
         self,
@@ -898,11 +896,11 @@ class TestViewDenialShortCircuitsObjectHook:
         assert _ViewDeniesObjectSpyForm.object_calls == []
 
 
-def _board_factory(**_kwargs: object) -> type:
+def _board_factory(**kwargs) -> type:
     return _SpyDBViewForm
 
 
-def _board_tuple_factory(**_kwargs: object) -> tuple[type, dict[str, object]]:
+def _board_tuple_factory(**kwargs) -> tuple[type, dict[str, object]]:
     return _ObjectOwnerModelForm, {}
 
 
@@ -1083,7 +1081,7 @@ class TestDepCacheReuse:
         GuardedTenantForm.resolutions.clear()
         seen: dict[str, object] = {}
 
-        def receiver(**kwargs: object) -> None:
+        def receiver(**kwargs) -> None:
             seen.update(kwargs)
 
         def tenant_provider() -> str:
@@ -1126,7 +1124,7 @@ class TestFormAccessDeniedPayload:
     def captured(self):
         events: list[dict[str, object]] = []
 
-        def receiver(**kwargs: object) -> None:
+        def receiver(**kwargs) -> None:
             events.append(kwargs)
 
         form_access_denied.connect(receiver)

--- a/tests/forms/test_instance_from_url.py
+++ b/tests/forms/test_instance_from_url.py
@@ -7,16 +7,8 @@ from django import forms as django_forms
 from django.contrib.auth.models import Group
 from django.http import Http404, HttpRequest, QueryDict
 
-from next.forms import (
-    ActionRegistration,
-    Form,
-    ModelForm,
-    RegistryFormActionBackend,
-)
-from next.forms.base import (
-    _instance_from_url_db_fields,
-    _instance_lookup_from_spec,
-)
+from next.forms import ActionRegistration, Form, ModelForm, RegistryFormActionBackend
+from next.forms.base import _instance_from_url_db_fields, _instance_lookup_from_spec
 from next.forms.checks import (
     check_instance_from_url_on_non_model_form,
     check_instance_from_url_unknown_field,
@@ -309,7 +301,7 @@ class TestAcceptsVarKeyword:
     def test_true_for_var_keyword(self) -> None:
         """A function declaring **kwargs is reported as accepting var-keyword."""
 
-        def fn(**kwargs: object) -> None:
+        def fn(**kwargs) -> None:
             return None
 
         assert _accepts_var_keyword(fn) is True
@@ -323,9 +315,7 @@ class TestAcceptsVarKeyword:
         assert _accepts_var_keyword(fn) is False
 
     @pytest.mark.parametrize(
-        "uninspectable",
-        [range, object()],
-        ids=("value_error", "type_error"),
+        "uninspectable", [range, object()], ids=("value_error", "type_error")
     )
     def test_false_for_uninspectable(self, uninspectable) -> None:
         """A callable whose signature can't be inspected is reported as False."""
@@ -341,10 +331,7 @@ class TestCallGetInitial:
         group = Group.objects.create(name="reviewers")
         request = mock_http_request(method="POST")
         result = _call_get_initial(
-            GroupByNameForm,
-            request,
-            {"name": "reviewers"},
-            deps=({}, []),
+            GroupByNameForm, request, {"name": "reviewers"}, deps=({}, [])
         )
         assert result == group
 
@@ -363,10 +350,7 @@ class TestCallGetInitial:
 
         request = mock_http_request(method="POST")
         result = _call_get_initial(
-            NamedOnlyForm,
-            request,
-            {"name": "ignored"},
-            deps=({}, []),
+            NamedOnlyForm, request, {"name": "ignored"}, deps=({}, [])
         )
         assert result == {}
         assert "request" in seen["received"]
@@ -393,10 +377,7 @@ class TestSaveUpdatesExistingRow:
         group = Group.objects.create(name="old-name")
         request = mock_http_request(method="POST")
         instance = _call_get_initial(
-            GroupByNameForm,
-            request,
-            {"name": "old-name"},
-            deps=({}, []),
+            GroupByNameForm, request, {"name": "old-name"}, deps=({}, [])
         )
         form = GroupByNameForm(data={"name": "new-name"}, instance=instance)
         assert form.is_valid()

--- a/tests/forms/test_markers.py
+++ b/tests/forms/test_markers.py
@@ -39,9 +39,7 @@ class TestDFormAndFormProvider:
         context.form = MyForm()
 
         param = inspect.Parameter(
-            "my_form",
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=MyForm,
+            "my_form", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=MyForm
         )
         assert provider.can_handle(param, context) is True
 
@@ -65,8 +63,7 @@ class TestDFormAndFormProvider:
         context.form = MyForm()
 
         param = inspect.Parameter(
-            "other_param",
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            "other_param", inspect.Parameter.POSITIONAL_OR_KEYWORD
         )
         assert provider.can_handle(param, context) is False
 

--- a/tests/forms/test_origin.py
+++ b/tests/forms/test_origin.py
@@ -248,7 +248,7 @@ class TestSiblingFormReRenderKwargs:
             seen: ClassVar[list] = []
 
             @classmethod
-            def get_initial(cls, request: HttpRequest, **kwargs: object) -> dict:
+            def get_initial(cls, request: HttpRequest, **kwargs) -> dict:
                 cls.seen.append(dict(kwargs))
                 return {}
 

--- a/tests/forms/test_perf_budgets.py
+++ b/tests/forms/test_perf_budgets.py
@@ -6,11 +6,7 @@ from django import forms as django_forms
 from django.http import HttpRequest, HttpResponseRedirect
 
 from next.deps import resolver
-from next.forms import (
-    ActionRegistration,
-    Form,
-    RegistryFormActionBackend,
-)
+from next.forms import ActionRegistration, Form, RegistryFormActionBackend
 from next.forms.dispatch import FormActionDispatch
 from next.forms.manager import form_action_manager
 from next.forms.wizard import (
@@ -46,10 +42,7 @@ class BudgetWizard(FormWizard):
     class Meta:
         """Two ordered steps with the default URL parameter."""
 
-        steps: ClassVar = [
-            ("identity", BudgetIdentityStep),
-            ("scope", BudgetScopeStep),
-        ]
+        steps: ClassVar = [("identity", BudgetIdentityStep), ("scope", BudgetScopeStep)]
 
     def done(self, request: HttpRequest, cleaned_data: dict) -> HttpResponseRedirect:
         """Redirect once the last step validates."""
@@ -62,10 +55,7 @@ class ConditionalBudgetWizard(FormWizard):
     class Meta:
         """Two declared steps that get_steps can expand."""
 
-        steps: ClassVar = [
-            ("identity", BudgetIdentityStep),
-            ("scope", BudgetScopeStep),
-        ]
+        steps: ClassVar = [("identity", BudgetIdentityStep), ("scope", BudgetScopeStep)]
 
     def get_steps(self) -> list:
         """Append an extra step when the first answer asks for it."""
@@ -141,10 +131,7 @@ class TestWizardStorageRoundTripBudgets:
     ) -> None:
         """A get_steps override that reads storage still pays a single load."""
         resp = _post_step(
-            client_no_csrf,
-            "conditional_budget_wizard",
-            "identity",
-            {"name": "expand"},
+            client_no_csrf, "conditional_budget_wizard", "identity", {"name": "expand"}
         )
         assert resp.status_code == 302
         assert resp.url == "/request/scope/"
@@ -185,7 +172,7 @@ class TestErrorRerenderFileReadBudget:
         reads = {"count": 0}
         original_read_text = Path.read_text
 
-        def counting_read_text(self, *args: object, **kwargs: object) -> str:
+        def counting_read_text(self, *args, **kwargs) -> str:
             reads["count"] += 1
             return original_read_text(self, *args, **kwargs)
 
@@ -230,7 +217,7 @@ class TestPermissionHookResolveBudgets:
         calls = {"n": 0}
         original = resolver.resolve_dependencies
 
-        def counting(*args: object, **kwargs: object) -> object:
+        def counting(*args, **kwargs) -> object:
             calls["n"] += 1
             return original(*args, **kwargs)
 

--- a/tests/forms/test_rendering.py
+++ b/tests/forms/test_rendering.py
@@ -79,10 +79,7 @@ class TestRenderInvalidPage:
         request = mock_http_request(method="GET")
         form = SimpleForm(initial={"name": "test"})
         html = form_action_manager.default_backend.render_invalid_page(
-            request,
-            "simple_form",
-            form,
-            page_file_path=PAGE_MODULE_FOR_FORM_TESTS,
+            request, "simple_form", form, page_file_path=PAGE_MODULE_FOR_FORM_TESTS
         )
         assert "test" in html or "name" in html
 
@@ -91,10 +88,7 @@ class TestRenderInvalidPage:
         request = mock_http_request(method="GET")
         form = SimpleForm(initial={"name": "x"})
         html = form_action_manager.default_backend.render_invalid_page(
-            request,
-            "simple_form",
-            form,
-            page_file_path=PAGE_MODULE_FOR_FORM_TESTS,
+            request, "simple_form", form, page_file_path=PAGE_MODULE_FOR_FORM_TESTS
         )
         assert isinstance(html, str)
         assert html.strip() != ""
@@ -103,10 +97,7 @@ class TestRenderInvalidPage:
         """Form None still returns a string when a page template exists."""
         request = mock_http_request(method="GET")
         html = form_action_manager.default_backend.render_invalid_page(
-            request,
-            "simple_form",
-            form=None,
-            page_file_path=PAGE_MODULE_FOR_FORM_TESTS,
+            request, "simple_form", form=None, page_file_path=PAGE_MODULE_FOR_FORM_TESTS
         )
         assert isinstance(html, str)
 
@@ -147,28 +138,18 @@ class TestRenderInvalidPage:
         form = RenderWizardStep(data={"name": ""})
         assert not form.is_valid()
         html = form_action_manager.default_backend.render_invalid_page(
-            request,
-            "render_wizard",
-            form,
-            page_file_path=PAGE_MODULE_FOR_FORM_TESTS,
+            request, "render_wizard", form, page_file_path=PAGE_MODULE_FOR_FORM_TESTS
         )
         assert isinstance(html, str)
         assert html.strip() != ""
 
     @pytest.mark.parametrize(
         ("template_body", "output_mode"),
-        [
-            ("{{ form.name }}", "form_fields"),
-            ("{{ current_template_path }}", "path"),
-        ],
+        [("{{ form.name }}", "form_fields"), ("{{ current_template_path }}", "path")],
         ids=("form_fields", "current_template_path"),
     )
     def test_renders_from_template_djx(
-        self,
-        mock_http_request,
-        tmp_path,
-        template_body: str,
-        output_mode: str,
+        self, mock_http_request, tmp_path, template_body: str, output_mode: str
     ) -> None:
         """Render the page reading the sibling template.djx of ``page_file_path``."""
         request = mock_http_request(method="GET")
@@ -182,10 +163,7 @@ class TestRenderInvalidPage:
         template_djx.write_text(template_body)
 
         html = backend.render_invalid_page(
-            request,
-            "simple_form",
-            form,
-            page_file_path=page_file,
+            request, "simple_form", form, page_file_path=page_file
         )
         if output_mode == "path":
             assert str(template_djx) in html
@@ -243,8 +221,7 @@ class TestFormTagSyntax:
             form_engine.from_string('{% form "foo" "bar" %}x{% endform %}')
 
     @pytest.mark.parametrize(
-        "attr",
-        ["action", "method", "data-next-action", "data-next-target"],
+        "attr", ["action", "method", "data-next-action", "data-next-target"]
     )
     def test_reserved_attribute_raises(self, form_engine, attr: str) -> None:
         """{% form %} rejects exact reserved names and the data-next- prefix."""
@@ -608,7 +585,7 @@ class TestFormTagFormsetRender:
                 name="bulk_rows",
                 file_path=str(PAGE_MODULE_FOR_FORM_TESTS),
                 scope="page",
-                handler=lambda **_kwargs: None,
+                handler=lambda **kwargs: None,
                 form_class=build_bulk_rows,
             )
         )
@@ -674,10 +651,7 @@ class TestActionUrlTag:
     def _register_page_action(name: str, page_path: str) -> None:
         form_action_manager.default_backend.register_action(
             ActionRegistration(
-                name=name,
-                file_path=page_path,
-                scope="page",
-                handler=lambda: None,
+                name=name, file_path=page_path, scope="page", handler=lambda: None
             )
         )
 
@@ -780,10 +754,10 @@ class TestFormTagMarkupIdentity:
         """A backend exposing no meta renders the tag without the marker."""
 
         class NoMetaBackend(FormActionBackend):
-            def register_action(self, *args: object, **kwargs: object) -> None:
+            def register_action(self, *args, **kwargs) -> None:
                 pass
 
-            def get_action_url(self, action_name: str, **kwargs: object) -> str:
+            def get_action_url(self, action_name: str, **kwargs) -> str:
                 return "/custom/submit/"
 
             def generate_urls(self) -> list:
@@ -802,9 +776,7 @@ class TestFormTagMarkupIdentity:
     def test_auto_enctype_for_multipart_form(self, form_engine, csrf_request) -> None:
         """A multipart form gains enctype="multipart/form-data" automatically."""
         html = self._render(
-            form_engine,
-            csrf_request,
-            '{% form "upload_enctype_form" %}x{% endform %}',
+            form_engine, csrf_request, '{% form "upload_enctype_form" %}x{% endform %}'
         )
         assert 'enctype="multipart/form-data">' in html
 

--- a/tests/forms/test_serializers.py
+++ b/tests/forms/test_serializers.py
@@ -260,11 +260,7 @@ class TestSpecsAreFrozen:
 
     def test_formset_row_spec_frozen(self) -> None:
         row = FormsetRowSpec(
-            fields=(),
-            hidden_html="",
-            delete_field=None,
-            errors={},
-            is_extra=False,
+            fields=(), hidden_html="", delete_field=None, errors={}, is_extra=False
         )
         with pytest.raises((AttributeError, TypeError)):
             row.is_extra = True  # type: ignore[misc]

--- a/tests/forms/test_signals.py
+++ b/tests/forms/test_signals.py
@@ -6,11 +6,7 @@ from django import forms as django_forms
 from django.dispatch import Signal
 from django.http import HttpRequest, HttpResponseRedirect
 
-from next.forms import (
-    ActionRegistration,
-    Form,
-    RegistryFormActionBackend,
-)
+from next.forms import ActionRegistration, Form, RegistryFormActionBackend
 from next.forms.manager import form_action_manager
 from next.forms.signals import (
     action_dispatched,
@@ -44,10 +40,7 @@ class SignalWizard(FormWizard):
     class Meta:
         """Two ordered steps routed through the wizard backend."""
 
-        steps: ClassVar = [
-            ("identity", SignalIdentityStep),
-            ("scope", SignalScopeStep),
-        ]
+        steps: ClassVar = [("identity", SignalIdentityStep), ("scope", SignalScopeStep)]
 
     def done(self, request: HttpRequest, cleaned_data: dict) -> HttpResponseRedirect:
         """Finalise the wizard with a redirect."""
@@ -58,7 +51,7 @@ class SignalWizard(FormWizard):
 def capture_action_registered() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     action_registered.connect(_listener)
@@ -72,7 +65,7 @@ def capture_action_registered() -> Generator[list[dict[str, Any]], None, None]:
 def capture_action_dispatched() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     action_dispatched.connect(_listener)
@@ -86,7 +79,7 @@ def capture_action_dispatched() -> Generator[list[dict[str, Any]], None, None]:
 def capture_form_validation_failed() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     form_validation_failed.connect(_listener)
@@ -100,7 +93,7 @@ def capture_form_validation_failed() -> Generator[list[dict[str, Any]], None, No
 def capture_wizard_step_submitted() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     wizard_step_submitted.connect(_listener)
@@ -114,7 +107,7 @@ def capture_wizard_step_submitted() -> Generator[list[dict[str, Any]], None, Non
 def capture_wizard_completed() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     wizard_completed.connect(_listener)
@@ -128,7 +121,7 @@ def capture_wizard_completed() -> Generator[list[dict[str, Any]], None, None]:
 def capture_form_access_denied() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     form_access_denied.connect(_listener)
@@ -141,10 +134,7 @@ def capture_form_access_denied() -> Generator[list[dict[str, Any]], None, None]:
 def _post_wizard_step(client, step: str, data: dict):
     """POST one wizard step through the dispatch client with the tag's hidden field."""
     url = form_action_manager.get_action_url("signal_wizard")
-    payload = {
-        "_next_form_origin": f"/request/{step}/",
-        **data,
-    }
+    payload = {"_next_form_origin": f"/request/{step}/", **data}
     return client.post(url, data=payload, follow=False)
 
 
@@ -190,7 +180,7 @@ class TestActionRegisteredSignal:
         """After the fixture tears down, the listener is no longer connected."""
         events: list[dict[str, Any]] = []
 
-        def _listener(sender: object, **kwargs: object) -> None:
+        def _listener(sender: object, **kwargs) -> None:
             events.append({"sender": sender})
 
         action_registered.connect(_listener)
@@ -241,7 +231,7 @@ class TestActionDispatchedSignal:
         """After the fixture tears down, the listener is no longer connected."""
         events: list[dict[str, Any]] = []
 
-        def _listener(sender: object, **kwargs: object) -> None:
+        def _listener(sender: object, **kwargs) -> None:
             events.append({"sender": sender})
 
         action_dispatched.connect(_listener)
@@ -292,7 +282,7 @@ class TestFormValidationFailedSignal:
         """After the fixture tears down, the listener is no longer connected."""
         events: list[dict[str, Any]] = []
 
-        def _listener(sender: object, **kwargs: object) -> None:
+        def _listener(sender: object, **kwargs) -> None:
             events.append({"sender": sender})
 
         form_validation_failed.connect(_listener)
@@ -320,11 +310,7 @@ class TestFormAccessDeniedSignal:
     ) -> None:
         """The denial payload preserves layer and reason for receivers."""
         form_access_denied.send(
-            sender=object,
-            action_name="edit",
-            uid="u1",
-            layer="object",
-            reason="denied",
+            sender=object, action_name="edit", uid="u1", layer="object", reason="denied"
         )
         event = capture_form_access_denied[0]
         assert event["action_name"] == "edit"
@@ -340,7 +326,7 @@ class TestFormAccessDeniedSignal:
         """After disconnecting, the listener is no longer notified."""
         events: list[dict[str, Any]] = []
 
-        def _listener(sender: object, **kwargs: object) -> None:
+        def _listener(sender: object, **kwargs) -> None:
             events.append({"sender": sender})
 
         form_access_denied.connect(_listener)
@@ -435,9 +421,7 @@ class TestActionDispatchedWiring:
     """``action_dispatched`` fires when the framework dispatches a real action."""
 
     def test_fires_on_successful_dispatch_without_form(
-        self,
-        client_no_csrf,
-        capture_action_dispatched: list[dict[str, Any]],
+        self, client_no_csrf, capture_action_dispatched: list[dict[str, Any]]
     ) -> None:
         """A handler without form_class fires the signal with response_status."""
         url = form_action_manager.get_action_url("test_no_form")
@@ -456,17 +440,11 @@ class TestActionDispatchedWiring:
         assert event["request"].path == url
 
     def test_fires_on_successful_dispatch_with_form(
-        self,
-        client_no_csrf,
-        capture_action_dispatched: list[dict[str, Any]],
+        self, client_no_csrf, capture_action_dispatched: list[dict[str, Any]]
     ) -> None:
         """A valid bound form fires the signal after on_valid runs."""
         url = form_action_manager.get_action_url("simple_form_redirect")
-        resp = client_no_csrf.post(
-            url,
-            data={"name": "Alice"},
-            follow=False,
-        )
+        resp = client_no_csrf.post(url, data={"name": "Alice"}, follow=False)
         assert resp.status_code == 302
         assert len(capture_action_dispatched) == 1
         event = capture_action_dispatched[0]
@@ -480,9 +458,7 @@ class TestActionDispatchedWiring:
         assert event["request"].method == "POST"
 
     def test_payload_includes_url_kwargs_from_resolved_origin(
-        self,
-        client_no_csrf,
-        capture_action_dispatched: list[dict[str, Any]],
+        self, client_no_csrf, capture_action_dispatched: list[dict[str, Any]]
     ) -> None:
         """The resolved origin's typed URL kwargs surface as `url_kwargs`."""
         url = form_action_manager.get_action_url("test_no_form")
@@ -491,19 +467,12 @@ class TestActionDispatchedWiring:
         assert capture_action_dispatched[0]["url_kwargs"] == {"id": 42}
 
     def test_does_not_fire_on_invalid_form(
-        self,
-        client_no_csrf,
-        capture_action_dispatched: list[dict[str, Any]],
+        self, client_no_csrf, capture_action_dispatched: list[dict[str, Any]]
     ) -> None:
         """An invalid form never reaches the handler, so no dispatched signal."""
         url = form_action_manager.get_action_url("simple_form")
         client_no_csrf.post(
-            url,
-            data={
-                "name": "",
-                "_next_form_origin": "/",
-            },
-            follow=False,
+            url, data={"name": "", "_next_form_origin": "/"}, follow=False
         )
         assert capture_action_dispatched == []
 
@@ -513,19 +482,12 @@ class TestFormValidationFailedWiring:
     """``form_validation_failed`` fires when validation fails during dispatch."""
 
     def test_fires_on_invalid_form_with_error_payload(
-        self,
-        client_no_csrf,
-        capture_form_validation_failed: list[dict[str, Any]],
+        self, client_no_csrf, capture_form_validation_failed: list[dict[str, Any]]
     ) -> None:
         """An invalid POST fires the signal with action_name, errors, fields."""
         url = form_action_manager.get_action_url("simple_form")
         resp = client_no_csrf.post(
-            url,
-            data={
-                "name": "",
-                "_next_form_origin": "/",
-            },
-            follow=False,
+            url, data={"name": "", "_next_form_origin": "/"}, follow=False
         )
         assert resp.status_code == 200
         assert len(capture_form_validation_failed) == 1
@@ -556,9 +518,7 @@ class TestWizardSignalsWiring:
     """Wizard signals fire as steps validate and the wizard finalises."""
 
     def test_step_submitted_fires_per_valid_step(
-        self,
-        client_no_csrf,
-        capture_wizard_step_submitted: list[dict[str, Any]],
+        self, client_no_csrf, capture_wizard_step_submitted: list[dict[str, Any]]
     ) -> None:
         """`wizard_step_submitted` fires once per valid step with its cleaned data."""
         _post_wizard_step(client_no_csrf, "identity", {"name": "Ada"})
@@ -575,9 +535,7 @@ class TestWizardSignalsWiring:
         assert capture_wizard_step_submitted[1]["step"] == "scope"
 
     def test_completed_fires_once_with_merged_data(
-        self,
-        client_no_csrf,
-        capture_wizard_completed: list[dict[str, Any]],
+        self, client_no_csrf, capture_wizard_completed: list[dict[str, Any]]
     ) -> None:
         """`wizard_completed` fires once after the last step's done with merged data."""
         _post_wizard_step(client_no_csrf, "identity", {"name": "Ada"})
@@ -593,9 +551,7 @@ class TestWizardSignalsWiring:
         assert event["request"].method == "POST"
 
     def test_action_dispatched_fires_per_step(
-        self,
-        client_no_csrf,
-        capture_action_dispatched: list[dict[str, Any]],
+        self, client_no_csrf, capture_action_dispatched: list[dict[str, Any]]
     ) -> None:
         """`action_dispatched` fires for each wizard step dispatch."""
         _post_wizard_step(client_no_csrf, "identity", {"name": "Ada"})
@@ -612,10 +568,10 @@ class TestWizardSignalsWiring:
         matched: list[dict[str, Any]] = []
         unmatched: list[dict[str, Any]] = []
 
-        def on_matched(sender: object, **kwargs: object) -> None:
+        def on_matched(sender: object, **kwargs) -> None:
             matched.append({"sender": sender, **kwargs})
 
-        def on_unmatched(sender: object, **kwargs: object) -> None:
+        def on_unmatched(sender: object, **kwargs) -> None:
             unmatched.append({"sender": sender, **kwargs})
 
         wizard_step_submitted.connect(on_matched, sender=SignalWizard)

--- a/tests/forms/test_success.py
+++ b/tests/forms/test_success.py
@@ -341,7 +341,7 @@ class TestSuccessMessageViaClient:
     def test_message_precedes_action_dispatched(self, client_no_csrf) -> None:
         seen: list[list[str] | None] = []
 
-        def receiver(sender, request, **kwargs: object) -> None:
+        def receiver(sender, request, **kwargs) -> None:
             storage = getattr(request, "_messages", None)
             seen.append(
                 [m.message for m in storage._queued_messages]

--- a/tests/forms/test_wizard.py
+++ b/tests/forms/test_wizard.py
@@ -351,18 +351,14 @@ class TestWizardGoto:
     def test_goto_swaps_current_segment(self) -> None:
         """`goto` rewrites the current-step segment to the target step."""
         wizard = DemoWizard(
-            _request(),
-            url_kwargs={"step": "identity"},
-            base_path="/request/identity/",
+            _request(), url_kwargs={"step": "identity"}, base_path="/request/identity/"
         )
         assert wizard.goto("scope") == "/request/scope/"
 
     def test_goto_falls_back_when_current_absent_from_path(self) -> None:
         """`goto` rewrites the last segment when the current step is absent."""
         wizard = DemoWizard(
-            _request(),
-            url_kwargs={"step": "identity"},
-            base_path="/request/landing/",
+            _request(), url_kwargs={"step": "identity"}, base_path="/request/landing/"
         )
         assert wizard.goto("scope") == "/request/scope/"
 

--- a/tests/forms/urls_i18n.py
+++ b/tests/forms/urls_i18n.py
@@ -13,5 +13,5 @@ _localized_page.next_page_path = "/i18n/pages/page.py"
 
 
 urlpatterns = i18n_patterns(
-    path("docs/<slug:slug>/", _localized_page, name="localized_page"),
+    path("docs/<slug:slug>/", _localized_page, name="localized_page")
 )

--- a/tests/pages/conftest.py
+++ b/tests/pages/conftest.py
@@ -87,7 +87,7 @@ def capture_template_loaded() -> Generator[list[dict[str, Any]], None, None]:
     """Capture ``template_loaded`` signal events."""
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     template_loaded.connect(_listener)
@@ -102,7 +102,7 @@ def capture_context_registered() -> Generator[list[dict[str, Any]], None, None]:
     """Capture ``context_registered`` signal events."""
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     context_registered.connect(_listener)
@@ -117,7 +117,7 @@ def capture_page_rendered() -> Generator[list[dict[str, Any]], None, None]:
     """Capture ``page_rendered`` signal events."""
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     page_rendered.connect(_listener)

--- a/tests/pages/test_checks.py
+++ b/tests/pages/test_checks.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import override_settings
@@ -10,6 +10,7 @@ from next.checks import (
     check_context_functions,
     check_layout_templates,
     check_page_functions,
+    reset_check_caches,
 )
 from next.conf import next_framework_settings as s
 from next.pages.checks import check_context_processor_signature, check_template_loaders
@@ -17,6 +18,31 @@ from tests.support import (
     patch_checks_router_manager,
     patch_checks_router_manager_with_routers,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_check_caches():
+    reset_check_caches()
+    yield
+    reset_check_caches()
+
+
+class _AppRouter:
+    app_dirs = True
+    pages_dir = "pages"
+
+    def __init__(self, pages_path: Path, page_file: Path) -> None:
+        self._pages_path = pages_path
+        self._page_file = page_file
+
+    def _get_installed_apps(self) -> list[str]:
+        return ["app"]
+
+    def _get_app_pages_path(self, _app: str) -> Path:
+        return self._pages_path
+
+    def _scan_pages_directory(self, _pages_dir: object) -> list[tuple[str, Path]]:
+        return [("test", self._page_file)]
 
 
 class TestPageChecks:
@@ -222,6 +248,74 @@ class TestMissingPageContentChecks:
             warnings = [m for m in messages if m.id.startswith("next.W")]
             assert len(errors) == expected_errors
             assert len(warnings) == expected_warnings
+
+
+class TestMemoAndBrokenPages:
+    """Memo reuse and the unchanged E012 masking of broken `page.py` files."""
+
+    def test_broken_page_still_reports_e012(self, tmp_path) -> None:
+        """A syntactically invalid page.py keeps masking as E012, not a parse code."""
+        page_file = tmp_path / "page.py"
+        page_file.write_text("def render( invalid syntax {\n")
+        loaders_module._MODULE_MEMO.pop(page_file, None)
+
+        with patch_checks_router_manager_with_routers(
+            routers=[_AppRouter(tmp_path, page_file)],
+        ):
+            messages = check_page_functions(None)
+        e012 = [m for m in messages if m.id == "next.E012"]
+        assert len(e012) == 1
+
+    def test_valid_body_page_has_no_e012(self, tmp_path) -> None:
+        """A page.py with a real render body raises no E012."""
+        page_file = tmp_path / "page.py"
+        page_file.write_text('def render(request, **kwargs):\n    return "x"\n')
+        loaders_module._MODULE_MEMO.pop(page_file, None)
+
+        with patch_checks_router_manager_with_routers(
+            routers=[_AppRouter(tmp_path, page_file)],
+        ):
+            messages = check_page_functions(None)
+        e012 = [m for m in messages if m.id == "next.E012"]
+        assert e012 == []
+
+    def test_empty_page_still_reports_e012(self, tmp_path) -> None:
+        """A valid but bodyless page.py keeps the genuine no-body-source E012."""
+        page_file = tmp_path / "page.py"
+        page_file.write_text("")
+        loaders_module._MODULE_MEMO.pop(page_file, None)
+
+        with patch_checks_router_manager_with_routers(
+            routers=[_AppRouter(tmp_path, page_file)],
+        ):
+            messages = check_page_functions(None)
+        e012 = [m for m in messages if m.id == "next.E012"]
+        assert len(e012) == 1
+
+    def test_page_module_execed_once_across_checks(self, tmp_path, monkeypatch) -> None:
+        """Two check passes over one page.py exec the module at most once per mtime."""
+        page_file = tmp_path / "page.py"
+        page_file.write_text('template = "hi"\n')
+        loaders_module._MODULE_MEMO.pop(page_file, None)
+
+        real_load = loaders_module._load_python_module
+        calls: list[Path] = []
+
+        def counting(file_path: Path) -> object:
+            calls.append(file_path)
+            return real_load(file_path)
+
+        monkeypatch.setattr(loaders_module, "_load_python_module", counting)
+
+        router = _AppRouter(tmp_path, page_file)
+        with (
+            patch_checks_router_manager_with_routers(routers=[router]),
+            patch("next.checks.common.get_pages_directory", return_value=tmp_path),
+        ):
+            check_page_functions(None)
+            check_context_functions(None)
+
+        assert calls.count(page_file) == 1
 
 
 class TestCheckTemplateLoaders:
@@ -460,6 +554,93 @@ def get_context_data():
         ):
             errors = check_context_functions(None)
             assert errors == []
+
+    def test_e029_on_page_context_attribute_form(self, tmp_path) -> None:
+        """E029 fires on the canonical `@page.context` keyless form."""
+        page_file = tmp_path / "page.py"
+        page_file.write_text("""
+from next.pages import page
+
+@page.context
+def get_context_data() -> str:
+    return {}
+        """)
+        loaders_module._MODULE_MEMO.pop(page_file, None)
+
+        with patch_checks_router_manager(
+            pages_directory=tmp_path,
+            scan_routes=[("test", page_file)],
+        ):
+            errors = check_context_functions(None)
+        assert len(errors) == 1
+        assert errors[0].id == "next.E029"
+
+    def test_e029_on_async_keyless_context(self, tmp_path) -> None:
+        """E029 fires on an `async def` keyless `@context` callable."""
+        page_file = tmp_path / "page.py"
+        page_file.write_text("""
+from next.pages import context
+
+@context
+async def get_context_data() -> str:
+    return {}
+        """)
+        loaders_module._MODULE_MEMO.pop(page_file, None)
+
+        with patch_checks_router_manager(
+            pages_directory=tmp_path,
+            scan_routes=[("test", page_file)],
+        ):
+            errors = check_context_functions(None)
+        assert len(errors) == 1
+        assert errors[0].id == "next.E029"
+
+    def test_e029_on_aliased_context_decorator(self, tmp_path) -> None:
+        """E029 fires when the decorator is imported under an alias."""
+        page_file = tmp_path / "page.py"
+        page_file.write_text("""
+from next.pages import context as ctx
+
+@ctx
+def get_context_data() -> str:
+    return {}
+        """)
+        loaders_module._MODULE_MEMO.pop(page_file, None)
+
+        with patch_checks_router_manager(
+            pages_directory=tmp_path,
+            scan_routes=[("test", page_file)],
+        ):
+            errors = check_context_functions(None)
+        assert len(errors) == 1
+        assert errors[0].id == "next.E029"
+
+    def test_e029_clears_after_context_decorator_removed(self, tmp_path) -> None:
+        """Removing the keyless `@context` stops E029 once caches are reset."""
+        page_file = tmp_path / "page.py"
+        page_file.write_text("""
+from next.pages import page
+
+@page.context
+def get_context_data() -> str:
+    return {}
+        """)
+        loaders_module._MODULE_MEMO.pop(page_file, None)
+
+        with patch_checks_router_manager(
+            pages_directory=tmp_path,
+            scan_routes=[("test", page_file)],
+        ):
+            first = check_context_functions(None)
+            assert [error.id for error in first] == ["next.E029"]
+
+            page_file.write_text("""
+def get_context_data():
+    return {}
+            """)
+            reset_check_caches()
+            second = check_context_functions(None)
+        assert second == []
 
     def test_check_context_functions_with_key_not_checked(self, tmp_path) -> None:
         """Test check_context_functions ignores functions with key."""

--- a/tests/pages/test_checks.py
+++ b/tests/pages/test_checks.py
@@ -10,6 +10,8 @@ from next.checks import (
     check_context_functions,
     check_layout_templates,
     check_page_functions,
+    check_page_module_imports,
+    check_single_keyless_context,
     reset_check_caches,
 )
 from next.conf import next_framework_settings as s
@@ -74,12 +76,7 @@ def render(request, **kwargs):
         ],
     )
     def test_has_template_or_djx(
-        self,
-        tmp_path,
-        page_content,
-        create_djx,
-        djx_content,
-        expected_result,
+        self, tmp_path, page_content, create_djx, djx_content, expected_result
     ) -> None:
         """Test _has_template_or_djx with different scenarios."""
         page_file = tmp_path / "page.py"
@@ -99,11 +96,7 @@ class TestLayoutChecks:
     @pytest.mark.parametrize(
         ("layout_body", "expected_warnings", "msg_substring"),
         [
-            (
-                "<html>{% block template %}{% endblock template %}</html>",
-                0,
-                None,
-            ),
+            ("<html>{% block template %}{% endblock template %}</html>", 0, None),
             (
                 "<html><body>No template block</body></html>",
                 1,
@@ -113,11 +106,7 @@ class TestLayoutChecks:
         ids=["with_block", "without_block"],
     )
     def test_check_layout_templates_scenarios(
-        self,
-        tmp_path,
-        layout_body,
-        expected_warnings,
-        msg_substring,
+        self, tmp_path, layout_body, expected_warnings, msg_substring
     ) -> None:
         """Layout.djx with or without required ``{% block template %}``."""
         (tmp_path / "layout.djx").write_text(layout_body)
@@ -125,8 +114,7 @@ class TestLayoutChecks:
         page_file.write_text("")
 
         with patch_checks_router_manager(
-            pages_directory=tmp_path,
-            scan_routes=[("test", page_file)],
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
         ):
             warnings = check_layout_templates(None)
         assert len(warnings) == expected_warnings
@@ -169,16 +157,7 @@ class TestMissingPageContentChecks:
                 0,
                 0,
             ),
-            (
-                "with_template_djx",
-                "",
-                True,
-                "<h1>Hello World</h1>",
-                False,
-                None,
-                0,
-                0,
-            ),
+            ("with_template_djx", "", True, "<h1>Hello World</h1>", False, None, 0, 0),
             (
                 "with_layout_djx",
                 "",
@@ -189,16 +168,7 @@ class TestMissingPageContentChecks:
                 0,
                 0,
             ),
-            (
-                "no_content",
-                "",
-                False,
-                None,
-                False,
-                None,
-                1,
-                0,
-            ),
+            ("no_content", "", False, None, False, None, 1, 0),
         ],
         ids=[
             "with_template",
@@ -260,7 +230,7 @@ class TestMemoAndBrokenPages:
         loaders_module._MODULE_MEMO.pop(page_file, None)
 
         with patch_checks_router_manager_with_routers(
-            routers=[_AppRouter(tmp_path, page_file)],
+            routers=[_AppRouter(tmp_path, page_file)]
         ):
             messages = check_page_functions(None)
         e012 = [m for m in messages if m.id == "next.E012"]
@@ -273,7 +243,7 @@ class TestMemoAndBrokenPages:
         loaders_module._MODULE_MEMO.pop(page_file, None)
 
         with patch_checks_router_manager_with_routers(
-            routers=[_AppRouter(tmp_path, page_file)],
+            routers=[_AppRouter(tmp_path, page_file)]
         ):
             messages = check_page_functions(None)
         e012 = [m for m in messages if m.id == "next.E012"]
@@ -286,7 +256,7 @@ class TestMemoAndBrokenPages:
         loaders_module._MODULE_MEMO.pop(page_file, None)
 
         with patch_checks_router_manager_with_routers(
-            routers=[_AppRouter(tmp_path, page_file)],
+            routers=[_AppRouter(tmp_path, page_file)]
         ):
             messages = check_page_functions(None)
         e012 = [m for m in messages if m.id == "next.E012"]
@@ -331,9 +301,7 @@ class TestCheckTemplateLoaders:
         loaders_module._REGISTERED_LOADERS_CACHE["value"] = None
 
     @override_settings(
-        NEXT_FRAMEWORK={
-            "TEMPLATE_LOADERS": ["next.pages.loaders.DjxTemplateLoader"],
-        }
+        NEXT_FRAMEWORK={"TEMPLATE_LOADERS": ["next.pages.loaders.DjxTemplateLoader"]}
     )
     def test_valid_default_is_clean(self) -> None:
 
@@ -427,22 +395,8 @@ class TestBodySourceConflicts:
                 None,
                 None,
             ),
-            (
-                "only_template_attr",
-                'template = "x"',
-                False,
-                0,
-                None,
-                None,
-            ),
-            (
-                "only_template_djx",
-                "",
-                True,
-                0,
-                None,
-                None,
-            ),
+            ("only_template_attr", 'template = "x"', False, 0, None, None),
+            ("only_template_djx", "", True, 0, None, None),
         ],
         ids=[
             "render_and_template_djx",
@@ -505,12 +459,11 @@ def get_context_data():
         """)
 
         with patch_checks_router_manager(
-            pages_directory=tmp_path,
-            scan_routes=[("test", page_file)],
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
         ) as (_mock_mgr, mock_router, _):
             mock_context_manager = MagicMock()
             mock_context_manager._context_registry = {
-                page_file: {None: (lambda: {"key": "value"}, False)},
+                page_file: {None: (lambda: {"key": "value"}, False)}
             }
             mock_router._context_manager = mock_context_manager
 
@@ -529,8 +482,7 @@ def get_context_data() -> str:
         """)
 
         with patch_checks_router_manager(
-            pages_directory=tmp_path,
-            scan_routes=[("test", page_file)],
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
         ):
             errors = check_context_functions(None)
             assert len(errors) == 1
@@ -549,8 +501,7 @@ def get_context_data():
         """)
 
         with patch_checks_router_manager(
-            pages_directory=tmp_path,
-            scan_routes=[("test", page_file)],
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
         ):
             errors = check_context_functions(None)
             assert errors == []
@@ -568,8 +519,7 @@ def get_context_data() -> str:
         loaders_module._MODULE_MEMO.pop(page_file, None)
 
         with patch_checks_router_manager(
-            pages_directory=tmp_path,
-            scan_routes=[("test", page_file)],
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
         ):
             errors = check_context_functions(None)
         assert len(errors) == 1
@@ -588,8 +538,7 @@ async def get_context_data() -> str:
         loaders_module._MODULE_MEMO.pop(page_file, None)
 
         with patch_checks_router_manager(
-            pages_directory=tmp_path,
-            scan_routes=[("test", page_file)],
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
         ):
             errors = check_context_functions(None)
         assert len(errors) == 1
@@ -608,8 +557,7 @@ def get_context_data() -> str:
         loaders_module._MODULE_MEMO.pop(page_file, None)
 
         with patch_checks_router_manager(
-            pages_directory=tmp_path,
-            scan_routes=[("test", page_file)],
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
         ):
             errors = check_context_functions(None)
         assert len(errors) == 1
@@ -628,8 +576,7 @@ def get_context_data() -> str:
         loaders_module._MODULE_MEMO.pop(page_file, None)
 
         with patch_checks_router_manager(
-            pages_directory=tmp_path,
-            scan_routes=[("test", page_file)],
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
         ):
             first = check_context_functions(None)
             assert [error.id for error in first] == ["next.E029"]
@@ -654,12 +601,11 @@ def get_context_data():
         """)
 
         with patch_checks_router_manager(
-            pages_directory=tmp_path,
-            scan_routes=[("test", page_file)],
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
         ) as (_mock_mgr, mock_router, _):
             mock_context_manager = MagicMock()
             mock_context_manager._context_registry = {
-                page_file: {"my_key": (lambda: "not a dict but with key", False)},
+                page_file: {"my_key": (lambda: "not a dict but with key", False)}
             }
             mock_router._context_manager = mock_context_manager
 
@@ -692,11 +638,11 @@ class TestContextProcessorSignature:
                     "PAGES_DIR": "pages",
                     "OPTIONS": {
                         "context_processors": [
-                            "tests.pages.test_checks._processor_with_request",
-                        ],
+                            "tests.pages.test_checks._processor_with_request"
+                        ]
                     },
-                },
-            ],
+                }
+            ]
         }
     )
     def test_processor_with_request_is_accepted(self) -> None:
@@ -713,11 +659,11 @@ class TestContextProcessorSignature:
                     "PAGES_DIR": "pages",
                     "OPTIONS": {
                         "context_processors": [
-                            "tests.pages.test_checks._processor_without_request",
-                        ],
+                            "tests.pages.test_checks._processor_without_request"
+                        ]
                     },
-                },
-            ],
+                }
+            ]
         }
     )
     def test_processor_without_request_triggers_error(self) -> None:
@@ -736,11 +682,11 @@ class TestContextProcessorSignature:
                     "PAGES_DIR": "pages",
                     "OPTIONS": {
                         "context_processors": [
-                            "tests.pages.nonexistent.missing_processor",
-                        ],
+                            "tests.pages.nonexistent.missing_processor"
+                        ]
                     },
-                },
-            ],
+                }
+            ]
         }
     )
     def test_unresolvable_processor_is_silently_skipped(self) -> None:
@@ -757,11 +703,11 @@ class TestContextProcessorSignature:
                     "PAGES_DIR": "pages",
                     "OPTIONS": {
                         "context_processors": [
-                            123,  # non-string entry
-                        ],
+                            123  # non-string entry
+                        ]
                     },
-                },
-            ],
+                }
+            ]
         }
     )
     def test_non_string_processor_entries_are_skipped(self) -> None:
@@ -784,9 +730,130 @@ class TestContextProcessorSignature:
                     "PAGES_DIR": "pages",
                     "OPTIONS": {},
                 },
-            ],
+            ]
         }
     )
     def test_non_dict_backend_entries_are_skipped(self) -> None:
         errors = check_context_processor_signature()
         assert errors == []
+
+
+class _RootPageRouter:
+    app_dirs = False
+    pages_dir = "pages"
+
+    def __init__(self, pages_path: Path, page_file: Path) -> None:
+        self._pages_path = pages_path
+        self._page_file = page_file
+
+    def _get_root_pages_paths(self) -> list[Path]:
+        return [self._pages_path]
+
+    def _scan_pages_directory(self, _pages_dir: object) -> list[tuple[str, Path]]:
+        return [("test", self._page_file)]
+
+
+class TestPageModuleImports:
+    """next.E017 flags a page.py that raises while importing."""
+
+    def test_broken_page_reports_e017(self, tmp_path) -> None:
+        page_file = tmp_path / "page.py"
+        page_file.write_text("def render( invalid syntax {\n")
+        with patch_checks_router_manager(
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
+        ):
+            messages = check_page_module_imports(None)
+        assert [m.id for m in messages] == ["next.E017"]
+
+    def test_valid_page_reports_no_e017(self, tmp_path) -> None:
+        page_file = tmp_path / "page.py"
+        page_file.write_text('template = "ok"\n')
+        with patch_checks_router_manager(
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
+        ):
+            messages = check_page_module_imports(None)
+        assert messages == []
+
+    def test_virtual_page_without_file_is_skipped(self, tmp_path) -> None:
+        missing = tmp_path / "virtual" / "page.py"
+        with patch_checks_router_manager(
+            pages_directory=tmp_path, scan_routes=[("virtual", missing)]
+        ):
+            messages = check_page_module_imports(None)
+        assert messages == []
+
+    def test_broken_page_beside_template_djx_is_caught_by_e017_not_e012(
+        self, tmp_path
+    ) -> None:
+        page_file = tmp_path / "page.py"
+        page_file.write_text("def render( invalid syntax {\n")
+        (tmp_path / "template.djx").write_text("<p>ok</p>\n")
+
+        with patch_checks_router_manager_with_routers(
+            routers=[_AppRouter(tmp_path, page_file)]
+        ):
+            body = check_page_functions(None)
+        assert [m for m in body if m.id == "next.E012"] == []
+
+        with patch_checks_router_manager(
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
+        ):
+            imports = check_page_module_imports(None)
+        assert [m.id for m in imports] == ["next.E017"]
+
+
+class TestSingleKeylessContext:
+    """next.E018 flags a page.py with more than one keyless @context."""
+
+    def test_two_keyless_contexts_report_e018(self, tmp_path) -> None:
+        page_file = tmp_path / "page.py"
+        page_file.write_text(
+            "from next.pages import page\n\n"
+            "@page.context\n"
+            "def first() -> dict:\n"
+            "    return {}\n\n"
+            "@page.context\n"
+            "def second() -> dict:\n"
+            "    return {}\n"
+        )
+        with patch_checks_router_manager(
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
+        ):
+            messages = check_single_keyless_context(None)
+        assert [m.id for m in messages] == ["next.E018"]
+        assert "first" in messages[0].msg
+        assert "second" in messages[0].msg
+
+    def test_single_keyless_context_reports_nothing(self, tmp_path) -> None:
+        page_file = tmp_path / "page.py"
+        page_file.write_text(
+            "from next.pages import page\n\n"
+            "@page.context\n"
+            "def only() -> dict:\n"
+            "    return {}\n"
+        )
+        with patch_checks_router_manager(
+            pages_directory=tmp_path, scan_routes=[("test", page_file)]
+        ):
+            messages = check_single_keyless_context(None)
+        assert messages == []
+
+
+class TestContextChecksDeduplicate:
+    """Checks report a page surfaced by several routers once, not per router."""
+
+    def test_e029_reported_once_across_routers(self, tmp_path) -> None:
+        page_file = tmp_path / "page.py"
+        page_file.write_text(
+            "from next.pages import page\n\n"
+            "@page.context\n"
+            "def bad() -> str:\n"
+            "    return {}\n"
+        )
+        routers = [
+            _RootPageRouter(tmp_path, page_file),
+            _RootPageRouter(tmp_path, page_file),
+        ]
+        with patch_checks_router_manager_with_routers(routers=routers):
+            messages = check_context_functions(None)
+        assert [m.id for m in messages] == ["next.E029"]

--- a/tests/pages/test_loaders.py
+++ b/tests/pages/test_loaders.py
@@ -17,10 +17,7 @@ from next.pages.loaders import (
     build_registered_loaders,
 )
 from next.pages.processors import _get_context_processors, _import_context_processor
-from tests.support import (
-    default_page_router_config,
-    file_router_config_entry,
-)
+from tests.support import default_page_router_config, file_router_config_entry
 
 
 class TestPythonTemplateLoader:
@@ -186,9 +183,7 @@ class TestDjxTemplateLoader:
                 page_instance.register_template(page_file, template_content)
 
         result = page_instance.render(
-            page_file,
-            title="Items",
-            items=["Apple", "Banana"],
+            page_file, title="Items", items=["Apple", "Banana"]
         )
 
         assert "Items" in result
@@ -223,7 +218,7 @@ def get_landing_data(*args, **kwargs):
         page_instance._context_manager.register_context(
             page_file,
             "landing",
-            lambda *_args, **_kwargs: {
+            lambda *args, **kwargs: {
                 "title": "Test Title",
                 "description": "Test Description",
             },
@@ -249,11 +244,7 @@ class TestLayoutTemplateLoader:
         ids=["layout_and_template", "template_only", "layout_only", "neither"],
     )
     def test_can_load_with_layout_files(
-        self,
-        tmp_path,
-        create_layout,
-        create_template,
-        expected_can_load,
+        self, tmp_path, create_layout, create_template, expected_can_load
     ) -> None:
         """Test can_load with different layout and template combinations."""
         loader = LayoutTemplateLoader()
@@ -264,7 +255,7 @@ class TestLayoutTemplateLoader:
         if create_layout:
             layout_file = tmp_path / "layout.djx"
             layout_file.write_text(
-                "<html><body>{% block template %}{% endblock template %}</body></html>",
+                "<html><body>{% block template %}{% endblock template %}</body></html>"
             )
 
         if create_template:
@@ -284,7 +275,7 @@ class TestLayoutTemplateLoader:
         layout_file.write_text("layout content")
 
         with override_settings(
-            NEXT_FRAMEWORK={"PAGE_BACKENDS": default_page_router_config(tmp_path)},
+            NEXT_FRAMEWORK={"PAGE_BACKENDS": default_page_router_config(tmp_path)}
         ):
             next_framework_settings.reload()
             result = loader._get_additional_layout_files()
@@ -297,8 +288,7 @@ class TestLayoutTemplateLoader:
         loader = LayoutTemplateLoader()
 
         mock_nf = SimpleNamespace(
-            PAGE_BACKENDS="not-a-list",
-            URL_NAME_TEMPLATE="page_{name}",
+            PAGE_BACKENDS="not-a-list", URL_NAME_TEMPLATE="page_{name}"
         )
         with patch("next.pages.loaders.next_framework_settings", mock_nf):
             assert loader._get_additional_layout_files() == []
@@ -314,20 +304,12 @@ class TestLayoutTemplateLoader:
                 ],
                 [],
             ),
-            (
-                "app_dirs_true",
-                [file_router_config_entry(app_dirs=True)],
-                [],
-            ),
+            ("app_dirs_true", [file_router_config_entry(app_dirs=True)], []),
         ],
         ids=["invalid_config", "app_dirs_true"],
     )
     def test_get_additional_layout_files_scenarios(
-        self,
-        tmp_path,
-        test_case,
-        config,
-        expected_result,
+        self, tmp_path, test_case, config, expected_result
     ) -> None:
         """Test _get_additional_layout_files with different configuration scenarios."""
         loader = LayoutTemplateLoader()
@@ -346,25 +328,13 @@ class TestLayoutTemplateLoader:
                 file_router_config_entry(pages_dir="test_dir"),
                 ["test_dir"],
             ),
-            (
-                "with_app_dirs",
-                file_router_config_entry(app_dirs=True),
-                [],
-            ),
-            (
-                "no_options",
-                file_router_config_entry(),
-                [],
-            ),
+            ("with_app_dirs", file_router_config_entry(app_dirs=True), []),
+            ("no_options", file_router_config_entry(), []),
         ],
         ids=["with_pages_dir", "with_app_dirs", "no_options"],
     )
     def test_get_pages_dirs_for_config_scenarios(
-        self,
-        tmp_path,
-        test_case,
-        config,
-        expected_list,
+        self, tmp_path, test_case, config, expected_list
     ) -> None:
         """Test _get_pages_dirs_for_config with different configuration scenarios."""
         loader = LayoutTemplateLoader()
@@ -471,7 +441,7 @@ class TestLayoutTemplateLoader:
         page_file = tmp_path / "page.py"
 
         with override_settings(
-            NEXT_FRAMEWORK={"PAGE_BACKENDS": default_page_router_config(tmp_path)},
+            NEXT_FRAMEWORK={"PAGE_BACKENDS": default_page_router_config(tmp_path)}
         ):
             next_framework_settings.reload()
             result = loader._find_layout_files(page_file)
@@ -517,7 +487,7 @@ class TestLayoutTemplateLoader:
         page_file = child_dir / "page.py"
 
         with override_settings(
-            NEXT_FRAMEWORK={"PAGE_BACKENDS": default_page_router_config(parent_dir)},
+            NEXT_FRAMEWORK={"PAGE_BACKENDS": default_page_router_config(parent_dir)}
         ):
             next_framework_settings.reload()
             result = loader._find_layout_files(page_file)
@@ -546,9 +516,7 @@ class TestLayoutTemplateLoader:
         additional_layout.write_text("additional layout")
 
         with override_settings(
-            NEXT_FRAMEWORK={
-                "PAGE_BACKENDS": default_page_router_config(additional_dir),
-            },
+            NEXT_FRAMEWORK={"PAGE_BACKENDS": default_page_router_config(additional_dir)}
         ):
             next_framework_settings.reload()
             result = loader._find_layout_files(page_file)
@@ -589,14 +557,14 @@ class TestLayoutTemplateLoader:
 
         root_layout = tmp_path / "layout.djx"
         root_layout.write_text(
-            "<html><head><title>Root</title></head><body>{% block template %}{% endblock template %}</body></html>",
+            "<html><head><title>Root</title></head><body>{% block template %}{% endblock template %}</body></html>"
         )
 
         sub_dir = tmp_path / "sub"
         sub_dir.mkdir()
         sub_layout = sub_dir / "layout.djx"
         sub_layout.write_text(
-            "<div class='sub-layout'>{% block template %}{% endblock template %}</div>",
+            "<div class='sub-layout'>{% block template %}{% endblock template %}</div>"
         )
 
         nested_dir = sub_dir / "nested"
@@ -620,7 +588,7 @@ class TestLayoutTemplateLoader:
 
         layout_file = tmp_path / "layout.djx"
         layout_file.write_text(
-            "<html><body>{% block template %}{% endblock template %}</body></html>",
+            "<html><body>{% block template %}{% endblock template %}</body></html>"
         )
 
         page_file = tmp_path / "page.py"
@@ -637,7 +605,7 @@ class TestLayoutTemplateLoader:
         loader = LayoutTemplateLoader()
         layout_file = tmp_path / "layout.djx"
         layout_file.write_text(
-            "<html><body>{% block template %}{% endblock %}</body></html>",
+            "<html><body>{% block template %}{% endblock %}</body></html>"
         )
         page_file = tmp_path / "page.py"
         result = loader.load_template(page_file)
@@ -698,10 +666,7 @@ class TestContextProcessors:
 
     def test_get_context_processors_empty_config(self, page_instance) -> None:
         """Test _get_context_processors with empty ``ROUTERS`` list."""
-        with override_settings(
-            NEXT_FRAMEWORK={"PAGE_BACKENDS": []},
-            TEMPLATES=[],
-        ):
+        with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": []}, TEMPLATES=[]):
             next_framework_settings.reload()
             processors = _get_context_processors()
             assert processors == []
@@ -719,10 +684,7 @@ class TestContextProcessors:
     def test_get_context_processors_no_context_processors(self, page_instance) -> None:
         """Test _get_context_processors with routers but no context_processors."""
         config = [file_router_config_entry(app_dirs=True)]
-        with override_settings(
-            NEXT_FRAMEWORK={"PAGE_BACKENDS": config},
-            TEMPLATES=[],
-        ):
+        with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": config}, TEMPLATES=[]):
             next_framework_settings.reload()
             processors = _get_context_processors()
             assert processors == []
@@ -745,9 +707,9 @@ class TestContextProcessors:
                     "context_processors": [
                         "test_app.context_processors.test_processor",
                         "test_app.context_processors.auth_processor",
-                    ],
+                    ]
                 },
-            },
+            }
         ]
 
         next_pages_config = [file_router_config_entry(app_dirs=True)]
@@ -781,20 +743,20 @@ class TestContextProcessors:
                 "BACKEND": "django.template.backends.django.DjangoTemplates",
                 "OPTIONS": {
                     "context_processors": [
-                        "test_app.context_processors.template_processor",
-                    ],
+                        "test_app.context_processors.template_processor"
+                    ]
                 },
-            },
+            }
         ]
         next_pages_config = [
             file_router_config_entry(
                 app_dirs=True,
                 options={
                     "context_processors": [
-                        "test_app.context_processors.next_pages_processor",
-                    ],
+                        "test_app.context_processors.next_pages_processor"
+                    ]
                 },
-            ),
+            )
         ]
 
         with patch("next.pages.processors.import_string") as mock_import:
@@ -820,13 +782,12 @@ class TestContextProcessors:
             {
                 "BACKEND": "django.template.backends.django.DjangoTemplates",
                 "OPTIONS": {"context_processors": [shared_path]},
-            },
+            }
         ]
         next_pages_config = [
             file_router_config_entry(
-                app_dirs=True,
-                options={"context_processors": [shared_path]},
-            ),
+                app_dirs=True, options={"context_processors": [shared_path]}
+            )
         ]
         with (
             patch("next.pages.processors.import_string", return_value=shared_processor),
@@ -844,10 +805,7 @@ class TestContextProcessors:
         self, page_instance
     ) -> None:
         """With empty TEMPLATES and no router processors, result is empty."""
-        with override_settings(
-            TEMPLATES=[],
-            NEXT_FRAMEWORK={"PAGE_BACKENDS": []},
-        ):
+        with override_settings(TEMPLATES=[], NEXT_FRAMEWORK={"PAGE_BACKENDS": []}):
             next_framework_settings.reload()
             result = _get_context_processors()
             assert result == []
@@ -861,8 +819,7 @@ class TestContextProcessors:
             }
         ]
         with override_settings(
-            TEMPLATES=templates_config,
-            NEXT_FRAMEWORK={"PAGE_BACKENDS": []},
+            TEMPLATES=templates_config, NEXT_FRAMEWORK={"PAGE_BACKENDS": []}
         ):
             next_framework_settings.reload()
             result = _get_context_processors()
@@ -887,14 +844,13 @@ class TestContextProcessors:
                         "context_processors": [
                             "test_app.context_processors.test_processor",
                             "test_app.context_processors.another_processor",
-                        ],
+                        ]
                     },
-                ),
+                )
             ]
 
             with override_settings(
-                NEXT_FRAMEWORK={"PAGE_BACKENDS": config},
-                TEMPLATES=[],
+                NEXT_FRAMEWORK={"PAGE_BACKENDS": config}, TEMPLATES=[]
             ):
                 next_framework_settings.reload()
                 processors = _get_context_processors()
@@ -911,9 +867,9 @@ class TestContextProcessors:
                     "context_processors": [
                         "invalid.module.path",
                         "django.template.context_processors.request",
-                    ],
+                    ]
                 },
-            ),
+            )
         ]
 
         with (
@@ -1015,11 +971,7 @@ class TestContextProcessors:
             ),
             patch("next.pages.manager.logger") as mock_logger,
         ):
-            result = page_instance.render(
-                page_file,
-                mock_request,
-                title="Test Title",
-            )
+            result = page_instance.render(page_file, mock_request, title="Test Title")
 
             assert "Test Title" in result
             assert "good_value" in result
@@ -1050,9 +1002,7 @@ class TestContextProcessors:
             page_instance.render(page_file, mock_request, title="Test Title")
 
     def test_render_with_context_processor_non_dict_return(
-        self,
-        page_instance,
-        tmp_path,
+        self, page_instance, tmp_path
     ) -> None:
         """Test render method with context processor that returns non-dict."""
         page_file = tmp_path / "page.py"
@@ -1133,7 +1083,7 @@ class TestBuildRegisteredLoaders:
             "TEMPLATE_LOADERS": [
                 "next.pages.loaders.DjxTemplateLoader",
                 "next.pages.loaders.PythonTemplateLoader",
-            ],
+            ]
         }
     )
     def test_user_list_replaces_default(self) -> None:
@@ -1152,7 +1102,7 @@ class TestBuildRegisteredLoaders:
                 "does.not.exist.Loader",
                 "next.pages.loaders.LayoutManager",
                 "next.pages.loaders.DjxTemplateLoader",
-            ],
+            ]
         }
     )
     def test_invalid_entries_are_skipped(self) -> None:
@@ -1173,7 +1123,7 @@ class TestBuildRegisteredLoaders:
             "TEMPLATE_LOADERS": [
                 "next.pages.loaders.DjxTemplateLoader",
                 "next.pages.loaders.DjxTemplateLoader",
-            ],
+            ]
         }
     )
     def test_duplicate_entries_registered_once(self) -> None:

--- a/tests/pages/test_manager.py
+++ b/tests/pages/test_manager.py
@@ -91,10 +91,7 @@ class TestPage:
         assert entry.serialize is False
 
     def test_context_decorator_with_inherit_context(
-        self,
-        page_instance,
-        context_temp_file,
-        mock_frame,
+        self, page_instance, context_temp_file, mock_frame
     ) -> None:
         """Test context decorator with inherit_context=True."""
         mock_frame.return_value.f_back.f_globals = {"__file__": str(context_temp_file)}
@@ -117,14 +114,11 @@ class TestPage:
         assert entry.serialize is False
 
     def test_context_decorator_without_key_inherit_context(
-        self,
-        page_instance,
-        context_temp_file,
-        mock_frame,
+        self, page_instance, context_temp_file, mock_frame
     ) -> None:
         """Test context decorator without key but with inherit_context=True."""
         mock_frame.return_value.f_back.f_back.f_globals = {
-            "__file__": str(context_temp_file),
+            "__file__": str(context_temp_file)
         }
 
         @page_instance.context(inherit_context=True)
@@ -180,7 +174,7 @@ class TestPage:
             (
                 "template_override",
                 "Hello {{ name }}! Count: {{ count }}",
-                {None: lambda *_args, **_kwargs: {"name": "ContextName", "count": 5}},
+                {None: lambda *args, **kwargs: {"name": "ContextName", "count": 5}},
                 {"name": "OverrideName", "count": 20},
                 "Hello ContextName! Count: 5",
             ),
@@ -215,9 +209,7 @@ class TestPage:
         if context_setup:
             for key, func in context_setup.items():
                 page_instance._context_manager.register_context(
-                    test_file_path,
-                    key,
-                    func,
+                    test_file_path, key, func
                 )
 
         # render
@@ -232,9 +224,7 @@ class TestPage:
         template1 = "Page 1: {{ title }}"
         page_instance.register_template(file1, template1)
         page_instance._context_manager.register_context(
-            file1,
-            "title",
-            lambda: "First Page",
+            file1, "title", lambda: "First Page"
         )
 
         # second file
@@ -242,9 +232,7 @@ class TestPage:
         template2 = "Page 2: {{ title }}"
         page_instance.register_template(file2, template2)
         page_instance._context_manager.register_context(
-            file2,
-            "title",
-            lambda: "Second Page",
+            file2, "title", lambda: "Second Page"
         )
 
         # render both
@@ -261,7 +249,7 @@ class TestPage:
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
         layout_file.write_text(
-            "<html>{% block template %}{% endblock template %}</html>",
+            "<html>{% block template %}{% endblock template %}</html>"
         )
 
         page_file = layout_dir / "page.py"
@@ -281,10 +269,7 @@ class TestPage:
             return "inherited_value"
 
         page_instance._context_manager.register_context(
-            page_file,
-            "inherited_var",
-            layout_func,
-            inherit_context=True,
+            page_file, "inherited_var", layout_func, inherit_context=True
         )
 
         # render child page
@@ -301,7 +286,7 @@ class TestPage:
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
         layout_file.write_text(
-            "<html>{% block template %}{% endblock template %}</html>",
+            "<html>{% block template %}{% endblock template %}</html>"
         )
 
         page_file = layout_dir / "page.py"
@@ -321,10 +306,7 @@ class TestPage:
             return "layout_value"
 
         page_instance._context_manager.register_context(
-            page_file,
-            "var",
-            layout_func,
-            inherit_context=True,
+            page_file, "var", layout_func, inherit_context=True
         )
 
         # register context in child page.py (should override inherited)
@@ -332,10 +314,7 @@ class TestPage:
             return "child_value"
 
         page_instance._context_manager.register_context(
-            child_page_file,
-            "var",
-            child_func,
-            inherit_context=False,
+            child_page_file, "var", child_func, inherit_context=False
         )
 
         # render child page
@@ -350,9 +329,7 @@ class TestPage:
         """Test that context registry uses defaultdict-like behavior."""
         # register context function - should create the file entry
         page_instance._context_manager.register_context(
-            test_file_path,
-            "test_key",
-            lambda: "test_value",
+            test_file_path, "test_key", lambda: "test_value"
         )
 
         assert test_file_path in page_instance._context_manager._context_registry
@@ -671,17 +648,13 @@ class TestGlobalPageInstance:
             (
                 "no_file",
                 lambda mock_frame: setattr(
-                    mock_frame.return_value.f_back,
-                    "f_globals",
-                    {"__file__": None},
+                    mock_frame.return_value.f_back, "f_globals", {"__file__": None}
                 ),
             ),
             (
                 "exhausted_frames",
                 lambda mock_frame: setattr(
-                    mock_frame.return_value.f_back,
-                    "f_back",
-                    None,
+                    mock_frame.return_value.f_back, "f_back", None
                 ),
             ),
         ],
@@ -695,8 +668,7 @@ class TestGlobalPageInstance:
             frame_setup(mock_frame)
 
             with pytest.raises(
-                RuntimeError,
-                match="Could not determine caller file path",
+                RuntimeError, match="Could not determine caller file path"
             ):
                 page_instance._get_caller_path(1)
 
@@ -717,7 +689,7 @@ class TestLayoutManager:
         # create layout structure
         layout_file = tmp_path / "layout.djx"
         layout_file.write_text(
-            "<html><body>{% block template %}{% endblock template %}</body></html>",
+            "<html><body>{% block template %}{% endblock template %}</body></html>"
         )
 
         sub_dir = tmp_path / "sub"
@@ -751,7 +723,7 @@ class TestLayoutManager:
         # create layout structure
         layout_file = tmp_path / "layout.djx"
         layout_file.write_text(
-            "<html><body>{% block template %}{% endblock template %}</body></html>",
+            "<html><body>{% block template %}{% endblock template %}</body></html>"
         )
 
         sub_dir = tmp_path / "sub"
@@ -855,7 +827,7 @@ class TestLayoutIntegration:
         """Page.render wraps the sibling template.djx body through ancestor layouts."""
         layout_file = tmp_path / "layout.djx"
         layout_file.write_text(
-            "<html><body>{% block template %}{% endblock template %}</body></html>",
+            "<html><body>{% block template %}{% endblock template %}</body></html>"
         )
 
         sub_dir = tmp_path / "sub"
@@ -952,7 +924,7 @@ class TestUnifiedViewBodyResolution:
     ) -> None:
         """`template = "..."` flows through an ancestor `layout.djx`."""
         (tmp_path / "layout.djx").write_text(
-            "<html><body>{% block template %}{% endblock template %}</body></html>",
+            "<html><body>{% block template %}{% endblock template %}</body></html>"
         )
         page_dir = tmp_path / "sub"
         page_dir.mkdir()
@@ -972,7 +944,7 @@ class TestUnifiedViewBodyResolution:
     ) -> None:
         """`render()` returning a string flows through the ancestor layout."""
         (tmp_path / "layout.djx").write_text(
-            "<html><body>{% block template %}{% endblock template %}</body></html>",
+            "<html><body>{% block template %}{% endblock template %}</body></html>"
         )
         page_dir = tmp_path / "sub"
         page_dir.mkdir()
@@ -993,7 +965,7 @@ class TestUnifiedViewBodyResolution:
     ) -> None:
         """`render()` returning HttpResponse is returned verbatim, no layout."""
         (tmp_path / "layout.djx").write_text(
-            "<html><body>{% block template %}{% endblock template %}</body></html>",
+            "<html><body>{% block template %}{% endblock template %}</body></html>"
         )
         page_dir = tmp_path / "sub"
         page_dir.mkdir()
@@ -1016,7 +988,7 @@ class TestUnifiedViewBodyResolution:
     ) -> None:
         """`HttpResponseRedirect` (an HttpResponse subclass) is returned verbatim."""
         (tmp_path / "layout.djx").write_text(
-            "<html>{% block template %}{% endblock template %}</html>",
+            "<html>{% block template %}{% endblock template %}</html>"
         )
         page_dir = tmp_path / "sub"
         page_dir.mkdir()
@@ -1038,7 +1010,7 @@ class TestUnifiedViewBodyResolution:
     ) -> None:
         """`JsonResponse` (an HttpResponse subclass) is returned verbatim."""
         (tmp_path / "layout.djx").write_text(
-            "<html>{% block template %}{% endblock template %}</html>",
+            "<html>{% block template %}{% endblock template %}</html>"
         )
         page_dir = tmp_path / "sub"
         page_dir.mkdir()
@@ -1057,12 +1029,7 @@ class TestUnifiedViewBodyResolution:
 
     @pytest.mark.parametrize(
         "return_value",
-        [
-            "None",
-            "{'x': 1}",
-            "[1, 2]",
-            "42",
-        ],
+        ["None", "{'x': 1}", "[1, 2]", "42"],
         ids=["None", "dict", "list", "int"],
     )
     def test_render_returning_non_str_non_response_raises(
@@ -1127,7 +1094,7 @@ class TestUnifiedViewBodyResolution:
     ) -> None:
         """A page with no body source still renders the ancestor layout's shell."""
         (tmp_path / "layout.djx").write_text(
-            "<html><body>{% block template %}{% endblock template %}</body></html>",
+            "<html><body>{% block template %}{% endblock template %}</body></html>"
         )
         page_dir = tmp_path / "sub"
         page_dir.mkdir()
@@ -1160,7 +1127,7 @@ class TestLoadStaticBodyEdgeCases:
     ) -> None:
         """`has_template` short-circuits to True when an ancestor layout applies."""
         (tmp_path / "layout.djx").write_text(
-            "<main>{% block template %}{% endblock template %}</main>",
+            "<main>{% block template %}{% endblock template %}</main>"
         )
         sub = tmp_path / "sub"
         sub.mkdir()
@@ -1182,7 +1149,7 @@ class TestLayoutComposeBody:
     def test_ancestor_layout_wraps_body_in_block(self, tmp_path) -> None:
         """Without a sibling layout the body is wrapped in a `{% block template %}`."""
         (tmp_path / "layout.djx").write_text(
-            "<main>{% block template %}{% endblock template %}</main>",
+            "<main>{% block template %}{% endblock template %}</main>"
         )
         sub = tmp_path / "sub"
         sub.mkdir()
@@ -1197,7 +1164,7 @@ class TestLayoutComposeBody:
     def test_sibling_layout_substitutes_body_directly(self, tmp_path) -> None:
         """With a sibling layout the body replaces the placeholder verbatim."""
         (tmp_path / "layout.djx").write_text(
-            "<section>{% block template %}{% endblock template %}</section>",
+            "<section>{% block template %}{% endblock template %}</section>"
         )
         page_file = tmp_path / "page.py"
         loader = LayoutTemplateLoader()
@@ -1242,7 +1209,7 @@ class TestCustomTemplateLoaderIntegration:
     ) -> None:
         """A custom loader for `template.md` feeds `_load_static_body`."""
         (tmp_path / "layout.djx").write_text(
-            "<html>{% block template %}{% endblock template %}</html>",
+            "<html>{% block template %}{% endblock template %}</html>"
         )
         page_dir = tmp_path / "post"
         page_dir.mkdir()

--- a/tests/pages/test_registry.py
+++ b/tests/pages/test_registry.py
@@ -37,12 +37,7 @@ class TestPageContextRegistry:
         ids=["keyed", "dict_merge"],
     )
     def test_register_and_collect_context(
-        self,
-        context_manager,
-        test_file_path,
-        key,
-        func_return,
-        expected_result,
+        self, context_manager, test_file_path, key, func_return, expected_result
     ) -> None:
         """Test registering and collecting context with different key types."""
         context_manager.register_context(test_file_path, key, func_return)
@@ -50,11 +45,7 @@ class TestPageContextRegistry:
         assert test_file_path in context_manager._context_registry
         assert key in context_manager._context_registry[test_file_path]
         assert context_manager._context_registry[test_file_path][key] == (
-            PageContextEntry(
-                func=func_return,
-                inherit_context=False,
-                serialize=False,
-            )
+            PageContextEntry(func=func_return, inherit_context=False, serialize=False)
         )
 
         result = context_manager.collect_context(test_file_path)
@@ -91,9 +82,7 @@ class TestPageContextRegistry:
             test_file_path, "custom_context_var", lambda: "12345"
         )
 
-        def landing(
-            custom_context_var: str = Context(),
-        ) -> dict[str, str]:
+        def landing(custom_context_var: str = Context()) -> dict[str, str]:
             return {"title": "Landing", "custom_context_var": custom_context_var}
 
         context_manager.register_context(test_file_path, "landing", landing)
@@ -134,9 +123,7 @@ class TestPageContextRegistry:
         assert result.js_context == {}
 
     def test_register_context_with_inherit_context(
-        self,
-        context_manager,
-        test_file_path,
+        self, context_manager, test_file_path
     ) -> None:
         """Test registering context with inherit_context=True."""
 
@@ -144,10 +131,7 @@ class TestPageContextRegistry:
             return "inherited_value"
 
         context_manager.register_context(
-            test_file_path,
-            "inherited_key",
-            test_func,
-            inherit_context=True,
+            test_file_path, "inherited_key", test_func, inherit_context=True
         )
 
         assert test_file_path in context_manager._context_registry
@@ -163,7 +147,7 @@ class TestPageContextRegistry:
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
         layout_file.write_text(
-            "<html>{% block template %}{% endblock template %}</html>",
+            "<html>{% block template %}{% endblock template %}</html>"
         )
 
         page_file = layout_dir / "page.py"
@@ -177,10 +161,7 @@ class TestPageContextRegistry:
             return "layout_value"
 
         context_manager.register_context(
-            page_file,
-            "layout_var",
-            layout_func,
-            inherit_context=True,
+            page_file, "layout_var", layout_func, inherit_context=True
         )
 
         result = context_manager.collect_context(child_page_file)
@@ -214,7 +195,7 @@ class TestPageContextRegistry:
         root_dir.mkdir()
         root_layout = root_dir / "layout.djx"
         root_layout.write_text(
-            "<html>{% block template %}{% endblock template %}</html>",
+            "<html>{% block template %}{% endblock template %}</html>"
         )
         root_page = root_dir / "page.py"
         root_page.write_text("")
@@ -237,16 +218,10 @@ class TestPageContextRegistry:
             return "sub_value"
 
         context_manager.register_context(
-            root_page,
-            "root_var",
-            root_func,
-            inherit_context=True,
+            root_page, "root_var", root_func, inherit_context=True
         )
         context_manager.register_context(
-            sub_page,
-            "sub_var",
-            sub_func,
-            inherit_context=True,
+            sub_page, "sub_var", sub_func, inherit_context=True
         )
 
         result = context_manager.collect_context(child_page)
@@ -272,7 +247,7 @@ class TestPageContextRegistry:
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
         layout_file.write_text(
-            "<html>{% block template %}{% endblock template %}</html>",
+            "<html>{% block template %}{% endblock template %}</html>"
         )
 
         child_dir = layout_dir / "child"
@@ -305,10 +280,7 @@ class TestPageContextRegistry:
             return "section_value"
 
         context_manager.register_context(
-            section_page,
-            "section_var",
-            inheritable,
-            inherit_context=True,
+            section_page, "section_var", inheritable, inherit_context=True
         )
 
         result = context_manager.collect_context(child_page_file)
@@ -324,7 +296,7 @@ class TestPageContextRegistry:
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
         layout_file.write_text(
-            "<html>{% block template %}{% endblock template %}</html>",
+            "<html>{% block template %}{% endblock template %}</html>"
         )
 
         page_file = layout_dir / "page.py"
@@ -338,10 +310,7 @@ class TestPageContextRegistry:
             return "layout_value"
 
         context_manager.register_context(
-            page_file,
-            "layout_var",
-            layout_func,
-            inherit_context=False,
+            page_file, "layout_var", layout_func, inherit_context=False
         )
 
         result = context_manager.collect_context(child_page_file)
@@ -356,7 +325,7 @@ class TestPageContextRegistry:
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
         layout_file.write_text(
-            "<html>{% block template %}{% endblock template %}</html>",
+            "<html>{% block template %}{% endblock template %}</html>"
         )
 
         page_file = layout_dir / "page.py"
@@ -370,10 +339,7 @@ class TestPageContextRegistry:
             return {"inherited_key1": "value1", "inherited_key2": "value2"}
 
         context_manager.register_context(
-            page_file,
-            None,
-            layout_dict_func,
-            inherit_context=True,
+            page_file, None, layout_dict_func, inherit_context=True
         )
 
         result = context_manager.collect_context(child_page_file)
@@ -382,6 +348,81 @@ class TestPageContextRegistry:
         assert "inherited_key2" in result.context_data
         assert result.context_data["inherited_key1"] == "value1"
         assert result.context_data["inherited_key2"] == "value2"
+
+
+class TestKeylessConflicts:
+    """`_keyless_conflicts` records overwritten keyless callables for next.E018."""
+
+    def test_single_keyless_records_no_conflict(
+        self, context_manager, test_file_path
+    ) -> None:
+        def only() -> dict:
+            return {}
+
+        context_manager.register_context(test_file_path, None, only)
+        assert context_manager._keyless_conflicts == {}
+
+    def test_keyed_alongside_keyless_records_no_conflict(
+        self, context_manager, test_file_path
+    ) -> None:
+        def keyed() -> str:
+            return "x"
+
+        def keyless() -> dict:
+            return {}
+
+        context_manager.register_context(test_file_path, "k", keyed)
+        context_manager.register_context(test_file_path, None, keyless)
+        assert context_manager._keyless_conflicts == {}
+
+    def test_multiple_keyless_records_every_name_in_order(
+        self, context_manager, test_file_path
+    ) -> None:
+        def first() -> dict:
+            return {}
+
+        def second() -> dict:
+            return {}
+
+        def third() -> dict:
+            return {}
+
+        for func in (first, second, third):
+            context_manager.register_context(test_file_path, None, func)
+
+        assert context_manager._keyless_conflicts[test_file_path] == [
+            "first",
+            "second",
+            "third",
+        ]
+
+    def test_reregistering_same_keyless_name_is_no_conflict(
+        self, context_manager, test_file_path
+    ) -> None:
+        def get_context_data() -> dict:
+            return {}
+
+        context_manager.register_context(test_file_path, None, get_context_data)
+        context_manager.register_context(test_file_path, None, get_context_data)
+
+        assert context_manager._keyless_conflicts == {}
+
+    def test_reset_clears_keyless_conflicts(
+        self, context_manager, test_file_path
+    ) -> None:
+        def first() -> dict:
+            return {}
+
+        def second() -> dict:
+            return {}
+
+        context_manager.register_context(test_file_path, None, first)
+        context_manager.register_context(test_file_path, None, second)
+        assert context_manager._keyless_conflicts
+
+        context_manager.reset()
+        assert context_manager._keyless_conflicts == {}
+        assert context_manager._context_registry == {}
 
 
 class TestContextMarker:
@@ -461,10 +502,7 @@ class TestPageContextRegistrySerialize:
 
     @pytest.mark.parametrize("serialize", [True, False], ids=["serialized", "plain"])
     def test_keyed_serialize_flag_controls_js_context(
-        self,
-        registry,
-        tmp_path,
-        serialize,
+        self, registry, tmp_path, serialize
     ) -> None:
         """A keyed context function with serialize controls js_context inclusion."""
         path = tmp_path / "page.py"
@@ -474,10 +512,7 @@ class TestPageContextRegistrySerialize:
 
     @pytest.mark.parametrize("serialize", [True, False], ids=["serialized", "plain"])
     def test_dict_merge_serialize_flag_controls_js_context(
-        self,
-        registry,
-        tmp_path,
-        serialize,
+        self, registry, tmp_path, serialize
     ) -> None:
         """An unkeyed context function with serialize controls js_context inclusion."""
         path = tmp_path / "page.py"
@@ -585,11 +620,7 @@ class TestPageContextRegistrySerializerOverride:
         path = tmp_path / "page.py"
         marker = self._MarkerSerializer()
         registry.register_context(
-            path,
-            None,
-            lambda: {"a": 1, "b": 2},
-            serialize=True,
-            serializer=marker,
+            path, None, lambda: {"a": 1, "b": 2}, serialize=True, serializer=marker
         )
         result = registry.collect_context(path)
         assert result.js_context_serializers == {"a": marker, "b": marker}

--- a/tests/pages/test_urls.py
+++ b/tests/pages/test_urls.py
@@ -38,11 +38,7 @@ class TestURLPatternParser:
         ],
     )
     def test_parse_url_pattern_variations(
-        self,
-        url_parser,
-        url_pattern,
-        expected_pattern,
-        expected_params,
+        self, url_parser, url_pattern, expected_pattern, expected_params
     ) -> None:
         """Test parsing URL patterns with different variations."""
         pattern, params = url_parser.parse_url_pattern(url_pattern)
@@ -62,15 +58,12 @@ class TestURLPatternParser:
                     "post_slug",
                     "args",
                 ],
-            ),
+            )
         ],
         ids=["complex_pattern"],
     )
     def test_parse_url_pattern_complex(
-        self,
-        url_parser,
-        url_pattern,
-        expected_contains,
+        self, url_parser, url_pattern, expected_contains
     ) -> None:
         """Test parsing complex URL pattern."""
         pattern, params = url_parser.parse_url_pattern(url_pattern)
@@ -92,11 +85,7 @@ class TestURLPatternParser:
         ids=["empty_bracket", "empty_double_bracket"],
     )
     def test_parse_url_pattern_edge_cases(
-        self,
-        url_parser,
-        url_pattern,
-        pattern_contains,
-        params_condition,
+        self, url_parser, url_pattern, pattern_contains, params_condition
     ) -> None:
         """Test parsing URL pattern edge cases."""
         pattern, params = url_parser.parse_url_pattern(url_pattern)
@@ -115,11 +104,7 @@ class TestURLPatternParser:
         ids=["simple_param", "typed_param", "empty", "whitespace", "colon_prefix"],
     )
     def test_parse_param_name_and_type_variations(
-        self,
-        url_parser,
-        param_string,
-        expected_name,
-        expected_type,
+        self, url_parser, param_string, expected_name, expected_type
     ) -> None:
         """Test parsing parameter name and type with different variations."""
         name, type_name = url_parser._parse_param_name_and_type(param_string)
@@ -133,16 +118,12 @@ class TestURLPatternParser:
                 "user/[[profile]]/[int:user-id]/posts",
                 ["profile", "user_id"],
                 "user/<path:profile>/<int:user_id>/posts/",
-            ),
+            )
         ],
         ids=["args_and_params"],
     )
     def test_parse_url_pattern_with_args_and_params(
-        self,
-        url_parser,
-        url_path,
-        expected_params,
-        expected_pattern,
+        self, url_parser, url_path, expected_params, expected_pattern
     ) -> None:
         """Test parsing URL pattern with both args and regular parameters."""
         django_pattern, parameters = url_parser.parse_url_pattern(url_path)
@@ -234,15 +215,7 @@ def render(request, **kwargs):
                 "page_test",
                 "<h1>Virtual view: {{ title }}</h1><p>{{ content }}</p>",
             ),
-            (
-                "virtual_view_no_djx",
-                None,
-                False,
-                None,
-                "test",
-                None,
-                None,
-            ),
+            ("virtual_view_no_djx", None, False, None, "test", None, None),
             (
                 "virtual_view_with_params",
                 None,
@@ -297,10 +270,7 @@ def render(request, **kwargs):
             assert pattern is None
 
     def test_create_url_pattern_render_function_fallback(
-        self,
-        page_instance,
-        tmp_path,
-        url_parser,
+        self, page_instance, tmp_path, url_parser
     ) -> None:
         """Test that render function is used as fallback when no template is found."""
         page_file = tmp_path / "page.py"
@@ -317,10 +287,7 @@ def render(request, **kwargs):
         assert pattern.name == "page_test"
 
     def test_create_url_pattern_virtual_view_rendering(
-        self,
-        page_instance,
-        tmp_path,
-        url_parser,
+        self, page_instance, tmp_path, url_parser
     ) -> None:
         """Test that virtual view can be rendered with context."""
         page_file = tmp_path / "page.py"
@@ -336,10 +303,7 @@ def render(request, **kwargs):
         assert result == "<h1>Welcome</h1><p>Hello World!</p>"
 
     def test_create_url_pattern_with_context_functions(
-        self,
-        page_instance,
-        tmp_path,
-        url_parser,
+        self, page_instance, tmp_path, url_parser
     ) -> None:
         """Test create_url_pattern with context functions for virtual view."""
         page_file = tmp_path / "page.py"
@@ -348,14 +312,10 @@ def render(request, **kwargs):
         djx_file.write_text(djx_content)
 
         page_instance._context_manager.register_context(
-            page_file,
-            "title",
-            lambda: "Context Title",
+            page_file, "title", lambda: "Context Title"
         )
         page_instance._context_manager.register_context(
-            page_file,
-            "description",
-            lambda: "Context Description",
+            page_file, "description", lambda: "Context Description"
         )
 
         pattern = page_instance.create_url_pattern("test", page_file, url_parser)
@@ -381,17 +341,12 @@ class TestPageCreateUrlPattern:
         clean_name = url_parser.prepare_url_name("test")
 
         result = page_instance._create_regular_page_pattern(
-            page_file,
-            django_pattern,
-            parameters,
-            clean_name,
+            page_file, django_pattern, parameters, clean_name
         )
         assert result is None
 
     def test_create_regular_page_pattern_no_template_no_render(
-        self,
-        page_instance,
-        tmp_path,
+        self, page_instance, tmp_path
     ) -> None:
         """Test _create_regular_page_pattern when no template and no render function."""
         page_file = tmp_path / "page.py"
@@ -402,9 +357,6 @@ class TestPageCreateUrlPattern:
         clean_name = url_parser.prepare_url_name("test")
 
         result = page_instance._create_regular_page_pattern(
-            page_file,
-            django_pattern,
-            parameters,
-            clean_name,
+            page_file, django_pattern, parameters, clean_name
         )
         assert result is None

--- a/tests/partial/test_builder.py
+++ b/tests/partial/test_builder.py
@@ -1,12 +1,7 @@
 import pytest
 from django.test import RequestFactory
 
-from next.partial import (
-    Patches,
-    PatchResponse,
-    UnknownZoneError,
-    register_patch_op,
-)
+from next.partial import Patches, PatchResponse, UnknownZoneError, register_patch_op
 from next.partial.headers import CONTENT_TYPE
 from next.partial.patches import (
     BuiltinPatchOpError,
@@ -170,10 +165,7 @@ class TestStandaloneVerbs:
 
     def test_layer_close_with_result(self) -> None:
         envelope = Patches.versioned("v1").layer_close(result={"id": 7}).envelope()
-        assert envelope.ops[0].as_dict() == {
-            "op": "layer.close",
-            "result": {"id": 7},
-        }
+        assert envelope.ops[0].as_dict() == {"op": "layer.close", "result": {"id": 7}}
 
     def test_layer_close_with_dismiss(self) -> None:
         envelope = Patches.versioned("v1").layer_close(dismiss="cancel").envelope()
@@ -291,10 +283,7 @@ class TestCustomOp:
 
     def test_registered_verb_emits_a_patch(self, custom_op: str) -> None:
         envelope = Patches.versioned("v1").op(custom_op, origin="button").envelope()
-        assert envelope.ops[0].as_dict() == {
-            "op": "confetti",
-            "origin": "button",
-        }
+        assert envelope.ops[0].as_dict() == {"op": "confetti", "origin": "button"}
 
     def test_unregistered_verb_raises_unknown_op(self) -> None:
         with pytest.raises(UnknownPatchOpError) as exc:
@@ -317,10 +306,7 @@ class TestContextPatch:
 
     def test_registered_serialize_name_serialises(self) -> None:
         envelope = Patches(partial_request()).context(flag=True).envelope()
-        assert envelope.ops[0].as_dict() == {
-            "op": "context",
-            "data": {"flag": True},
-        }
+        assert envelope.ops[0].as_dict() == {"op": "context", "data": {"flag": True}}
 
     def test_unregistered_name_raises_unknown_context(self) -> None:
         with pytest.raises(UnknownContextNameError) as exc:

--- a/tests/partial/test_checks.py
+++ b/tests/partial/test_checks.py
@@ -6,10 +6,18 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.test import override_settings
 
+from next.checks import reset_check_caches
 from next.components import ComponentInfo, FileComponentsBackend
 from next.forms.backends import FormActionBackend, RegistryFormActionBackend
 from next.partial import checks
 from next.partial.registry import patch_op_registry, register_patch_op
+
+
+@pytest.fixture(autouse=True)
+def _reset_check_caches():
+    reset_check_caches()
+    yield
+    reset_check_caches()
 
 
 @contextmanager
@@ -264,7 +272,6 @@ def _component(template_path: Path | None) -> Generator[None, None, None]:
         )
     backend._loaded = True
     manager = MagicMock()
-    manager._reload_config = lambda: None
     manager._backends = [backend]
 
     settings_ns = MagicMock()
@@ -273,7 +280,10 @@ def _component(template_path: Path | None) -> Generator[None, None, None]:
     ]
     with (
         patch("next.partial.checks.next_framework_settings", settings_ns),
-        patch("next.partial.checks.ComponentsManager", return_value=manager),
+        patch(
+            "next.partial.checks.get_components_manager",
+            return_value=manager,
+        ),
     ):
         yield
 
@@ -535,3 +545,71 @@ class TestChecksSilentOnValidComposite:
             assert checks.check_zone_not_in_if() == []
             assert checks.check_lazy_zone_has_placeholder() == []
             assert checks.check_with_directly_over_zone() == []
+
+
+_ZONE_CHECKS = (
+    checks.check_duplicate_zone_names,
+    checks.check_zone_name_is_slug,
+    checks.check_zone_not_in_loop,
+    checks.check_zone_not_in_if,
+    checks.check_repeated_form_has_key,
+    checks.check_lazy_zone_has_placeholder,
+    checks.check_with_directly_over_zone,
+)
+
+
+@contextmanager
+def _counting_collect() -> Iterator[list[int]]:
+    """Count calls to the composed-page collector, delegating to the real one."""
+    real = checks._collect_composed_pages
+    calls = [0]
+
+    def counting(manager: object) -> Iterator[tuple[Path, object]]:
+        calls[0] += 1
+        return real(manager)
+
+    with patch.object(checks, "_collect_composed_pages", side_effect=counting):
+        yield calls
+
+
+class TestComposedPagesMemo:
+    """The seven zone checks share one walk of the composed-page tree."""
+
+    def test_seven_checks_collect_pages_once(self, tmp_path: Path) -> None:
+        page_file = _page_dir(tmp_path, "shared")
+        body = '{% zone "z" %}<p>{{ a }}</p>{% endzone %}'
+        with _composed_pages((page_file, body)), _counting_collect() as calls:
+            for check in _ZONE_CHECKS:
+                check()
+        assert calls[0] == 1
+
+    def test_new_manager_invalidates_memo(self, tmp_path: Path) -> None:
+        first_page = _page_dir(tmp_path, "one")
+        with _composed_pages(
+            (first_page, '{% zone "solo" %}<p>{{ a }}</p>{% endzone %}'),
+        ):
+            assert checks.check_duplicate_zone_names() == []
+        second_page = _page_dir(tmp_path, "two")
+        dup = '{% zone "x" %}a{% endzone %}{% zone "x" %}b{% endzone %}'
+        with _composed_pages((second_page, dup)):
+            ids = [m.id for m in checks.check_duplicate_zone_names()]
+        assert ids == [checks.E_DUPLICATE_ZONE]
+
+    def test_reset_hook_recollects_on_live_manager(self, tmp_path: Path) -> None:
+        page_file = _page_dir(tmp_path, "live")
+        body = '{% zone "z" %}<p>{{ a }}</p>{% endzone %}'
+        with _composed_pages((page_file, body)), _counting_collect() as calls:
+            checks.check_duplicate_zone_names()
+            checks.check_zone_name_is_slug()
+            assert calls[0] == 1
+            checks.reset_composed_pages_memo()
+            checks.check_zone_not_in_loop()
+            assert calls[0] == 2
+
+    def test_memo_does_not_hide_e072(self, tmp_path: Path) -> None:
+        broken = _page_dir(tmp_path, "torn")
+        body = '{% zone "z" %}b{% placeholder %}p{% endzone %}'
+        with _composed_pages((broken, body)):
+            checks.check_duplicate_zone_names()
+            messages = checks.check_composed_templates_compile()
+        assert [m.id for m in messages] == [checks.E_COMPOSED_TEMPLATE_SYNTAX]

--- a/tests/partial/test_checks.py
+++ b/tests/partial/test_checks.py
@@ -280,10 +280,7 @@ def _component(template_path: Path | None) -> Generator[None, None, None]:
     ]
     with (
         patch("next.partial.checks.next_framework_settings", settings_ns),
-        patch(
-            "next.partial.checks.get_components_manager",
-            return_value=manager,
-        ),
+        patch("next.partial.checks.get_components_manager", return_value=manager),
     ):
         yield
 
@@ -354,7 +351,7 @@ class _PartialUnawareBackend(RegistryFormActionBackend):
 
 
 @contextmanager
-def _form_backends(*backends: object, partial_active: bool) -> Iterator[None]:
+def _form_backends(*backends, partial_active: bool) -> Iterator[None]:
     """Point the W068 check at given form backends and partial-config state."""
     manager = MagicMock()
     manager.backends = tuple(backends)
@@ -519,9 +516,7 @@ class TestBackendNamesPathCheck:
         assert ids == [checks.E_BACKEND_WITHOUT_PATH]
 
     @pytest.mark.parametrize(
-        "config",
-        [[_BACKEND_DICT], "not-a-list"],
-        ids=["valid_entry", "non_sequence"],
+        "config", [[_BACKEND_DICT], "not-a-list"], ids=["valid_entry", "non_sequence"]
     )
     def test_valid_or_non_sequence_config_is_silent(self, config: object) -> None:
         with _partial_backends(config):
@@ -586,7 +581,7 @@ class TestComposedPagesMemo:
     def test_new_manager_invalidates_memo(self, tmp_path: Path) -> None:
         first_page = _page_dir(tmp_path, "one")
         with _composed_pages(
-            (first_page, '{% zone "solo" %}<p>{{ a }}</p>{% endzone %}'),
+            (first_page, '{% zone "solo" %}<p>{{ a }}</p>{% endzone %}')
         ):
             assert checks.check_duplicate_zone_names() == []
         second_page = _page_dir(tmp_path, "two")

--- a/tests/partial/test_foreign_zone.py
+++ b/tests/partial/test_foreign_zone.py
@@ -2,11 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from next.partial import (
-    ForeignPageNotAuthorizedError,
-    Patches,
-    resolve_partial_origin,
-)
+from next.partial import ForeignPageNotAuthorizedError, Patches, resolve_partial_origin
 from next.partial.origin import OriginSource
 from next.partial.patches import DynamicForeignPageError
 from tests.support import partial_request

--- a/tests/partial/test_golden.py
+++ b/tests/partial/test_golden.py
@@ -100,9 +100,7 @@ def _invalid_form() -> GoldenCase:
         '<input name="name" value="" aria-invalid="true"></form>'
     )
     form = FormMeta(
-        uid="ab12cd34",
-        valid=False,
-        errors={"name": ["This field is required."]},
+        uid="ab12cd34", valid=False, errors={"name": ["This field is required."]}
     )
     envelope = (
         Patches.versioned("9f3c2e1b")
@@ -147,10 +145,7 @@ def _invalid_form_extract() -> GoldenCase:
             "the failed form by uid, the document trimmed to it by the client."
         ),
         version="9f3c2e1b",
-        extra_headers={
-            "X-Next-Form": "invalid",
-            "X-Next-Action": "3f9ac21d75e04b88",
-        },
+        extra_headers={"X-Next-Form": "invalid", "X-Next-Action": "3f9ac21d75e04b88"},
     )
 
 
@@ -161,9 +156,7 @@ def _validate_form() -> GoldenCase:
         '<input name="email" value="bad" aria-invalid="true"></form>'
     )
     form = FormMeta(
-        uid="ab12cd34",
-        valid=False,
-        errors={"email": ["Enter a valid email address."]},
+        uid="ab12cd34", valid=False, errors={"email": ["Enter a valid email address."]}
     )
     envelope = (
         Patches.versioned("9f3c2e1b")

--- a/tests/partial/test_headers.py
+++ b/tests/partial/test_headers.py
@@ -157,8 +157,7 @@ class TestZoneResponseVary:
     """A zone GET response stamps the protective partial Vary header."""
 
     @pytest.mark.parametrize(
-        "header",
-        ["X-Next-Request", "X-Next-Zone", "X-Next-Merge", "X-Next-Version"],
+        "header", ["X-Next-Request", "X-Next-Zone", "X-Next-Merge", "X-Next-Version"]
     )
     def test_zone_response_varies_on_partial_header(self, header: str) -> None:
         response = NextClient().get_zones("/zoned/", "alpha")

--- a/tests/partial/test_patches.py
+++ b/tests/partial/test_patches.py
@@ -35,11 +35,7 @@ class TestPatchAsDict:
 
     def test_event_carries_extras(self) -> None:
         patch = Patch(op="event", extras={"name": "ping", "detail": {"x": 1}})
-        assert patch.as_dict() == {
-            "op": "event",
-            "name": "ping",
-            "detail": {"x": 1},
-        }
+        assert patch.as_dict() == {"op": "event", "name": "ping", "detail": {"x": 1}}
 
 
 class TestAssetAsDict:
@@ -212,10 +208,7 @@ class TestPatchesBuilder:
 
     def test_add_context_records_a_context_op(self) -> None:
         envelope = Patches.versioned("v1")._add_context({"unread": 3}).envelope()
-        assert envelope.ops[0].as_dict() == {
-            "op": "context",
-            "data": {"unread": 3},
-        }
+        assert envelope.ops[0].as_dict() == {"op": "context", "data": {"unread": 3}}
 
     def test_version_carried(self) -> None:
         assert Patches.versioned("9f3c").envelope().version == "9f3c"
@@ -366,7 +359,7 @@ class TestOriginRenderContextMemoised:
         calls = 0
         original = next.pages.page.build_render_context
 
-        def _counting(*args: object, **kwargs: object) -> object:
+        def _counting(*args, **kwargs) -> object:
             nonlocal calls
             calls += 1
             return original(*args, **kwargs)
@@ -381,7 +374,7 @@ class TestOriginRenderContextMemoised:
         calls = 0
         original = next.pages.page.build_render_context
 
-        def _counting(*args: object, **kwargs: object) -> object:
+        def _counting(*args, **kwargs) -> object:
             nonlocal calls
             calls += 1
             return original(*args, **kwargs)

--- a/tests/partial/test_registry.py
+++ b/tests/partial/test_registry.py
@@ -46,7 +46,7 @@ class TestRegisterPatchOp:
     def test_register_emits_signal(self) -> None:
         seen: list[dict[str, object]] = []
 
-        def receiver(sender: object, **kwargs: object) -> None:
+        def receiver(sender: object, **kwargs) -> None:
             seen.append({"sender": sender, **kwargs})
 
         patch_op_registered.connect(receiver)
@@ -147,7 +147,7 @@ class TestZoneRegisteredSignal:
     def test_fires_once_per_object(self) -> None:
         seen: list[dict[str, object]] = []
 
-        def receiver(sender: object, **kwargs: object) -> None:
+        def receiver(sender: object, **kwargs) -> None:
             seen.append({"sender": sender, **kwargs})
 
         zone_registered.connect(receiver)
@@ -164,7 +164,7 @@ class TestZoneRegisteredSignal:
     def test_sends_lazy_and_poll_kwargs(self) -> None:
         seen: list[dict[str, object]] = []
 
-        def receiver(sender: object, **kwargs: object) -> None:
+        def receiver(sender: object, **kwargs) -> None:
             seen.append({"sender": sender, **kwargs})
 
         zone_registered.connect(receiver)
@@ -187,9 +187,7 @@ class TestZoneRequested:
 
     def test_named_zone_is_requested(self) -> None:
         request = RequestFactory().get(
-            "/",
-            HTTP_X_NEXT_REQUEST="1",
-            HTTP_X_NEXT_ZONE="first, second",
+            "/", HTTP_X_NEXT_REQUEST="1", HTTP_X_NEXT_ZONE="first, second"
         )
         assert zone_requested(request, "first") is True
         assert zone_requested(request, "missing") is False

--- a/tests/partial/test_render.py
+++ b/tests/partial/test_render.py
@@ -53,9 +53,7 @@ class TestRenderZoneBatch:
     def test_context_collected_once_for_the_batch(self) -> None:
         original = render_module.page.build_render_context
         with patch.object(
-            render_module.page,
-            "build_render_context",
-            side_effect=original,
+            render_module.page, "build_render_context", side_effect=original
         ) as spy:
             render_zone(ZONED_PAGE, ("alpha", "beta", "later"), _request())
         assert spy.call_count == 1
@@ -66,10 +64,7 @@ class TestRenderZoneOverrides:
 
     def test_override_replaces_context_value(self) -> None:
         result = render_zone(
-            ZONED_PAGE,
-            ("alpha",),
-            _request(),
-            overrides={"greeting": "override"},
+            ZONED_PAGE, ("alpha",), _request(), overrides={"greeting": "override"}
         )
         assert "override" in result.html["alpha"]
 
@@ -123,7 +118,7 @@ class TestZoneRenderedSignal:
     def test_signal_fires_per_zone(self) -> None:
         seen: list[dict[str, object]] = []
 
-        def receiver(sender: object, **kwargs: object) -> None:
+        def receiver(sender: object, **kwargs) -> None:
             seen.append({"sender": sender, **kwargs})
 
         zone_rendered.connect(receiver)

--- a/tests/partial/test_render_budgets.py
+++ b/tests/partial/test_render_budgets.py
@@ -14,10 +14,7 @@ class TestOneZoneRenderPerInvalidPost:
     def test_zone_body_renders_once(self, next_client: NextClient) -> None:
         original = patches_module.Patches._render_zone
         with patch.object(
-            patches_module.Patches,
-            "_render_zone",
-            autospec=True,
-            side_effect=original,
+            patches_module.Patches, "_render_zone", autospec=True, side_effect=original
         ) as spy:
             response = next_client.post_action(
                 "zoned_rename_form",

--- a/tests/partial/test_shaping_units.py
+++ b/tests/partial/test_shaping_units.py
@@ -71,8 +71,7 @@ class TestAdvanceWithoutAResolvableTarget:
 
     def test_missing_redirect_returns_no_content(self) -> None:
         outcome = ActionOutcome(
-            kind=ActionOutcomeKind.WIZARD_ADVANCE,
-            action_name="step_wizard",
+            kind=ActionOutcomeKind.WIZARD_ADVANCE, action_name="step_wizard"
         )
         backend = form_action_manager.default_backend
         response = shape_partial(backend, partial_request(origin=None), outcome)
@@ -264,9 +263,7 @@ class TestFormOverridesWithoutAForm:
 
     def test_no_form_yields_no_overrides(self) -> None:
         outcome = ActionOutcome(
-            kind=ActionOutcomeKind.INVALID,
-            action_name="step_form",
-            form=None,
+            kind=ActionOutcomeKind.INVALID, action_name="step_form", form=None
         )
         assert shaping_module._form_overrides(outcome) == {}
 

--- a/tests/partial/test_sse.py
+++ b/tests/partial/test_sse.py
@@ -90,12 +90,7 @@ class TestPolitenessHeaders:
         _consume(response)
 
 
-_NO_SSE_BACKEND = [
-    {
-        "BACKEND": "next.partial.PartialProtocolBackend",
-        "OPTIONS": {},
-    },
-]
+_NO_SSE_BACKEND = [{"BACKEND": "next.partial.PartialProtocolBackend", "OPTIONS": {}}]
 
 
 class TestRetryOption:
@@ -115,7 +110,7 @@ class TestRetryOption:
             {
                 "BACKEND": "next.partial.PartialProtocolBackend",
                 "OPTIONS": {"SSE": {"RETRY_MS": "fast"}},
-            },
+            }
         ]
         with _partial_backend_config(backend):
             assert _retry_ms() == 3000
@@ -127,7 +122,7 @@ def _custom_heartbeat_backend(seconds: object) -> list[dict]:
         {
             "BACKEND": "next.partial.PartialProtocolBackend",
             "OPTIONS": {"SSE": {"HEARTBEAT_SECONDS": seconds}},
-        },
+        }
     ]
 
 
@@ -170,7 +165,7 @@ class _Recorder:
         """Start with an empty event list."""
         self.events: list[dict] = []
 
-    def __call__(self, **kwargs: object) -> None:
+    def __call__(self, **kwargs) -> None:
         """Record one signal payload."""
         self.events.append(kwargs)
 

--- a/tests/partial/test_validate.py
+++ b/tests/partial/test_validate.py
@@ -102,7 +102,7 @@ class TestValidateBehindGuard:
     ) -> None:
         received: list[dict] = []
 
-        def _record(**kwargs: object) -> None:
+        def _record(**kwargs) -> None:
             received.append(kwargs)
 
         field_validated.connect(_record)
@@ -151,7 +151,7 @@ class TestValidateBehindViewPermissions:
     ) -> None:
         received: list[dict] = []
 
-        def _record(**kwargs: object) -> None:
+        def _record(**kwargs) -> None:
             received.append(kwargs)
 
         field_validated.connect(_record)
@@ -289,7 +289,7 @@ class TestValidateSignalAndFieldNames:
     ) -> None:
         received: list[dict] = []
 
-        def _record(**kwargs: object) -> None:
+        def _record(**kwargs) -> None:
             received.append(kwargs)
 
         field_validated.connect(_record)

--- a/tests/partial/test_wizard_advance.py
+++ b/tests/partial/test_wizard_advance.py
@@ -9,7 +9,7 @@ from next.testing import NextClient, envelope_of
 from tests.support import CountingWizardBackend
 
 
-def _advance_identity(next_client: NextClient, **kwargs: object) -> HttpResponse:
+def _advance_identity(next_client: NextClient, **kwargs) -> HttpResponse:
     return next_client.post_action(
         "step_wizard",
         {"name": "Ada"},
@@ -104,7 +104,7 @@ class TestWizardAdvanceRendersZoneNotPageView:
         calls: list[tuple] = []
         original = shaping_module.render_zone
 
-        def _spy(page_path, zones, request, **kwargs: object):
+        def _spy(page_path, zones, request, **kwargs):
             calls.append((page_path, zones))
             return original(page_path, zones, request, **kwargs)
 
@@ -189,7 +189,7 @@ class TestWizardAdvanceShipsZoneAssetsAndContext:
             collector=collector,
         )
         monkeypatch.setattr(
-            shaping_module, "render_zone", lambda *_args, **_kwargs: crafted
+            shaping_module, "render_zone", lambda *args, **kwargs: crafted
         )
         response = _advance_identity(next_client, zones="wizard-zone")
         envelope = envelope_of(response)

--- a/tests/partial/test_zone.py
+++ b/tests/partial/test_zone.py
@@ -14,7 +14,7 @@ from next.partial.zone import (
 )
 
 
-def _render(source: str, **ctx: object) -> str:
+def _render(source: str, **ctx) -> str:
     return Template(source).render(Context(ctx))
 
 

--- a/tests/partial/test_zone_acceptance.py
+++ b/tests/partial/test_zone_acceptance.py
@@ -73,9 +73,7 @@ class TestZoneBatchOneContextCollection:
     def test_context_built_once_for_a_two_zone_batch(self) -> None:
         original = render_module.page.build_render_context
         with patch.object(
-            render_module.page,
-            "build_render_context",
-            side_effect=original,
+            render_module.page, "build_render_context", side_effect=original
         ) as spy:
             response = NextClient().get_zones("/counted/", ("alpha", "beta"))
         assert envelope_of(response).zone_targets() == ["alpha", "beta"]
@@ -84,9 +82,7 @@ class TestZoneBatchOneContextCollection:
     def test_context_built_once_for_a_three_zone_batch(self) -> None:
         original = render_module.page.build_render_context
         with patch.object(
-            render_module.page,
-            "build_render_context",
-            side_effect=original,
+            render_module.page, "build_render_context", side_effect=original
         ) as spy:
             NextClient().get_zones("/counted/", ("alpha", "beta", "gamma"))
         assert spy.call_count == 1

--- a/tests/partial/test_zone_form_override.py
+++ b/tests/partial/test_zone_form_override.py
@@ -30,10 +30,7 @@ class TestBoundFormOverride:
         form = EditorForm(data={"name": "Ada"})
         assert form.is_valid()
         result = render_zone(
-            FORMZONE_PAGE,
-            ("editor",),
-            _request(),
-            overrides={"form": form},
+            FORMZONE_PAGE, ("editor",), _request(), overrides={"form": form}
         )
         assert 'value="Ada"' in result.html["editor"]
 
@@ -41,10 +38,7 @@ class TestBoundFormOverride:
         form = EditorForm(data={"name": ""})
         assert not form.is_valid()
         result = render_zone(
-            FORMZONE_PAGE,
-            ("editor",),
-            _request(),
-            overrides={"form": form},
+            FORMZONE_PAGE, ("editor",), _request(), overrides={"form": form}
         )
         assert 'data-next-zone="editor"' in result.html["editor"]
         assert "required" in result.html["editor"].lower()

--- a/tests/partial/test_zone_observability.py
+++ b/tests/partial/test_zone_observability.py
@@ -172,8 +172,7 @@ class TestFullPageRenderEquivalence:
         zoned_dir.mkdir()
         plain_page = _write_zone_page(plain_dir, "<main><p>{{ msg }}</p></main>")
         zoned_page = _write_zone_page(
-            zoned_dir,
-            '<main>{% zone "z" %}<p>{{ msg }}</p>{% endzone %}</main>',
+            zoned_dir, '<main>{% zone "z" %}<p>{{ msg }}</p>{% endzone %}</main>'
         )
 
         plain = page_instance.render(plain_page, msg="hi")
@@ -355,9 +354,7 @@ class TestZoneRequestedGuardsExpensiveProviders:
     def test_provider_runs_only_when_zone_requested(self) -> None:
         hits: list[int] = []
         requested = RequestFactory().get(
-            "/",
-            HTTP_X_NEXT_REQUEST="1",
-            HTTP_X_NEXT_ZONE="report",
+            "/", HTTP_X_NEXT_REQUEST="1", HTTP_X_NEXT_ZONE="report"
         )
         assert _expensive_provider(requested, hits) == "computed"
         assert hits == [1]
@@ -371,9 +368,7 @@ class TestZoneRequestedGuardsExpensiveProviders:
     def test_provider_skips_unrelated_zone_request(self) -> None:
         hits: list[int] = []
         other = RequestFactory().get(
-            "/",
-            HTTP_X_NEXT_REQUEST="1",
-            HTTP_X_NEXT_ZONE="sidebar",
+            "/", HTTP_X_NEXT_REQUEST="1", HTTP_X_NEXT_ZONE="sidebar"
         )
         assert _expensive_provider(other, hits) is None
         assert hits == []

--- a/tests/server/test_autoreload.py
+++ b/tests/server/test_autoreload.py
@@ -60,10 +60,7 @@ class TestNextStatReloader:
         indirect=["reloader_tick_scenario"],
     )
     def test_tick_scenario_notify_behavior(
-        self,
-        reloader_tick_scenario,
-        num_ticks: int,
-        expect: str,
+        self, reloader_tick_scenario, num_ticks: int, expect: str
     ) -> None:
         """tick() under each patched scenario matches expected notify behavior."""
         reloader, payload = reloader_tick_scenario
@@ -106,7 +103,7 @@ class TestTreeDirSignature:
                     entry.is_dir.side_effect = OSError
                     return iter([entry])
 
-                def __exit__(self, *_: object) -> bool:
+                def __exit__(self, *args) -> bool:
                     return False
 
             return _CM()

--- a/tests/server/test_signals.py
+++ b/tests/server/test_signals.py
@@ -13,7 +13,7 @@ from next.server.watcher import _registered_extra_watch_specs
 def capture_watch_specs_ready() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender, **kwargs: object) -> None:
+    def _listener(sender, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     watch_specs_ready.connect(_listener)
@@ -32,8 +32,7 @@ class TestWatchSpecsReadySignal:
     ) -> None:
         """Calling ``iter_all_autoreload_watch_specs()`` emits ``watch_specs_ready``."""
         with patch(
-            "next.server.watcher._iter_default_autoreload_watch_specs",
-            return_value=[],
+            "next.server.watcher._iter_default_autoreload_watch_specs", return_value=[]
         ):
             iter_all_autoreload_watch_specs()
         assert len(capture_watch_specs_ready) == 1
@@ -43,8 +42,7 @@ class TestWatchSpecsReadySignal:
     ) -> None:
         """Sender is the ``iter_all_autoreload_watch_specs`` function."""
         with patch(
-            "next.server.watcher._iter_default_autoreload_watch_specs",
-            return_value=[],
+            "next.server.watcher._iter_default_autoreload_watch_specs", return_value=[]
         ):
             iter_all_autoreload_watch_specs()
         assert capture_watch_specs_ready[0]["sender"] is iter_all_autoreload_watch_specs
@@ -54,8 +52,7 @@ class TestWatchSpecsReadySignal:
     ) -> None:
         """``specs`` kwarg is the final deduplicated list."""
         with patch(
-            "next.server.watcher._iter_default_autoreload_watch_specs",
-            return_value=[],
+            "next.server.watcher._iter_default_autoreload_watch_specs", return_value=[]
         ):
             result = iter_all_autoreload_watch_specs()
         assert capture_watch_specs_ready[0]["specs"] == result

--- a/tests/server/test_watcher.py
+++ b/tests/server/test_watcher.py
@@ -65,7 +65,7 @@ class TestServerAutoreloadWatchApi:
                         "COMPONENTS_DIR": "_components",
                     },
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             specs = _iter_default_autoreload_watch_specs()
@@ -88,21 +88,18 @@ class TestServerAutoreloadWatchApi:
                         "BACKEND": "next.urls.FileRouterBackend",
                         "PAGES_DIR": "pages",
                         "APP_DIRS": False,
-                        "DIRS": [
-                            str(custom.resolve()),
-                            str(pages_tree.resolve()),
-                        ],
+                        "DIRS": [str(custom.resolve()), str(pages_tree.resolve())],
                         "OPTIONS": {},
-                    },
+                    }
                 ],
                 "COMPONENT_BACKENDS": [
                     {
                         "BACKEND": "next.components.FileComponentsBackend",
                         "DIRS": [],
                         "COMPONENTS_DIR": "_",
-                    },
+                    }
                 ],
-            },
+            }
         ):
             next_framework_settings.reload()
             specs = _iter_default_autoreload_watch_specs()

--- a/tests/site_pages/wizard_push/[step]/page.py
+++ b/tests/site_pages/wizard_push/[step]/page.py
@@ -24,10 +24,7 @@ class PushStepWizard(FormWizard):
     class Meta:
         """Two ordered steps with step history pushing enabled."""
 
-        steps: ClassVar = [
-            ("identity", PushIdentityStep),
-            ("scope", PushScopeStep),
-        ]
+        steps: ClassVar = [("identity", PushIdentityStep), ("scope", PushScopeStep)]
         url_param = "step"
         push_steps = True
 

--- a/tests/static/conftest.py
+++ b/tests/static/conftest.py
@@ -28,12 +28,7 @@ JS_URL = "https://example.com/a.js"
 class DeterministicBackend(StaticFilesBackend):
     """Backend with stable deterministic URLs for discovery-order tests."""
 
-    def register_file(
-        self,
-        _source_path: Path,
-        logical_name: str,
-        kind: str,
-    ) -> str:
+    def register_file(self, _source_path: Path, logical_name: str, kind: str) -> str:
         return f"/static/next/{logical_name}{default_kinds.extension(kind)}"
 
 
@@ -100,8 +95,7 @@ def make_discovery() -> Callable[..., tuple[AssetDiscovery, StaticManager]]:
     """Build an ``AssetDiscovery`` wired to a given backend and page roots."""
 
     def _factory(
-        backend: StaticBackend,
-        page_roots: tuple[Path, ...] = (),
+        backend: StaticBackend, page_roots: tuple[Path, ...] = ()
     ) -> tuple[AssetDiscovery, StaticManager]:
         manager = StaticManager()
         manager._backends = [backend]

--- a/tests/static/test_assets.py
+++ b/tests/static/test_assets.py
@@ -123,10 +123,7 @@ class TestKindRegistryRegister:
         reg.register("css", extension=".css", slot="styles", renderer="render_link_tag")
         with pytest.raises(ValueError, match="already registered"):
             reg.register(
-                "css",
-                extension=".sass",
-                slot="styles",
-                renderer="render_link_tag",
+                "css", extension=".sass", slot="styles", renderer="render_link_tag"
             )
 
     def test_register_rejects_empty_kind(self) -> None:

--- a/tests/static/test_backends.py
+++ b/tests/static/test_backends.py
@@ -6,11 +6,7 @@ from unittest import mock
 import pytest
 from django.test import override_settings
 
-from next.static import (
-    StaticBackend,
-    StaticFilesBackend,
-    StaticsFactory,
-)
+from next.static import StaticBackend, StaticFilesBackend, StaticsFactory
 from next.static.backends import StaticBackend as _StaticBackendDirect
 from next.static.signals import backend_loaded
 
@@ -30,29 +26,14 @@ MJS_URL = "https://cdn.example.com/site.mjs"
 class _CollectingBackend(StaticBackend):
     """Minimal concrete backend for ABC compliance + config probing."""
 
-    def register_file(
-        self,
-        source_path: Path,
-        logical_name: str,
-        kind: str,
-    ) -> str:
+    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
         return f"/{logical_name}.{kind}"
 
-    def render_link_tag(
-        self,
-        url: str,
-        *,
-        request: HttpRequest | None = None,
-    ) -> str:
+    def render_link_tag(self, url: str, *, request: HttpRequest | None = None) -> str:
         del request
         return f"<link {url}>"
 
-    def render_script_tag(
-        self,
-        url: str,
-        *,
-        request: HttpRequest | None = None,
-    ) -> str:
+    def render_script_tag(self, url: str, *, request: HttpRequest | None = None) -> str:
         del request
         return f"<script {url}>"
 
@@ -95,11 +76,7 @@ class TestStaticFilesBackendOptions:
 
     def test_custom_css_tag_with_crossorigin(self) -> None:
         backend = StaticFilesBackend(
-            {
-                "OPTIONS": {
-                    "css_tag": '<link rel="stylesheet" crossorigin href="{url}">',
-                },
-            }
+            {"OPTIONS": {"css_tag": '<link rel="stylesheet" crossorigin href="{url}">'}}
         )
         assert backend.render_link_tag(CSS_URL) == (
             f'<link rel="stylesheet" crossorigin href="{CSS_URL}">'
@@ -107,11 +84,7 @@ class TestStaticFilesBackendOptions:
 
     def test_custom_js_tag_with_defer(self) -> None:
         backend = StaticFilesBackend(
-            {
-                "OPTIONS": {
-                    "js_tag": '<script defer src="{url}"></script>',
-                },
-            }
+            {"OPTIONS": {"js_tag": '<script defer src="{url}"></script>'}}
         )
         assert backend.render_script_tag(JS_URL) == (
             f'<script defer src="{JS_URL}"></script>'
@@ -240,7 +213,7 @@ class TestStaticsFactoryCreateBackend:
     def test_fires_backend_loaded_signal(self) -> None:
         received: list[dict[str, Any]] = []
 
-        def _listener(sender: object, **kwargs: object) -> None:
+        def _listener(sender: object, **kwargs) -> None:
             received.append({"sender": sender, **kwargs})
 
         backend_loaded.connect(_listener)

--- a/tests/static/test_collector.py
+++ b/tests/static/test_collector.py
@@ -127,17 +127,10 @@ class TestStaticCollectorInline:
 
     @pytest.mark.parametrize(
         ("kind", "body", "slot"),
-        [
-            ("js", "console.log(1)", "scripts"),
-            ("css", "body{color:red}", "styles"),
-        ],
+        [("js", "console.log(1)", "scripts"), ("css", "body{color:red}", "styles")],
     )
     def test_inline_asset_lands_in_bucket(
-        self,
-        collector: StaticCollector,
-        kind: str,
-        body: str,
-        slot: str,
+        self, collector: StaticCollector, kind: str, body: str, slot: str
     ) -> None:
         collector.add(StaticAsset(url="", kind=kind, inline=body))
         items = collector.assets_in_slot(slot)

--- a/tests/static/test_discovery.py
+++ b/tests/static/test_discovery.py
@@ -156,9 +156,7 @@ class TestAssetDiscoveryPageTemplate:
     """template.css/js are collected from the page directory."""
 
     def test_collects_template_css_and_js(
-        self,
-        tmp_path: Path,
-        file_backend: StaticBackend,
+        self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
         (tmp_path / "template.css").write_text("body{}")
         (tmp_path / "template.js").write_text("/* js */")
@@ -176,9 +174,7 @@ class TestAssetDiscoveryPageTemplate:
         assert script_urls == ["/static/next/index.js"]
 
     def test_missing_files_are_skipped(
-        self,
-        tmp_path: Path,
-        file_backend: StaticBackend,
+        self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
         page_path = tmp_path / "page.djx"
         page_path.write_text("")
@@ -195,9 +191,7 @@ class TestAssetDiscoveryLayoutChain:
     """Outer-most layout is collected before inner layouts and template."""
 
     def test_layouts_come_before_template(
-        self,
-        tmp_path: Path,
-        file_backend: StaticBackend,
+        self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
         (tmp_path / "layout.djx").write_text("")
         (tmp_path / "layout.css").write_text("")
@@ -228,9 +222,7 @@ class TestAssetDiscoveryModuleLists:
     """styles/scripts list vars in page.py are appended to the collector."""
 
     def test_reads_styles_and_scripts(
-        self,
-        tmp_path: Path,
-        file_backend: StaticBackend,
+        self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
         page_dir = tmp_path / "about"
         page_dir.mkdir()
@@ -253,9 +245,7 @@ class TestAssetDiscoveryModuleLists:
         ]
 
     def test_module_list_cache_skips_reparse(
-        self,
-        tmp_path: Path,
-        file_backend: StaticBackend,
+        self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
         page_dir = tmp_path / "cached"
         page_dir.mkdir()
@@ -277,10 +267,7 @@ class TestAssetDiscoveryModuleLists:
         ]
 
     def test_module_list_and_layout_caches_evict_oldest(
-        self,
-        tmp_path: Path,
-        file_backend: StaticBackend,
-        monkeypatch,
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
     ) -> None:
         """Both module-list and layout-dir caches drop the oldest key past the limit."""
         monkeypatch.setattr(discovery_mod, "_MODULE_LIST_CACHE_MAX_SIZE", 1)
@@ -324,9 +311,7 @@ class TestAssetDiscoveryModuleListUrlRouting:
     """`scripts`/`styles` list URLs are dropped when their suffix mismatches."""
 
     def test_url_without_extension_is_dropped(
-        self,
-        tmp_path: Path,
-        file_backend: StaticBackend,
+        self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
         page_dir = tmp_path / "noext"
         page_dir.mkdir()
@@ -341,9 +326,7 @@ class TestAssetDiscoveryModuleListUrlRouting:
         assert collector.assets_in_slot("scripts") == []
 
     def test_url_with_unregistered_extension_is_dropped(
-        self,
-        tmp_path: Path,
-        file_backend: StaticBackend,
+        self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
         page_dir = tmp_path / "weird"
         page_dir.mkdir()
@@ -358,9 +341,7 @@ class TestAssetDiscoveryModuleListUrlRouting:
         assert collector.assets_in_slot("scripts") == []
 
     def test_url_with_mismatched_slot_is_dropped(
-        self,
-        tmp_path: Path,
-        file_backend: StaticBackend,
+        self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
         page_dir = tmp_path / "mismatch"
         page_dir.mkdir()
@@ -378,9 +359,7 @@ class TestAssetDiscoveryModuleListUrlRouting:
 
 class TestAssetDiscoveryComponents:
     def test_simple_component_yields_nothing(
-        self,
-        file_backend: StaticBackend,
-        simple_component: ComponentInfo,
+        self, file_backend: StaticBackend, simple_component: ComponentInfo
     ) -> None:
         provider = _Provider(file_backend, ())
         discovery = AssetDiscovery(provider)
@@ -391,9 +370,7 @@ class TestAssetDiscoveryComponents:
         assert collector.assets_in_slot("scripts") == []
 
     def test_composite_component_picks_up_css_js_and_module_lists(
-        self,
-        file_backend: StaticBackend,
-        composite_component: ComponentInfo,
+        self, file_backend: StaticBackend, composite_component: ComponentInfo
     ) -> None:
         provider = _Provider(file_backend, ())
         discovery = AssetDiscovery(provider)
@@ -410,21 +387,14 @@ class TestAssetDiscoveryComponents:
 
 
 class _FailingBackend(StaticFilesBackend):
-    def register_file(
-        self,
-        source_path: Path,
-        logical_name: str,
-        kind: str,
-    ) -> str:
+    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
         msg = "cannot resolve"
         raise ValueError(msg)
 
 
 class TestAssetDiscoveryErrorHandling:
     def test_warning_logged_on_value_error(
-        self,
-        tmp_path: Path,
-        caplog: pytest.LogCaptureFixture,
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         (tmp_path / "template.css").write_text("")
         page_path = tmp_path / "page.djx"
@@ -445,9 +415,7 @@ class TestAssetDiscoveryErrorHandling:
 
 class TestAssetDiscoveryCustomStems:
     def test_custom_template_stem_is_picked_up(
-        self,
-        tmp_path: Path,
-        file_backend: StaticBackend,
+        self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
         stems = StemRegistry()
         stems.register("template", "page")
@@ -469,9 +437,7 @@ class TestMakeDiscoveryFixture:
     """Ensure the conftest helper builds a wired-up AssetDiscovery."""
 
     def test_factory_produces_usable_pair(
-        self,
-        file_backend: StaticBackend,
-        make_discovery: Callable[..., object],
+        self, file_backend: StaticBackend, make_discovery: Callable[..., object]
     ) -> None:
         discovery, manager = make_discovery(file_backend)  # type: ignore[misc]
         assert isinstance(discovery, AssetDiscovery)

--- a/tests/static/test_finders.py
+++ b/tests/static/test_finders.py
@@ -10,10 +10,7 @@ from django.core.management import call_command
 from django.test import override_settings
 
 from next.static import NextStaticFilesFinder
-from next.static.finders import (
-    _MappedSourceStorage,
-    discover_colocated_static_assets,
-)
+from next.static.finders import _MappedSourceStorage, discover_colocated_static_assets
 
 
 if TYPE_CHECKING:
@@ -50,8 +47,7 @@ class TestDiscoverColocatedAssets:
                 return_value={pages_tree / "layout.djx"},
             ),
             mock.patch(
-                "next.static.finders.get_component_paths_for_watch",
-                return_value=set(),
+                "next.static.finders.get_component_paths_for_watch", return_value=set()
             ),
         ):
             mapping = discover_colocated_static_assets()
@@ -71,8 +67,7 @@ class TestDiscoverColocatedAssets:
         (unrelated / "template.css").write_text("")
         with (
             mock.patch(
-                "next.static.finders.get_pages_directories_for_watch",
-                return_value=[],
+                "next.static.finders.get_pages_directories_for_watch", return_value=[]
             ),
             mock.patch(
                 "next.static.finders.get_template_djx_paths_for_watch",
@@ -82,8 +77,7 @@ class TestDiscoverColocatedAssets:
                 "next.static.finders.get_layout_djx_paths_for_watch", return_value=set()
             ),
             mock.patch(
-                "next.static.finders.get_component_paths_for_watch",
-                return_value=set(),
+                "next.static.finders.get_component_paths_for_watch", return_value=set()
             ),
         ):
             mapping = discover_colocated_static_assets()
@@ -106,8 +100,7 @@ class TestNextStaticFilesFinderFind:
                 "next.static.finders.get_layout_djx_paths_for_watch", return_value=set()
             ),
             mock.patch(
-                "next.static.finders.get_component_paths_for_watch",
-                return_value=set(),
+                "next.static.finders.get_component_paths_for_watch", return_value=set()
             ),
         ):
             result = finder.find("next/about.css")
@@ -129,8 +122,7 @@ class TestNextStaticFilesFinderFind:
                 "next.static.finders.get_layout_djx_paths_for_watch", return_value=set()
             ),
             mock.patch(
-                "next.static.finders.get_component_paths_for_watch",
-                return_value=set(),
+                "next.static.finders.get_component_paths_for_watch", return_value=set()
             ),
         ):
             assert finder.find("next/missing.css") is None
@@ -150,8 +142,7 @@ class TestNextStaticFilesFinderFind:
                 "next.static.finders.get_layout_djx_paths_for_watch", return_value=set()
             ),
             mock.patch(
-                "next.static.finders.get_component_paths_for_watch",
-                return_value=set(),
+                "next.static.finders.get_component_paths_for_watch", return_value=set()
             ),
         ):
             found = finder.find("next/about.css", find_all=True)
@@ -173,8 +164,7 @@ class TestNextStaticFilesFinderFind:
                 "next.static.finders.get_layout_djx_paths_for_watch", return_value=set()
             ),
             mock.patch(
-                "next.static.finders.get_component_paths_for_watch",
-                return_value=set(),
+                "next.static.finders.get_component_paths_for_watch", return_value=set()
             ),
         ):
             found = finder.find("next/about.css", all=True)
@@ -199,8 +189,7 @@ class TestNextStaticFilesFinderList:
                 return_value={pages_tree / "layout.djx"},
             ),
             mock.patch(
-                "next.static.finders.get_component_paths_for_watch",
-                return_value=set(),
+                "next.static.finders.get_component_paths_for_watch", return_value=set()
             ),
         ):
             items = list(finder.list(ignore_patterns=None))
@@ -223,8 +212,7 @@ class TestNextStaticFilesFinderList:
                 "next.static.finders.get_layout_djx_paths_for_watch", return_value=set()
             ),
             mock.patch(
-                "next.static.finders.get_component_paths_for_watch",
-                return_value=set(),
+                "next.static.finders.get_component_paths_for_watch", return_value=set()
             ),
         ):
             items = list(finder.list(ignore_patterns=["*.js"]))
@@ -285,17 +273,12 @@ class TestCollectstaticIntegration:
                 return_value={pages_tree / "layout.djx"},
             ),
             mock.patch(
-                "next.static.finders.get_component_paths_for_watch",
-                return_value=set(),
+                "next.static.finders.get_component_paths_for_watch", return_value=set()
             ),
         ):
             out = StringIO()
             call_command(
-                "collectstatic",
-                "--noinput",
-                "--dry-run",
-                "--ignore=*.py",
-                stdout=out,
+                "collectstatic", "--noinput", "--dry-run", "--ignore=*.py", stdout=out
             )
         # Dry-run completes without ImproperlyConfigured. The finder wires
         # up the staticfiles command path — full asset enumeration is tested

--- a/tests/static/test_integration.py
+++ b/tests/static/test_integration.py
@@ -7,11 +7,7 @@ import pytest
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.template import Context, Template
 
-from next.static import (
-    StaticCollector,
-    StaticFilesBackend,
-    StaticManager,
-)
+from next.static import StaticCollector, StaticFilesBackend, StaticManager
 from next.static.collector import HEAD_CLOSE
 
 
@@ -161,8 +157,7 @@ class TestEmptyCollectorIntegration:
         static_url_mock: None,
     ) -> None:
         out = wired_manager.inject(
-            f"<head>{HEAD_CLOSE}<body>{SCRIPTS_PLACEHOLDER}</body>",
-            collector,
+            f"<head>{HEAD_CLOSE}<body>{SCRIPTS_PLACEHOLDER}</body>", collector
         )
         assert "next/next.min.js" in out
         assert STYLES_PLACEHOLDER not in out

--- a/tests/static/test_manager.py
+++ b/tests/static/test_manager.py
@@ -296,14 +296,10 @@ class TestInjectForwardsRequest:
         collector.add(StaticAsset(url=CSS_URL, kind="css"))
         sentinel = RequestFactory().get("/")
         with mock.patch.object(
-            fresh_manager.default_backend,
-            "render_link_tag",
-            return_value="<link/>",
+            fresh_manager.default_backend, "render_link_tag", return_value="<link/>"
         ) as render:
             fresh_manager.inject(
-                f"<head>{STYLES_PLACEHOLDER}</head>",
-                collector,
-                request=sentinel,
+                f"<head>{STYLES_PLACEHOLDER}</head>", collector, request=sentinel
             )
         render.assert_called_once_with(CSS_URL, request=sentinel)
 
@@ -318,8 +314,7 @@ class TestInjectForwardsRequest:
                 fresh_manager,
                 "_next_script_builder",
                 return_value=NextScriptBuilder(
-                    "/static/next/next.min.js",
-                    policy=ScriptInjectionPolicy.DISABLED,
+                    "/static/next/next.min.js", policy=ScriptInjectionPolicy.DISABLED
                 ),
             ),
             mock.patch.object(
@@ -339,9 +334,7 @@ class TestInjectForwardsRequest:
         collector = StaticCollector()
         collector.add(StaticAsset(url=CSS_URL, kind="css"))
         with mock.patch.object(
-            fresh_manager.default_backend,
-            "render_link_tag",
-            return_value="<link/>",
+            fresh_manager.default_backend, "render_link_tag", return_value="<link/>"
         ) as render:
             fresh_manager.inject(f"<head>{STYLES_PLACEHOLDER}</head>", collector)
         render.assert_called_once_with(CSS_URL, request=None)
@@ -349,9 +342,7 @@ class TestInjectForwardsRequest:
 
 class TestDiscoveryForwarding:
     def test_discover_page_assets_delegates(
-        self,
-        tmp_path: Path,
-        fresh_manager: StaticManager,
+        self, tmp_path: Path, fresh_manager: StaticManager
     ) -> None:
         (tmp_path / "template.css").write_text("")
         page_path = tmp_path / "page.djx"
@@ -369,9 +360,7 @@ class TestDiscoveryForwarding:
         ]
 
     def test_discover_component_assets_delegates(
-        self,
-        composite_component: ComponentInfo,
-        fresh_manager: StaticManager,
+        self, composite_component: ComponentInfo, fresh_manager: StaticManager
     ) -> None:
         collector = StaticCollector()
         with mock.patch(

--- a/tests/static/test_options.py
+++ b/tests/static/test_options.py
@@ -21,9 +21,9 @@ CONFIG_HASH_DEEP = {
                     "DEDUP_STRATEGY": "next.static.collector.HashContentDedup",
                     "JS_CONTEXT_POLICY": "next.static.collector.DeepMergePolicy",
                 },
-            },
-        ],
-    },
+            }
+        ]
+    }
 }
 
 CONFIG_LAST_WINS_ONLY = {
@@ -32,11 +32,11 @@ CONFIG_LAST_WINS_ONLY = {
             {
                 "BACKEND": "next.static.StaticFilesBackend",
                 "OPTIONS": {
-                    "JS_CONTEXT_POLICY": "next.static.collector.LastWinsPolicy",
+                    "JS_CONTEXT_POLICY": "next.static.collector.LastWinsPolicy"
                 },
-            },
-        ],
-    },
+            }
+        ]
+    }
 }
 
 

--- a/tests/static/test_scripts.py
+++ b/tests/static/test_scripts.py
@@ -120,15 +120,13 @@ class TestNextScriptBuilderCustomTemplates:
 
     def test_custom_script_tag(self) -> None:
         builder = NextScriptBuilder(
-            URL,
-            script_tag_template='<script defer src="{url}"></script>',
+            URL, script_tag_template='<script defer src="{url}"></script>'
         )
         assert builder.script_tag() == f'<script defer src="{URL}"></script>'
 
     def test_custom_init_template(self) -> None:
         builder = NextScriptBuilder(
-            URL,
-            init_template="<script>window.MyNext.boot({payload})</script>",
+            URL, init_template="<script>window.MyNext.boot({payload})</script>"
         )
         out = builder.init_script({"x": 1})
         assert out == '<script>window.MyNext.boot({"x":1})</script>'

--- a/tests/static/test_signals.py
+++ b/tests/static/test_signals.py
@@ -34,7 +34,7 @@ SCRIPTS_PLACEHOLDER = "<!-- next:scripts -->"
 def capture_asset_registered() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     asset_registered.connect(_listener)
@@ -48,7 +48,7 @@ def capture_asset_registered() -> Generator[list[dict[str, Any]], None, None]:
 def capture_collector_finalized() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     collector_finalized.connect(_listener)
@@ -62,7 +62,7 @@ def capture_collector_finalized() -> Generator[list[dict[str, Any]], None, None]
 def capture_html_injected() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     html_injected.connect(_listener)
@@ -76,7 +76,7 @@ def capture_html_injected() -> Generator[list[dict[str, Any]], None, None]:
 def capture_backend_loaded() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     backend_loaded.connect(_listener)
@@ -150,20 +150,14 @@ class TestCollectorFinalizedSignal:
     ) -> None:
         collector = StaticCollector()
         sentinel = RequestFactory().get("/")
-        fresh_manager.inject(
-            "<body/>",
-            collector,
-            request=sentinel,
-        )
+        fresh_manager.inject("<body/>", collector, request=sentinel)
 
         assert capture_collector_finalized[0]["request"] is sentinel
 
 
 class TestHtmlInjectedSignal:
     def test_fired_with_before_and_after(
-        self,
-        fresh_manager: StaticManager,
-        capture_html_injected: list[dict[str, Any]],
+        self, fresh_manager: StaticManager, capture_html_injected: list[dict[str, Any]]
     ) -> None:
         collector = StaticCollector()
         collector.add(StaticAsset(url="https://cdn/a.css", kind="css"))
@@ -180,18 +174,14 @@ class TestHtmlInjectedSignal:
         assert event["injected_bytes"] == len(out) - len(html)
 
     def test_reports_no_placeholders_when_html_has_none(
-        self,
-        fresh_manager: StaticManager,
-        capture_html_injected: list[dict[str, Any]],
+        self, fresh_manager: StaticManager, capture_html_injected: list[dict[str, Any]]
     ) -> None:
         collector = StaticCollector()
         fresh_manager.inject("<body/>", collector)
         assert capture_html_injected[0]["placeholders_replaced"] == ()
 
     def test_reports_both_placeholders_when_html_has_both(
-        self,
-        fresh_manager: StaticManager,
-        capture_html_injected: list[dict[str, Any]],
+        self, fresh_manager: StaticManager, capture_html_injected: list[dict[str, Any]]
     ) -> None:
         collector = StaticCollector()
         collector.add(StaticAsset(url="https://cdn/a.css", kind="css"))
@@ -204,17 +194,13 @@ class TestHtmlInjectedSignal:
         )
 
     def test_carries_request_when_provided(
-        self,
-        fresh_manager: StaticManager,
-        capture_html_injected: list[dict[str, Any]],
+        self, fresh_manager: StaticManager, capture_html_injected: list[dict[str, Any]]
     ) -> None:
         collector = StaticCollector()
         collector.add(StaticAsset(url="https://cdn/a.css", kind="css"))
         sentinel = RequestFactory().get("/")
         fresh_manager.inject(
-            f"<head>{STYLES_PLACEHOLDER}</head>",
-            collector,
-            request=sentinel,
+            f"<head>{STYLES_PLACEHOLDER}</head>", collector, request=sentinel
         )
         assert capture_html_injected[0]["request"] is sentinel
 
@@ -228,7 +214,7 @@ class TestLegacyReceiverCompat:
         """A receiver with `(sender, **kwargs)` consumes the new `request` kwarg."""
         seen: list[dict[str, object]] = []
 
-        def legacy(sender: object, **kwargs: object) -> None:
+        def legacy(sender: object, **kwargs) -> None:
             seen.append({"sender": sender, **kwargs})
 
         collector_finalized.connect(legacy)
@@ -250,7 +236,7 @@ class TestLegacyReceiverCompat:
         """A receiver with `(sender, **kwargs)` consumes the new `request` kwarg."""
         seen: list[dict[str, object]] = []
 
-        def legacy(sender: object, **kwargs: object) -> None:
+        def legacy(sender: object, **kwargs) -> None:
             seen.append({"sender": sender, **kwargs})
 
         html_injected.connect(legacy)

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -8,10 +8,7 @@ from tests.support.cases import (
     UrlByAnnotationResolveCase,
     UrlKwargsResolveCase,
 )
-from tests.support.forms import (
-    GuardedTenantForm,
-    build_post_request,
-)
+from tests.support.forms import GuardedTenantForm, build_post_request
 from tests.support.helpers import (
     _ctx,
     _full_resolver,

--- a/tests/support/cases.py
+++ b/tests/support/cases.py
@@ -70,11 +70,7 @@ URL_KWARGS_RESOLVE_CASES: tuple[UrlKwargsResolveCase, ...] = (
     UrlKwargsResolveCase("int_match", "id", int, {"id": 42}, 42),
     UrlKwargsResolveCase("str_to_int", "id", int, {"id": "99"}, 99),
     UrlKwargsResolveCase(
-        "no_annotation",
-        "slug",
-        inspect.Parameter.empty,
-        {"slug": "hello"},
-        "hello",
+        "no_annotation", "slug", inspect.Parameter.empty, {"slug": "hello"}, "hello"
     ),
     UrlKwargsResolveCase(
         "int_conv_fail", "id", int, {"id": "not-a-number"}, "not-a-number"
@@ -117,18 +113,10 @@ URL_BY_ANNOTATION_RESOLVE_CASES: tuple[UrlByAnnotationResolveCase, ...] = (
         "two_arg_reads_named_key", "note_id", DUrl["id", int], {"note_id": "9"}, None
     ),
     UrlByAnnotationResolveCase(
-        "coerce_uuid_preserved",
-        "pk",
-        DUrl[UUID],
-        {"pk": _UUID_VALUE},
-        _UUID_VALUE,
+        "coerce_uuid_preserved", "pk", DUrl[UUID], {"pk": _UUID_VALUE}, _UUID_VALUE
     ),
     UrlByAnnotationResolveCase(
-        "coerce_uuid_from_text",
-        "pk",
-        DUrl[UUID],
-        {"pk": _UUID_TEXT},
-        _UUID_VALUE,
+        "coerce_uuid_from_text", "pk", DUrl[UUID], {"pk": _UUID_TEXT}, _UUID_VALUE
     ),
 )
 
@@ -162,24 +150,13 @@ class PermissionHookCase:
 PERMISSION_OUTCOME_CASES: tuple[PermissionHookCase, ...] = (
     PermissionHookCase("none_allows", None, 302, expected_redirect="/"),
     PermissionHookCase("true_allows", True, 302, expected_redirect="/"),
+    PermissionHookCase("false_denies", False, None, raises_permission_denied=True),
     PermissionHookCase(
-        "false_denies",
-        False,
-        None,
-        raises_permission_denied=True,
-    ),
-    PermissionHookCase(
-        "redirect_short_circuits",
-        "redirect",
-        302,
-        expected_redirect="/paywall/",
+        "redirect_short_circuits", "redirect", 302, expected_redirect="/paywall/"
     ),
     PermissionHookCase("response_403_verbatim", "response_403", 403),
     PermissionHookCase(
-        "raised_propagates",
-        PERMISSION_HOOK_RAISE,
-        None,
-        raises_permission_denied=True,
+        "raised_propagates", PERMISSION_HOOK_RAISE, None, raises_permission_denied=True
     ),
     PermissionHookCase(
         "bad_type_raises_type_error",

--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -20,9 +20,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
 
-def build_mock_http_request(
-    *, path: str | None = "/test/", **attrs: object
-) -> MagicMock:
+def build_mock_http_request(*, path: str | None = "/test/", **attrs) -> MagicMock:
     """Return ``MagicMock(spec=HttpRequest)`` with optional ``path`` and attributes."""
     m = MagicMock(spec=HttpRequest)
     if path is not None:
@@ -51,9 +49,7 @@ def next_framework_settings_for_checks(*, backends: list) -> object:
     """Stand-in for ``next_framework_settings`` in checks tests."""
     return SimpleNamespace(
         COMPONENT_BACKENDS=backends,
-        PAGE_BACKENDS=list(
-            NextFrameworkSettings.DEFAULTS["PAGE_BACKENDS"],
-        ),
+        PAGE_BACKENDS=list(NextFrameworkSettings.DEFAULTS["PAGE_BACKENDS"]),
         URL_NAME_TEMPLATE=NextFrameworkSettings.DEFAULTS["URL_NAME_TEMPLATE"],
     )
 
@@ -82,7 +78,7 @@ def _ctx(
     stack=None,
     resolver_inst=None,
     _context_data=None,
-    **kwargs: object,
+    **kwargs,
 ) -> SimpleNamespace:
     """Build dynamic context (SimpleNamespace) for provider tests."""
     if url_kwargs is None:
@@ -115,9 +111,7 @@ def _minimal_resolver() -> DependencyResolver:
 def _resolver_with_form() -> DependencyResolver:
     """Return a resolver with request, URL and form providers."""
     return DependencyResolver(
-        HttpRequestProvider(),
-        UrlKwargsProvider(),
-        FormProvider(),
+        HttpRequestProvider(), UrlKwargsProvider(), FormProvider()
     )
 
 
@@ -168,11 +162,7 @@ def file_router_backend_from_params(params: object) -> object:
     """Build FileRouterBackend from tuple params or return params unchanged."""
     if isinstance(params, tuple):
         if len(params) == 3:
-            return FileRouterBackend(
-                params[0],
-                app_dirs=params[1],
-                options=params[2],
-            )
+            return FileRouterBackend(params[0], app_dirs=params[1], options=params[2])
         if len(params) == 2:
             return FileRouterBackend(params[0], app_dirs=params[1])
         if len(params) == 1:

--- a/tests/support/partial_requests.py
+++ b/tests/support/partial_requests.py
@@ -21,10 +21,7 @@ def partial_meta(host: str | None = None) -> dict[str, str]:
     return meta
 
 
-def partial_request(
-    origin: str | None = "/zoned/",
-    host: str | None = None,
-):
+def partial_request(origin: str | None = "/zoned/", host: str | None = None):
     """Return a partial POST whose form origin resolves to a real page.
 
     Pass `origin=None` to post a partial that names no resolvable origin

--- a/tests/support/patches.py
+++ b/tests/support/patches.py
@@ -14,9 +14,7 @@ if TYPE_CHECKING:
 
 @contextmanager
 def patch_checks_router_manager(
-    *,
-    pages_directory: Path,
-    scan_routes: Iterable[tuple[str, Path]],
+    *, pages_directory: Path, scan_routes: Iterable[tuple[str, Path]]
 ) -> Generator[tuple[MagicMock, MagicMock, MagicMock], None, None]:
     """Patch `get_router_manager` and `get_pages_directory` for page checks tests."""
     routes = list(scan_routes)
@@ -27,17 +25,10 @@ def patch_checks_router_manager(
     mock_router.app_dirs = True
     mock_router._scan_pages_directory.return_value = routes
     with (
+        patch("next.pages.checks.get_router_manager", return_value=(mock_mgr, [])),
+        patch("next.urls.checks.get_router_manager", return_value=(mock_mgr, [])),
         patch(
-            "next.pages.checks.get_router_manager",
-            return_value=(mock_mgr, []),
-        ),
-        patch(
-            "next.urls.checks.get_router_manager",
-            return_value=(mock_mgr, []),
-        ),
-        patch(
-            "next.checks.common.get_pages_directory",
-            return_value=pages_directory,
+            "next.checks.common.get_pages_directory", return_value=pages_directory
         ) as mock_get_pages_dir,
     ):
         yield mock_mgr, mock_router, mock_get_pages_dir
@@ -45,29 +36,20 @@ def patch_checks_router_manager(
 
 @contextmanager
 def patch_checks_router_manager_with_routers(
-    *,
-    routers: list[object],
+    *, routers: list[object]
 ) -> Generator[MagicMock, None, None]:
     """Patch `get_router_manager` so the manager exposes the given routers list."""
     mock_mgr = MagicMock()
     mock_mgr._backends = list(routers)
     with (
-        patch(
-            "next.pages.checks.get_router_manager",
-            return_value=(mock_mgr, []),
-        ),
-        patch(
-            "next.urls.checks.get_router_manager",
-            return_value=(mock_mgr, []),
-        ),
+        patch("next.pages.checks.get_router_manager", return_value=(mock_mgr, [])),
+        patch("next.urls.checks.get_router_manager", return_value=(mock_mgr, [])),
     ):
         yield mock_mgr
 
 
 @contextmanager
-def patch_checks_components_manager(
-    *fake_backends: object,
-) -> Generator[MagicMock, None, None]:
+def patch_checks_components_manager(*fake_backends) -> Generator[MagicMock, None, None]:
     """Patch components-check settings and `ComponentsManager` with fake backends."""
     mock_ns = next_framework_settings_for_checks(
         backends=[
@@ -75,16 +57,15 @@ def patch_checks_components_manager(
                 "BACKEND": "next.components.FileComponentsBackend",
                 "DIRS": [],
                 "COMPONENTS_DIR": "_components",
-            },
-        ],
+            }
+        ]
     )
     mock_manager = MagicMock()
     mock_manager._backends = list(fake_backends)
     with (
         patch("next.components.checks.next_framework_settings", mock_ns),
         patch(
-            "next.components.checks.get_components_manager",
-            return_value=mock_manager,
+            "next.components.checks.get_components_manager", return_value=mock_manager
         ),
     ):
         yield mock_manager

--- a/tests/support/patches.py
+++ b/tests/support/patches.py
@@ -78,11 +78,13 @@ def patch_checks_components_manager(
             },
         ],
     )
+    mock_manager = MagicMock()
+    mock_manager._backends = list(fake_backends)
     with (
         patch("next.components.checks.next_framework_settings", mock_ns),
-        patch("next.components.checks.ComponentsManager") as mock_manager_klass,
+        patch(
+            "next.components.checks.get_components_manager",
+            return_value=mock_manager,
+        ),
     ):
-        mock_manager = mock_manager_klass.return_value
-        mock_manager._reload_config = lambda: None
-        mock_manager._backends = list(fake_backends)
         yield mock_manager

--- a/tests/support/scenarios.py
+++ b/tests/support/scenarios.py
@@ -14,9 +14,7 @@ if TYPE_CHECKING:
 
 @contextmanager
 def route_watch_layer_patches(
-    *,
-    get_pages_directories_for_watch,
-    scan_pages_tree,
+    *, get_pages_directories_for_watch, scan_pages_tree
 ) -> Generator[None, None, None]:
     """Apply the usual ``next.server`` patches around route discovery for ``tick()`` tests."""
     with (
@@ -118,8 +116,7 @@ def tick_scenario_mtime_change(reloader: NextStatReloader):
 
     with (
         route_watch_layer_patches(
-            get_pages_directories_for_watch=list,
-            scan_pages_tree=lambda _p: iter([]),
+            get_pages_directories_for_watch=list, scan_pages_tree=lambda _p: iter([])
         ),
         patch.object(reloader, "snapshot_files", side_effect=snapshot_side_effect),
         patch.object(reloader, "notify_file_changed") as mock_notify,

--- a/tests/testing/test_client.py
+++ b/tests/testing/test_client.py
@@ -20,10 +20,7 @@ class TestNextClient:
 
     def test_post_action_dispatches_form(self) -> None:
         client = NextClient(enforce_csrf_checks=False)
-        response = client.post_action(
-            "simple_form_redirect",
-            {"name": "Carol"},
-        )
+        response = client.post_action("simple_form_redirect", {"name": "Carol"})
         assert response.status_code in (200, 302)
 
     @pytest.mark.django_db()

--- a/tests/testing/test_deps.py
+++ b/tests/testing/test_deps.py
@@ -20,9 +20,7 @@ class TestMakeResolutionContext:
 
     def test_forwards_fields(self) -> None:
         ctx = make_resolution_context(
-            form="f",
-            url_kwargs={"slug": "abc"},
-            context_data={"title": "T"},
+            form="f", url_kwargs={"slug": "abc"}, context_data={"title": "T"}
         )
         assert ctx.form == "f"
         assert ctx.url_kwargs == {"slug": "abc"}

--- a/tests/testing/test_isolation.py
+++ b/tests/testing/test_isolation.py
@@ -3,10 +3,7 @@ from pathlib import Path
 from django.template import Template
 
 from next.components.manager import components_manager
-from next.forms import (
-    ActionRegistration,
-    RegistryFormActionBackend,
-)
+from next.forms import ActionRegistration, RegistryFormActionBackend
 from next.forms.diagnostics import registration_diagnostics
 from next.forms.manager import form_action_manager
 from next.pages.manager import page

--- a/tests/testing/test_loaders.py
+++ b/tests/testing/test_loaders.py
@@ -74,7 +74,7 @@ class TestEagerLoadPages:
     def test_import_spec_failure_raises(self, tmp_path: Path, monkeypatch) -> None:
         _write_page(tmp_path / "page.py", "VALUE = 6\n")
 
-        def fake_spec(*_args: object, **_kwargs: object) -> None:
+        def fake_spec(*args, **kwargs) -> None:
             return None
 
         monkeypatch.setattr(
@@ -116,7 +116,7 @@ class TestEagerLoadComponents:
                 NEXT_FRAMEWORK={
                     "COMPONENT_BACKENDS": [config],
                     "LAZY_COMPONENT_MODULES": True,
-                },
+                }
             ):
                 components_manager._reload_config()
                 assert not marker.exists()

--- a/tests/testing/test_rendering.py
+++ b/tests/testing/test_rendering.py
@@ -52,9 +52,7 @@ class TestRenderComponentByName:
         components_manager._backends.append(backend)
         try:
             html = render_component_by_name(
-                "greeter",
-                at=tmp_path / "page.djx",
-                context={"name": "World"},
+                "greeter", at=tmp_path / "page.djx", context={"name": "World"}
             )
         finally:
             components_manager._backends.clear()

--- a/tests/urls/conftest.py
+++ b/tests/urls/conftest.py
@@ -16,10 +16,7 @@ def router():
 def mock_settings():
     """Patch ``settings`` in both ``urls`` and ``filesystem`` (``resolve_base_dir``)."""
     mock = Mock()
-    with (
-        patch("next.urls.backends.settings", mock),
-        patch("next.utils.settings", mock),
-    ):
+    with patch("next.urls.backends.settings", mock), patch("next.utils.settings", mock):
         yield mock
 
 

--- a/tests/urls/test_backends.py
+++ b/tests/urls/test_backends.py
@@ -5,11 +5,7 @@ import pytest
 from django.test import RequestFactory
 
 from next.pages import page
-from next.urls import (
-    FileRouterBackend,
-    RouterBackend,
-    RouterFactory,
-)
+from next.urls import FileRouterBackend, RouterBackend, RouterFactory
 from tests.support import file_router_backend_from_params
 
 
@@ -37,15 +33,7 @@ class TestFileRouterBackend:
         ),
         [
             ("defaults", None, None, None, "pages", True, {}),
-            (
-                "custom",
-                "views",
-                False,
-                {"custom": "value"},
-                "views",
-                False,
-                {},
-            ),
+            ("custom", "views", False, {"custom": "value"}, "views", False, {}),
         ],
         ids=["defaults", "custom"],
     )
@@ -102,11 +90,7 @@ class TestFileRouterBackend:
         ids=["same_instance", "different_instance", "wrong_type"],
     )
     def test_equality_variations(
-        self,
-        test_case,
-        router1_params,
-        router2_params,
-        expected_equal,
+        self, test_case, router1_params, router2_params, expected_equal
     ) -> None:
         """Equality and inequality for matching config, different config, and wrong type."""
         router1 = file_router_backend_from_params(router1_params)
@@ -177,12 +161,7 @@ class TestFileRouterBackend:
         ids=["success", "import_error", "no_file"],
     )
     def test_get_app_pages_path_variations(
-        self,
-        router,
-        test_case,
-        import_side_effect,
-        file_path,
-        expected_result,
+        self, router, test_case, import_side_effect, file_path, expected_result
     ) -> None:
         """Resolves app package path or returns None on import error or missing file."""
         with patch("builtins.__import__") as mock_import:
@@ -203,7 +182,7 @@ class TestFileRouterBackend:
                         mock_pages_path.exists.return_value = True
                         mock_path_class.return_value = mock_app_path
                         mock_app_path.parent.__truediv__ = Mock(
-                            return_value=mock_pages_path,
+                            return_value=mock_pages_path
                         )
 
                         result = router._get_app_pages_path("testapp")
@@ -223,13 +202,7 @@ class TestFileRouterBackend:
         ids=["with_base_dir", "string_base_dir", "no_base_dir", "does_not_exist"],
     )
     def test_get_root_pages_path_variations(
-        self,
-        router,
-        mock_settings,
-        test_case,
-        base_dir,
-        exists,
-        expected_result,
+        self, router, mock_settings, test_case, base_dir, exists, expected_result
     ) -> None:
         """Root pages paths from BASE_DIR when directory exists or missing."""
         mock_settings.BASE_DIR = base_dir
@@ -243,10 +216,7 @@ class TestFileRouterBackend:
             mock_pages_path.exists.return_value = exists
             mock_base = Mock()
             mock_base.__truediv__ = Mock(return_value=mock_pages_path)
-            with patch(
-                "next.urls.backends.resolve_base_dir",
-                return_value=mock_base,
-            ):
+            with patch("next.urls.backends.resolve_base_dir", return_value=mock_base):
                 result = root_router._get_root_pages_paths()
             if exists:
                 assert len(result) == 1
@@ -264,10 +234,7 @@ class TestFileRouterBackend:
     def test_get_root_pages_paths_skips_nonexistent(self) -> None:
         """Nonexistent ``extra_root_paths`` entries are omitted."""
         router = FileRouterBackend(
-            extra_root_paths=[
-                Path("/nonexistent/path"),
-                Path("/also/nonexistent"),
-            ],
+            extra_root_paths=[Path("/nonexistent/path"), Path("/also/nonexistent")]
         )
         result = router._get_root_pages_paths()
         assert result == []
@@ -294,9 +261,7 @@ class TestFileRouterBackend:
         """A second generate_urls reuses cached root patterns without re-walking."""
         router = FileRouterBackend(app_dirs=False, extra_root_paths=[tmp_path])
         with patch.object(
-            router,
-            "_generate_patterns_from_directory",
-            return_value=iter(["p1"]),
+            router, "_generate_patterns_from_directory", return_value=iter(["p1"])
         ) as mock_gen:
             first = router.generate_urls()
             second = router.generate_urls()
@@ -319,9 +284,7 @@ class TestFileRouterBackend:
 
         router = _AppendingRouter(app_dirs=False, extra_root_paths=[tmp_path])
         with patch.object(
-            router,
-            "_generate_patterns_from_directory",
-            return_value=iter(["p1"]),
+            router, "_generate_patterns_from_directory", return_value=iter(["p1"])
         ):
             first = router.generate_urls()
             second = router.generate_urls()
@@ -349,9 +312,7 @@ class TestFileRouterBackend:
         with (
             patch.object(router, "_generate_app_urls", return_value=[]),
             patch.object(
-                router,
-                "_generate_patterns_from_directory",
-                return_value=[],
+                router, "_generate_patterns_from_directory", return_value=[]
             ) as mock_gen,
         ):
             urls = router.generate_urls()
@@ -395,9 +356,7 @@ class TestFileRouterBackend:
             assert result == expected_result
         else:
             with patch.object(
-                router,
-                "_get_app_pages_path",
-                return_value=pages_path_return,
+                router, "_get_app_pages_path", return_value=pages_path_return
             ):
                 if pages_path_return:
                     with patch.object(
@@ -427,9 +386,7 @@ class TestFileRouterBackend:
         ):
             mock_create.side_effect = ["pattern1", "pattern2"]
 
-            patterns = list(
-                router._generate_patterns_from_directory(mock_pages_path),
-            )
+            patterns = list(router._generate_patterns_from_directory(mock_pages_path))
             assert patterns == ["pattern1", "pattern2"]
 
     def test_scan_pages_directory_empty(self) -> None:
@@ -489,11 +446,7 @@ class TestFileRouterBackend:
             "def render(request, args):\n    return 'response-' + args\n"
         )
 
-        pattern = page.create_url_pattern(
-            "test/[[args]]",
-            page_py,
-            router._url_parser,
-        )
+        pattern = page.create_url_pattern("test/[[args]]", page_py, router._url_parser)
         assert pattern is not None
         assert pattern.callback is not None
         response = pattern.callback(RequestFactory().get("/"), args="arg1/arg2/arg3")
@@ -523,16 +476,12 @@ class TestRouterFactory:
                 },
                 FileRouterBackend,
                 {"pages_dir": "pages", "app_dirs": True, "options": {}},
-            ),
+            )
         ],
         ids=["success"],
     )
     def test_create_backend_variations(
-        self,
-        test_case,
-        config,
-        expected_type,
-        expected_attrs,
+        self, test_case, config, expected_type, expected_attrs
     ) -> None:
         """Valid FileRouterBackend config produces a router with expected attributes."""
         router = RouterFactory.create_backend(config)
@@ -553,10 +502,7 @@ class TestRouterFactory:
         mock_s = Mock()
         with (
             patch("next.urls.backends.settings", mock_s),
-            patch(
-                "next.utils.settings",
-                mock_s,
-            ),
+            patch("next.utils.settings", mock_s),
         ):
             mock_s.BASE_DIR = "/tmp/next_base_str"
             router = RouterFactory.create_backend(cfg)
@@ -574,10 +520,7 @@ class TestRouterFactory:
         mock_s = Mock()
         with (
             patch("next.urls.backends.settings", mock_s),
-            patch(
-                "next.utils.settings",
-                mock_s,
-            ),
+            patch("next.utils.settings", mock_s),
         ):
             mock_s.BASE_DIR = Path("/tmp")
             router = RouterFactory.create_backend(cfg)
@@ -590,10 +533,7 @@ class TestRouterFactory:
             ({}, "BACKEND"),
             ({"BACKEND": "next.urls.FileRouterBackend"}, "PAGES_DIR"),
             (
-                {
-                    "BACKEND": "next.urls.FileRouterBackend",
-                    "PAGES_DIR": "pages",
-                },
+                {"BACKEND": "next.urls.FileRouterBackend", "PAGES_DIR": "pages"},
                 "APP_DIRS",
             ),
             (
@@ -623,9 +563,7 @@ class TestRouterFactory:
         ],
     )
     def test_create_backend_keyerror_when_required_key_missing(
-        self,
-        config,
-        missing_key,
+        self, config, missing_key
     ) -> None:
         """FileRouterBackend config must list PAGES_DIR, APP_DIRS, OPTIONS, and DIRS."""
         with pytest.raises(KeyError) as exc:
@@ -658,8 +596,7 @@ class TestRouterFactory:
         assert isinstance(router, custom_backend_class)
 
     def test_create_backend_non_file_router_backend_else_branch(
-        self,
-        custom_backend_class,
+        self, custom_backend_class
     ) -> None:
         """Minimal config dict hits the non FileRouterBackend branch."""
         RouterFactory.register_backend("custom", custom_backend_class)
@@ -676,9 +613,7 @@ class TestRouterFactory:
         """Only type objects are treated as router classes."""
         assert RouterFactory.is_filesystem_discovery_router_class(object()) is False
 
-    def test_resolve_components_folder_name_from_first_component_backend(
-        self,
-    ) -> None:
+    def test_resolve_components_folder_name_from_first_component_backend(self) -> None:
         """Skip-folder name comes from the first ``COMPONENT_BACKENDS`` entry."""
         with patch("next.urls.backends.next_framework_settings") as nfs:
             nfs.COMPONENT_BACKENDS = [{"COMPONENTS_DIR": "custom_comp"}]
@@ -716,9 +651,7 @@ class TestRouterFactory:
             is True
         )
 
-    def test_is_filesystem_discovery_router_class_rejects_non_router_type(
-        self,
-    ) -> None:
+    def test_is_filesystem_discovery_router_class_rejects_non_router_type(self) -> None:
         """Types that are not URL router backends are rejected."""
 
         class NotRouter:

--- a/tests/urls/test_checks.py
+++ b/tests/urls/test_checks.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from django.core.checks import Error
 
+from next.checks import reset_check_caches
 from next.testing import override_next_settings
 from next.urls.checks import (
     _collect_url_patterns,
@@ -10,6 +12,13 @@ from next.urls.checks import (
     check_url_patterns,
 )
 from tests.support import patch_checks_router_manager_with_routers
+
+
+@pytest.fixture(autouse=True)
+def _reset_check_caches():
+    reset_check_caches()
+    yield
+    reset_check_caches()
 
 
 def _write_page(tree: Path, route: str) -> Path:

--- a/tests/urls/test_checks.py
+++ b/tests/urls/test_checks.py
@@ -194,10 +194,7 @@ class TestCheckUrlPatterns:
         router = _TreeRouter(root_trees=[tmp_path])
 
         with patch_checks_router_manager_with_routers(routers=[router]):
-            messages = [
-                *check_url_patterns(None),
-                *check_reverse_name_collisions(None),
-            ]
+            messages = [*check_url_patterns(None), *check_reverse_name_collisions(None)]
 
         assert [m.id for m in messages] == ["next.E028"]
 
@@ -213,8 +210,7 @@ class TestCheckUrlPatterns:
             assert any(m.id == "next.E015" for m in check_url_patterns(None))
 
         skipped = _TreeRouter(
-            root_trees=[tree_a, tree_b],
-            skip_dir_names=frozenset({"_components"}),
+            root_trees=[tree_a, tree_b], skip_dir_names=frozenset({"_components"})
         )
         with patch_checks_router_manager_with_routers(routers=[skipped]):
             assert check_url_patterns(None) == []
@@ -283,8 +279,7 @@ class TestCheckReverseNameCollisions:
         init_error = Error("router manager unavailable", id="next.E007")
 
         with patch(
-            "next.urls.checks.get_router_manager",
-            return_value=(None, [init_error]),
+            "next.urls.checks.get_router_manager", return_value=(None, [init_error])
         ):
             messages = check_reverse_name_collisions(None)
 

--- a/tests/urls/test_dispatcher.py
+++ b/tests/urls/test_dispatcher.py
@@ -10,10 +10,7 @@ from next.pages.watch import (
     iter_pages_roots_with_components_folder_names,
 )
 from next.urls import FileRouterBackend, RouterBackend
-from next.urls.dispatcher import (
-    _scan_pages_directory,
-    scan_pages_tree,
-)
+from next.urls.dispatcher import _scan_pages_directory, scan_pages_tree
 from next.utils import classify_dirs_entries
 
 
@@ -28,9 +25,7 @@ class TestGetPagesDirectoriesForWatch:
 
     def test_skips_non_dict_config(self) -> None:
         """List entries that are not dicts are skipped."""
-        with override_settings(
-            NEXT_FRAMEWORK={"PAGE_BACKENDS": ["not a dict", None]},
-        ):
+        with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": ["not a dict", None]}):
             next_framework_settings.reload()
             assert get_pages_directories_for_watch() == []
 
@@ -46,12 +41,12 @@ class TestGetPagesDirectoriesForWatch:
                         "APP_DIRS": False,
                         "OPTIONS": {
                             "BASE_DIR": str(
-                                Path(__file__).parent.parent.parent / "tests" / "pages",
-                            ),
+                                Path(__file__).parent.parent.parent / "tests" / "pages"
+                            )
                         },
                     },
-                ],
-            },
+                ]
+            }
         ):
             next_framework_settings.reload()
             result = get_pages_directories_for_watch()
@@ -65,7 +60,7 @@ class TestGetPagesDirectoriesForWatch:
             mock_backend._get_installed_apps = Mock(return_value=[])
             mock_create.return_value = mock_backend
             with override_settings(
-                NEXT_FRAMEWORK={"PAGE_BACKENDS": [{"BACKEND": "other.Backend"}]},
+                NEXT_FRAMEWORK={"PAGE_BACKENDS": [{"BACKEND": "other.Backend"}]}
             ):
                 next_framework_settings.reload()
                 assert get_pages_directories_for_watch() == []
@@ -81,7 +76,7 @@ class TestGetPagesDirectoriesForWatch:
             mock_backend.options = {}
             mock_backend.generate_urls = Mock(return_value=[])
             mock_backend._get_root_pages_paths = Mock(
-                return_value=[tmp_path / "root_pages"],
+                return_value=[tmp_path / "root_pages"]
             )
             mock_backend._get_installed_apps = Mock(return_value=["myapp"])
             mock_backend._get_app_pages_path = Mock(return_value=app_pages)
@@ -96,9 +91,9 @@ class TestGetPagesDirectoriesForWatch:
                             "APP_DIRS": True,
                             "DIRS": [],
                             "OPTIONS": {},
-                        },
-                    ],
-                },
+                        }
+                    ]
+                }
             ):
                 next_framework_settings.reload()
                 result = get_pages_directories_for_watch()
@@ -117,9 +112,7 @@ class TestIterPagesRootsWithComponentsFolderNames:
 
     def test_skips_non_dict_config(self) -> None:
         """Non-dict entries are skipped."""
-        with override_settings(
-            NEXT_FRAMEWORK={"PAGE_BACKENDS": ["not a dict"]},
-        ):
+        with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": ["not a dict"]}):
             next_framework_settings.reload()
             assert iter_pages_roots_with_components_folder_names() == []
 
@@ -131,7 +124,7 @@ class TestIterPagesRootsWithComponentsFolderNames:
             mock_backend._get_installed_apps = Mock(return_value=[])
             mock_create.return_value = mock_backend
             with override_settings(
-                NEXT_FRAMEWORK={"PAGE_BACKENDS": [{"BACKEND": "other.Backend"}]},
+                NEXT_FRAMEWORK={"PAGE_BACKENDS": [{"BACKEND": "other.Backend"}]}
             ):
                 next_framework_settings.reload()
                 assert iter_pages_roots_with_components_folder_names() == []
@@ -147,14 +140,12 @@ class TestIterPagesRootsWithComponentsFolderNames:
                         "PAGES_DIR": "pages",
                         "APP_DIRS": False,
                         "DIRS": [
-                            str(
-                                Path(__file__).parent.parent.parent / "tests" / "pages"
-                            ),
+                            str(Path(__file__).parent.parent.parent / "tests" / "pages")
                         ],
                         "OPTIONS": {},
                     },
-                ],
-            },
+                ]
+            }
         ):
             next_framework_settings.reload()
             result = iter_pages_roots_with_components_folder_names()
@@ -200,9 +191,7 @@ class TestScanPagesDirectory:
         (tmp_path / "_components" / "card.djx").write_text("<div>card</div>")
         (tmp_path / "_components" / "nested").mkdir()
         (tmp_path / "_components" / "nested" / "page.py").write_text("z = 3")
-        result = list(
-            scan_pages_tree(tmp_path, skip_dir_names=("_components",)),
-        )
+        result = list(scan_pages_tree(tmp_path, skip_dir_names=("_components",)))
         url_paths = {r[0] for r in result}
         assert "" in url_paths
         assert "home" in url_paths
@@ -219,8 +208,7 @@ class TestScanPagesDirectory:
             calls.append((folder, root, scope))
 
         with patch(
-            "next.urls.dispatcher.register_components_folder_from_router_walk",
-            capture,
+            "next.urls.dispatcher.register_components_folder_from_router_walk", capture
         ):
             list(
                 scan_pages_tree(
@@ -228,7 +216,7 @@ class TestScanPagesDirectory:
                     skip_dir_names=("_components",),
                     register_components=True,
                     components_folder_name="_components",
-                ),
+                )
             )
         assert len(calls) == 1
         assert calls[0][0].name == "_components"

--- a/tests/urls/test_manager.py
+++ b/tests/urls/test_manager.py
@@ -59,12 +59,7 @@ class TestRouterManager:
         assert repr(manager) == "<RouterManager backends=0>"
 
     @pytest.mark.parametrize(
-        ("router_count", "expected_len"),
-        [
-            (0, 0),
-            (1, 1),
-        ],
-        ids=["empty", "one_router"],
+        ("router_count", "expected_len"), [(0, 0), (1, 1)], ids=["empty", "one_router"]
     )
     def test_len_variations(self, manager, router_count, expected_len) -> None:
         """``len`` matches number of registered routers."""
@@ -104,7 +99,7 @@ class TestRouterManager:
                     "PAGES_DIR": "pages",
                     "APP_DIRS": True,
                     "OPTIONS": {},
-                },
+                }
             ]
             mock_router = Mock()
             mock_router.generate_urls.return_value = ["url1"]
@@ -157,8 +152,7 @@ class TestRouterManager:
         """Each config-error type from backend creation is logged and swallowed."""
         with (
             patch(
-                "next.urls.RouterFactory.create_backend",
-                side_effect=exc_type("boom"),
+                "next.urls.RouterFactory.create_backend", side_effect=exc_type("boom")
             ),
             caplog.at_level(logging.ERROR, logger="next.urls.manager"),
         ):
@@ -277,9 +271,7 @@ class TestGlobalInstances:
         render_module_path.write_text(file_content)
 
         pattern = page.create_url_pattern(
-            "test/[[args]]",
-            render_module_path,
-            router._url_parser,
+            "test/[[args]]", render_module_path, router._url_parser
         )
         assert pattern is not None
 
@@ -297,9 +289,7 @@ class TestGlobalInstances:
         )
 
         pattern = page.create_url_pattern(
-            "test/[[args]]",
-            render_module_path,
-            router._url_parser,
+            "test/[[args]]", render_module_path, router._url_parser
         )
         assert pattern is not None
 
@@ -314,10 +304,7 @@ class TestGlobalInstances:
         mock_s.BASE_DIR = None
         with (
             patch("next.urls.backends.settings", mock_s),
-            patch(
-                "next.utils.settings",
-                mock_s,
-            ),
+            patch("next.utils.settings", mock_s),
         ):
             urls = router._generate_root_urls()
             assert urls == []
@@ -343,17 +330,13 @@ class TestGlobalInstances:
         mock_s.INSTALLED_APPS = ["testapp1", "testapp2"]
         with (
             patch("next.urls.backends.settings", mock_s),
-            patch(
-                "next.utils.settings",
-                mock_s,
-            ),
+            patch("next.utils.settings", mock_s),
             patch.object(router, "_get_app_pages_path") as mock_get_path,
         ):
             mock_get_path.side_effect = [None, Path("/tmp/pages")]
 
             with patch.object(
-                router,
-                "_generate_patterns_from_directory",
+                router, "_generate_patterns_from_directory"
             ) as mock_gen_patterns:
                 mock_gen_patterns.return_value = ["pattern1", "pattern2"]
 
@@ -370,9 +353,7 @@ class TestGlobalInstances:
 
         with (
             patch.object(
-                router,
-                "_get_root_pages_paths",
-                return_value=[Path("/tmp/pages")],
+                router, "_get_root_pages_paths", return_value=[Path("/tmp/pages")]
             ),
             patch.object(
                 router,
@@ -392,17 +373,17 @@ class TestGlobalInstances:
 
         (pages_dir / "home").mkdir(parents=True, exist_ok=True)
         (pages_dir / "home" / "page.py").write_text(
-            "def render(request):\n    return 'home'\n",
+            "def render(request):\n    return 'home'\n"
         )
 
         (pages_dir / "items" / "[int:id]").mkdir(parents=True, exist_ok=True)
         (pages_dir / "items" / "[int:id]" / "page.py").write_text(
-            "def render(request, id):\n    return id\n",
+            "def render(request, id):\n    return id\n"
         )
 
         (pages_dir / "blog" / "post").mkdir(parents=True, exist_ok=True)
         (pages_dir / "blog" / "post" / "page.py").write_text(
-            "def render(request):\n    return 'post'\n",
+            "def render(request):\n    return 'post'\n"
         )
 
         results = list(router._scan_pages_directory(pages_dir))
@@ -417,11 +398,7 @@ class TestGlobalInstances:
         router = FileRouterBackend()
 
         with named_temp_py('template = "Hello {{ name }}!"') as temp_file:
-            pattern = page.create_url_pattern(
-                "test",
-                temp_file,
-                router._url_parser,
-            )
+            pattern = page.create_url_pattern("test", temp_file, router._url_parser)
             assert pattern is not None
             assert hasattr(pattern, "callback")
             assert hasattr(pattern, "name")
@@ -432,11 +409,7 @@ class TestGlobalInstances:
         router = FileRouterBackend()
 
         with named_temp_py('template = "Hello {{ name }}!"') as temp_file:
-            pattern = page.create_url_pattern(
-                "test",
-                temp_file,
-                router._url_parser,
-            )
+            pattern = page.create_url_pattern("test", temp_file, router._url_parser)
 
             view_func = pattern.callback
             response = view_func(RequestFactory().get("/"), name="John")
@@ -451,11 +424,7 @@ class TestGlobalInstances:
         router = FileRouterBackend()
 
         with named_temp_py('template = "Hello {{ name }}!"') as temp_file:
-            pattern = page.create_url_pattern(
-                "test",
-                temp_file,
-                router._url_parser,
-            )
+            pattern = page.create_url_pattern("test", temp_file, router._url_parser)
 
             view_func = pattern.callback
             response = view_func(
@@ -471,9 +440,7 @@ class TestGlobalInstances:
 
         with named_temp_py('template = "Hello {{ name }}!"') as temp_file:
             pattern = page.create_url_pattern(
-                "test/[[args]]",
-                temp_file,
-                router._url_parser,
+                "test/[[args]]", temp_file, router._url_parser
             )
 
             view_func = pattern.callback
@@ -496,9 +463,7 @@ class TestGlobalInstances:
 
         with patch("importlib.util.spec_from_file_location", return_value=None):
             pattern = page.create_url_pattern(
-                "test",
-                Path("/nonexistent/file.py"),
-                router._url_parser,
+                "test", Path("/nonexistent/file.py"), router._url_parser
             )
             assert pattern is None
 
@@ -511,9 +476,7 @@ class TestGlobalInstances:
 
         with patch("importlib.util.spec_from_file_location", return_value=mock_spec):
             pattern = page.create_url_pattern(
-                "test",
-                Path("/some/file.py"),
-                router._url_parser,
+                "test", Path("/some/file.py"), router._url_parser
             )
             assert pattern is None
 
@@ -549,9 +512,7 @@ class TestLazyUrlPatterns:
         """Explicit ``__reversed__`` walks one ``_patterns()`` build, not one per index."""
         assert "__reversed__" in type(lazy_urlpatterns).__dict__
         with patch.object(
-            type(lazy_urlpatterns),
-            "_patterns",
-            return_value=["r1", "r2", "f1"],
+            type(lazy_urlpatterns), "_patterns", return_value=["r1", "r2", "f1"]
         ) as mock_patterns:
             assert list(reversed(lazy_urlpatterns)) == ["f1", "r2", "r1"]
         assert mock_patterns.call_count == 1
@@ -559,9 +520,7 @@ class TestLazyUrlPatterns:
     def test_cache_hit_builds_once(self) -> None:
         """Two accesses with stable versions expand the routers once."""
         with patch.object(
-            RouterManager,
-            "__iter__",
-            side_effect=lambda *_args: iter([]),
+            RouterManager, "__iter__", side_effect=lambda *args: iter([])
         ) as mock_iter:
             first = list(lazy_urlpatterns)
             second = list(lazy_urlpatterns)
@@ -571,9 +530,7 @@ class TestLazyUrlPatterns:
     def test_invalidated_by_router_reload(self) -> None:
         """`router_manager.reload()` bumps the version and forces a rebuild."""
         with patch.object(
-            RouterManager,
-            "__iter__",
-            side_effect=lambda *_args: iter([]),
+            RouterManager, "__iter__", side_effect=lambda *args: iter([])
         ) as mock_iter:
             list(lazy_urlpatterns)
             router_manager.reload()
@@ -674,9 +631,7 @@ class TestLazyUrlPatterns:
     def test_include_defers_materialisation_until_first_resolve(self) -> None:
         """``include()`` does not iterate patterns, the first resolve does."""
         with patch.object(
-            RouterManager,
-            "__iter__",
-            side_effect=lambda *_args: iter([]),
+            RouterManager, "__iter__", side_effect=lambda *args: iter([])
         ) as mock_iter:
             included = include("next.urls")
             mock_iter.assert_not_called()

--- a/tests/urls/test_parser.py
+++ b/tests/urls/test_parser.py
@@ -24,11 +24,7 @@ class TestParseUrlPatternHappyPath:
             ("item/[uuid:pk]", "item/<uuid:pk>/", {"pk": "pk"}),
             ("files/[[args]]", "files/<path:args>/", {"args": "args"}),
             ("files/[[args]]/", "files/<path:args>/", {"args": "args"}),
-            (
-                "docs/[[doc-path]]",
-                "docs/<path:doc_path>/",
-                {"doc_path": "doc_path"},
-            ),
+            ("docs/[[doc-path]]", "docs/<path:doc_path>/", {"doc_path": "doc_path"}),
             (
                 "user/[int:id]/files/[[rest]]",
                 "user/<int:id>/files/<path:rest>/",
@@ -50,11 +46,7 @@ class TestParseUrlPatternHappyPath:
         ],
     )
     def test_parse_url_pattern(
-        self,
-        url_parser,
-        url_path,
-        expected_pattern,
-        expected_params,
+        self, url_parser, url_path, expected_pattern, expected_params
     ) -> None:
         """Each converter kind maps to its Django path syntax unchanged."""
         pattern, params = url_parser.parse_url_pattern(url_path)
@@ -98,10 +90,7 @@ class TestParseUrlPatternDuplicates:
         ],
     )
     def test_duplicate_names_raise(
-        self,
-        url_parser,
-        url_path,
-        expected_param_name,
+        self, url_parser, url_path, expected_param_name
     ) -> None:
         """Any repeat of a normalised name, wildcard included, raises."""
         with pytest.raises(DuplicateURLParameterError) as excinfo:

--- a/tests/urls/test_resolver.py
+++ b/tests/urls/test_resolver.py
@@ -82,11 +82,11 @@ def _write_page(tree: Path, route: str) -> None:
     (directory / "page.py").write_text('template = "ok"\n')
 
 
-def _plain_view(_request, **_kwargs: object) -> HttpResponse:
+def _plain_view(_request, **kwargs) -> HttpResponse:
     return HttpResponse(b"plain")
 
 
-def _other_view(_request, **_kwargs: object) -> HttpResponse:
+def _other_view(_request, **kwargs) -> HttpResponse:
     return HttpResponse(b"other")
 
 

--- a/tests/urls/test_reverse.py
+++ b/tests/urls/test_reverse.py
@@ -37,10 +37,7 @@ class TestPageReverse:
 
     def test_unknown_template_propagates_no_reverse_match(self) -> None:
         with (
-            patch(
-                "next.urls.reverse.reverse",
-                side_effect=NoReverseMatch("nope"),
-            ),
+            patch("next.urls.reverse.reverse", side_effect=NoReverseMatch("nope")),
             pytest.raises(NoReverseMatch),
         ):
             page_reverse("[str:missing]", missing="x")

--- a/tests/urls/test_signals.py
+++ b/tests/urls/test_signals.py
@@ -15,7 +15,7 @@ from next.urls.signals import route_registered, router_reloaded
 def capture_route_registered() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     route_registered.connect(_listener)
@@ -29,7 +29,7 @@ def capture_route_registered() -> Generator[list[dict[str, Any]], None, None]:
 def capture_router_reloaded() -> Generator[list[dict[str, Any]], None, None]:
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs: object) -> None:
+    def _listener(sender: object, **kwargs) -> None:
         events.append({"sender": sender, **kwargs})
 
     router_reloaded.connect(_listener)
@@ -81,7 +81,7 @@ class TestRouteRegisteredSignal:
         """After the fixture tears down, the listener is no longer connected."""
         events: list[dict[str, Any]] = []
 
-        def _listener(sender: object, **kwargs: object) -> None:
+        def _listener(sender: object, **kwargs) -> None:
             events.append({"sender": sender})
 
         route_registered.connect(_listener)
@@ -174,7 +174,7 @@ class TestRouterReloadedSignal:
         """After the fixture tears down, the listener is no longer connected."""
         events: list[dict[str, Any]] = []
 
-        def _listener(sender: object, **kwargs: object) -> None:
+        def _listener(sender: object, **kwargs) -> None:
             events.append({"sender": sender})
 
         router_reloaded.connect(_listener)

--- a/tests/urls/urls_namespaced.py
+++ b/tests/urls/urls_namespaced.py
@@ -1,6 +1,4 @@
 from django.urls import include, path
 
 
-urlpatterns = [
-    path("", include("next.urls")),
-]
+urlpatterns = [path("", include("next.urls"))]


### PR DESCRIPTION
## Description

Unify the next-dj system checks under a shared `next` tag and cache the expensive tree scans so a full `manage.py check` no longer rescans the page and component trees once per registered check.

**Shared tag.** `next.checks` now exposes `NEXT = "next"`, registered on every check. Checks that were `Tags.compatibility` carry only `next`, while the `templates` and `urls` checks keep their built-in tag and add `next`, so `manage.py check --tag next` runs the whole framework suite in one shot.

**Per-run caching.** The router manager, components manager, scanned page pairs, composed page templates and collected URL patterns are each built once per run and shared across checks. Every cache resets on `settings_reloaded` (so `override_settings(NEXT_FRAMEWORK=...)` stays correct), and `reset_check_caches()` is the explicit hook for tests and scripts that edit the page tree in place between runs.

**Registry-based context check.** `check_context_functions` now reads keyless `@context` errors from the page context registry instead of re-parsing each module with `ast`, and reuses the mtime-memoised module load shared with the page checks, so each `page.py` loads once per run.

**Cache coherence.** `reset_check_caches` clears the module memo and the context registry together, so a re-executed `page.py` repopulates the registry from its current source rather than keeping a stale `@context` that would keep firing `next.E029`. The collected-pattern cache is keyed on the router-manager identity it holds alive, mirroring the partial composed-pages memo, so a freed manager's `id` can never be reused for a stale hit.

**Cleanup.** Drop the now-empty `next.server.checks` and `next.deps.checks` stub modules along with their coverage-omit entries.

## How to test

Ran locally: `make test` — 2986 passed, 19 skipped, 100% coverage on `next/`. `uv run ruff check` and `uv run mypy next/` both clean. Docs changed (`system-checks`, `troubleshooting`), so run `make docs` or rely on the CI docs job for the `-W` build. Run the full `make ci` before merge.

## Related issues

<!-- e.g. Fixes #123 / Closes #456 -->

## Checklist

- [ ] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [ ] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable
