### PR TITLE
refactor(core): sweep orphaned dead code across pages, components, deps, urls, forms

### DIFF
--- a/docs/content/ref/components.rst
+++ b/docs/content/ref/components.rst
@@ -105,7 +105,6 @@ Prefer the Application Imports tier unless you are building framework tooling.
 .. autoclass:: next.components.ComponentInfo
    :members:
 
-``scope_key`` is a stable value-object tuple for grouping by name and scope.
 The duplicate-name check groups by ``(scope_root, name)`` and ignores ``scope_relative``, so two same-named components anywhere in one tree collide under ``next.E020``.
 
 .. autoclass:: next.components.ContextFunction

--- a/docs/content/ref/pages.rst
+++ b/docs/content/ref/pages.rst
@@ -70,7 +70,11 @@ It runs on a dedicated path and is not registered through ``TEMPLATE_LOADERS``.
 .. autoclass:: next.pages.loaders.LayoutTemplateLoader
    :members:
 
-``LayoutManager`` caches the composed layout string per page path so repeated renders skip recomposition.
+``LayoutManager`` holds the ``LayoutTemplateLoader`` instance the page manager composes bodies through.
+It keeps no cache of its own.
+Composition results live on ``Page`` instead, where ``composed_template_for`` stores the composed source alongside the compiled ``Template``, so a warm render reads no files and parses nothing.
+Both layers are dropped together once a ``template.djx`` or ``layout.djx`` behind the page changes on disk.
+A page whose body comes from ``render()`` bypasses that cache and recomposes the layout chain on every request.
 
 .. autoclass:: next.pages.loaders.LayoutManager
    :members:

--- a/docs/content/ref/pages.rst
+++ b/docs/content/ref/pages.rst
@@ -70,14 +70,11 @@ It runs on a dedicated path and is not registered through ``TEMPLATE_LOADERS``.
 .. autoclass:: next.pages.loaders.LayoutTemplateLoader
    :members:
 
-``LayoutManager`` holds the ``LayoutTemplateLoader`` instance the page manager composes bodies through.
-It keeps no cache of its own.
-Composition results live on ``Page`` instead, where ``composed_template_for`` stores the composed source alongside the compiled ``Template``, so a warm render reads no files and parses nothing.
-Both layers are dropped together once a ``template.djx`` or ``layout.djx`` behind the page changes on disk.
-A page whose body comes from ``render()`` bypasses that cache and recomposes the layout chain on every request.
-
-.. autoclass:: next.pages.loaders.LayoutManager
-   :members:
+``LayoutTemplateLoader`` keeps no cache of its own.
+Composition results live on ``Page``, where ``composed_template_for`` stores the composed source alongside the compiled ``Template``, so a warm render parses nothing and opens no template file.
+It still stats every source file behind the page to detect a change.
+Both layers are dropped together once a ``template.djx`` or ``layout.djx`` changes on disk.
+A page whose body comes from a module-level ``render()`` in ``page.py`` bypasses that cache and recomposes the layout chain on every request.
 
 Processors
 ~~~~~~~~~~

--- a/docs/content/topics/forms/backends.rst
+++ b/docs/content/topics/forms/backends.rst
@@ -310,9 +310,6 @@ Tests that register actions through ``@action`` must drop the global registry be
 Call :func:`next.testing.reset_form_actions` from a pytest fixture or a ``setUp`` method.
 The helper invokes ``form_action_manager._reload_config()``, which rebuilds the backend list from the current ``NEXT_FRAMEWORK["FORM_ACTION_BACKENDS"]`` setting and discards any actions registered against the previous backend instances.
 
-A test that registers extra actions on a live ``RegistryFormActionBackend`` takes a snapshot first and restores it afterwards.
-``backend.snapshot()`` returns a ``RegistryBackendSnapshot``, an immutable copy of the three registry maps, and ``backend.restore(snapshot)`` puts the registry back exactly as it was, without reaching into the backend's private state.
-
 See :doc:`/content/topics/testing` for the surrounding helpers and fixtures.
 
 System Checks

--- a/docs/content/topics/forms/backends.rst
+++ b/docs/content/topics/forms/backends.rst
@@ -310,6 +310,9 @@ Tests that register actions through ``@action`` must drop the global registry be
 Call :func:`next.testing.reset_form_actions` from a pytest fixture or a ``setUp`` method.
 The helper invokes ``form_action_manager._reload_config()``, which rebuilds the backend list from the current ``NEXT_FRAMEWORK["FORM_ACTION_BACKENDS"]`` setting and discards any actions registered against the previous backend instances.
 
+A test that registers extra actions on a live ``RegistryFormActionBackend`` takes a snapshot first and restores it afterwards.
+``backend.snapshot()`` returns a ``RegistryBackendSnapshot``, an immutable copy of the three registry maps, and ``backend.restore(snapshot)`` puts the registry back exactly as it was, without reaching into the backend's private state.
+
 See :doc:`/content/topics/testing` for the surrounding helpers and fixtures.
 
 System Checks

--- a/next/apps/checks.py
+++ b/next/apps/checks.py
@@ -1,13 +1,8 @@
 """System checks for next-dj template engine wiring.
 
-Registered identifiers.
-
-- `next.W062`. Warning raised when no `DjangoTemplates` engine is
-  configured in `TEMPLATES`. The next-dj `{% %}` tags install only into
-  that backend, so they are unavailable without it.
-- `next.W063`. Warning raised when a tag library module under
-  `next.templatetags` is not listed in the explicit builtin tuple, so it
-  never installs as a template builtin.
+The next-dj tags install only into a `DjangoTemplates` backend and only
+through the explicit builtin tuple, so both conditions are worth a
+warning rather than a silent missing tag at render time.
 """
 
 from __future__ import annotations

--- a/next/apps/checks.py
+++ b/next/apps/checks.py
@@ -1,8 +1,8 @@
 """System checks for next-dj template engine wiring.
 
 The next-dj tags install only into a `DjangoTemplates` backend and only
-through the explicit builtin tuple, so both conditions are worth a
-warning rather than a silent missing tag at render time.
+through the explicit builtin tuple. A project missing either one gets a
+warning here instead of a missing-tag error at render time.
 """
 
 from __future__ import annotations

--- a/next/components/backends.py
+++ b/next/components/backends.py
@@ -45,8 +45,12 @@ class FileComponentsBackend(ComponentsBackend):
     """Load components from `DIRS` and from the filesystem walk in `next.urls`."""
 
     def __init__(self, config: dict[str, Any]) -> None:
-        """Build registry and scanner from merged `COMPONENTS_DIR` and `DIRS`."""
-        self.components_dir = str(config["COMPONENTS_DIR"])
+        """Build registry and scanner from the merged `DIRS` roots.
+
+        `COMPONENTS_DIR` is not read here. It names the folder the URL
+        router skips inside a page tree, and `FileRouterBackend` reads it
+        straight from the settings.
+        """
         self._extra_component_roots = component_extra_roots_from_config(config)
 
         self._registry = ComponentRegistry()

--- a/next/components/backends.py
+++ b/next/components/backends.py
@@ -51,9 +51,7 @@ class FileComponentsBackend(ComponentsBackend):
 
         self._registry = ComponentRegistry()
         self._module_loader = ModuleLoader()
-        self._scanner = ComponentScanner(
-            self.components_dir, module_loader=self._module_loader
-        )
+        self._scanner = ComponentScanner(module_loader=self._module_loader)
         self._visibility_resolver = ComponentVisibilityResolver(self._registry)
 
         self._loaded = False
@@ -128,7 +126,6 @@ class DummyBackend(ComponentsBackend):
     def __init__(self, config: dict[str, Any]) -> None:
         """Keep `config` on `self` for assertions about wiring."""
         self.config = config
-        self.created = True
 
     @override
     def get_component(self, _name: str, _template_path: Path) -> ComponentInfo | None:

--- a/next/components/info.py
+++ b/next/components/info.py
@@ -31,11 +31,6 @@ class ComponentInfo:
             resolved = self.scope_root
         object.__setattr__(self, "resolved_scope_root", resolved)
 
-    @property
-    def scope_key(self) -> tuple[str, Path, str]:
-        """Stable tuple for grouping by name and scope (ignores template paths)."""
-        return (self.name, self.scope_root, self.scope_relative)
-
 
 def _paths_from_component_info(info: ComponentInfo) -> set[Path]:
     """Return resolved filesystem paths that define one component."""

--- a/next/components/registry.py
+++ b/next/components/registry.py
@@ -244,11 +244,5 @@ class ComponentVisibilityResolver:
         except ValueError:
             return None
 
-    def clear_cache(self) -> None:
-        """Drop every cached visibility result and scope index."""
-        self._path_cache.clear()
-        self._result_cache.clear()
-        self._scope_index_registry_version = -1
-
 
 __all__ = ["ComponentRegistry", "ComponentVisibilityResolver"]

--- a/next/components/scanner.py
+++ b/next/components/scanner.py
@@ -27,20 +27,8 @@ logger = logging.getLogger(__name__)
 class ComponentScanner:
     """Scan one folder for `.djx` files and composite component directories."""
 
-    DEFAULT_COMPONENTS_DIR_NAME: str = "_components"
-
-    def __init__(
-        self,
-        components_dir: str | None = None,
-        *,
-        module_loader: ModuleLoader | None = None,
-    ) -> None:
-        """Store the configured dir name and wire a module loader."""
-        self._components_dir = (
-            components_dir
-            if components_dir is not None
-            else self.DEFAULT_COMPONENTS_DIR_NAME
-        )
+    def __init__(self, *, module_loader: ModuleLoader | None = None) -> None:
+        """Wire a module loader for composite `component.py` files."""
         self._module_loader = module_loader or ModuleLoader()
 
     def scan_directory(

--- a/next/components/signals.py
+++ b/next/components/signals.py
@@ -1,7 +1,5 @@
 """Django signals emitted by the components subsystem."""
 
-from __future__ import annotations
-
 from django.dispatch import Signal
 
 

--- a/next/components/watch.py
+++ b/next/components/watch.py
@@ -71,7 +71,7 @@ def _collect_component_paths_under_page_trees() -> set[Path]:
             continue
         fs_backend: Any = backend
         comp_name = str(fs_backend._components_folder_name)
-        scanner = ComponentScanner(comp_name)
+        scanner = ComponentScanner()
         for root in itertools.chain(
             (p.resolve() for p in fs_backend._get_root_pages_paths()),
             (
@@ -102,7 +102,7 @@ def _collect_component_paths_from_backend_dirs() -> set[Path]:
             continue
         if not isinstance(backend, FileComponentsBackend):
             continue
-        scanner = ComponentScanner(backend.components_dir, module_loader=ModuleLoader())
+        scanner = ComponentScanner(module_loader=ModuleLoader())
         for root in component_extra_roots_from_config(config):
             try:
                 for info in scanner.scan_directory(root, root, ""):

--- a/next/conf/signals.py
+++ b/next/conf/signals.py
@@ -7,8 +7,6 @@ Django `setting_changed` signal so that tests using `override_settings`
 trigger the reload path automatically.
 """
 
-from __future__ import annotations
-
 from django.core.signals import setting_changed
 from django.dispatch import Signal
 

--- a/next/deps/cache.py
+++ b/next/deps/cache.py
@@ -48,7 +48,6 @@ class DependencyCache:
         """Initialise storage, optionally sharing an externally owned dict."""
         self._cache: dict[str, Any] = backing_dict if backing_dict is not None else {}
         self._in_progress: set[str] = set()
-        self._owns_cache = backing_dict is None
 
     def get(self, key: str) -> object:
         """Return the cached value, `_IN_PROGRESS`, or `_CACHE_MISS`."""
@@ -70,10 +69,6 @@ class DependencyCache:
     def unmark_in_progress(self, key: str) -> None:
         """Clear the in-progress marker for the key."""
         self._in_progress.discard(key)
-
-    def is_in_progress(self, key: str) -> bool:
-        """Return True while the key is mid-resolution."""
-        return key in self._in_progress
 
     def __len__(self) -> int:
         """Return the number of stored values."""

--- a/next/deps/resolver.py
+++ b/next/deps/resolver.py
@@ -62,10 +62,6 @@ class DependencyResolver:
 
     EXPLICIT_RESOLVE_KEYS: ClassVar[frozenset[str]] = RESERVED_KEYS
 
-    def __get__(self, obj: object, owner: type[object]) -> DependencyResolver:
-        """Return the resolver itself when accessed as a descriptor."""
-        return self
-
     def __init__(
         self, *providers: ParameterProvider | RegisteredParameterProvider
     ) -> None:

--- a/next/deps/signals.py
+++ b/next/deps/signals.py
@@ -6,8 +6,6 @@ the signal to observe provider wiring, typically in tests or
 diagnostics.
 """
 
-from __future__ import annotations
-
 from django.dispatch import Signal
 
 

--- a/next/forms/__init__.py
+++ b/next/forms/__init__.py
@@ -30,6 +30,7 @@ from .backends import (
     ActionRegistration,
     FormActionBackend,
     FormActionNotFoundError,
+    RegistryBackendSnapshot,
     RegistryFormActionBackend,
 )
 from .base import (
@@ -183,6 +184,7 @@ __all__ = [
     "PermissionOutcome",
     "RadioSelect",
     "RegexField",
+    "RegistryBackendSnapshot",
     "RegistryFormActionBackend",
     "Select",
     "SelectMultiple",

--- a/next/forms/__init__.py
+++ b/next/forms/__init__.py
@@ -30,7 +30,6 @@ from .backends import (
     ActionRegistration,
     FormActionBackend,
     FormActionNotFoundError,
-    RegistryBackendSnapshot,
     RegistryFormActionBackend,
 )
 from .base import (
@@ -184,7 +183,6 @@ __all__ = [
     "PermissionOutcome",
     "RadioSelect",
     "RegexField",
-    "RegistryBackendSnapshot",
     "RegistryFormActionBackend",
     "Select",
     "SelectMultiple",

--- a/next/forms/backends.py
+++ b/next/forms/backends.py
@@ -228,6 +228,15 @@ class ActionMeta(TypedDict, total=False):
     guard: ActionGuard | None
 
 
+@dataclass(frozen=True, slots=True)
+class RegistryBackendSnapshot:
+    """An immutable copy of a registry backend's action maps for rollback."""
+
+    registry: "dict[tuple[str, str], ActionMeta]"
+    uid_to_name: "dict[str, tuple[str, str]]"
+    name_index: "dict[str, tuple[str, str]]"
+
+
 @dataclass(frozen=True)
 class ActionRegistration:
     """A form action to register with its name, declaration site, and target.
@@ -346,6 +355,26 @@ class RegistryFormActionBackend(FormActionBackend):
         self._registry = {}
         self._uid_to_name = {}
         self._name_index = {}
+        self._url_cache = {}
+
+    def snapshot(self) -> "RegistryBackendSnapshot":
+        """Capture the registered actions so a later `restore` rolls them back.
+
+        A test that registers extra actions takes a snapshot first and
+        restores it afterwards, so a later suite sees the registry exactly
+        as it was without reaching into the backend's private maps.
+        """
+        return RegistryBackendSnapshot(
+            registry=dict(self._registry),
+            uid_to_name=dict(self._uid_to_name),
+            name_index=dict(self._name_index),
+        )
+
+    def restore(self, snapshot: "RegistryBackendSnapshot") -> None:
+        """Restore the registered actions captured by `snapshot`."""
+        self._registry = dict(snapshot.registry)
+        self._uid_to_name = dict(snapshot.uid_to_name)
+        self._name_index = dict(snapshot.name_index)
         self._url_cache = {}
 
     @override
@@ -543,6 +572,7 @@ __all__ = [
     "FormActionBackend",
     "FormActionFactory",
     "FormActionNotFoundError",
+    "RegistryBackendSnapshot",
     "RegistryFormActionBackend",
     "build_action_guard",
     "file_to_dotted_module",

--- a/next/forms/backends.py
+++ b/next/forms/backends.py
@@ -228,15 +228,6 @@ class ActionMeta(TypedDict, total=False):
     guard: ActionGuard | None
 
 
-@dataclass(frozen=True, slots=True)
-class RegistryBackendSnapshot:
-    """An immutable copy of a registry backend's action maps for rollback."""
-
-    registry: "dict[tuple[str, str], ActionMeta]"
-    uid_to_name: "dict[str, tuple[str, str]]"
-    name_index: "dict[str, tuple[str, str]]"
-
-
 @dataclass(frozen=True)
 class ActionRegistration:
     """A form action to register with its name, declaration site, and target.
@@ -355,26 +346,6 @@ class RegistryFormActionBackend(FormActionBackend):
         self._registry = {}
         self._uid_to_name = {}
         self._name_index = {}
-        self._url_cache = {}
-
-    def snapshot(self) -> "RegistryBackendSnapshot":
-        """Capture the registered actions so a later `restore` rolls them back.
-
-        A test that registers extra actions takes a snapshot first and
-        restores it afterwards, so a later suite sees the registry exactly
-        as it was without reaching into the backend's private maps.
-        """
-        return RegistryBackendSnapshot(
-            registry=dict(self._registry),
-            uid_to_name=dict(self._uid_to_name),
-            name_index=dict(self._name_index),
-        )
-
-    def restore(self, snapshot: "RegistryBackendSnapshot") -> None:
-        """Restore the registered actions captured by `snapshot`."""
-        self._registry = dict(snapshot.registry)
-        self._uid_to_name = dict(snapshot.uid_to_name)
-        self._name_index = dict(snapshot.name_index)
         self._url_cache = {}
 
     @override
@@ -572,7 +543,6 @@ __all__ = [
     "FormActionBackend",
     "FormActionFactory",
     "FormActionNotFoundError",
-    "RegistryBackendSnapshot",
     "RegistryFormActionBackend",
     "build_action_guard",
     "file_to_dotted_module",

--- a/next/forms/signals.py
+++ b/next/forms/signals.py
@@ -60,8 +60,6 @@ denial. `reason` is `"raised"` when the hook raised `PermissionDenied`,
 `HttpResponse` short-circuit.
 """
 
-from __future__ import annotations
-
 from django.dispatch import Signal
 
 

--- a/next/pages/checks.py
+++ b/next/pages/checks.py
@@ -196,7 +196,6 @@ def _check_missing_page_files(
             if page_file.exists() or layout_file.exists() or template_file.exists():
                 continue
 
-            # Check if parameter directory has child routes
             has_child_routes = False
             for child in item.iterdir():
                 if child.is_dir() and (child / "page.py").exists():

--- a/next/pages/loaders.py
+++ b/next/pages/loaders.py
@@ -301,14 +301,6 @@ class LayoutTemplateLoader(TemplateLoader):
         return result
 
 
-class LayoutManager:
-    """Hold the layout template loader used to compose page bodies."""
-
-    def __init__(self) -> None:
-        """Instantiate the layout loader."""
-        self._layout_loader = LayoutTemplateLoader()
-
-
 # A single-slot holder mutated in place so cache invalidation never rebinds a
 # module global, which keeps the reset and read paths free of `global`.
 _REGISTERED_LOADERS_CACHE: dict[str, list[TemplateLoader] | None] = {"value": None}

--- a/next/pages/loaders.py
+++ b/next/pages/loaders.py
@@ -302,31 +302,11 @@ class LayoutTemplateLoader(TemplateLoader):
 
 
 class LayoutManager:
-    """Cache composed layout strings per page path."""
+    """Hold the layout template loader used to compose page bodies."""
 
     def __init__(self) -> None:
-        """Initialise an empty layout cache."""
-        self._layout_registry: dict[Path, str] = {}
+        """Instantiate the layout loader."""
         self._layout_loader = LayoutTemplateLoader()
-
-    def discover_layouts_for_template(self, template_path: Path) -> str | None:
-        """Compose and store layout text when `LayoutTemplateLoader` applies."""
-        if not self._layout_loader.can_load(template_path):
-            return None
-
-        composed_template = self._layout_loader.load_template(template_path)
-        if composed_template:
-            self._layout_registry[template_path] = composed_template
-
-        return composed_template
-
-    def get_layout_template(self, template_path: Path) -> str | None:
-        """Return the cached composed template for `template_path`."""
-        return self._layout_registry.get(template_path)
-
-    def clear_registry(self) -> None:
-        """Drop all cached layout strings."""
-        self._layout_registry.clear()
 
 
 # A single-slot holder mutated in place so cache invalidation never rebinds a

--- a/next/pages/manager.py
+++ b/next/pages/manager.py
@@ -25,7 +25,11 @@ from next.conf import next_framework_settings
 from next.deps import DependencyResolver, resolver
 from next.utils import caller_source_path
 
-from .loaders import LayoutManager, _load_python_module_memo, build_registered_loaders
+from .loaders import (
+    LayoutTemplateLoader,
+    _load_python_module_memo,
+    build_registered_loaders,
+)
 from .processors import _get_context_processors
 from .registry import PageContextRegistry
 from .signals import page_rendered, template_loaded
@@ -77,7 +81,7 @@ class Page:
     """Coordinate template loading, context, layouts, rendering, and URL wiring."""
 
     def __init__(self) -> None:
-        """Initialise fresh registries and layout manager.
+        """Initialise fresh registries and the layout loader.
 
         File-based template loaders are not held as an instance
         attribute. The module-level `build_registered_loaders()` helper
@@ -87,7 +91,7 @@ class Page:
         self._compiled_registry: dict[Path, Template] = {}
         self._template_source_mtimes: dict[Path, dict[Path, float]] = {}
         self._context_manager = PageContextRegistry(None)
-        self._layout_manager = LayoutManager()
+        self._layout_loader = LayoutTemplateLoader()
 
     def _get_resolver(self) -> DependencyResolver:
         """Return the shared `resolver` singleton."""
@@ -365,7 +369,7 @@ class Page:
         produced by `render()` do not poison the cache.
         """
         start = time.perf_counter()
-        composed = self._layout_manager._layout_loader.compose_body(body, file_path)
+        composed = self._layout_loader.compose_body(body, file_path)
         return self._render_template_str(file_path, composed, start, request, **kwargs)
 
     def composed_template_for(self, file_path: Path) -> Template:
@@ -383,7 +387,7 @@ class Page:
             self._template_source_mtimes.pop(file_path, None)
             module = _load_python_module_memo(file_path)
             body = self._load_static_body(file_path, module)
-            composed = self._layout_manager._layout_loader.compose_body(body, file_path)
+            composed = self._layout_loader.compose_body(body, file_path)
             self.register_template(file_path, composed)
             self._record_template_source_mtimes(file_path)
         compiled = self._compiled_registry.get(file_path)
@@ -474,7 +478,7 @@ class Page:
         self, file_path: Path, module: types.ModuleType | None = None
     ) -> bool:
         """Return whether any source can supply a template for this path."""
-        if self._layout_manager._layout_loader.can_load(file_path):
+        if self._layout_loader.can_load(file_path):
             return True
         if module is not None and hasattr(module, "template"):
             return True
@@ -487,7 +491,7 @@ class Page:
             source = loader.source_path(file_path)
             if source is not None:
                 loader_paths.append(source)
-        layout_files = self._layout_manager._layout_loader._find_layout_files(file_path)
+        layout_files = self._layout_loader._find_layout_files(file_path)
         return loader_paths + (layout_files or [])
 
     def _record_template_source_mtimes(self, file_path: Path) -> None:
@@ -563,7 +567,7 @@ class Page:
                 return True
         if any(loader.can_load(file_path) for loader in build_registered_loaders()):
             return True
-        return self._layout_manager._layout_loader.can_load(file_path)
+        return self._layout_loader.can_load(file_path)
 
     def create_url_pattern(
         self, url_path: str, file_path: Path, url_parser: URLPatternParser

--- a/next/pages/manager.py
+++ b/next/pages/manager.py
@@ -86,7 +86,6 @@ class Page:
         self._template_registry: dict[Path, str] = {}
         self._compiled_registry: dict[Path, Template] = {}
         self._template_source_mtimes: dict[Path, dict[Path, float]] = {}
-        self._resolver: DependencyResolver | None = None
         self._context_manager = PageContextRegistry(None)
         self._layout_manager = LayoutManager()
 
@@ -451,9 +450,7 @@ class Page:
             if resolution.http_response is not None:
                 return resolution.http_response
             # next.partial imports next.pages, so the zone branch defers
-            # its imports to break the cycle. Without the partial switch the
-            # intent carries no zones and the full render path below runs
-            # byte-for-byte the same as before.
+            # its imports to break the cycle.
             from next.partial import partial_intent  # noqa: PLC0415
             from next.partial.view import zone_response  # noqa: PLC0415
 

--- a/next/pages/signals.py
+++ b/next/pages/signals.py
@@ -17,8 +17,6 @@ keyword arguments are `file_path`, `duration_ms`, `styles_count`,
 `scripts_count`, and `context_keys`.
 """
 
-from __future__ import annotations
-
 from django.dispatch import Signal
 
 

--- a/next/partial/checks.py
+++ b/next/partial/checks.py
@@ -72,24 +72,6 @@ _FORM_TARGET_ATTR: Final = "data-next-target"
 _FORM_KEY_ATTR: Final = "data-next-key"
 
 
-CHECK_IDS: Final = (
-    E_DUPLICATE_ZONE,
-    E_NON_ASCII_ZONE,
-    E_ZONE_IN_FOR,
-    E_ZONE_IN_IF,
-    E_LAZY_WITHOUT_PLACEHOLDER,
-    E_ZONE_IN_COMPONENT,
-    E_UNREGISTERED_OP,
-    E_COMPOSED_TEMPLATE_SYNTAX,
-    E_BACKEND_WITHOUT_PATH,
-    W_WITH_OVER_ZONE,
-    W_FORM_BACKEND_NOT_AWARE,
-    W_MANIFEST_VERSION_NO_STORAGE,
-    W_FORM_IN_FOR_NO_KEY,
-    W_TOO_MANY_BACKENDS,
-)
-
-
 _ZONE_SLUG = re.compile(r"\A[A-Za-z0-9_-]+\Z")
 
 
@@ -665,7 +647,6 @@ def _staticfiles_storage_path() -> str | None:
 
 
 __all__ = [
-    "CHECK_IDS",
     "E_BACKEND_WITHOUT_PATH",
     "E_COMPOSED_TEMPLATE_SYNTAX",
     "E_DUPLICATE_ZONE",

--- a/next/partial/headers.py
+++ b/next/partial/headers.py
@@ -58,11 +58,6 @@ class PartialIntent:
     request_id: str | None = None
     origin: str | None = None
 
-    @property
-    def is_partial(self) -> bool:
-        """Return True when the request carries the partial switch."""
-        return self.partial
-
 
 def _split_names(raw: str | None) -> tuple[str, ...]:
     """Split a comma-separated header value into trimmed non-empty names."""

--- a/next/server/signals.py
+++ b/next/server/signals.py
@@ -5,8 +5,6 @@ watch specs. Subscribers can inspect or augment the effective spec set
 without subclassing the reloader.
 """
 
-from __future__ import annotations
-
 from django.dispatch import Signal
 
 

--- a/next/signals.py
+++ b/next/signals.py
@@ -5,8 +5,6 @@ Import from here when one module subscribes to several subsystems and prefers on
 import path.
 """
 
-from __future__ import annotations
-
 from next.components.signals import (
     component_backend_loaded,
     component_registered,

--- a/next/static/discovery.py
+++ b/next/static/discovery.py
@@ -110,8 +110,6 @@ class StemRegistry:
     `AppConfig.ready` to teach discovery about further filenames.
     """
 
-    DEFAULT_ROLES: tuple[str, ...] = ("template", "layout", "component")
-
     def __init__(self) -> None:
         """Seed the registry with the built-in template, layout, and component roles."""
         self._roles: dict[str, list[str]] = {
@@ -129,10 +127,6 @@ class StemRegistry:
     def stems(self, role: str) -> tuple[str, ...]:
         """Return registered stems for the role in registration order."""
         return tuple(self._roles.get(role, ()))
-
-    def roles(self) -> tuple[str, ...]:
-        """Return all registered roles in registration order."""
-        return tuple(self._roles)
 
 
 default_stems: StemRegistry = StemRegistry()

--- a/next/static/signals.py
+++ b/next/static/signals.py
@@ -28,8 +28,6 @@ instantiates a backend. The sender is the backend class. The keyword
 arguments are `config` and `instance`.
 """
 
-from __future__ import annotations
-
 from django.dispatch import Signal
 
 

--- a/next/testing/html.py
+++ b/next/testing/html.py
@@ -33,10 +33,6 @@ class _FirstTagAttrs(HTMLParser):
             self.tag = tag
             self.attrs = {k: ("" if v is None else v) for k, v in attrs}
 
-    def error(self, message: str) -> None:  # pragma: no cover
-        """Silence the (unused on Py3.10+) abstract error hook."""
-        return
-
 
 class _TextOnly(HTMLParser):
     """Collect text nodes, ignore tags and comments."""
@@ -49,10 +45,6 @@ class _TextOnly(HTMLParser):
     def handle_data(self, data: str) -> None:
         """Append text data chunks."""
         self.parts.append(data)
-
-    def error(self, message: str) -> None:  # pragma: no cover
-        """Silence the (unused on Py3.10+) abstract error hook."""
-        return
 
 
 def _first_tag_attrs(fragment: str) -> dict[str, str]:

--- a/next/urls/__init__.py
+++ b/next/urls/__init__.py
@@ -1,8 +1,8 @@
 """URL routing, router backends, and URL parameter injection providers.
 
-`__all__` is the supported surface. Advanced callers reach the walk
-helpers and `_LazyUrlPatterns` through deep imports, which keeps the
-package namespace small.
+`_LazyUrlPatterns` and the tree-walk helpers stay out of `__all__` on
+purpose. They are wiring internals, and a caller that needs one imports
+it from the module that defines it.
 """
 
 from . import checks, signals

--- a/next/urls/__init__.py
+++ b/next/urls/__init__.py
@@ -1,19 +1,8 @@
 """URL routing, router backends, and URL parameter injection providers.
 
-Built-in entry points.
-
-- `RouterBackend` and `FileRouterBackend` as extension surface.
-- `RouterFactory` to map dotted paths to backend classes.
-- `RouterManager` plus singleton `router_manager`.
-- `URLPatternParser` for bracket-segment parsing.
-- `DuplicateURLParameterError` raised on conflicting bracket names.
-- `DUrl` marker used in `@context` annotations for URL path segments.
-- `DQuery` marker used in `@context` annotations for query parameters.
-- `TrieURLResolver` dispatching resolve() through a route trie.
-- Django integration via `app_name` and `urlpatterns`.
-
-Deep-import paths expose `FilesystemTreeDispatcher`, `scan_pages_tree`,
-the parameter providers, and `_LazyUrlPatterns` for advanced callers.
+`__all__` is the supported surface. Advanced callers reach the walk
+helpers and `_LazyUrlPatterns` through deep imports, which keeps the
+package namespace small.
 """
 
 from . import checks, signals

--- a/next/urls/dispatcher.py
+++ b/next/urls/dispatcher.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 class FilesystemTreeDispatcher:
-    """Run one depth-first walk: routes per node or skip component folders."""
+    """Run one depth-first walk that yields routes and skips component folders."""
 
     def __init__(
         self,
@@ -89,22 +89,6 @@ def scan_pages_tree(
         register_components=register_components,
     )
     yield from dispatcher.walk(pages_path)
-
-
-def _scan_pages_directory(
-    pages_path: Path,
-    skip_dir_names: Iterable[str] = (),
-    *,
-    components_folder_name: str = "_components",
-    register_components: bool = False,
-) -> Generator[tuple[str, Path], None, None]:
-    """Yield the same pairs as `scan_pages_tree`."""
-    yield from scan_pages_tree(
-        pages_path,
-        skip_dir_names,
-        components_folder_name=components_folder_name,
-        register_components=register_components,
-    )
 
 
 __all__ = ["FilesystemTreeDispatcher", "scan_pages_tree"]

--- a/next/urls/signals.py
+++ b/next/urls/signals.py
@@ -1,7 +1,5 @@
 """Django signals emitted by the URL routing subsystem."""
 
-from __future__ import annotations
-
 from django.dispatch import Signal
 
 

--- a/tests/benchmarks/components/test_bench_facade.py
+++ b/tests/benchmarks/components/test_bench_facade.py
@@ -25,7 +25,7 @@ def _send_component_rendered(
 class TestBenchComponentRenderedSignal:
     @pytest.mark.benchmark(group="components.signals")
     def test_send_no_receiver(self, tmp_path: Path, benchmark) -> None:
-        """Baseline: ``component_rendered.send`` with zero receivers."""
+        """``component_rendered.send`` with zero receivers."""
         info = build_component_info(tmp_path)
         benchmark(_send_component_rendered, component_rendered, object(), info)
 

--- a/tests/benchmarks/forms/test_bench_checks.py
+++ b/tests/benchmarks/forms/test_bench_checks.py
@@ -21,18 +21,18 @@ _WRONG_SUBCLASS = {"FORM_ACTION_BACKENDS": [{"BACKEND": "django.http.HttpRespons
 class TestBenchFormActionBackendsCheck:
     @pytest.mark.benchmark(group="forms.checks")
     def test_check_clean(self, benchmark) -> None:
-        """Happy path: two valid entries that import cleanly."""
+        """Two valid entries that import cleanly."""
         with override_settings(NEXT_FRAMEWORK=_VALID_TWO_ENTRY):
             benchmark(check_form_action_backends_configuration)
 
     @pytest.mark.benchmark(group="forms.checks")
     def test_check_e044_unimportable(self, benchmark) -> None:
-        """E044 path: dotted path raises ``ImportError``."""
+        """An unimportable dotted path raises ``ImportError``."""
         with override_settings(NEXT_FRAMEWORK=_INVALID_BACKEND_PATH):
             benchmark(check_form_action_backends_configuration)
 
     @pytest.mark.benchmark(group="forms.checks")
     def test_check_e045_wrong_subclass(self, benchmark) -> None:
-        """E045 path: imported class is not a `FormActionBackend`."""
+        """An imported class that is not a `FormActionBackend` raises E045."""
         with override_settings(NEXT_FRAMEWORK=_WRONG_SUBCLASS):
             benchmark(check_form_action_backends_configuration)

--- a/tests/benchmarks/forms/test_bench_factory.py
+++ b/tests/benchmarks/forms/test_bench_factory.py
@@ -12,13 +12,13 @@ _REGISTRY_CONFIG = {"BACKEND": "next.forms.RegistryFormActionBackend"}
 class TestBenchFormActionFactory:
     @pytest.mark.benchmark(group="forms.factory")
     def test_create_backend_cached(self, benchmark) -> None:
-        """Warm cache: dotted path served from the framework import cache."""
+        """The dotted path is served from the framework import cache."""
         FormActionFactory.create_backend(_REGISTRY_CONFIG)
         benchmark(FormActionFactory.create_backend, _REGISTRY_CONFIG)
 
     @pytest.mark.benchmark(group="forms.factory")
     def test_create_backend_cold(self, benchmark) -> None:
-        """Cache-miss path: framework import cache cleared per round.
+        """The framework import cache is cleared on every round.
 
         `clear_import_cache()` only invalidates the per-framework dict
         cache. The underlying module already lives in `sys.modules`, so

--- a/tests/benchmarks/forms/test_bench_manager.py
+++ b/tests/benchmarks/forms/test_bench_manager.py
@@ -32,14 +32,14 @@ class TestBenchEnsureBackends:
 
     @pytest.mark.benchmark(group="forms.manager")
     def test_ensure_backends_warm(self, benchmark) -> None:
-        """Hot path: backends already loaded, no settings touch."""
+        """Backends are already loaded, so the call touches no settings."""
         manager = FormActionManager()
         manager._ensure_backends()
         benchmark(manager._ensure_backends)
 
     @pytest.mark.benchmark(group="forms.manager")
     def test_reload_config_cold(self, benchmark) -> None:
-        """Cold path: drop and reload backends from settings."""
+        """Dropping the backends forces a full reload from settings."""
         manager = FormActionManager()
 
         def run() -> None:

--- a/tests/components/test_backends.py
+++ b/tests/components/test_backends.py
@@ -50,7 +50,7 @@ class TestComponentInfo:
 
 
 class TestComponentInfoDunders:
-    """ComponentInfo repr, hash, eq, scope_key."""
+    """ComponentInfo repr, hash, eq."""
 
     def test_repr_contains_fields(self) -> None:
         """Repr includes name and scope fields."""
@@ -69,13 +69,12 @@ class TestComponentInfoDunders:
         assert "ComponentInfo" in r
 
     def test_hash_eq_includes_paths(self) -> None:
-        """Same name and scope but different files are not equal. ``scope_key`` can still match."""
+        """Same name and scope but different files are not equal."""
         r = Path("/p")
         a = ComponentInfo("x", r, "", Path("/p/a.djx"), None, True)
         b = ComponentInfo("x", r, "", Path("/p/b.djx"), None, True)
         c = ComponentInfo("x", r, "sub", Path("/p/a.djx"), None, True)
         assert a != b
-        assert a.scope_key == b.scope_key
         assert a != c
         d = ComponentInfo("x", r, "", Path("/p/a.djx"), None, True)
         assert a == d

--- a/tests/components/test_backends.py
+++ b/tests/components/test_backends.py
@@ -103,7 +103,7 @@ class TestFileComponentsBackend:
     def test_discover_in_component_root_simple(
         self, tmp_path: Path, min_component_config: dict
     ) -> None:
-        """Root component dir: .djx files are discovered as simple components."""
+        """A bare ``.djx`` file in a component root registers as a simple component."""
         (tmp_path / "header.djx").write_text("<header>Hi</header>")
         backend = FileComponentsBackend(
             {**min_component_config, "DIRS": [str(tmp_path)]}
@@ -121,7 +121,7 @@ class TestFileComponentsBackend:
     def test_discover_in_component_root_composite(
         self, tmp_path: Path, min_component_config: dict
     ) -> None:
-        """Root component dir: subdir with component.djx is composite."""
+        """A subdirectory holding ``component.djx`` registers as a composite."""
         (tmp_path / "profile").mkdir()
         (tmp_path / "profile" / "component.djx").write_text("<div>profile</div>")
         backend = FileComponentsBackend(
@@ -282,19 +282,18 @@ class TestComponentsFactory:
         }
         backend = ComponentsFactory.create_backend(config)
         assert isinstance(backend, FileComponentsBackend)
-        assert backend.components_dir == "_components"
+        assert backend._extra_component_roots == []
 
-    def test_create_backend_file_with_component_dirs(self) -> None:
-        """Create FileComponentsBackend with ``COMPONENTS_DIR`` and empty ``DIRS``."""
+    def test_create_backend_file_ignores_the_components_dir_name(self) -> None:
+        """``COMPONENTS_DIR`` names a router skip folder and never reaches the backend."""
         config = {
             "BACKEND": "next.components.FileComponentsBackend",
-            "DIRS": [],
+            "DIRS": [str(Path(__file__).parent)],
             "COMPONENTS_DIR": "components",
         }
         backend = ComponentsFactory.create_backend(config)
         assert isinstance(backend, FileComponentsBackend)
-        assert backend.components_dir == "components"
-        assert backend._extra_component_roots == []
+        assert backend._extra_component_roots == [Path(__file__).parent]
 
     def test_create_backend_unknown_raises(self) -> None:
         """Unknown backend class path raises ImportError."""

--- a/tests/components/test_context.py
+++ b/tests/components/test_context.py
@@ -194,7 +194,7 @@ class TestComponentContextRegistryInternals:
             reg.register(p, "slot", g2)
 
     def test_is_same_function_true_same_file_same_name(self, tmp_path: Path) -> None:
-        """Heuristic: identical name and source file counts as same function."""
+        """An identical name and source file counts as the same function."""
 
         def h() -> int:
             return 7

--- a/tests/components/test_registry.py
+++ b/tests/components/test_registry.py
@@ -132,8 +132,10 @@ class TestComponentVisibilityResolver:
         outside.parent.mkdir(parents=True)
         assert resolver.resolve_visible(outside) == {}
 
-    def test_path_cache_and_clear_cache(self, tmp_path: Path) -> None:
-        """The second resolve reuses the cache. ``clear_cache`` resets it."""
+    def test_second_resolve_returns_the_cached_result_object(
+        self, tmp_path: Path
+    ) -> None:
+        """The second resolve hands back the very mapping built by the first."""
         pages = tmp_path / "pages"
         tmpl = pages / "home.djx"
         tmpl.parent.mkdir(parents=True)
@@ -148,12 +150,11 @@ class TestComponentVisibilityResolver:
         (pages / "_components" / "c.djx").write_text("y")
         res = ComponentVisibilityResolver(reg)
         r1 = res.resolve_visible(tmpl)
+        assert (tmpl.resolve(), pages.resolve()) in res._path_cache
+        assert res._resolved_path_cache[tmpl] == tmpl.resolve()
         r2 = res.resolve_visible(tmpl)
-        assert r1 == r2
-        assert "c" in r1
+        assert r2 is r1
         assert r1["c"].name == "c"
-        res.clear_cache()
-        assert res._path_cache == {}
 
     def test_scope_index_reused_for_second_template_path(self, tmp_path: Path) -> None:
         """Second template path does not rebuild the per-root index."""
@@ -171,8 +172,37 @@ class TestComponentVisibilityResolver:
         t1.parent.mkdir(parents=True, exist_ok=True)
         t1.write_text("z")
         t2.write_text("z")
-        res.resolve_visible(t1)
-        res.resolve_visible(t2)
+        assert "c" in res.resolve_visible(t1)
+        index_after_first = res._scope_index
+        version_after_first = res._scope_index_registry_version
+
+        assert "c" in res.resolve_visible(t2)
+        assert res._scope_index is index_after_first
+        assert res._scope_index_registry_version == version_after_first
+
+    def test_scope_index_rebuilt_after_registry_changes(self, tmp_path: Path) -> None:
+        """A registry mutation invalidates the scope index and the result caches."""
+        pages = tmp_path / "pages"
+        comp_dir = pages / "about" / "_components"
+        comp_dir.mkdir(parents=True)
+        (comp_dir / "c.djx").write_text("x")
+        reg = ComponentRegistry()
+        reg.register(
+            ComponentInfo("c", pages.resolve(), "about", comp_dir / "c.djx", None, True)
+        )
+        res = ComponentVisibilityResolver(reg)
+        tmpl = pages / "about" / "a.djx"
+        tmpl.write_text("z")
+        first = res.resolve_visible(tmpl)
+        index_after_first = res._scope_index
+        assert set(first) == {"c"}
+
+        reg.register(
+            ComponentInfo("d", pages.resolve(), "about", comp_dir / "d.djx", None, True)
+        )
+        second = res.resolve_visible(tmpl)
+        assert res._scope_index is not index_after_first
+        assert set(second) == {"c", "d"}
 
     def test_global_root_component_with_scope_relative_not_visible_far_away(
         self, tmp_path: Path

--- a/tests/components/test_registry.py
+++ b/tests/components/test_registry.py
@@ -150,8 +150,6 @@ class TestComponentVisibilityResolver:
         (pages / "_components" / "c.djx").write_text("y")
         res = ComponentVisibilityResolver(reg)
         r1 = res.resolve_visible(tmpl)
-        assert (tmpl.resolve(), pages.resolve()) in res._path_cache
-        assert res._resolved_path_cache[tmpl] == tmpl.resolve()
         r2 = res.resolve_visible(tmpl)
         assert r2 is r1
         assert r1["c"].name == "c"

--- a/tests/components/test_tags.py
+++ b/tests/components/test_tags.py
@@ -212,7 +212,7 @@ class TestComponentTag:
         expected_substring: str,
         forbidden_substrings: tuple[str, ...],
     ) -> None:
-        """End-to-end: props named like a slot never leak into the slot lookup.
+        """A prop named like a slot never leaks into the slot lookup.
 
         The component template wraps its content in
         ``{% #set_slot "description" %}<i>fallback</i>{% /set_slot %}``.

--- a/tests/deps/test_cache.py
+++ b/tests/deps/test_cache.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from next.deps import Depends, resolver
-from next.deps.cache import _IN_PROGRESS, DependencyCache
+import pytest
+
+from next.deps import DependencyResolver, Depends, resolver
+from next.deps.cache import _CACHE_MISS, _IN_PROGRESS, DependencyCache
 
 
 if TYPE_CHECKING:
@@ -21,6 +23,14 @@ class TestDependencyCache:
         cache.set("dep", "done")
         assert cache.get("dep") == "done"
 
+    def test_unmark_in_progress_returns_key_to_cache_miss(self) -> None:
+        """After unmark_in_progress the key reads as a miss, not as in-progress."""
+        cache = DependencyCache()
+        cache.mark_in_progress("dep")
+        assert cache.get("dep") is _IN_PROGRESS
+        cache.unmark_in_progress("dep")
+        assert cache.get("dep") is _CACHE_MISS
+
     def test_len_and_contains_use_backing_cache(self) -> None:
         """__len__ and __contain__ reflect stored values, not in-progress markers."""
         cache = DependencyCache()
@@ -29,14 +39,6 @@ class TestDependencyCache:
         cache.set("x", 1)
         assert len(cache) == 1
         assert "x" in cache
-
-    def test_is_in_progress_and_unmark(self) -> None:
-        """The ``is_in_progress`` flag reflects ``mark``. ``unmark`` clears it."""
-        cache = DependencyCache()
-        cache.mark_in_progress("k")
-        assert cache.is_in_progress("k")
-        cache.unmark_in_progress("k")
-        assert not cache.is_in_progress("k")
 
 
 class TestCallableDependencyCache:
@@ -77,6 +79,33 @@ class TestCallableDependencyCache:
             assert cache.get("current_user") == "alice"
         finally:
             resolver._dependency_callables.pop("current_user", None)
+
+    def test_failed_dependency_is_retried_on_the_next_resolve(self) -> None:
+        """A dependency that raised is retried, not read back as a false cycle."""
+        attempts = 0
+
+        def flaky() -> str:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                msg = "first attempt fails"
+                raise RuntimeError(msg)
+            return "ok"
+
+        r = DependencyResolver()
+        r.register_dependency("flaky", flaky)
+
+        def view(value: str = Depends("flaky")) -> str:
+            return value
+
+        # The shared DependencyCache instance also shares the in-progress set,
+        # which a dict-backed cache would not.
+        cache = DependencyCache()
+        with pytest.raises(RuntimeError):
+            r.resolve_dependencies(view, _cache=cache)
+
+        assert r.resolve_dependencies(view, _cache=cache) == {"value": "ok"}
+        assert attempts == 2
 
     def test_without_cache_dependency_called_each_resolve(
         self, mock_http_request

--- a/tests/deps/test_cache.py
+++ b/tests/deps/test_cache.py
@@ -98,8 +98,8 @@ class TestCallableDependencyCache:
         def view(value: str = Depends("flaky")) -> str:
             return value
 
-        # The shared DependencyCache instance also shares the in-progress set,
-        # which a dict-backed cache would not.
+        # One DependencyCache instance carries the in-progress set across both
+        # resolves, which a plain dict-backed cache would not.
         cache = DependencyCache()
         with pytest.raises(RuntimeError):
             r.resolve_dependencies(view, _cache=cache)

--- a/tests/deps/test_markers.py
+++ b/tests/deps/test_markers.py
@@ -106,7 +106,7 @@ class TestRegisterDependency:
     def test_depends_provider_resolve_returns_none_when_default_not_depends(
         self,
     ) -> None:
-        """Defensive: DependsProvider.resolve returns None when default isn't Depends."""
+        """``DependsProvider.resolve`` yields ``None`` for a non-``Depends`` default."""
         provider = DependsProvider(DependencyResolver())
         param = inspect_parameter("x", int, default=123)
         ctx = _ctx()

--- a/tests/deps/test_providers.py
+++ b/tests/deps/test_providers.py
@@ -41,13 +41,14 @@ def _no_request() -> None:
     return None
 
 
-class TestResolverDescriptor:
-    """``ContextByNameProvider`` accesses ``resolver`` via class descriptor."""
+class TestProviderResolverAttribute:
+    """``ContextByNameProvider`` reads ``resolver`` from the class attribute."""
 
     def test_context_provider_resolver_attribute_returns_singleton(self) -> None:
-        """ContextByNameProvider has no resolver in ``__init__``. ``self.resolver`` returns the global resolver."""
+        """A provider without a ``resolver`` argument sees the global resolver."""
         provider = ContextByNameProvider()
         assert provider.resolver is resolver
+        assert ContextByNameProvider.resolver is resolver
 
 
 class TestHttpRequestProvider:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -10,7 +10,7 @@ from django.test import Client
 
 from next.conf import NextFrameworkSettings, next_framework_settings
 from next.pages import Page
-from next.pages.loaders import DjxTemplateLoader, LayoutManager, PythonTemplateLoader
+from next.pages.loaders import DjxTemplateLoader, PythonTemplateLoader
 from next.pages.registry import PageContextRegistry
 from next.server import NextStatReloader
 from next.urls import URLPatternParser
@@ -78,12 +78,6 @@ def djx_template_loader():
 def context_manager():
     """Create a PageContextRegistry instance for testing."""
     return PageContextRegistry(None)
-
-
-@pytest.fixture()
-def layout_manager():
-    """Create a LayoutManager instance for testing."""
-    return LayoutManager()
 
 
 @pytest.fixture()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -130,7 +130,7 @@ def csrf_request():
 
 @pytest.fixture()
 def dependency_resolver(request):
-    """Indirect fixture: ``DependencyResolver`` from ``next.deps`` (``minimal``, ``with_form``, or ``full``)."""
+    """Build a ``DependencyResolver`` for the ``minimal``, ``with_form``, or ``full`` param."""
     kind = getattr(request, "param", "minimal")
     factories = {
         "minimal": _minimal_resolver,
@@ -142,7 +142,7 @@ def dependency_resolver(request):
 
 @pytest.fixture()
 def reloader_tick_scenario(request):
-    """Indirect: param is a key from ``tests.support.TICK_SCENARIOS``."""
+    """Run the reloader tick scenario named by the indirect param."""
     name = request.param
     reloader = NextStatReloader()
     with tick_scenario(name, reloader) as payload:
@@ -151,7 +151,7 @@ def reloader_tick_scenario(request):
 
 @pytest.fixture()
 def checks_router_patch(request, tmp_path):
-    """Indirect: ``request.param`` is ``list[tuple[str, Path]]`` routes for page checks mocks."""
+    """Patch the checks router manager with the routes given as the indirect param."""
     routes = request.param
     with patch_checks_router_manager(
         pages_directory=tmp_path, scan_routes=routes

--- a/tests/forms/test_backends.py
+++ b/tests/forms/test_backends.py
@@ -21,7 +21,12 @@ from next.forms import (
     FormActionNotFoundError,
     RegistryFormActionBackend,
 )
-from next.forms.backends import FormActionFactory, file_to_dotted_module, scope_key_for
+from next.forms.backends import (
+    FormActionFactory,
+    RegistryBackendSnapshot,
+    file_to_dotted_module,
+    scope_key_for,
+)
 from next.forms.manager import FormActionManager, form_action_manager
 
 
@@ -145,7 +150,7 @@ class TestFormActionNotFoundError:
 
 
 class TestFormActionManager:
-    """FormActionManager: get_action_url, default_backend, __iter__."""
+    """``FormActionManager`` reverse URLs, its default backend, and iteration."""
 
     def test_get_action_url_returns_url(self) -> None:
         """Return URL for known action."""
@@ -1105,3 +1110,44 @@ class TestSharedScopeKeysAcrossApps:
         ]
         uids = {meta["uid"] for meta in backend._registry.values()}
         assert len(uids) == 2
+
+
+def _register(backend: RegistryFormActionBackend, name: str) -> None:
+    def handler() -> None:
+        pass
+
+    backend.register_action(
+        ActionRegistration(
+            name=name, file_path=_FAKE_FILE, scope="shared", handler=handler
+        )
+    )
+
+
+class TestRegistryBackendSnapshotRestore:
+    """`snapshot`/`restore` roll the action maps back without private access."""
+
+    def test_restore_drops_actions_registered_after_the_snapshot(self) -> None:
+        backend = RegistryFormActionBackend()
+        _register(backend, "kept")
+        saved = backend.snapshot()
+        _register(backend, "extra")
+        assert backend.get_meta("extra") is not None
+        backend.restore(saved)
+        assert backend.get_meta("extra") is None
+        assert backend.get_meta("kept") is not None
+
+    def test_snapshot_is_a_value_object_copy(self) -> None:
+        backend = RegistryFormActionBackend()
+        _register(backend, "kept")
+        saved = backend.snapshot()
+        assert isinstance(saved, RegistryBackendSnapshot)
+        _register(backend, "extra")
+        assert "extra" not in {name for _, name in saved.name_index.values()}
+
+    def test_restore_resets_the_reverse_url_cache(self) -> None:
+        backend = RegistryFormActionBackend()
+        _register(backend, "kept")
+        saved = backend.snapshot()
+        _register(backend, "extra")
+        backend.restore(saved)
+        assert backend._url_cache == {}

--- a/tests/forms/test_backends.py
+++ b/tests/forms/test_backends.py
@@ -21,12 +21,7 @@ from next.forms import (
     FormActionNotFoundError,
     RegistryFormActionBackend,
 )
-from next.forms.backends import (
-    FormActionFactory,
-    RegistryBackendSnapshot,
-    file_to_dotted_module,
-    scope_key_for,
-)
+from next.forms.backends import FormActionFactory, file_to_dotted_module, scope_key_for
 from next.forms.manager import FormActionManager, form_action_manager
 
 
@@ -1110,44 +1105,3 @@ class TestSharedScopeKeysAcrossApps:
         ]
         uids = {meta["uid"] for meta in backend._registry.values()}
         assert len(uids) == 2
-
-
-def _register(backend: RegistryFormActionBackend, name: str) -> None:
-    def handler() -> None:
-        pass
-
-    backend.register_action(
-        ActionRegistration(
-            name=name, file_path=_FAKE_FILE, scope="shared", handler=handler
-        )
-    )
-
-
-class TestRegistryBackendSnapshotRestore:
-    """`snapshot`/`restore` roll the action maps back without private access."""
-
-    def test_restore_drops_actions_registered_after_the_snapshot(self) -> None:
-        backend = RegistryFormActionBackend()
-        _register(backend, "kept")
-        saved = backend.snapshot()
-        _register(backend, "extra")
-        assert backend.get_meta("extra") is not None
-        backend.restore(saved)
-        assert backend.get_meta("extra") is None
-        assert backend.get_meta("kept") is not None
-
-    def test_snapshot_is_a_value_object_copy(self) -> None:
-        backend = RegistryFormActionBackend()
-        _register(backend, "kept")
-        saved = backend.snapshot()
-        assert isinstance(saved, RegistryBackendSnapshot)
-        _register(backend, "extra")
-        assert "extra" not in {name for _, name in saved.name_index.values()}
-
-    def test_restore_resets_the_reverse_url_cache(self) -> None:
-        backend = RegistryFormActionBackend()
-        _register(backend, "kept")
-        saved = backend.snapshot()
-        _register(backend, "extra")
-        backend.restore(saved)
-        assert backend._url_cache == {}

--- a/tests/forms/test_checks.py
+++ b/tests/forms/test_checks.py
@@ -112,7 +112,7 @@ class TestFormActionCollisions:
         assert callable(record_possible_collision)
 
     def test_first_registration_records_no_collision(self) -> None:
-        """Common case: a name registered once never touches the collision map."""
+        """A name registered once never touches the collision map."""
         backend = RegistryFormActionBackend()
         backend.register_action(
             ActionRegistration(

--- a/tests/forms/test_decorators.py
+++ b/tests/forms/test_decorators.py
@@ -232,7 +232,7 @@ class TestActionDecoratorFormClass:
 
 
 class TestBaseFormGetInitial:
-    """BaseForm.get_initial: default implementation and override."""
+    """``BaseForm.get_initial`` in its default form and when a subclass overrides it."""
 
     def test_get_initial_returns_empty_dict_by_default(self) -> None:
         """Default get_initial returns empty dict."""

--- a/tests/pages/conftest.py
+++ b/tests/pages/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from next.pages import Page
-from next.pages.loaders import DjxTemplateLoader, LayoutManager, PythonTemplateLoader
+from next.pages.loaders import DjxTemplateLoader, PythonTemplateLoader
 from next.pages.registry import PageContextRegistry
 from next.pages.signals import context_registered, page_rendered, template_loaded
 from next.urls import URLPatternParser
@@ -41,12 +41,6 @@ def djx_template_loader():
 def context_manager():
     """Create a PageContextRegistry instance for testing."""
     return PageContextRegistry(None)
-
-
-@pytest.fixture()
-def layout_manager():
-    """Create a LayoutManager instance for testing."""
-    return LayoutManager()
 
 
 @pytest.fixture()

--- a/tests/pages/test_checks.py
+++ b/tests/pages/test_checks.py
@@ -48,7 +48,7 @@ class _AppRouter:
 
 
 class TestPageChecks:
-    """Test cases for page checks functionality."""
+    """Checks that decide whether a routed ``page.py`` can produce a body."""
 
     @pytest.mark.parametrize(
         ("page_content", "create_djx", "djx_content", "expected_result"),
@@ -78,7 +78,7 @@ def render(request, **kwargs):
     def test_has_template_or_djx(
         self, tmp_path, page_content, create_djx, djx_content, expected_result
     ) -> None:
-        """Test _has_template_or_djx with different scenarios."""
+        """Only a ``template`` attribute or a sibling ``template.djx`` counts, ``render()`` does not."""
         page_file = tmp_path / "page.py"
         page_file.write_text(page_content)
 
@@ -91,7 +91,7 @@ def render(request, **kwargs):
 
 
 class TestLayoutChecks:
-    """Test cases for layout checks functionality."""
+    """Checks over ``layout.djx`` files found in the page trees."""
 
     @pytest.mark.parametrize(
         ("layout_body", "expected_warnings", "msg_substring"),
@@ -330,7 +330,7 @@ class TestCheckTemplateLoaders:
         assert "cannot be imported" in msgs[0].msg
 
     @override_settings(
-        NEXT_FRAMEWORK={"TEMPLATE_LOADERS": ["next.pages.loaders.LayoutManager"]}
+        NEXT_FRAMEWORK={"TEMPLATE_LOADERS": ["next.pages.registry.PageContextRegistry"]}
     )
     def test_non_subclass_entry_is_e043(self) -> None:
 
@@ -445,10 +445,10 @@ class TestBodySourceConflicts:
 
 
 class TestContextFunctionsChecks:
-    """Test cases for context functions checks."""
+    """Checks over the return shape of registered ``@context`` functions."""
 
     def test_check_context_functions_valid_dict_return(self, tmp_path) -> None:
-        """Test check_context_functions with valid dict return."""
+        """A keyless ``@context`` returning a dict raises nothing."""
         page_file = tmp_path / "page.py"
         page_file.write_text("""
 from next.pages import context
@@ -590,7 +590,7 @@ def get_context_data():
         assert second == []
 
     def test_check_context_functions_with_key_not_checked(self, tmp_path) -> None:
-        """Test check_context_functions ignores functions with key."""
+        """A keyed ``@context`` may return any type and is left alone."""
         page_file = tmp_path / "page.py"
         page_file.write_text("""
 from next.pages import context

--- a/tests/pages/test_loaders.py
+++ b/tests/pages/test_loaders.py
@@ -21,7 +21,7 @@ from tests.support import default_page_router_config, file_router_config_entry
 
 
 class TestPythonTemplateLoader:
-    """Test cases for Python template loader."""
+    """``PythonTemplateLoader`` reading a ``template`` attribute out of ``page.py``."""
 
     @pytest.mark.parametrize(
         ("file_content", "expected_can_load", "expected_load_result"),
@@ -40,7 +40,7 @@ class TestPythonTemplateLoader:
         expected_can_load,
         expected_load_result,
     ) -> None:
-        """Test can_load and load_template with different file contents."""
+        """Only a ``page.py`` defining ``template`` loads, a broken or bare one does not."""
         page_file = tmp_path / "page.py"
         page_file.write_text(file_content)
 
@@ -52,7 +52,7 @@ class TestPythonTemplateLoader:
 
 
 class TestDjxTemplateLoader:
-    """Test cases for DJX template loader."""
+    """``DjxTemplateLoader`` reading a sibling ``template.djx``."""
 
     @pytest.mark.parametrize(
         ("create_djx_file", "djx_content", "expected_result"),
@@ -74,7 +74,7 @@ class TestDjxTemplateLoader:
         djx_content,
         expected_result,
     ) -> None:
-        """Test loading of template.djx template with different scenarios."""
+        """A sibling ``template.djx`` loads verbatim, its absence yields ``None``."""
         page_file = tmp_path / "page.py"
         page_file.write_text('print("test")')
 
@@ -117,7 +117,7 @@ class TestDjxTemplateLoader:
         djx_content,
         expected_template,
     ) -> None:
-        """Test create_url_pattern with different template scenarios."""
+        """A ``template`` attribute wins over a sibling ``template.djx`` at render time."""
         page_file = tmp_path / "page.py"
         page_file.write_text(page_content)
 
@@ -136,7 +136,7 @@ class TestDjxTemplateLoader:
         assert expected_rendered in result
 
     def test_render_djx_template_with_context(self, page_instance, tmp_path) -> None:
-        """Test rendering template.djx template with context."""
+        """A ``template.djx`` body interpolates the keyword arguments passed to render."""
         page_file = tmp_path / "page.py"
         page_file.write_text('print("test")')
 
@@ -157,7 +157,7 @@ class TestDjxTemplateLoader:
     def test_render_djx_template_with_django_tags(
         self, page_instance, tmp_path
     ) -> None:
-        """Test rendering template.djx template with Django tags."""
+        """Django ``if`` and ``for`` tags inside ``template.djx`` execute normally."""
         page_file = tmp_path / "page.py"
         page_file.write_text('print("test")')
 
@@ -192,7 +192,7 @@ class TestDjxTemplateLoader:
         assert "<li>" in result
 
     def test_djx_template_with_context_functions(self, page_instance, tmp_path) -> None:
-        """Test template.djx template with context functions."""
+        """A registered ``@context`` key resolves inside a ``template.djx`` body."""
         page_file = tmp_path / "page.py"
         page_file.write_text("""
 from next.pages import context
@@ -231,7 +231,7 @@ def get_landing_data(*args, **kwargs):
 
 
 class TestLayoutTemplateLoader:
-    """Test cases for LayoutTemplateLoader."""
+    """``LayoutTemplateLoader`` discovering and composing the ``layout.djx`` chain."""
 
     @pytest.mark.parametrize(
         ("create_layout", "create_template", "expected_can_load"),
@@ -246,7 +246,7 @@ class TestLayoutTemplateLoader:
     def test_can_load_with_layout_files(
         self, tmp_path, create_layout, create_template, expected_can_load
     ) -> None:
-        """Test can_load with different layout and template combinations."""
+        """An ancestor ``layout.djx`` alone makes the page loadable, a lone template does not."""
         loader = LayoutTemplateLoader()
 
         sub_dir = tmp_path / "sub" / "nested"
@@ -268,7 +268,7 @@ class TestLayoutTemplateLoader:
         assert result is expected_can_load
 
     def test_get_additional_layout_files_with_next_pages_config(self, tmp_path) -> None:
-        """Test _get_additional_layout_files with ``NEXT['PAGES']['ROUTERS']``."""
+        """Layout roots configured on a page backend contribute their ``layout.djx``."""
         loader = LayoutTemplateLoader()
 
         layout_file = tmp_path / "layout.djx"
@@ -311,7 +311,7 @@ class TestLayoutTemplateLoader:
     def test_get_additional_layout_files_scenarios(
         self, tmp_path, test_case, config, expected_result
     ) -> None:
-        """Test _get_additional_layout_files with different configuration scenarios."""
+        """A malformed entry or a missing directory contributes no layout files."""
         loader = LayoutTemplateLoader()
 
         with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": config}):
@@ -336,7 +336,7 @@ class TestLayoutTemplateLoader:
     def test_get_pages_dirs_for_config_scenarios(
         self, tmp_path, test_case, config, expected_list
     ) -> None:
-        """Test _get_pages_dirs_for_config with different configuration scenarios."""
+        """Only existing ``DIRS`` paths become page roots, ``APP_DIRS`` alone yields none."""
         loader = LayoutTemplateLoader()
 
         if test_case == "with_pages_dir":
@@ -410,7 +410,7 @@ class TestLayoutTemplateLoader:
         template_content,
         expected_result,
     ) -> None:
-        """Test _wrap_in_template_block with different file scenarios."""
+        """A body is wrapped in a ``template`` block only when no local layout owns it."""
         loader = LayoutTemplateLoader()
 
         if create_layout:
@@ -429,7 +429,7 @@ class TestLayoutTemplateLoader:
     def test_find_layout_files_with_duplicate_additional_layouts(
         self, tmp_path
     ) -> None:
-        """Test _find_layout_files when additional layouts are already in local hierarchy."""
+        """A configured root that repeats the local layout is not counted twice."""
         loader = LayoutTemplateLoader()
 
         layout_file = tmp_path / "layout.djx"
@@ -451,7 +451,7 @@ class TestLayoutTemplateLoader:
         assert layout_file in result
 
     def test_get_additional_layout_files_with_duplicate_layouts(self, tmp_path) -> None:
-        """Test _get_additional_layout_files with duplicate layout files."""
+        """Two backends pointing at one root yield that root's layout once."""
         loader = LayoutTemplateLoader()
 
         layout_file = tmp_path / "layout.djx"
@@ -471,7 +471,7 @@ class TestLayoutTemplateLoader:
     def test_find_layout_files_with_additional_layouts_already_present(
         self, tmp_path
     ) -> None:
-        """Test _find_layout_files when additional layouts are already in layout_files."""
+        """A configured root above the page adds nothing the local walk already found."""
         loader = LayoutTemplateLoader()
 
         parent_dir = tmp_path / "parent"
@@ -499,7 +499,7 @@ class TestLayoutTemplateLoader:
     def test_find_layout_files_with_different_additional_layouts(
         self, tmp_path
     ) -> None:
-        """Test _find_layout_files when additional layouts are different from local ones."""
+        """A configured root outside the page hierarchy adds its own layout to the chain."""
         loader = LayoutTemplateLoader()
 
         local_layout = tmp_path / "layout.djx"
@@ -527,7 +527,7 @@ class TestLayoutTemplateLoader:
         assert additional_layout in result
 
     def test_load_template_with_single_layout(self, tmp_path) -> None:
-        """Test load_template with single layout file."""
+        """One ancestor layout wraps the body and keeps its ``template`` block."""
         loader = LayoutTemplateLoader()
 
         layout_file = tmp_path / "layout.djx"
@@ -552,7 +552,7 @@ class TestLayoutTemplateLoader:
         assert "{% block template %}" in result
 
     def test_load_template_with_multiple_layouts(self, tmp_path) -> None:
-        """Test load_template with multiple layout files in hierarchy."""
+        """Nested layouts compose outermost first, with the body innermost."""
         loader = LayoutTemplateLoader()
 
         root_layout = tmp_path / "layout.djx"
@@ -583,7 +583,7 @@ class TestLayoutTemplateLoader:
         assert "{% block template %}" in result
 
     def test_load_template_without_template_djx(self, tmp_path) -> None:
-        """Test load_template when template.djx doesn't exist."""
+        """A layout with no body behind it composes to an empty ``template`` block."""
         loader = LayoutTemplateLoader()
 
         layout_file = tmp_path / "layout.djx"
@@ -616,7 +616,7 @@ class TestLayoutTemplateLoader:
         assert "{% block template %}{% endblock template %}" in result
 
     def test_find_layout_files(self, tmp_path) -> None:
-        """Test _find_layout_files method."""
+        """The walk collects every ``layout.djx`` from the page up to the tree root."""
         loader = LayoutTemplateLoader()
 
         sub_dir = tmp_path / "sub" / "nested"
@@ -637,7 +637,7 @@ class TestLayoutTemplateLoader:
         assert root_layout in layout_files
 
     def test_compose_layout_hierarchy_exception_handling(self, tmp_path) -> None:
-        """Test _compose_layout_hierarchy handles exceptions gracefully."""
+        """A layout that cannot be read leaves the body unwrapped instead of raising."""
         loader = LayoutTemplateLoader()
 
         layout_file = tmp_path / "layout.djx"
@@ -651,7 +651,7 @@ class TestLayoutTemplateLoader:
             assert result == "test content"
 
     def test_load_template_no_layout_files(self, tmp_path) -> None:
-        """Test load_template when no layout files exist."""
+        """A page with no layout above it yields ``None``."""
         loader = LayoutTemplateLoader()
 
         page_file = tmp_path / "page.py"
@@ -662,10 +662,10 @@ class TestLayoutTemplateLoader:
 
 
 class TestContextProcessors:
-    """Test context_processors functionality."""
+    """Resolving context processors from page backends and from ``TEMPLATES``."""
 
     def test_get_context_processors_empty_config(self, page_instance) -> None:
-        """Test _get_context_processors with empty ``ROUTERS`` list."""
+        """No backends and no ``TEMPLATES`` resolve to no processors."""
         with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": []}, TEMPLATES=[]):
             next_framework_settings.reload()
             processors = _get_context_processors()
@@ -682,7 +682,7 @@ class TestContextProcessors:
             assert processors == []
 
     def test_get_context_processors_no_context_processors(self, page_instance) -> None:
-        """Test _get_context_processors with routers but no context_processors."""
+        """A backend that declares no processors contributes none."""
         config = [file_router_config_entry(app_dirs=True)]
         with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": config}, TEMPLATES=[]):
             next_framework_settings.reload()
@@ -692,7 +692,7 @@ class TestContextProcessors:
     def test_get_context_processors_inherits_from_templates(
         self, page_instance
     ) -> None:
-        """Test _get_context_processors inherits from TEMPLATES when routers omit processors."""
+        """A backend silent on processors falls back to the ``TEMPLATES`` list."""
 
         def test_processor(request):
             return {"test_var": "test_value"}
@@ -826,7 +826,7 @@ class TestContextProcessors:
             assert result == []
 
     def test_get_context_processors_with_valid_processors(self, page_instance) -> None:
-        """Test _get_context_processors with valid context processors."""
+        """Declared processors are imported and kept in declaration order."""
 
         def test_processor(request):
             return {"test_var": "test_value"}
@@ -859,7 +859,7 @@ class TestContextProcessors:
                 assert processors[1] == another_processor
 
     def test_get_context_processors_with_invalid_processor(self, page_instance) -> None:
-        """Test _get_context_processors with invalid processor path."""
+        """An unimportable path is warned about and dropped, the rest still load."""
         config = [
             file_router_config_entry(
                 app_dirs=True,
@@ -890,7 +890,7 @@ class TestContextProcessors:
             mock_warning.assert_called_once()
 
     def test_import_context_processor_non_callable(self, page_instance) -> None:
-        """Test _import_context_processor with non-callable import."""
+        """A dotted path resolving to a non-callable yields ``None``."""
         with patch("next.pages.processors.import_string") as mock_import:
             mock_import.return_value = "not a callable"
 
@@ -898,7 +898,7 @@ class TestContextProcessors:
             assert processor is None
 
     def test_render_with_context_processors(self, page_instance, tmp_path) -> None:
-        """Test render method with context_processors."""
+        """Processor output reaches the template alongside the render keyword arguments."""
         page_file = tmp_path / "page.py"
         template_str = "<h1>{{ title }}</h1><p>{{ request_var }}</p>"
         page_instance.register_template(page_file, template_str)
@@ -918,7 +918,7 @@ class TestContextProcessors:
             assert "from_processor" in result
 
     def test_render_without_request_object(self, page_instance, tmp_path) -> None:
-        """Test render method without request object (should use regular Context)."""
+        """Without a request the processors never run."""
         page_file = tmp_path / "page.py"
         template_str = "<h1>{{ title }}</h1>"
         page_instance.register_template(page_file, template_str)
@@ -935,7 +935,7 @@ class TestContextProcessors:
             assert "from_processor" not in result
 
     def test_render_without_context_processors(self, page_instance, tmp_path) -> None:
-        """Test render method without context_processors (should use regular Context)."""
+        """An empty processor list renders through a plain context."""
         page_file = tmp_path / "page.py"
         template_str = "<h1>{{ title }}</h1>"
         page_instance.register_template(page_file, template_str)
@@ -949,7 +949,7 @@ class TestContextProcessors:
             assert result == "<h1>Test Title</h1>"
 
     def test_render_with_context_processor_error(self, page_instance, tmp_path) -> None:
-        """Test render method with context processor that raises an exception."""
+        """A raising processor is warned about and skipped, later ones still apply."""
         page_file = tmp_path / "page.py"
         template_str = "<h1>{{ title }}</h1><p>{{ good_var }}</p>"
         page_instance.register_template(page_file, template_str)
@@ -1004,7 +1004,7 @@ class TestContextProcessors:
     def test_render_with_context_processor_non_dict_return(
         self, page_instance, tmp_path
     ) -> None:
-        """Test render method with context processor that returns non-dict."""
+        """A processor returning a non-mapping is ignored, later ones still apply."""
         page_file = tmp_path / "page.py"
         template_str = "<h1>{{ title }}</h1><p>{{ good_var }}</p>"
         page_instance.register_template(page_file, template_str)
@@ -1100,7 +1100,7 @@ class TestBuildRegisteredLoaders:
             "TEMPLATE_LOADERS": [
                 123,
                 "does.not.exist.Loader",
-                "next.pages.loaders.LayoutManager",
+                "next.pages.registry.PageContextRegistry",
                 "next.pages.loaders.DjxTemplateLoader",
             ]
         }

--- a/tests/pages/test_manager.py
+++ b/tests/pages/test_manager.py
@@ -60,7 +60,6 @@ class TestPage:
         frame_chain,
     ) -> None:
         """Test context decorator with different variations."""
-        # set up the frame chain based on the test case
         frame = mock_frame.return_value
         for attr in frame_chain.split("."):
             frame = getattr(frame, attr)
@@ -81,7 +80,6 @@ class TestPage:
 
             func = get_context_data
 
-        # verify context function was registered
         assert context_temp_file in page_instance._context_manager._context_registry
         assert (
             expected_key
@@ -104,7 +102,6 @@ class TestPage:
         def get_inherited_value() -> str:
             return "inherited_value"
 
-        # verify context function was registered with inherit_context=True
         assert context_temp_file in page_instance._context_manager._context_registry
         assert (
             "inherited_key"
@@ -129,7 +126,6 @@ class TestPage:
         def get_context_data():
             return {"key1": "value1", "key2": "value2"}
 
-        # verify context function was registered with inherit_context=True
         assert context_temp_file in page_instance._context_manager._context_registry
         assert (
             None in page_instance._context_manager._context_registry[context_temp_file]
@@ -206,24 +202,20 @@ class TestPage:
         expected,
     ) -> None:
         """Test various render scenarios with parametrized test cases."""
-        # register template
         page_instance.register_template(test_file_path, template_str)
 
-        # register context functions if any
         if context_setup:
             for key, func in context_setup.items():
                 page_instance._context_manager.register_context(
                     test_file_path, key, func
                 )
 
-        # render
         result = page_instance.render(test_file_path, **render_kwargs)
 
         assert result == expected
 
     def test_render_with_multiple_files(self, page_instance) -> None:
         """Test render method with multiple files having different templates and contexts."""
-        # first file
         file1 = Path("/test/path/page1.py")
         template1 = "Page 1: {{ title }}"
         page_instance.register_template(file1, template1)
@@ -231,7 +223,6 @@ class TestPage:
             file1, "title", lambda: "First Page"
         )
 
-        # second file
         file2 = Path("/test/path/page2.py")
         template2 = "Page 2: {{ title }}"
         page_instance.register_template(file2, template2)
@@ -239,7 +230,6 @@ class TestPage:
             file2, "title", lambda: "Second Page"
         )
 
-        # render both
         result1 = page_instance.render(file1)
         result2 = page_instance.render(file2)
 
@@ -248,7 +238,6 @@ class TestPage:
 
     def test_render_with_inherited_context(self, page_instance, tmp_path) -> None:
         """Test render method with inherited context from layout directories."""
-        # create layout structure
         layout_dir = tmp_path / "layout_dir"
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
@@ -259,16 +248,13 @@ class TestPage:
         page_file = layout_dir / "page.py"
         page_file.write_text("")
 
-        # create child directory
         child_dir = layout_dir / "child"
         child_dir.mkdir()
         child_page_file = child_dir / "page.py"
 
-        # register template for child page
         template_str = "Child page: {{ inherited_var }}"
         page_instance.register_template(child_page_file, template_str)
 
-        # register context in layout page.py with inherit_context=True
         def layout_func() -> str:
             return "inherited_value"
 
@@ -276,7 +262,6 @@ class TestPage:
             page_file, "inherited_var", layout_func, inherit_context=True
         )
 
-        # render child page
         result = page_instance.render(child_page_file)
 
         assert "Child page: inherited_value" in result
@@ -285,7 +270,6 @@ class TestPage:
         self, page_instance, tmp_path
     ) -> None:
         """Test that child page context overrides inherited context."""
-        # create layout structure
         layout_dir = tmp_path / "layout_dir"
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
@@ -296,16 +280,13 @@ class TestPage:
         page_file = layout_dir / "page.py"
         page_file.write_text("")
 
-        # create child directory
         child_dir = layout_dir / "child"
         child_dir.mkdir()
         child_page_file = child_dir / "page.py"
 
-        # register template for child page
         template_str = "Child page: {{ var }}"
         page_instance.register_template(child_page_file, template_str)
 
-        # register context in layout page.py with inherit_context=True
         def layout_func() -> str:
             return "layout_value"
 
@@ -313,7 +294,6 @@ class TestPage:
             page_file, "var", layout_func, inherit_context=True
         )
 
-        # register context in child page.py (should override inherited)
         def child_func() -> str:
             return "child_value"
 
@@ -321,17 +301,14 @@ class TestPage:
             child_page_file, "var", child_func, inherit_context=False
         )
 
-        # render child page
         result = page_instance.render(child_page_file)
 
-        # child context should override inherited context
         assert "Child page: child_value" in result
 
     def test_context_registry_defaultdict_behavior(
         self, page_instance, test_file_path
     ) -> None:
         """Test that context registry uses defaultdict-like behavior."""
-        # register context function - should create the file entry
         page_instance._context_manager.register_context(
             test_file_path, "test_key", lambda: "test_value"
         )
@@ -683,84 +660,7 @@ class TestLayoutManager:
     def test_init(self) -> None:
         """Test LayoutManager initialization."""
         manager = LayoutManager()
-        assert manager._layout_registry == {}
         assert isinstance(manager._layout_loader, LayoutTemplateLoader)
-
-    def test_discover_layouts_for_template(self, tmp_path) -> None:
-        """Test discover_layouts_for_template method."""
-        manager = LayoutManager()
-
-        # create layout structure
-        layout_file = tmp_path / "layout.djx"
-        layout_file.write_text(
-            "<html><body>{% block template %}{% endblock template %}</body></html>"
-        )
-
-        sub_dir = tmp_path / "sub"
-        sub_dir.mkdir()
-        template_file = sub_dir / "template.djx"
-        template_file.write_text("<h1>Test</h1>")
-
-        page_file = sub_dir / "page.py"
-        result = manager.discover_layouts_for_template(page_file)
-
-        assert result is not None
-        assert page_file in manager._layout_registry
-
-    def test_discover_layouts_no_layouts(self, tmp_path) -> None:
-        """Test discover_layouts_for_template when no layouts exist."""
-        manager = LayoutManager()
-
-        sub_dir = tmp_path / "sub"
-        sub_dir.mkdir()
-        page_file = sub_dir / "page.py"
-
-        result = manager.discover_layouts_for_template(page_file)
-
-        assert result is None
-        assert page_file not in manager._layout_registry
-
-    def test_get_layout_template(self, tmp_path) -> None:
-        """Test get_layout_template method."""
-        manager = LayoutManager()
-
-        # create layout structure
-        layout_file = tmp_path / "layout.djx"
-        layout_file.write_text(
-            "<html><body>{% block template %}{% endblock template %}</body></html>"
-        )
-
-        sub_dir = tmp_path / "sub"
-        sub_dir.mkdir()
-        template_file = sub_dir / "template.djx"
-        template_file.write_text("<h1>Test</h1>")
-
-        page_file = sub_dir / "page.py"
-        manager.discover_layouts_for_template(page_file)
-
-        result = manager.get_layout_template(page_file)
-        assert result is not None
-
-    def test_get_layout_template_not_found(self, tmp_path) -> None:
-        """Test get_layout_template when template not found."""
-        manager = LayoutManager()
-
-        page_file = tmp_path / "page.py"
-        result = manager.get_layout_template(page_file)
-
-        assert result is None
-
-    def test_clear_registry(self) -> None:
-        """Test clear_registry method."""
-        layout_manager = LayoutManager()
-
-        # add some data to registry
-        layout_manager._layout_registry["test_path"] = "test_template"
-        assert len(layout_manager._layout_registry) == 1
-
-        # clear registry
-        layout_manager.clear_registry()
-        assert len(layout_manager._layout_registry) == 0
 
 
 class TestLayoutIntegration:
@@ -775,14 +675,12 @@ class TestLayoutIntegration:
         self, page_instance, tmp_path, url_parser
     ) -> None:
         """Test create_url_pattern with layout inheritance."""
-        # create layout structure
         layout_file = tmp_path / "layout.djx"
         layout_content = (
             "<html><body>{% block template %}{% endblock template %}</body></html>"
         )
         layout_file.write_text(layout_content)
 
-        # create template.djx
         sub_dir = tmp_path / "sub"
         sub_dir.mkdir()
         template_file = sub_dir / "template.djx"
@@ -793,37 +691,29 @@ class TestLayoutIntegration:
         pattern = page_instance.create_url_pattern("test", page_file, url_parser)
 
         assert pattern is not None
-        # Template loaded lazily at first render
         result = page_instance.render(page_file, title="Test")
         assert "Test" in result
 
     def test_render_with_layout_inheritance(self, page_instance, tmp_path) -> None:
-        """Test rendering with layout inheritance."""
-        # create layout structure
-        layout_file = tmp_path / "layout.djx"
-        layout_content = (
+        """`Page.render` nests a sibling layout inside its ancestor layout."""
+        (tmp_path / "layout.djx").write_text(
             "<html><body>{% block template %}{% endblock template %}</body></html>"
         )
-        layout_file.write_text(layout_content)
 
-        # create template.djx
         sub_dir = tmp_path / "sub"
         sub_dir.mkdir()
-        template_file = sub_dir / "template.djx"
-        template_content = "<h1>{{ title }}</h1>"
-        template_file.write_text(template_content)
+        (sub_dir / "layout.djx").write_text(
+            "<main>{% block template %}{% endblock template %}</main>"
+        )
+        (sub_dir / "template.djx").write_text("<h1>{{ title }}</h1>")
 
         page_file = sub_dir / "page.py"
+        result = page_instance.render(page_file, title="Test")
 
-        # discover layouts
-        page_instance._layout_manager.discover_layouts_for_template(page_file)
-        layout_template = page_instance._layout_manager.get_layout_template(page_file)
-        page_instance.register_template(page_file, layout_template)
-
-        # check that template contains layout content
-        assert "<html><body>" in layout_template
-        assert "</body></html>" in layout_template
-        assert "{% block template %}" in layout_template
+        assert result.startswith("<html><body><main>")
+        assert "<h1>Test</h1>" in result
+        assert result.endswith("</main></body></html>")
+        assert "{% block template %}" not in result
 
     def test_render_composes_template_djx_under_ancestor_layout(
         self, page_instance, tmp_path
@@ -851,14 +741,12 @@ class TestLayoutIntegration:
         self, page_instance, tmp_path
     ) -> None:
         """Test render method with layout template detection."""
-        # create a template that looks like a layout template but doesn't use extends
         page_file = tmp_path / "page.py"
         template_str = "<h1>{{ title }}</h1>"
         page_instance.register_template(page_file, template_str)
 
         result = page_instance.render(page_file, title="Test")
 
-        # should use regular template rendering
         assert result == "<h1>Test</h1>"
 
 
@@ -867,7 +755,6 @@ class TestLoadPythonModule:
 
     def test_load_python_module_invalid_file(self, tmp_path) -> None:
         """Test _load_python_module with invalid Python file."""
-        # create an invalid Python file
         invalid_file = tmp_path / "invalid.py"
         invalid_file.write_text("invalid python syntax {")
 
@@ -917,11 +804,9 @@ class TestUnifiedViewBodyResolution:
     def _isolate(self):
         page._template_registry.clear()
         page._template_source_mtimes.clear()
-        page._layout_manager._layout_registry.clear()
         yield
         page._template_registry.clear()
         page._template_source_mtimes.clear()
-        page._layout_manager._layout_registry.clear()
 
     def test_template_attribute_with_ancestor_layout_composes(
         self, page_instance, tmp_path
@@ -1177,7 +1062,7 @@ class TestLayoutComposeBody:
 
 
 class _MdLoader(TemplateLoader):
-    """Test double: render sibling `template.md` as `<article>{body}</article>`."""
+    """Test-only loader wrapping a sibling `template.md` in an `<article>`."""
 
     source_name = "template.md"
 

--- a/tests/pages/test_manager.py
+++ b/tests/pages/test_manager.py
@@ -11,7 +11,6 @@ import next.pages.loaders as loaders_module
 from next.checks import _load_python_module
 from next.pages import Page, context, page
 from next.pages.loaders import (
-    LayoutManager,
     LayoutTemplateLoader,
     TemplateLoader,
     _load_python_module_memo,
@@ -23,16 +22,16 @@ from tests.support import patch_checks_router_manager
 
 
 class TestPage:
-    """Test cases for Page class."""
+    """Registration, context collection, and rendering on a fresh ``Page``."""
 
     def test_init(self, page_instance) -> None:
-        """Test Page initialization."""
+        """A fresh ``Page`` starts with empty registries and its own layout loader."""
         assert page_instance._template_registry == {}
         assert isinstance(page_instance._context_manager, PageContextRegistry)
-        assert isinstance(page_instance._layout_manager, LayoutManager)
+        assert isinstance(page_instance._layout_loader, LayoutTemplateLoader)
 
     def test_register_template_direct(self, page_instance) -> None:
-        """Test register_template method with direct file path."""
+        """``register_template`` stores the source under the exact path it was given."""
         file_path = Path("/test/path/page.py")
         template_str = "Hello {{ name }}!"
 
@@ -59,7 +58,7 @@ class TestPage:
         expected_key,
         frame_chain,
     ) -> None:
-        """Test context decorator with different variations."""
+        """``@context`` keys on the caller file whether or not a key and parentheses are given."""
         frame = mock_frame.return_value
         for attr in frame_chain.split("."):
             frame = getattr(frame, attr)
@@ -95,7 +94,7 @@ class TestPage:
     def test_context_decorator_with_inherit_context(
         self, page_instance, context_temp_file, mock_frame
     ) -> None:
-        """Test context decorator with inherit_context=True."""
+        """A keyed ``@context`` records ``inherit_context`` on the registry entry."""
         mock_frame.return_value.f_back.f_globals = {"__file__": str(context_temp_file)}
 
         @page_instance.context("inherited_key", inherit_context=True)
@@ -117,7 +116,7 @@ class TestPage:
     def test_context_decorator_without_key_inherit_context(
         self, page_instance, context_temp_file, mock_frame
     ) -> None:
-        """Test context decorator without key but with inherit_context=True."""
+        """A dict-merge ``@context`` registers under the ``None`` key and keeps inheritance."""
         mock_frame.return_value.f_back.f_back.f_globals = {
             "__file__": str(context_temp_file)
         }
@@ -201,7 +200,7 @@ class TestPage:
         render_kwargs,
         expected,
     ) -> None:
-        """Test various render scenarios with parametrized test cases."""
+        """``render`` merges registered context functions with the caller keyword arguments."""
         page_instance.register_template(test_file_path, template_str)
 
         if context_setup:
@@ -215,7 +214,7 @@ class TestPage:
         assert result == expected
 
     def test_render_with_multiple_files(self, page_instance) -> None:
-        """Test render method with multiple files having different templates and contexts."""
+        """Two page paths keep separate templates and context, with no cross-talk."""
         file1 = Path("/test/path/page1.py")
         template1 = "Page 1: {{ title }}"
         page_instance.register_template(file1, template1)
@@ -237,7 +236,7 @@ class TestPage:
         assert result2 == "Page 2: Second Page"
 
     def test_render_with_inherited_context(self, page_instance, tmp_path) -> None:
-        """Test render method with inherited context from layout directories."""
+        """A child page reads a parent ``page.py`` value marked ``inherit_context``."""
         layout_dir = tmp_path / "layout_dir"
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
@@ -269,7 +268,7 @@ class TestPage:
     def test_render_with_inherited_context_override(
         self, page_instance, tmp_path
     ) -> None:
-        """Test that child page context overrides inherited context."""
+        """A child page value shadows the inherited one under the same key."""
         layout_dir = tmp_path / "layout_dir"
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
@@ -308,7 +307,7 @@ class TestPage:
     def test_context_registry_defaultdict_behavior(
         self, page_instance, test_file_path
     ) -> None:
-        """Test that context registry uses defaultdict-like behavior."""
+        """Registering a key creates the per-file entry without pre-seeding it."""
         page_instance._context_manager.register_context(
             test_file_path, "test_key", lambda: "test_value"
         )
@@ -527,7 +526,7 @@ class TestComposedTemplateCache:
 
 
 class TestGlobalPageInstance:
-    """Test cases for global page instance."""
+    """The module-level ``page`` singleton and its ``context`` alias."""
 
     @pytest.fixture(autouse=True)
     def clear_global_state(self):
@@ -553,18 +552,18 @@ class TestGlobalPageInstance:
         page._context_manager._context_registry.update(context_snapshot)
 
     def test_global_page_instance(self) -> None:
-        """Test that global page instance is properly initialized."""
+        """The exported ``page`` is a ``Page`` carrying the same registries."""
         assert page is not None
         assert isinstance(page, Page)
         assert page._template_registry == {}
         assert page._context_manager._context_registry == {}
 
     def test_context_alias(self) -> None:
-        """Test that context alias points to page.context."""
+        """The exported ``context`` is the singleton's own bound decorator."""
         assert context == page.context
 
     def test_global_page_template_registration(self, global_file_path) -> None:
-        """Test template registration using global page instance."""
+        """A template registered on the singleton lands in its registry."""
         template_str = "Global template: {{ message }}"
         page.register_template(global_file_path, template_str)
 
@@ -574,7 +573,7 @@ class TestGlobalPageInstance:
     def test_global_page_context_registration(
         self, global_file_path, mock_frame
     ) -> None:
-        """Test context registration using global page instance."""
+        """A context function registered on the singleton lands in its registry."""
         mock_frame.return_value.f_back.f_globals = {"__file__": str(global_file_path)}
 
         @page.context("global_key")
@@ -585,7 +584,7 @@ class TestGlobalPageInstance:
         assert "global_key" in page._context_manager._context_registry[global_file_path]
 
     def test_global_page_render(self, global_file_path, mock_frame) -> None:
-        """Test rendering using global page instance."""
+        """The singleton renders a registered template with its own context."""
         template_str = "Global: {{ key }}"
         page.register_template(global_file_path, template_str)
 
@@ -601,7 +600,7 @@ class TestGlobalPageInstance:
     def test_context_decorator_with_global_page(
         self, global_file_path, mock_frame
     ) -> None:
-        """Test context decorator with global page instance."""
+        """The exported ``context`` decorator registers against the calling file."""
         mock_frame.return_value.f_back.f_globals = {"__file__": str(global_file_path)}
 
         @context("test_key")
@@ -644,7 +643,7 @@ class TestGlobalPageInstance:
     def test_get_caller_path_error_cases(
         self, page_instance, test_case, frame_setup
     ) -> None:
-        """Test _get_caller_path error cases with parametrized test cases."""
+        """A frame chain with no usable ``__file__`` raises instead of guessing a path."""
         with patch("next.pages.manager.inspect.currentframe") as mock_frame:
             frame_setup(mock_frame)
 
@@ -654,27 +653,13 @@ class TestGlobalPageInstance:
                 page_instance._get_caller_path(1)
 
 
-class TestLayoutManager:
-    """Test cases for LayoutManager."""
-
-    def test_init(self) -> None:
-        """Test LayoutManager initialization."""
-        manager = LayoutManager()
-        assert isinstance(manager._layout_loader, LayoutTemplateLoader)
-
-
 class TestLayoutIntegration:
-    """Test cases for layout integration with Page class."""
-
-    def test_page_with_layout_manager(self, page_instance) -> None:
-        """Test that Page class has LayoutManager."""
-        assert hasattr(page_instance, "_layout_manager")
-        assert isinstance(page_instance._layout_manager, LayoutManager)
+    """``Page`` composing page bodies through the ``layout.djx`` chain."""
 
     def test_create_url_pattern_with_layout(
         self, page_instance, tmp_path, url_parser
     ) -> None:
-        """Test create_url_pattern with layout inheritance."""
+        """A pattern built before any render still renders through the ancestor layout."""
         layout_file = tmp_path / "layout.djx"
         layout_content = (
             "<html><body>{% block template %}{% endblock template %}</body></html>"
@@ -740,7 +725,7 @@ class TestLayoutIntegration:
     def test_render_with_layout_template_detection(
         self, page_instance, tmp_path
     ) -> None:
-        """Test render method with layout template detection."""
+        """A body with no layout on disk renders verbatim, with nothing wrapped around it."""
         page_file = tmp_path / "page.py"
         template_str = "<h1>{{ title }}</h1>"
         page_instance.register_template(page_file, template_str)
@@ -751,10 +736,10 @@ class TestLayoutIntegration:
 
 
 class TestLoadPythonModule:
-    """Test _load_python_module functionality."""
+    """Loading a ``page.py`` module from a filesystem path."""
 
     def test_load_python_module_invalid_file(self, tmp_path) -> None:
-        """Test _load_python_module with invalid Python file."""
+        """A file that fails to parse yields ``None`` rather than raising."""
         invalid_file = tmp_path / "invalid.py"
         invalid_file.write_text("invalid python syntax {")
 
@@ -762,14 +747,14 @@ class TestLoadPythonModule:
         assert result is None
 
     def test_load_python_module_nonexistent_file(self, tmp_path) -> None:
-        """Test _load_python_module with nonexistent file."""
+        """A path that does not exist yields ``None``."""
         nonexistent_file = tmp_path / "nonexistent.py"
 
         result = _load_python_module(nonexistent_file)
         assert result is None
 
     def test_load_python_module_no_spec_returns_none(self, tmp_path) -> None:
-        """Test _load_python_module when spec_from_file_location returns None."""
+        """A path importlib cannot build a spec for yields ``None``."""
         valid_file = tmp_path / "page.py"
         valid_file.write_text("x = 1")
         with patch("importlib.util.spec_from_file_location", return_value=None):
@@ -777,7 +762,7 @@ class TestLoadPythonModule:
         assert result is None
 
     def test_load_python_module_valid_file_returns_module(self, tmp_path) -> None:
-        """Test _load_python_module with valid Python file returns the module."""
+        """A valid module is imported and handed back with its attributes bound."""
         valid_file = tmp_path / "page.py"
         valid_file.write_text("x = 42\ntemplate = '<p>{{ x }}</p>'")
 

--- a/tests/pages/test_registry.py
+++ b/tests/pages/test_registry.py
@@ -12,10 +12,10 @@ from tests.support import inspect_parameter
 
 
 class TestPageContextRegistry:
-    """Test cases for PageContextRegistry."""
+    """``PageContextRegistry`` storing and collecting ``@context`` functions."""
 
     def test_init(self, context_manager) -> None:
-        """Test PageContextRegistry initialization."""
+        """A fresh registry holds no entries."""
         assert context_manager._context_registry == {}
 
     def test_get_resolver_returns_injected_resolver(self) -> None:
@@ -39,7 +39,7 @@ class TestPageContextRegistry:
     def test_register_and_collect_context(
         self, context_manager, test_file_path, key, func_return, expected_result
     ) -> None:
-        """Test registering and collecting context with different key types."""
+        """A keyed function fills its key, a keyless one merges its dict."""
         context_manager.register_context(test_file_path, key, func_return)
 
         assert test_file_path in context_manager._context_registry
@@ -55,7 +55,7 @@ class TestPageContextRegistry:
     def test_collect_context_multiple_functions(
         self, context_manager, test_file_path
     ) -> None:
-        """Test collecting context with multiple functions."""
+        """Keyed and keyless functions on one file merge into a single mapping."""
 
         def func1() -> str:
             return "value1"
@@ -116,7 +116,7 @@ class TestPageContextRegistry:
     def test_collect_context_no_functions(
         self, context_manager, test_file_path
     ) -> None:
-        """Test collecting context when no functions are registered."""
+        """A file with no registrations collects an empty context."""
         result = context_manager.collect_context(test_file_path)
 
         assert result.context_data == {}
@@ -125,7 +125,7 @@ class TestPageContextRegistry:
     def test_register_context_with_inherit_context(
         self, context_manager, test_file_path
     ) -> None:
-        """Test registering context with inherit_context=True."""
+        """``inherit_context`` is recorded on the entry at registration time."""
 
         def test_func() -> str:
             return "inherited_value"
@@ -142,7 +142,7 @@ class TestPageContextRegistry:
         assert entry.serialize is False
 
     def test_collect_inherited_context(self, context_manager, tmp_path) -> None:
-        """Test collecting inherited context from layout directories."""
+        """A child page picks up an inheritable value from the layout directory above it."""
         layout_dir = tmp_path / "layout_dir"
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
@@ -190,7 +190,7 @@ class TestPageContextRegistry:
     def test_collect_inherited_context_multiple_levels(
         self, context_manager, tmp_path
     ) -> None:
-        """Test collecting inherited context from multiple layout levels."""
+        """Inheritable values accumulate down every layout level on the way to the page."""
         root_dir = tmp_path / "root"
         root_dir.mkdir()
         root_layout = root_dir / "layout.djx"
@@ -234,7 +234,7 @@ class TestPageContextRegistry:
     def test_collect_inherited_context_no_layout(
         self, context_manager, tmp_path
     ) -> None:
-        """Test collecting context when no layout files exist."""
+        """With no layout above it a page inherits nothing."""
         page_file = tmp_path / "page.py"
         result = context_manager.collect_context(page_file)
         assert result.context_data == {}
@@ -242,7 +242,7 @@ class TestPageContextRegistry:
     def test_collect_inherited_context_no_page_py(
         self, context_manager, tmp_path
     ) -> None:
-        """Test collecting context when layout.djx exists but no page.py."""
+        """A layout directory without ``page.py`` contributes no inherited context."""
         layout_dir = tmp_path / "layout_dir"
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
@@ -291,7 +291,7 @@ class TestPageContextRegistry:
     def test_collect_inherited_context_inherit_false(
         self, context_manager, tmp_path
     ) -> None:
-        """Test that context with inherit_context=False is not inherited."""
+        """A value registered without ``inherit_context`` stays in its own directory."""
         layout_dir = tmp_path / "layout_dir"
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
@@ -320,7 +320,7 @@ class TestPageContextRegistry:
     def test_collect_inherited_context_dict_return(
         self, context_manager, tmp_path
     ) -> None:
-        """Test collecting inherited context with dict return (key=None)."""
+        """A keyless inheritable function merges its whole dict into the child."""
         layout_dir = tmp_path / "layout_dir"
         layout_dir.mkdir()
         layout_file = layout_dir / "layout.djx"
@@ -485,7 +485,7 @@ class TestContextMarker:
     def test_context_provider_resolve_returns_none_when_default_not_context(
         self,
     ) -> None:
-        """Defensive: ContextByDefaultProvider.resolve returns None when default isn't Context."""
+        """``ContextByDefaultProvider.resolve`` yields ``None`` for a non-``Context`` default."""
         provider = ContextByDefaultProvider(DependencyResolver())
         param = inspect_parameter("x", int, default=123)
         ctx = MagicMock()
@@ -633,7 +633,7 @@ class TestPageContextRegistrySerializerOverride:
         assert result.js_context_serializers == {}
 
     def test_render_routes_override_key_through_marker(self, tmp_path) -> None:
-        """End-to-end: the override serializer encodes its key in the init script."""
+        """A render carries the override serializer's key through to the init script."""
         marker = self._MarkerSerializer()
         page_inst = Page()
         path = tmp_path / "page.py"

--- a/tests/pages/test_urls.py
+++ b/tests/pages/test_urls.py
@@ -4,7 +4,7 @@ from next.urls import FileRouterBackend, URLPatternParser
 
 
 class TestURLPatternParser:
-    """Test cases for URL pattern parsing methods."""
+    """``URLPatternParser`` turning bracket segments into Django path patterns."""
 
     @pytest.mark.parametrize(
         ("url_pattern", "expected_pattern", "expected_params"),
@@ -40,7 +40,7 @@ class TestURLPatternParser:
     def test_parse_url_pattern_variations(
         self, url_parser, url_pattern, expected_pattern, expected_params
     ) -> None:
-        """Test parsing URL patterns with different variations."""
+        """Each bracket form maps to its Django converter and a normalised parameter name."""
         pattern, params = url_parser.parse_url_pattern(url_pattern)
         assert pattern == expected_pattern
         assert params == expected_params
@@ -65,7 +65,7 @@ class TestURLPatternParser:
     def test_parse_url_pattern_complex(
         self, url_parser, url_pattern, expected_contains
     ) -> None:
-        """Test parsing complex URL pattern."""
+        """Typed, slug, and catch-all segments coexist in one pattern."""
         pattern, params = url_parser.parse_url_pattern(url_pattern)
 
         for expected in expected_contains:
@@ -87,7 +87,7 @@ class TestURLPatternParser:
     def test_parse_url_pattern_edge_cases(
         self, url_parser, url_pattern, pattern_contains, params_condition
     ) -> None:
-        """Test parsing URL pattern edge cases."""
+        """Malformed brackets pass through without raising."""
         pattern, params = url_parser.parse_url_pattern(url_pattern)
         assert any(contains in pattern for contains in pattern_contains)
         assert params_condition(params)
@@ -106,7 +106,7 @@ class TestURLPatternParser:
     def test_parse_param_name_and_type_variations(
         self, url_parser, param_string, expected_name, expected_type
     ) -> None:
-        """Test parsing parameter name and type with different variations."""
+        """A bare name defaults to ``str``, a leading colon leaves the type empty."""
         name, type_name = url_parser._parse_param_name_and_type(param_string)
         assert name == expected_name
         assert type_name == expected_type
@@ -125,7 +125,7 @@ class TestURLPatternParser:
     def test_parse_url_pattern_with_args_and_params(
         self, url_parser, url_path, expected_params, expected_pattern
     ) -> None:
-        """Test parsing URL pattern with both args and regular parameters."""
+        """A catch-all segment and a typed segment resolve side by side."""
         django_pattern, parameters = url_parser.parse_url_pattern(url_path)
 
         for param in expected_params:
@@ -147,13 +147,13 @@ class TestURLPatternParser:
     def test_prepare_url_name_with_colons(
         self, url_parser, url_path, expected_name
     ) -> None:
-        """Test URL name preparation with colons in parameter syntax."""
+        """The route name flattens brackets and colons into a reversible identifier."""
         clean_name = url_parser.prepare_url_name(url_path)
         assert clean_name == expected_name
         assert ":" not in clean_name
 
     def test_scan_pages_directory_virtual_view_detection(self, tmp_path) -> None:
-        """Test _scan_pages_directory detects virtual views (template.djx without page.py)."""
+        """A directory holding only ``template.djx`` routes to a synthesised ``page.py``."""
         backend = FileRouterBackend()
 
         virtual_dir = tmp_path / "virtual"
@@ -170,7 +170,7 @@ class TestURLPatternParser:
 
 
 class TestCreateUrlPatternScenarios:
-    """Test cases for different URL pattern creation scenarios."""
+    """``create_url_pattern`` across the body sources a page can have."""
 
     @pytest.mark.parametrize(
         (
@@ -247,7 +247,7 @@ def render(request, **kwargs):
         expected_pattern_name,
         expected_template,
     ) -> None:
-        """Test various create_url_pattern scenarios."""
+        """A page yields a named pattern whenever any body source can serve it."""
         page_file = tmp_path / "page.py"
 
         if page_content:
@@ -272,7 +272,7 @@ def render(request, **kwargs):
     def test_create_url_pattern_render_function_fallback(
         self, page_instance, tmp_path, url_parser
     ) -> None:
-        """Test that render function is used as fallback when no template is found."""
+        """A ``render()`` with no template beside it still produces a route."""
         page_file = tmp_path / "page.py"
         page_file.write_text("""
 from django.http import HttpResponse
@@ -289,7 +289,7 @@ def render(request, **kwargs):
     def test_create_url_pattern_virtual_view_rendering(
         self, page_instance, tmp_path, url_parser
     ) -> None:
-        """Test that virtual view can be rendered with context."""
+        """A virtual page backed only by ``template.djx`` renders its interpolated body."""
         page_file = tmp_path / "page.py"
         djx_file = tmp_path / "template.djx"
         djx_content = "<h1>{{ title }}</h1><p>Hello {{ name }}!</p>"
@@ -305,7 +305,7 @@ def render(request, **kwargs):
     def test_create_url_pattern_with_context_functions(
         self, page_instance, tmp_path, url_parser
     ) -> None:
-        """Test create_url_pattern with context functions for virtual view."""
+        """A virtual page reads the ``@context`` values registered against its path."""
         page_file = tmp_path / "page.py"
         djx_file = tmp_path / "template.djx"
         djx_content = "<h1>{{ title }}</h1><p>{{ description }}</p>"
@@ -327,12 +327,12 @@ def render(request, **kwargs):
 
 
 class TestPageCreateUrlPattern:
-    """Test Page create_url_pattern functionality."""
+    """``_create_regular_page_pattern`` refusing pages it cannot serve."""
 
     def test_create_regular_page_pattern_no_module(
         self, page_instance, tmp_path
     ) -> None:
-        """Test _create_regular_page_pattern when module cannot be loaded."""
+        """A ``page.py`` that fails to import yields no pattern."""
         page_file = tmp_path / "page.py"
         page_file.write_text("invalid python syntax {")
 
@@ -348,7 +348,7 @@ class TestPageCreateUrlPattern:
     def test_create_regular_page_pattern_no_template_no_render(
         self, page_instance, tmp_path
     ) -> None:
-        """Test _create_regular_page_pattern when no template and no render function."""
+        """A module with neither a body nor ``render()`` yields no pattern."""
         page_file = tmp_path / "page.py"
         page_file.write_text("def other_function(): pass")
 

--- a/tests/partial/conftest.py
+++ b/tests/partial/conftest.py
@@ -1,3 +1,4 @@
+import copy
 from collections.abc import Generator
 from pathlib import Path
 
@@ -38,14 +39,17 @@ _PARTIAL_MODULES = (
 def _partial_form_registries():
     """Register the partial-suite forms and restore the clean baseline after.
 
-    The snapshot is taken before the partial modules load, so the teardown
+    The registries are copied before the partial modules load, so the teardown
     drops every action and provider they registered. A later forms suite
     then sees the registry exactly as it was, not the partial fixtures.
     Re-execution each test is idempotent because registration keys on the
     file path.
     """
     backend = form_action_manager.default_backend
-    backend_snapshot = backend.snapshot()
+    registry_snapshot = copy.deepcopy(backend._registry)
+    uid_snapshot = copy.deepcopy(backend._uid_to_name)
+    name_index_snapshot = copy.deepcopy(backend._name_index)
+    url_cache_snapshot = copy.deepcopy(backend._url_cache)
     diagnostics_snapshot = registration_diagnostics.snapshot()
 
     wizard_backend_manager.reset()
@@ -56,7 +60,15 @@ def _partial_form_registries():
 
     yield
 
-    backend.restore(backend_snapshot)
+    backend._registry.clear()
+    backend._registry.update(registry_snapshot)
+    backend._uid_to_name.clear()
+    backend._uid_to_name.update(uid_snapshot)
+    backend._name_index.clear()
+    backend._name_index.update(name_index_snapshot)
+    backend._url_cache.clear()
+    backend._url_cache.update(url_cache_snapshot)
+
     registration_diagnostics.restore(diagnostics_snapshot)
 
     wizard_backend_manager.reset()

--- a/tests/partial/conftest.py
+++ b/tests/partial/conftest.py
@@ -1,4 +1,3 @@
-import copy
 from collections.abc import Generator
 from pathlib import Path
 
@@ -39,17 +38,14 @@ _PARTIAL_MODULES = (
 def _partial_form_registries():
     """Register the partial-suite forms and restore the clean baseline after.
 
-    The registries are copied before the partial modules load, so the teardown
+    The snapshot is taken before the partial modules load, so the teardown
     drops every action and provider they registered. A later forms suite
     then sees the registry exactly as it was, not the partial fixtures.
     Re-execution each test is idempotent because registration keys on the
     file path.
     """
     backend = form_action_manager.default_backend
-    registry_snapshot = copy.deepcopy(backend._registry)
-    uid_snapshot = copy.deepcopy(backend._uid_to_name)
-    name_index_snapshot = copy.deepcopy(backend._name_index)
-    url_cache_snapshot = copy.deepcopy(backend._url_cache)
+    backend_snapshot = backend.snapshot()
     diagnostics_snapshot = registration_diagnostics.snapshot()
 
     wizard_backend_manager.reset()
@@ -60,15 +56,7 @@ def _partial_form_registries():
 
     yield
 
-    backend._registry.clear()
-    backend._registry.update(registry_snapshot)
-    backend._uid_to_name.clear()
-    backend._uid_to_name.update(uid_snapshot)
-    backend._name_index.clear()
-    backend._name_index.update(name_index_snapshot)
-    backend._url_cache.clear()
-    backend._url_cache.update(url_cache_snapshot)
-
+    backend.restore(backend_snapshot)
     registration_diagnostics.restore(diagnostics_snapshot)
 
     wizard_backend_manager.reset()

--- a/tests/partial/test_headers.py
+++ b/tests/partial/test_headers.py
@@ -30,7 +30,7 @@ class TestPartialIntentParsing:
         request = RequestFactory().get("/")
         intent = partial_intent(request)
         assert intent == PartialIntent()
-        assert intent.is_partial is False
+        assert intent.partial is False
         assert is_partial_request(request) is False
 
     def test_flag_other_than_one_is_not_partial(self) -> None:

--- a/tests/static/test_discovery.py
+++ b/tests/static/test_discovery.py
@@ -87,7 +87,9 @@ class TestDefaultStems:
         assert isinstance(default_stems, StemRegistry)
 
     def test_preserves_core_roles(self) -> None:
-        assert "template" in default_stems.stems("template")
+        assert default_stems.stems("template") == ("template",)
+        assert default_stems.stems("layout") == ("layout",)
+        assert default_stems.stems("component") == ("component",)
 
 
 class TestPathResolverFindPageRoot:

--- a/tests/static/test_discovery.py
+++ b/tests/static/test_discovery.py
@@ -63,10 +63,6 @@ class TestStemRegistryDefaults:
         reg = StemRegistry()
         assert reg.stems("ghost") == ()
 
-    def test_roles_returns_all(self) -> None:
-        reg = StemRegistry()
-        assert set(reg.roles()) == {"template", "layout", "component"}
-
 
 class TestStemRegistryRegister:
     def test_add_stem_to_existing_role(self) -> None:
@@ -77,7 +73,6 @@ class TestStemRegistryRegister:
     def test_add_stem_creates_role(self) -> None:
         reg = StemRegistry()
         reg.register("meta", "head")
-        assert "meta" in reg.roles()
         assert reg.stems("meta") == ("head",)
 
     def test_register_is_idempotent(self) -> None:
@@ -92,7 +87,7 @@ class TestDefaultStems:
         assert isinstance(default_stems, StemRegistry)
 
     def test_preserves_core_roles(self) -> None:
-        assert "template" in default_stems.roles()
+        assert "template" in default_stems.stems("template")
 
 
 class TestPathResolverFindPageRoot:

--- a/tests/static/test_finders.py
+++ b/tests/static/test_finders.py
@@ -244,7 +244,7 @@ class TestMappedSourceStorage:
 
 
 class TestCollectstaticIntegration:
-    """E2E: --dry-run must enumerate next-namespace assets."""
+    """``collectstatic --dry-run`` enumerates the next-namespace assets."""
 
     def test_finder_is_registered(self) -> None:
 

--- a/tests/urls/test_dispatcher.py
+++ b/tests/urls/test_dispatcher.py
@@ -10,7 +10,7 @@ from next.pages.watch import (
     iter_pages_roots_with_components_folder_names,
 )
 from next.urls import FileRouterBackend, RouterBackend
-from next.urls.dispatcher import _scan_pages_directory, scan_pages_tree
+from next.urls.dispatcher import scan_pages_tree
 from next.utils import classify_dirs_entries
 
 
@@ -220,13 +220,6 @@ class TestScanPagesDirectory:
             )
         assert len(calls) == 1
         assert calls[0][0].name == "_components"
-
-    def test_scan_pages_directory_matches_scan_pages_tree(self, tmp_path) -> None:
-        """The module helper yields the same pairs as ``scan_pages_tree``."""
-        (tmp_path / "page.py").write_text("x=1")
-        a = list(scan_pages_tree(tmp_path))
-        b = list(_scan_pages_directory(tmp_path))
-        assert a == b
 
 
 class TestClassifyDirsEntries:


### PR DESCRIPTION
## Description

Dead-code and legacy sweep across `next/pages`, `next/components`, `next/deps`, `next/urls`, `next/forms`, `next/static`, `next/partial` and `next/testing`, plus the matching doc-sync. Nothing is built here, the PR only removes orphaned surfaces so the structural refactors landing later in 0.9.0 (file-attribution, the `dispatch.py`/`Page` split, DI changes) diff against clean code instead of dead methods that read like part of an area pattern.

Every removal was verified to have no production caller, including dynamic access (`getattr`/`hasattr`, dotted paths in `NEXT_FRAMEWORK`, templatetags, `.djx` templates, autodoc, the TypeScript client and the examples). Each deleted symbol drops its paired test in the same change, so the 100% coverage gate holds throughout.

Removed surfaces:

- `Page._resolver` — written once, never read.
- `LayoutManager` collapses to a thin holder over `LayoutTemplateLoader`: `_layout_registry`, `discover_layouts_for_template`, `get_layout_template` and `clear_registry` are gone. There was no cache on the render path, `Page.composed_template_for` is where composition is actually memoised.
- `DependencyCache.is_in_progress` and the write-only `_owns_cache` field.
- `DependencyResolver.__get__` — a no-op descriptor duplicating default Python attribute access (own commit, hot-path, gated on `make bench`).
- `urls.dispatcher._scan_pages_directory` — module-level duplicate of the live `FileRouterBackend._scan_pages_directory` method.
- `ComponentRegistry`/`ComponentVisibilityResolver.clear_cache` and `ComponentInfo.scope_key`.
- `RegistryFormActionBackend.snapshot`/`restore` and the `RegistryBackendSnapshot` dataclass. Test isolation copies the private maps directly, as it already did. `RegistrationDiagnostics.snapshot`/`restore` are untouched.
- `ComponentScanner`'s `components_dir` parameter, `_components_dir` field and `DEFAULT_COMPONENTS_DIR_NAME`. The scanner never read the folder name, it is resolved by `FileRouterBackend` and the watchers upstream. This was checked against a latent-bug reading and confirmed redundant, not a silent ignore.
- `StemRegistry.roles()` and `DEFAULT_ROLES`. `default_stems`, `register()` and `stems()` stay.
- `partial.checks.CHECK_IDS` and `PartialIntent.is_partial` (the `partial` field and `is_partial_request` stay).
- `DummyBackend.created`.
- Both dead `HTMLParser.error` overrides in `testing/html.py`, removed from the base class since Python 3.10 and the project floor is 3.12.
- The redundant `from __future__ import annotations` across the `signals` modules, kept only in `testing/signals.py` where a slotted dataclass evaluates a `Signal` annotation at import time.

Doc-sync in the same PR: the `pages.rst` note that claimed `LayoutManager` caches composed layouts (false against the current code) is rewritten to describe where composition is really cached, the `scope_key` paragraph leaves `components.rst`, and the `snapshot` testing note leaves `topics/forms/backends.rst`.

Two API-name breaks, both internal 0.x surfaces: `next.forms.RegistryBackendSnapshot` is no longer exported, and `DependencyResolver` stops being a descriptor (access is semantically identical). Nothing here was in `next/__init__.py` or an area `__all__` beyond that one forms export.

Out of scope on purpose: `import inspect`/`_ = inspect` in `pages/manager.py` and the `tests/pages/conftest.py` fixture belong to the file-attribution PR and are left untouched. `LayoutTemplateLoader.load_template` and `_wrap_in_template_block` look orphaned but implement an abstract `TemplateLoader` contract that `LayoutManager` instantiates, so they stay. `next/server/checks.py` and `next/deps/checks.py` were already removed on main. Docstring-length and `Subject: description` style cleanups are a separate PR, this one is dead code only.

## How to test

`make ci` passes locally. Additionally `make bench` is green (the resolver descriptor and cache changes are hot-path), `make docs` builds clean under `-W`, and `make test-examples` holds 100% per example. Behaviour was checked live, not only through tests: `examples/kanban` (custom `COMPONENTS_DIR: "_pieces"`) serves 200s with its components rendered and all form actions resolving, `examples/audit-forms` (subclasses `RegistryFormActionBackend`) checks clean, and `examples/observability` still returns a `morph` patch envelope for a zoned partial request with all three asset roles present.

## Related issues

<!-- Fixes #… -->

## Checklist

- [x] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [x] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable
