### PR TITLE
refactor(core): defining-file attribution for registrations, orphan-context checks, kanban dev-server repair

### DIFF
--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -302,6 +302,15 @@ Errors
    * - ``next.E073``
      - A ``PARTIAL_BACKENDS`` entry has no ``BACKEND`` key, so the factory would refuse it with ``ImproperlyConfigured`` on the first partial request.
      - ``next.partial.checks``
+   * - ``next.E077``
+     - A ``@context`` callable is registered against a file that is not a ``page.py``, so no render collects it.
+       A registration keys on the file declaring the callable, so decorating an imported helper binds it to the helper's module.
+       Declare the callable in the ``page.py`` that needs it and let it call the shared helper.
+     - ``next.pages.checks``
+   * - ``next.E078``
+     - A ``@component.context`` callable is registered against a file that is not a ``component.py``, so no component render collects it.
+       The rule and the fix match ``next.E077``.
+     - ``next.components.checks``
 
 A code emitted by ``next.checks.common`` is produced by a shared helper that the listed subsystem check modules call.
 

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -302,14 +302,14 @@ Errors
    * - ``next.E073``
      - A ``PARTIAL_BACKENDS`` entry has no ``BACKEND`` key, so the factory would refuse it with ``ImproperlyConfigured`` on the first partial request.
      - ``next.partial.checks``
-   * - ``next.E077``
-     - A ``@context`` callable is registered against a file that is not a ``page.py``, so no render collects it.
-       A registration keys on the file declaring the callable, so decorating an imported helper binds it to the helper's module.
+   * - ``next.E074``
+     - A ``@context`` registration binds to a file no page render collects.
+       A registration keys on the file declaring the callable, so decorating an imported helper binds it to the helper's module, and decorating a callable imported from a sibling ``page.py`` binds it to that other page.
        Declare the callable in the ``page.py`` that needs it and let it call the shared helper.
      - ``next.pages.checks``
-   * - ``next.E078``
-     - A ``@component.context`` callable is registered against a file that is not a ``component.py``, so no component render collects it.
-       The rule and the fix match ``next.E077``.
+   * - ``next.E075``
+     - A ``@component.context`` registration binds to a file no component render collects.
+       The rule and the fix match ``next.E074``.
      - ``next.components.checks``
 
 A code emitted by ``next.checks.common`` is produced by a shared helper that the listed subsystem check modules call.

--- a/docs/content/ref/utils.rst
+++ b/docs/content/ref/utils.rst
@@ -7,7 +7,7 @@ Module Summary
 --------------
 
 ``next.utils`` exposes two helpers that project code can import, ``resolve_base_dir`` and ``classify_dirs_entries``.
-Two further helpers serve registration and are excluded from the table below, one attributing a decorated object to the file where it was declared, the other naming it for diagnostics.
+The rest of the module serves decorator registration and is excluded from the table below, attributing a decorated object to the file where it was declared, naming it for diagnostics, and collecting the registrations that landed on another file.
 
 ``resolve_base_dir`` returns ``settings.BASE_DIR`` coerced to ``pathlib.Path``, or ``None`` when it is unset, for backends that resolve project-relative paths.
 ``classify_dirs_entries`` splits a backend ``DIRS`` list into existing directory roots and plain skip-name segments, the same split the file router applies.
@@ -17,7 +17,7 @@ Public API
 
 .. automodule:: next.utils
    :members:
-   :exclude-members: _classify_one_dir_entry, callable_name, defining_file
+   :exclude-members: _classify_one_dir_entry, callable_name, defining_file, MisattributedContext, MisattributionLog
 
 See Also
 --------

--- a/docs/content/ref/utils.rst
+++ b/docs/content/ref/utils.rst
@@ -7,8 +7,7 @@ Module Summary
 --------------
 
 ``next.utils`` exposes two helpers that project code can import, ``resolve_base_dir`` and ``classify_dirs_entries``.
-The module also defines a registration-internal frame helper that the framework uses to attribute decorated callables to their defining file.
-That helper is not part of the public surface and is excluded from the autodoc table below.
+Two further helpers serve registration and are excluded from the table below, one attributing a decorated object to the file where it was declared, the other naming it for diagnostics.
 
 ``resolve_base_dir`` returns ``settings.BASE_DIR`` coerced to ``pathlib.Path``, or ``None`` when it is unset, for backends that resolve project-relative paths.
 ``classify_dirs_entries`` splits a backend ``DIRS`` list into existing directory roots and plain skip-name segments, the same split the file router applies.
@@ -18,7 +17,7 @@ Public API
 
 .. automodule:: next.utils
    :members:
-   :exclude-members: _classify_one_dir_entry, caller_source_path
+   :exclude-members: _classify_one_dir_entry, callable_name, defining_file
 
 See Also
 --------

--- a/docs/content/topics/context.rst
+++ b/docs/content/topics/context.rst
@@ -133,8 +133,13 @@ A helper that lives in a shared module therefore needs a thin wrapper in the pag
 
 The same rule holds for ``@component.context``.
 Decorating the imported helper directly registers it under the module that declares it, where no render reaches it.
-``manage.py check`` reports that as ``next.E077`` for a page context and ``next.E078`` for a component one.
+A function imported from a sibling ``page.py`` lands the same way, on that other page rather than on the one running the decorator.
+``manage.py check`` reports both as ``next.E074`` for a page context and ``next.E075`` for a component one.
 :doc:`/content/topics/forms/actions` covers ``@action`` and what a decorator stacked under it has to preserve.
+
+The decorated object has to carry a declaring file of its own, which a function, a class, or a ``functools.partial`` over either does.
+A built-in such as ``datetime.now`` carries none, and decorating one raises ``TypeError`` at import time naming the object.
+Wrap it in a function declared in the page module instead.
 
 Reading Values Into a Context Function
 --------------------------------------

--- a/docs/content/topics/context.rst
+++ b/docs/content/topics/context.rst
@@ -115,20 +115,26 @@ The inherit_context Flag
 Use this for header copy, brand colors, feature flags, and other shared values.
 Without the flag the value is only available when that exact ``page.py`` handles the request, and descendant routes cannot read it.
 
-Direct Registration
-~~~~~~~~~~~~~~~~~~~
+Reusing a Shared Helper
+~~~~~~~~~~~~~~~~~~~~~~~
 
-Treat ``context("key")`` as a callable that registers an existing function.
+``@context`` keys the registration on the file where the decorated function is declared, not on the file that runs the decorator.
+A helper that lives in a shared module therefore needs a thin wrapper in the page module that uses it.
 
 .. code-block:: python
-   :caption: registering an external function
+   :caption: notes/pages/dashboard/page.py
 
    from next.pages import context
    from notes.cache import pending_clicks
 
-   context("pending_clicks")(pending_clicks)
+   @context("pending_clicks")
+   def dashboard_pending_clicks() -> dict[str, int]:
+       return pending_clicks()
 
-This is useful when the function lives in a shared module and you want to register it without a decorator on the original source.
+The same rule holds for ``@component.context``.
+Decorating the imported helper directly registers it under the module that declares it, where no render reaches it.
+``manage.py check`` reports that as ``next.E077`` for a page context and ``next.E078`` for a component one.
+:doc:`/content/topics/forms/actions` covers ``@action`` and what a decorator stacked under it has to preserve.
 
 Reading Values Into a Context Function
 --------------------------------------

--- a/docs/content/topics/forms/actions.rst
+++ b/docs/content/topics/forms/actions.rst
@@ -89,6 +89,9 @@ Override with ``Meta.scope``.
 Customise the set of anchor file names through ``NEXT_FRAMEWORK["FORM_ANCHOR_FILES"]``.
 The default set is ``["page.py", "component.py"]``.
 
+The file is the one the ``class`` statement is written in, not the file that imports the class.
+A class built by a factory such as ``next.forms.modelform_factory`` is attributed to the module that calls the factory, not to the module that runs the underlying ``type()`` call.
+
 .. _topics-forms-actions-uid:
 
 UID Stability
@@ -204,6 +207,32 @@ The ``login_required`` and ``permission_required`` keywords guard the endpoint, 
 Applying ``@action`` to a class registers no action.
 The decorator records the misuse, returns the class unchanged, and ``manage.py check`` reports it as ``next.E053``.
 Form classes register through ``__init_subclass__`` and must not use ``@action``.
+
+Stacking Decorators on ``@action``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``@action`` keys the registration on the file where the decorated function is declared, not on the file that runs the decorator.
+Decorating an imported function registers it under the module that defines that function.
+A shared helper therefore needs a thin wrapper in the page module that uses it, the same wrapper :doc:`/content/topics/context` shows for context functions.
+
+Keep ``@action`` outermost when other decorators apply to the same handler.
+
+.. code-block:: python
+   :caption: page.py
+
+   from django.db import transaction
+   from django.http import HttpRequest
+   from next.forms import action, redirect_to_origin
+   from next.urls import DUrl
+
+   @action("publish_note")
+   @transaction.atomic
+   def publish_note(request: HttpRequest, note_id: DUrl["id", int]):
+       Note.objects.filter(pk=note_id).update(published=True)
+       return redirect_to_origin(request)
+
+``transaction.atomic`` copies ``__wrapped__`` through :func:`functools.wraps`, so the action still registers under this ``page.py``.
+A hand-written decorator that omits ``functools.wraps`` hides the wrapped function, and the action registers under the decorator's own module instead.
 
 Injecting the Form Into a Handler
 ---------------------------------

--- a/docs/content/topics/forms/actions.rst
+++ b/docs/content/topics/forms/actions.rst
@@ -231,7 +231,7 @@ Keep ``@action`` outermost when other decorators apply to the same handler.
        Note.objects.filter(pk=note_id).update(published=True)
        return redirect_to_origin(request)
 
-``transaction.atomic`` copies ``__wrapped__`` through :func:`functools.wraps`, so the action still registers under this ``page.py``.
+``transaction.atomic`` sets ``__wrapped__`` through :func:`functools.wraps`, so the action still registers under this ``page.py``.
 A hand-written decorator that omits ``functools.wraps`` hides the wrapped function, and the action registers under the decorator's own module instead.
 
 Injecting the Form Into a Handler

--- a/examples/feature-flags/flags/panels/admin/metrics/page.py
+++ b/examples/feature-flags/flags/panels/admin/metrics/page.py
@@ -4,6 +4,16 @@ from flags.receivers import access_denied_count, feature_guard_count
 from next.pages import context
 
 
-context("render_counts")(render_counts)
-context("feature_guard_count")(feature_guard_count)
-context("access_denied_count")(access_denied_count)
+@context("render_counts")
+def page_render_counts() -> dict[str, int]:
+    return render_counts()
+
+
+@context("feature_guard_count")
+def page_feature_guard_count() -> int:
+    return feature_guard_count()
+
+
+@context("access_denied_count")
+def page_access_denied_count() -> int:
+    return access_denied_count()

--- a/examples/kanban/README.md
+++ b/examples/kanban/README.md
@@ -27,20 +27,22 @@ uv run python manage.py runserver     # http://127.0.0.1:8000/
 
 The first `migrate` run seeds three demo boards. Open the index to land on the board list.
 
-For the React layer to hot-reload, start the Vite dev server:
+The React layer loads from the Vite dev server, so start it next to Django:
 
 ```bash
 npm install
 npm run dev                            # http://localhost:5173
 ```
 
-With the dev server running, Django resolves every `.jsx` asset to the Vite dev-server URL and the React Refresh preamble plus the `@vite/client` HMR script load through the `collector_finalized` signal. Override the Vite origin with the `VITE_ORIGIN` environment variable.
+Django resolves every `.jsx` asset to a dev-server URL, and the React Refresh preamble plus the `@vite/client` HMR script load through the `collector_finalized` signal. `VITE_ORIGIN` overrides that origin for the asset URLs and the HMR client.
 
-For a production-shaped build:
+A typed route segment such as `[int:id]` puts a colon in the directory name, and the Vite dev server refuses to serve a path holding one before it consults `server.fs.allow`. Co-locating assets under a typed segment therefore needs `server: { fs: { strict: false } }`, which both `vite.config.ts` and `vitest.config.ts` carry. Only the dev server applies that guard, so the production build and Django static serving stay untouched.
+
+For a production-shaped build, hand the backend an empty origin so it resolves through the manifest:
 
 ```bash
 npm run build                          # writes hashed files into kanban/static/kanban/dist/
-uv run python manage.py runserver
+VITE_ORIGIN= uv run python manage.py runserver
 ```
 
 The backend reads `dist/.vite/manifest.json` and delegates URL resolution to Django staticfiles. If the manifest file is missing, the backend logs a single warning and falls back to staticfiles so dev workflows stay unblocked.

--- a/examples/kanban/README.md
+++ b/examples/kanban/README.md
@@ -38,12 +38,14 @@ Django resolves every `.jsx` asset to a dev-server URL, and the React Refresh pr
 
 A typed route segment such as `[int:id]` puts a colon in the directory name, and the Vite dev server refuses to serve a path holding one before it consults `server.fs.allow`. Co-locating assets under a typed segment therefore needs `server: { fs: { strict: false } }`, which both `vite.config.ts` and `vitest.config.ts` carry. Only the dev server applies that guard, so the production build and Django static serving stay untouched.
 
-For a production-shaped build, hand the backend an empty origin so it resolves through the manifest:
+For a production-shaped build, hand the backend an empty origin so it resolves through the manifest instead of the dev server:
 
 ```bash
 npm run build                          # writes hashed files into kanban/static/kanban/dist/
 VITE_ORIGIN= uv run python manage.py runserver
 ```
+
+The origin decides the mode on its own rather than following the presence of a build, so a stale `dist/` never silently changes how `runserver` behaves.
 
 The backend reads `dist/.vite/manifest.json` and delegates URL resolution to Django staticfiles. If the manifest file is missing, the backend logs a single warning and falls back to staticfiles so dev workflows stay unblocked.
 

--- a/examples/kanban/config/settings.py
+++ b/examples/kanban/config/settings.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from next.conf import extend_default_backend
@@ -99,7 +100,9 @@ NEXT_FRAMEWORK = {
             "OPTIONS": {
                 "DEDUP_STRATEGY": "next.static.collector.HashContentDedup",
                 "JS_CONTEXT_POLICY": "next.static.collector.DeepMergePolicy",
-                "DEV_ORIGIN": "http://localhost:5173",
+                # The HMR receiver reads this value back from the backend
+                # options, so one variable moves every dev-server URL.
+                "DEV_ORIGIN": os.environ.get("VITE_ORIGIN", "http://localhost:5173"),
                 "VITE_ROOT": str(BASE_DIR),
                 "MANIFEST_PATH": str(
                     BASE_DIR / "kanban/static/kanban/dist/.vite/manifest.json"

--- a/examples/kanban/config/settings.py
+++ b/examples/kanban/config/settings.py
@@ -72,6 +72,9 @@ STATIC_URL = "static/"
 SHARED_DIR = BASE_DIR.parent / "_shared"
 STATICFILES_DIRS = [SHARED_DIR / "static"]
 
+VITE_DEV_ORIGIN = "http://localhost:5173"
+VITE_MANIFEST = BASE_DIR / "kanban/static/kanban/dist/.vite/manifest.json"
+
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 NEXT_FRAMEWORK = {
@@ -101,12 +104,11 @@ NEXT_FRAMEWORK = {
                 "DEDUP_STRATEGY": "next.static.collector.HashContentDedup",
                 "JS_CONTEXT_POLICY": "next.static.collector.DeepMergePolicy",
                 # The HMR receiver reads this value back from the backend
-                # options, so one variable moves every dev-server URL.
-                "DEV_ORIGIN": os.environ.get("VITE_ORIGIN", "http://localhost:5173"),
+                # options, so one variable moves every dev-server URL. An empty
+                # value is what routes assets through the built manifest.
+                "DEV_ORIGIN": os.environ.get("VITE_ORIGIN", VITE_DEV_ORIGIN),
                 "VITE_ROOT": str(BASE_DIR),
-                "MANIFEST_PATH": str(
-                    BASE_DIR / "kanban/static/kanban/dist/.vite/manifest.json"
-                ),
+                "MANIFEST_PATH": str(VITE_MANIFEST),
             },
         }
     ],

--- a/examples/kanban/kanban/boards/board/[int:id]/page.jsx
+++ b/examples/kanban/kanban/boards/board/[int:id]/page.jsx
@@ -89,7 +89,9 @@ export function Board() {
   );
 }
 
-const roots = new WeakMap();
+// A hot update re-evaluates this module, so the registry lives on window to
+// outlive it and React Refresh keeps updating Board inside the existing root.
+const roots = (window.__kanbanRoots ??= new WeakMap());
 
 // onMount re-runs over an element a morph reconciled in place, so the
 // WeakMap guard keeps the mount idempotent.

--- a/examples/kanban/kanban/signals.py
+++ b/examples/kanban/kanban/signals.py
@@ -1,8 +1,8 @@
 import base64
-import os
 
 from django.conf import settings
 
+from next.conf import next_framework_settings
 from next.static.assets import StaticAsset
 from next.static.signals import collector_finalized
 
@@ -10,6 +10,15 @@ from next.static.signals import collector_finalized
 def _has_module_assets(collector: object) -> bool:
     scripts = collector.assets_in_slot("scripts")  # type: ignore[attr-defined]
     return any(asset.kind == "jsx" for asset in scripts)
+
+
+def _dev_origin() -> str:
+    """Return the origin the static backend resolves jsx assets against."""
+    for backend in next_framework_settings.STATIC_BACKENDS:
+        origin = (backend.get("OPTIONS") or {}).get("DEV_ORIGIN", "")
+        if origin:
+            return str(origin)
+    return ""
 
 
 def inject_vite_dev_assets(sender: object, **kwargs) -> None:
@@ -21,11 +30,12 @@ def inject_vite_dev_assets(sender: object, **kwargs) -> None:
     preamble JS is base64-encoded into a `data:` URL so it stays a
     single self-contained module script tag. The receiver only fires on
     pages that actually carry jsx scripts so the index page stays free
-    of Vite dev plumbing.
+    of Vite dev plumbing, and only while the backend points jsx at a
+    dev server.
     """
-    if not _has_module_assets(sender):
+    origin = _dev_origin()
+    if not origin or not _has_module_assets(sender):
         return
-    origin = os.environ.get("VITE_ORIGIN", "http://localhost:5173")
     preamble_code = (
         f'import RefreshRuntime from "{origin}/@react-refresh";'
         "RefreshRuntime.injectIntoGlobalHook(window);"

--- a/examples/kanban/tests/test_unit.py
+++ b/examples/kanban/tests/test_unit.py
@@ -1,11 +1,14 @@
 import base64
+import copy
 import importlib.util
 import inspect
 import json
 from pathlib import Path
 
 import pytest
+from django.conf import settings
 from django.http import Http404, HttpRequest
+from django.test import override_settings
 from kanban.backends import ViteManifestBackend
 from kanban.forms import CreateCardForm, MoveCardForm
 from kanban.models import Board, Card, Column
@@ -423,6 +426,13 @@ def _decode_preamble_data_url(url: str) -> str:
     return base64.b64decode(url[len(prefix) :]).decode()
 
 
+def _static_backend_origin(origin: str):
+    config = copy.deepcopy(settings.NEXT_FRAMEWORK)
+    for backend in config["STATIC_BACKENDS"]:
+        backend.setdefault("OPTIONS", {})["DEV_ORIGIN"] = origin
+    return override_settings(NEXT_FRAMEWORK=config)
+
+
 class TestInjectViteDevAssetsGuard:
     def test_skips_when_no_jsx_assets(self) -> None:
         collector = StaticCollector()
@@ -440,16 +450,24 @@ class TestInjectViteDevAssetsGuard:
         assert preamble_idx < vite_idx < jsx_idx
         assert "RefreshRuntime" in _decode_preamble_data_url(urls[preamble_idx])
 
-    def test_uses_env_origin(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("VITE_ORIGIN", "http://example.test:4242")
+    def test_uses_backend_origin(self) -> None:
         collector = StaticCollector()
         collector.add(StaticAsset(url="/static/page.jsx", kind="jsx"))
-        inject_vite_dev_assets(collector)
+        with _static_backend_origin("http://example.test:4242"):
+            inject_vite_dev_assets(collector)
         urls = [a.url for a in collector.assets_in_slot("scripts")]
         assert "http://example.test:4242/@vite/client" in urls
         preamble = next(u for u in urls if u.startswith("data:"))
         decoded = _decode_preamble_data_url(preamble)
         assert 'from "http://example.test:4242/@react-refresh"' in decoded
+
+    def test_skips_when_no_dev_origin_configured(self) -> None:
+        collector = StaticCollector()
+        collector.add(StaticAsset(url="/static/page.jsx", kind="jsx"))
+        with _static_backend_origin(""):
+            inject_vite_dev_assets(collector)
+        urls = [a.url for a in collector.assets_in_slot("scripts")]
+        assert urls == ["/static/page.jsx"]
 
 
 class TestColumnCardsContext:

--- a/examples/kanban/vite.config.ts
+++ b/examples/kanban/vite.config.ts
@@ -14,6 +14,10 @@ const entries = Object.fromEntries(
 export default defineConfig({
   plugins: [react()],
   root: path.resolve(__dirname),
+  // A typed route segment is spelled [int:id], and the dev server refuses any
+  // path holding a colon before it consults server.fs.allow. vitest.config.ts
+  // carries the same flag.
+  server: { fs: { strict: false } },
   build: {
     outDir: "kanban/static/kanban/dist",
     emptyOutDir: true,

--- a/examples/shortener/README.md
+++ b/examples/shortener/README.md
@@ -98,16 +98,18 @@ def link_context(link: DLink[Link]) -> dict[str, object]:
 
 `@context("link")` + `@context("cache_key")` would each trigger the `DLink` provider and hit the database twice. The unkeyed form runs the dependency once, merges the dict into the template context.
 
-**Direct registration** of an already-existing function — no wrapper needed:
+**Reusing a shared helper** — wrap it in the page module that needs it:
 
 ```python
 # routes/admin/page.py
 from shortener.cache import pending_clicks
 
-context("pending_clicks")(pending_clicks)
+@context("pending_clicks")
+def admin_pending_clicks() -> dict[str, int]:
+    return pending_clicks()
 ```
 
-`context("key")` returns the decorator, and calling it on a function registers the function exactly like `@context("key")` would.
+`@context` keys the registration on the file where the decorated function is declared, so decorating `pending_clicks` in place would bind it to `shortener/cache.py` instead of to this page.
 
 ### 4. `inherit_context=True` — sharing context down the tree
 

--- a/examples/shortener/shortener/routes/admin/page.py
+++ b/examples/shortener/shortener/routes/admin/page.py
@@ -12,7 +12,9 @@ def recent_links() -> list[Link]:
     return list(Link.objects.order_by("-clicks", "-created_at")[:10])
 
 
-context("pending_clicks")(pending_clicks)
+@context("pending_clicks")
+def admin_pending_clicks() -> dict[str, int]:
+    return pending_clicks()
 
 
 class EditLinkForm(ModelForm):

--- a/next/checks/__init__.py
+++ b/next/checks/__init__.py
@@ -21,6 +21,7 @@ NEXT: str = "next"
 
 if TYPE_CHECKING:
     from next.components.checks import (
+        check_component_context_registration_files,
         check_component_py_no_pages_context,
         check_cross_root_component_name_conflicts,
         check_duplicate_component_names,
@@ -32,6 +33,7 @@ if TYPE_CHECKING:
         _has_template_or_djx,
         check_context_functions,
         check_context_processor_signature,
+        check_context_registration_files,
         check_layout_templates,
         check_page_functions,
         check_page_module_imports,
@@ -56,6 +58,7 @@ if TYPE_CHECKING:
 
 _LAZY_SOURCES_BY_MODULE: dict[str, tuple[str, ...]] = {
     "next.components.checks": (
+        "check_component_context_registration_files",
         "check_component_py_no_pages_context",
         "check_cross_root_component_name_conflicts",
         "check_duplicate_component_names",
@@ -67,6 +70,7 @@ _LAZY_SOURCES_BY_MODULE: dict[str, tuple[str, ...]] = {
         "_has_template_or_djx",
         "check_context_functions",
         "check_context_processor_signature",
+        "check_context_registration_files",
         "check_layout_templates",
         "check_page_functions",
         "check_page_module_imports",

--- a/next/checks/common.py
+++ b/next/checks/common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from weakref import WeakKeyDictionary
@@ -14,10 +15,104 @@ from next.conf.signals import settings_reloaded
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
 
     from next.components.manager import ComponentsManager
     from next.urls import FileRouterBackend, RouterBackend, RouterManager
+
+
+@dataclass(frozen=True, slots=True)
+class RegistrationSubject:
+    """The wording one context decorator uses in its registration-file check."""
+
+    decorator: str
+    anchor_name: str
+    render: str
+    code: str
+
+
+def registration_file_errors(
+    subject: RegistrationSubject,
+    *,
+    registrations: dict[Path, tuple[str, ...]],
+    misattributed: Iterable[tuple[Path, Path, str]],
+) -> list[CheckMessage]:
+    """Report registrations that no render of the intended file ever collects.
+
+    A registration keys on the file declaring the callable, so decorating an
+    imported helper binds it either to a file that is no anchor at all, or to
+    another anchor file whose render answers a different URL.
+    """
+    records = sorted(misattributed, key=_by_paths)
+    errors = _cross_file_errors(subject, records)
+    errors.extend(_dead_file_errors(subject, registrations, _names_by_file(records)))
+    return errors
+
+
+def _names_by_file(records: list[tuple[Path, Path, str]]) -> dict[Path, set[str]]:
+    """Group the misattributed names by the file they landed on."""
+    grouped: dict[Path, set[str]] = {}
+    for _registered_from, declared_in, name in records:
+        grouped.setdefault(declared_in, set()).add(name)
+    return grouped
+
+
+def _cross_file_errors(
+    subject: RegistrationSubject, records: list[tuple[Path, Path, str]]
+) -> list[CheckMessage]:
+    """Report each registration that landed on a file other than the one running it."""
+    errors: list[CheckMessage] = []
+    for registered_from, declared_in, name in records:
+        errors.append(
+            Error(
+                f"{registered_from} runs {subject.decorator} on {name}, declared in "
+                f"{declared_in}, so the registration binds to {declared_in} and no "
+                f"{subject.render} of {registered_from} collects it. Declare the "
+                f"callable in {registered_from}, wrapping the shared helper.",
+                obj=str(registered_from),
+                id=subject.code,
+            )
+        )
+    return errors
+
+
+def _dead_file_errors(
+    subject: RegistrationSubject,
+    registrations: dict[Path, tuple[str, ...]],
+    already_reported: dict[Path, set[str]],
+) -> list[CheckMessage]:
+    """Report registrations sitting on a file the renderer never looks at.
+
+    A name in `already_reported` is left out, because the cross-file report
+    has named that callable and its fix already.
+    """
+    errors: list[CheckMessage] = []
+    for file_path in sorted(registrations, key=str):
+        if file_path.name == subject.anchor_name:
+            continue
+        unreported = set(registrations[file_path]) - already_reported.get(
+            file_path, set()
+        )
+        if not unreported:
+            continue
+        names = ", ".join(sorted(unreported))
+        errors.append(
+            Error(
+                f"{file_path} registers {subject.decorator} callables ({names}) but "
+                f"is not a {subject.anchor_name}, so no {subject.render} collects "
+                f"them. Declare the callable in the {subject.anchor_name} that "
+                "needs it, wrapping this helper.",
+                obj=str(file_path),
+                id=subject.code,
+            )
+        )
+    return errors
+
+
+def _by_paths(record: tuple[Path, Path, str]) -> tuple[str, str, str]:
+    """Order misattribution records so the report is stable across runs."""
+    registered_from, declared_in, name = record
+    return (str(registered_from), str(declared_in), name)
 
 
 def errors_for_unknown_keys(

--- a/next/components/checks.py
+++ b/next/components/checks.py
@@ -9,9 +9,13 @@ from django.conf import settings
 from django.core.checks import CheckMessage, Error, register
 
 from next.checks import NEXT
-from next.checks.common import errors_for_unknown_keys, get_components_manager
+from next.checks.common import (
+    RegistrationSubject,
+    errors_for_unknown_keys,
+    get_components_manager,
+    registration_file_errors,
+)
 from next.conf import next_framework_settings
-from next.utils import callable_name
 
 from .backends import FileComponentsBackend
 from .context import component
@@ -23,8 +27,14 @@ if TYPE_CHECKING:
 
 _COMPONENT_BACKEND_SETTINGS_KEY = "COMPONENT_BACKENDS"
 
-# The scanner discovers only this name, so a context on another file is dead.
-_COMPONENT_FILE_NAME = "component.py"
+# The scanner renders only this name, so a context bound anywhere else is dead,
+# including one bound to the component.py next door.
+_COMPONENT_CONTEXT_SUBJECT = RegistrationSubject(
+    decorator="@component.context",
+    anchor_name="component.py",
+    render="component render",
+    code="next.E075",
+)
 
 _FILE_COMPONENT_BACKEND_CONFIG_KEYS = frozenset({"BACKEND", "COMPONENTS_DIR", "DIRS"})
 
@@ -247,10 +257,11 @@ def check_component_py_no_pages_context(*args, **kwargs) -> list[CheckMessage]:
 
 @register(NEXT)
 def check_component_context_registration_files(*args, **kwargs) -> list[CheckMessage]:
-    """Flag a `@component.context` bound to no `component.py` (`next.E078`).
+    """Flag a `@component.context` no component render collects (`next.E075`).
 
     A registration keys on the file declaring the callable, so decorating an
-    imported helper binds it to that module, which no component render reads.
+    imported helper binds it to that module, and decorating a callable from a
+    sibling `component.py` binds it to that other component.
     """
     configs = next_framework_settings.COMPONENT_BACKENDS
     if not isinstance(configs, list) or not configs:
@@ -259,26 +270,15 @@ def check_component_context_registration_files(*args, **kwargs) -> list[CheckMes
     manager = get_components_manager()
     for backend in manager._backends:
         if isinstance(backend, FileComponentsBackend):
+            # Called for the import it performs, which is what runs the
+            # decorators this check then reads out of the registry.
             backend.loaded_module_paths()
 
-    errors: list[CheckMessage] = []
-    registry = component._registry._registry
-    for file_path in sorted(registry, key=str):
-        if file_path.name == _COMPONENT_FILE_NAME:
-            continue
-        names = ", ".join(
-            sorted(callable_name(entry.func) for entry in registry[file_path].values())
-        )
-        errors.append(
-            Error(
-                f"{file_path} registers @component.context callables ({names}) but "
-                "is not a component.py, so no render collects them. Declare the "
-                "callable in the component.py that needs it, wrapping this helper.",
-                obj=str(file_path),
-                id="next.E078",
-            )
-        )
-    return errors
+    return registration_file_errors(
+        _COMPONENT_CONTEXT_SUBJECT,
+        registrations=component._registry.registered_names(),
+        misattributed=component._registry.misattributed(),
+    )
 
 
 __all__ = [

--- a/next/components/checks.py
+++ b/next/components/checks.py
@@ -11,8 +11,10 @@ from django.core.checks import CheckMessage, Error, register
 from next.checks import NEXT
 from next.checks.common import errors_for_unknown_keys, get_components_manager
 from next.conf import next_framework_settings
+from next.utils import callable_name
 
 from .backends import FileComponentsBackend
+from .context import component
 
 
 if TYPE_CHECKING:
@@ -20,6 +22,9 @@ if TYPE_CHECKING:
 
 
 _COMPONENT_BACKEND_SETTINGS_KEY = "COMPONENT_BACKENDS"
+
+# The scanner discovers only this name, so a context on another file is dead.
+_COMPONENT_FILE_NAME = "component.py"
 
 _FILE_COMPONENT_BACKEND_CONFIG_KEYS = frozenset({"BACKEND", "COMPONENTS_DIR", "DIRS"})
 
@@ -240,7 +245,44 @@ def check_component_py_no_pages_context(*args, **kwargs) -> list[CheckMessage]:
     return errors
 
 
+@register(NEXT)
+def check_component_context_registration_files(*args, **kwargs) -> list[CheckMessage]:
+    """Flag a `@component.context` bound to no `component.py` (`next.E078`).
+
+    A registration keys on the file declaring the callable, so decorating an
+    imported helper binds it to that module, which no component render reads.
+    """
+    configs = next_framework_settings.COMPONENT_BACKENDS
+    if not isinstance(configs, list) or not configs:
+        return []
+
+    manager = get_components_manager()
+    for backend in manager._backends:
+        if isinstance(backend, FileComponentsBackend):
+            backend.loaded_module_paths()
+
+    errors: list[CheckMessage] = []
+    registry = component._registry._registry
+    for file_path in sorted(registry, key=str):
+        if file_path.name == _COMPONENT_FILE_NAME:
+            continue
+        names = ", ".join(
+            sorted(callable_name(entry.func) for entry in registry[file_path].values())
+        )
+        errors.append(
+            Error(
+                f"{file_path} registers @component.context callables ({names}) but "
+                "is not a component.py, so no render collects them. Declare the "
+                "callable in the component.py that needs it, wrapping this helper.",
+                obj=str(file_path),
+                id="next.E078",
+            )
+        )
+    return errors
+
+
 __all__ = [
+    "check_component_context_registration_files",
     "check_component_py_no_pages_context",
     "check_cross_root_component_name_conflicts",
     "check_duplicate_component_names",

--- a/next/components/context.py
+++ b/next/components/context.py
@@ -8,20 +8,19 @@ component template is rendered.
 
 from __future__ import annotations
 
-import inspect
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, overload
 
 from next.checks.common import get_components_manager
 from next.deps import resolver
-from next.utils import caller_source_path
+from next.utils import callable_name, defining_file
 
 from .backends import FileComponentsBackend
 
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
+    from pathlib import Path
 
     from next.static.serializers import JsContextSerializer
 
@@ -96,17 +95,11 @@ class ComponentContextRegistry:
     ) -> bool:
         if func1 is func2:
             return True
-        name1 = getattr(func1, "__name__", None)
-        name2 = getattr(func2, "__name__", None)
-        if not name1 or not name2 or name1 != name2:
+        if callable_name(func1) != callable_name(func2):
             return False
         try:
-            file1 = inspect.getsourcefile(func1)
-            file2 = inspect.getsourcefile(func2)
-            if not file1 or not file2:
-                return False
-            return Path(file1).resolve() == Path(file2).resolve()
-        except (OSError, TypeError, ValueError):
+            return defining_file(func1).resolve() == defining_file(func2).resolve()
+        except (OSError, TypeError):
             return False
 
     def __len__(self) -> int:
@@ -120,13 +113,6 @@ class ComponentContextManager:
     def __init__(self) -> None:
         """Create an empty registry for context callables."""
         self._registry = ComponentContextRegistry()
-
-    def _get_caller_path(self, back_count: int = 1) -> Path:
-        return caller_source_path(
-            back_count=back_count,
-            max_walk=10,
-            skip_framework_file=("context.py", "components"),
-        )
 
     @overload
     def context[C: Callable[..., Any]](self, func_or_key: C, /) -> C: ...
@@ -156,18 +142,16 @@ class ComponentContextManager:
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             if callable(func_or_key):
-                caller_path = self._get_caller_path(2)
                 self._registry.register(
-                    caller_path,
+                    defining_file(func),
                     None,
                     func_or_key,
                     serialize=serialize,
                     serializer=serializer,
                 )
             else:
-                caller_path = self._get_caller_path(1)
                 self._registry.register(
-                    caller_path,
+                    defining_file(func),
                     func_or_key,
                     func,
                     serialize=serialize,

--- a/next/components/context.py
+++ b/next/components/context.py
@@ -1,26 +1,32 @@
 """Context registration for `component.py` modules.
 
 `ComponentContextManager` is the public handle used by decorator
-`@component.context` inside a `component.py` file. It records the
-caller's path so the right context callables run when the matching
-component template is rendered.
+`@component.context` inside a `component.py` file. It records the file
+declaring each callable so the right context functions run when the
+matching component template is rendered.
 """
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, overload
 
 from next.checks.common import get_components_manager
 from next.deps import resolver
-from next.utils import callable_name, defining_file
+from next.utils import (
+    MisattributedContext,
+    MisattributionLog,
+    callable_name,
+    defining_file,
+)
 
 from .backends import FileComponentsBackend
 
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
-    from pathlib import Path
 
     from next.static.serializers import JsContextSerializer
 
@@ -46,6 +52,28 @@ class ComponentContextRegistry:
     def __init__(self) -> None:
         """Create an empty path-keyed context-function mapping."""
         self._registry: dict[Path, dict[str | None, ContextFunction]] = {}
+        self._misattributions = MisattributionLog()
+
+    def misattributed(self) -> tuple[MisattributedContext, ...]:
+        """Return every registration bound to a file other than the one running it."""
+        return self._misattributions.entries()
+
+    def note_misattribution(
+        self, registered_from: Path, declared_in: Path, func: Callable[..., Any]
+    ) -> None:
+        """Record a `@component.context` declared outside the running file.
+
+        The registration binds to `declared_in`, which no render of
+        `registered_from` reads, so the pair feeds the `next.E075` diagnostic.
+        """
+        self._misattributions.record(registered_from, declared_in, func)
+
+    def registered_names(self) -> dict[Path, tuple[str, ...]]:
+        """Return the callable names registered per file, for the diagnostics."""
+        return {
+            file_path: tuple(callable_name(entry.func) for entry in entries.values())
+            for file_path, entries in self._registry.items()
+        }
 
     def register(
         self,
@@ -139,24 +167,18 @@ class ComponentContextManager:
         through a custom `JsContextSerializer` instead of the global
         `JS_CONTEXT_SERIALIZER` setting.
         """
+        # Captured here rather than inside the decorator so both spellings see
+        # the component.py that ran `@component.context`, not this module.
+        registered_from = Path(sys._getframe(1).f_code.co_filename)
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-            if callable(func_or_key):
-                self._registry.register(
-                    defining_file(func),
-                    None,
-                    func_or_key,
-                    serialize=serialize,
-                    serializer=serializer,
-                )
-            else:
-                self._registry.register(
-                    defining_file(func),
-                    func_or_key,
-                    func,
-                    serialize=serialize,
-                    serializer=serializer,
-                )
+            declared_in = defining_file(func)
+            if declared_in != registered_from:
+                self._registry.note_misattribution(registered_from, declared_in, func)
+            key = None if callable(func_or_key) else func_or_key
+            self._registry.register(
+                declared_in, key, func, serialize=serialize, serializer=serializer
+            )
             return func
 
         return decorator(func_or_key) if callable(func_or_key) else decorator

--- a/next/forms/base.py
+++ b/next/forms/base.py
@@ -1,6 +1,7 @@
 """Base form classes and auto-registration machinery for next.forms."""
 
 import inspect
+import os
 import re
 import sys
 from pathlib import Path
@@ -17,6 +18,7 @@ from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 
 from next.conf import next_framework_settings
+from next.utils import defining_file
 
 from .backends import (
     ActionGuard,
@@ -29,28 +31,53 @@ from .manager import form_action_manager
 from .uid import redirect_to_origin
 
 
+def _root_prefix(root: str) -> str:
+    """Return the root with one trailing separator so prefix tests respect segments."""
+    return root if root.endswith(os.sep) else root + os.sep
+
+
 _ANCHOR_FILE_NAMES: frozenset[str] = frozenset({"page.py", "component.py"})
 _SELF_REGISTERED_ATTR: Final[str] = "__next_registered__"
 _FRAMEWORK_ROOT: Final[Path] = Path(__file__).resolve().parent.parent
 _DJANGO_FORMS_ROOT: Final[Path] = Path(inspect.getfile(django_forms)).resolve().parent
+_FRAMEWORK_ROOT_STR: Final[str] = str(_FRAMEWORK_ROOT)
+_FRAMEWORK_ROOT_PREFIX: Final[str] = _root_prefix(_FRAMEWORK_ROOT_STR)
+# A class attributed to either root was built by type() inside foreign code,
+# so only the stack names the file that asked for it.
+_FOREIGN_ROOTS: Final[tuple[tuple[str, str], ...]] = (
+    (str(_DJANGO_FORMS_ROOT), _root_prefix(str(_DJANGO_FORMS_ROOT))),
+    (_FRAMEWORK_ROOT_STR, _FRAMEWORK_ROOT_PREFIX),
+)
+
+# Both roots are process constants, so a per-path answer can never go stale.
+# The BASE_DIR decision stays uncached because settings repoint it.
+_foreign_file_cache: dict[str, bool] = {}
 
 # HttpResponseRedirect is a subclass of HttpResponse, so the login-redirect
 # short-circuit needs no extra arm.
 type PermissionOutcome = bool | HttpResponse | None
 
 
+_ACRONYM_BOUNDARY_RE: Final[re.Pattern[str]] = re.compile(r"([A-Z]+)([A-Z][a-z])")
+_CASE_BOUNDARY_RE: Final[re.Pattern[str]] = re.compile(r"([a-z\d])([A-Z])")
+
+
 def _to_snake_case(name: str) -> str:
-    s1 = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", name)
-    return re.sub(r"([a-z\d])([A-Z])", r"\1_\2", s1).lower()
+    s1 = _ACRONYM_BOUNDARY_RE.sub(r"\1_\2", name)
+    return _CASE_BOUNDARY_RE.sub(r"\1_\2", s1).lower()
 
 
-def _is_framework_file(file_path: str) -> bool:
-    try:
-        Path(_resolved_path_str(file_path)).relative_to(_FRAMEWORK_ROOT)
-    except ValueError:
-        return False
-    else:
-        return True
+def _is_foreign_file(file_path: str) -> bool:
+    """Return True when file_path resolves inside django.forms or the framework."""
+    cached = _foreign_file_cache.get(file_path)
+    if cached is None:
+        resolved = _resolved_path_str(file_path)
+        cached = any(
+            resolved == root or resolved.startswith(prefix)
+            for root, prefix in _FOREIGN_ROOTS
+        )
+        _foreign_file_cache[file_path] = cached
+    return cached
 
 
 def _compute_scope(file_path: str) -> str:
@@ -59,9 +86,9 @@ def _compute_scope(file_path: str) -> str:
     anchor_names = (
         frozenset(configured) if configured is not None else _ANCHOR_FILE_NAMES
     )
-    return (
-        "page" if Path(_resolved_path_str(file_path)).name in anchor_names else "shared"
-    )
+    # The tail after the last separator equals PurePath.name for a resolved path.
+    name = _resolved_path_str(file_path).rpartition(os.sep)[2]
+    return "page" if name in anchor_names else "shared"
 
 
 def _record_invalid_meta_scope(cls: type, bad_value: object) -> None:
@@ -125,17 +152,8 @@ def _validate_instance_from_url(cls: type, *, is_model_form: bool) -> None:
             )
 
 
-def _is_django_forms_file(file_path: str) -> bool:
-    try:
-        Path(_resolved_path_str(file_path)).relative_to(_DJANGO_FORMS_ROOT)
-    except ValueError:
-        return False
-    else:
-        return True
-
-
-def _find_definition_frame() -> str:
-    """Walk the call stack to find the file where a class was defined."""
+def _find_frame_outside() -> str:
+    """Walk the stack for the first frame outside django.forms and the framework."""
     depth = 1
     while True:
         try:
@@ -143,10 +161,28 @@ def _find_definition_frame() -> str:
         except ValueError:
             return ""
         filename = frame.f_code.co_filename
-        if _is_django_forms_file(filename) or _is_framework_file(filename):
+        if _is_foreign_file(filename):
             depth += 1
             continue
         return filename
+
+
+def _definition_file_of(cls: type) -> str:
+    """Return the file where cls was declared, empty when no frame names one.
+
+    A foreign file never survives, so the caller needs no framework arm.
+    """
+    try:
+        path = defining_file(cls)
+    except (OSError, TypeError):
+        # inspect.getfile raises for a class whose module has no __file__ or
+        # is missing from sys.modules, which is every page.py the file router
+        # execs from a spec it never registers.
+        return _find_frame_outside()
+    file_path = str(path)
+    if _is_foreign_file(file_path):
+        return _find_frame_outside()
+    return file_path
 
 
 def _registration_gate(cls: type) -> tuple[str, str, str] | None:
@@ -156,22 +192,17 @@ def _registration_gate(cls: type) -> tuple[str, str, str] | None:
     if getattr(cls.__dict__.get("Meta"), "abstract", False):
         return None
 
-    file_path = _find_definition_frame()
+    file_path = _definition_file_of(cls)
 
     # Skip virtual frames (importlib bootstrap, interactive shell, etc.)
     if not file_path or file_path.startswith("<"):
         return None
 
-    if _is_framework_file(file_path):
-        return None
-
     base = getattr(settings, "BASE_DIR", None)
     if base is not None:
-        try:
-            Path(_resolved_path_str(file_path)).relative_to(
-                Path(_resolved_path_str(str(base)))
-            )
-        except ValueError:
+        resolved = _resolved_path_str(file_path)
+        base_root = _resolved_path_str(str(base))
+        if resolved != base_root and not resolved.startswith(_root_prefix(base_root)):
             registration_diagnostics.outside_base_dir.append(
                 (cls.__qualname__, file_path)
             )

--- a/next/forms/base.py
+++ b/next/forms/base.py
@@ -167,20 +167,33 @@ def _find_frame_outside() -> str:
         return filename
 
 
+def _module_declared_file(cls: type) -> str | None:
+    """Return the file of the module that still binds cls under its own name.
+
+    The file router execs every `page.py` under one throwaway module name it
+    never registers, so a same-named module a project happens to import must
+    not answer for a class it never declared.
+    """
+    module = sys.modules.get(getattr(cls, "__module__", "") or "")
+    if module is None or getattr(module, cls.__name__, None) is not cls:
+        return None
+    try:
+        return str(defining_file(cls))
+    except (OSError, TypeError):
+        # A module without __file__, such as one built for an interactive
+        # session, names no file for the classes declared in it.
+        return None
+
+
 def _definition_file_of(cls: type) -> str:
     """Return the file where cls was declared, empty when no frame names one.
 
-    A foreign file never survives, so the caller needs no framework arm.
+    `__init_subclass__` runs while the declaring frame is still on the stack,
+    so the walk answers wherever the module cannot. A foreign file never
+    survives it, which is why the caller needs no framework arm.
     """
-    try:
-        path = defining_file(cls)
-    except (OSError, TypeError):
-        # inspect.getfile raises for a class whose module has no __file__ or
-        # is missing from sys.modules, which is every page.py the file router
-        # execs from a spec it never registers.
-        return _find_frame_outside()
-    file_path = str(path)
-    if _is_foreign_file(file_path):
+    file_path = _module_declared_file(cls)
+    if file_path is None or _is_foreign_file(file_path):
         return _find_frame_outside()
     return file_path
 

--- a/next/forms/decorators.py
+++ b/next/forms/decorators.py
@@ -1,10 +1,11 @@
 """The @action decorator for named form actions."""
 
-import sys
 import types
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any, overload
+
+from next.utils import defining_file
 
 from .backends import (
     ActionGuard,
@@ -87,15 +88,13 @@ def action(
     guard the endpoint before origin resolution, `get_initial`, and form
     binding, so no application code runs for a denied request.
     """
-    # The definition file must be captured here. The bare form invokes the
-    # inner decorator from this module, so a frame lookup inside it would
-    # name decorators.py instead of the defining module.
-    file_path = sys._getframe(1).f_code.co_filename
     if isinstance(name, type):
         _record_class_misuse(name)
         return name
     if isinstance(name, types.FunctionType):
-        _register_handler(name, file_path, _HandlerSpec(name=name.__name__))
+        _register_handler(
+            name, str(defining_file(name)), _HandlerSpec(name=name.__name__)
+        )
         return name
     if isinstance(form_class, type) and _is_self_registered(form_class):
         msg = (
@@ -115,7 +114,7 @@ def action(
             return func
         _register_handler(
             func,
-            file_path,
+            str(defining_file(func)),
             _HandlerSpec(
                 name=action_name if action_name is not None else func.__name__,
                 scope=scope,

--- a/next/pages/checks.py
+++ b/next/pages/checks.py
@@ -19,6 +19,7 @@ from django.core.checks import (
 from next.checks import NEXT
 from next.checks.common import get_router_manager, iter_scanned_page_pairs
 from next.conf import import_class_cached, next_framework_settings
+from next.utils import callable_name
 
 from .loaders import TemplateLoader, _load_python_module_memo, build_registered_loaders
 from .manager import page
@@ -37,6 +38,9 @@ EXPECTED_PARAMETER_PARTS = 2
 
 # A page declares a body-source conflict only when two or more sources claim it.
 _MIN_CONFLICTING_BODY_SOURCES = 2
+
+# The file router discovers only this name, so a context on another file is dead.
+_PAGE_FILE_NAME = "page.py"
 
 
 @register(Tags.templates, NEXT)
@@ -524,16 +528,18 @@ def _check_context_function(
 def _check_registered_context_functions(page_path: Path) -> list[CheckMessage]:
     """Return keyless `@context` errors recorded for `page_path` in the registry.
 
-    The registry keys on the caller's `__file__`, which is the same path the
-    check loads the module by, so a direct `page_path` lookup matches whatever
-    spelling the scanner used without resolving symlinks on either side.
+    The registry keys on the file declaring the callable, which for a `page.py`
+    is the absolute path importlib gave the module, the same path this check
+    loads it by, so a direct lookup needs no symlink resolution on either side.
     """
     errors: list[CheckMessage] = []
     registry = page._context_manager._context_registry.get(page_path, {})
     for key, entry in registry.items():
         if key is not None:
             continue
-        error = _check_context_function(entry.func.__name__, entry.func, page_path)
+        error = _check_context_function(
+            callable_name(entry.func), entry.func, page_path
+        )
         if error is not None:
             errors.append(error)
     return errors
@@ -585,6 +591,40 @@ def check_context_functions(*args, **kwargs) -> list[CheckMessage]:
         if _load_python_module_memo(page_path) is None:
             continue
         errors.extend(_check_registered_context_functions(page_path))
+    return errors
+
+
+@register(Tags.templates, NEXT)
+def check_context_registration_files(*args, **kwargs) -> list[CheckMessage]:
+    """Flag a `@context` bound to a file that is no `page.py` (`next.E077`).
+
+    A registration keys on the file declaring the callable, so decorating an
+    imported helper binds it to that helper's module, which no render reads.
+    """
+    router_manager, init_errors = get_router_manager()
+    if router_manager is None:
+        return init_errors
+
+    for page_path in _iter_existing_scanned_pages(router_manager, set()):
+        _load_python_module_memo(page_path)
+
+    errors: list[CheckMessage] = []
+    registry = page._context_manager._context_registry
+    for file_path in sorted(registry, key=str):
+        if file_path.name == _PAGE_FILE_NAME:
+            continue
+        names = ", ".join(
+            sorted(callable_name(entry.func) for entry in registry[file_path].values())
+        )
+        errors.append(
+            Error(
+                f"{file_path} registers @context callables ({names}) but is not a "
+                "page.py, so no render collects them. Declare the callable in the "
+                "page.py that needs it, wrapping this helper.",
+                obj=str(file_path),
+                id="next.E077",
+            )
+        )
     return errors
 
 
@@ -722,6 +762,7 @@ def check_template_loaders(*args, **kwargs) -> list[CheckMessage]:
 __all__ = [
     "check_context_functions",
     "check_context_processor_signature",
+    "check_context_registration_files",
     "check_layout_templates",
     "check_page_functions",
     "check_page_module_imports",

--- a/next/pages/checks.py
+++ b/next/pages/checks.py
@@ -17,7 +17,12 @@ from django.core.checks import (
 )
 
 from next.checks import NEXT
-from next.checks.common import get_router_manager, iter_scanned_page_pairs
+from next.checks.common import (
+    RegistrationSubject,
+    get_router_manager,
+    iter_scanned_page_pairs,
+    registration_file_errors,
+)
 from next.conf import import_class_cached, next_framework_settings
 from next.utils import callable_name
 
@@ -39,8 +44,11 @@ EXPECTED_PARAMETER_PARTS = 2
 # A page declares a body-source conflict only when two or more sources claim it.
 _MIN_CONFLICTING_BODY_SOURCES = 2
 
-# The file router discovers only this name, so a context on another file is dead.
-_PAGE_FILE_NAME = "page.py"
+# The file router routes only this name, so a context bound anywhere else is
+# dead, including one bound to the page.py next door.
+_PAGE_CONTEXT_SUBJECT = RegistrationSubject(
+    decorator="@context", anchor_name="page.py", render="page render", code="next.E074"
+)
 
 
 @register(Tags.templates, NEXT)
@@ -596,10 +604,11 @@ def check_context_functions(*args, **kwargs) -> list[CheckMessage]:
 
 @register(Tags.templates, NEXT)
 def check_context_registration_files(*args, **kwargs) -> list[CheckMessage]:
-    """Flag a `@context` bound to a file that is no `page.py` (`next.E077`).
+    """Flag a `@context` no page render collects (`next.E074`).
 
     A registration keys on the file declaring the callable, so decorating an
-    imported helper binds it to that helper's module, which no render reads.
+    imported helper binds it to that helper's module, and decorating a
+    callable from a sibling `page.py` binds it to that other page.
     """
     router_manager, init_errors = get_router_manager()
     if router_manager is None:
@@ -608,24 +617,11 @@ def check_context_registration_files(*args, **kwargs) -> list[CheckMessage]:
     for page_path in _iter_existing_scanned_pages(router_manager, set()):
         _load_python_module_memo(page_path)
 
-    errors: list[CheckMessage] = []
-    registry = page._context_manager._context_registry
-    for file_path in sorted(registry, key=str):
-        if file_path.name == _PAGE_FILE_NAME:
-            continue
-        names = ", ".join(
-            sorted(callable_name(entry.func) for entry in registry[file_path].values())
-        )
-        errors.append(
-            Error(
-                f"{file_path} registers @context callables ({names}) but is not a "
-                "page.py, so no render collects them. Declare the callable in the "
-                "page.py that needs it, wrapping this helper.",
-                obj=str(file_path),
-                id="next.E077",
-            )
-        )
-    return errors
+    return registration_file_errors(
+        _PAGE_CONTEXT_SUBJECT,
+        registrations=page._context_manager.registered_names(),
+        misattributed=page._context_manager.misattributed(),
+    )
 
 
 @register(Tags.templates, NEXT)

--- a/next/pages/manager.py
+++ b/next/pages/manager.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import sys
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, overload
 
 from django.http import HttpRequest, HttpResponse
@@ -37,7 +39,6 @@ from .signals import page_rendered, template_loaded
 if TYPE_CHECKING:
     import types
     from collections.abc import Callable, Iterator
-    from pathlib import Path
 
     from next.static import StaticCollector
     from next.static.serializers import JsContextSerializer
@@ -125,7 +126,7 @@ class Page:
         serialize: bool = False,
         serializer: JsContextSerializer | None = None,
     ) -> Callable[..., Any]:
-        """Register a keyed or dict-merge `@context` for the caller file.
+        """Register a keyed or dict-merge `@context` for the file declaring `func`.
 
         Pass `serialize=True` to include the return value in
         `Next.context` so JavaScript code on the page can read it via
@@ -133,26 +134,25 @@ class Page:
         through a custom `JsContextSerializer` instead of the global
         `JS_CONTEXT_SERIALIZER` setting.
         """
+        # Captured here rather than inside the decorator so both spellings see
+        # the page.py that ran `@context`, not this module.
+        registered_from = Path(sys._getframe(1).f_code.co_filename)
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-            if callable(func_or_key):
-                self._context_manager.register_context(
-                    defining_file(func),
-                    None,
-                    func_or_key,
-                    inherit_context=inherit_context,
-                    serialize=serialize,
-                    serializer=serializer,
+            declared_in = defining_file(func)
+            if declared_in != registered_from:
+                self._context_manager.note_misattribution(
+                    registered_from, declared_in, func
                 )
-            else:
-                self._context_manager.register_context(
-                    defining_file(func),
-                    func_or_key,
-                    func,
-                    inherit_context=inherit_context,
-                    serialize=serialize,
-                    serializer=serializer,
-                )
+            key = None if callable(func_or_key) else func_or_key
+            self._context_manager.register_context(
+                declared_in,
+                key,
+                func,
+                inherit_context=inherit_context,
+                serialize=serialize,
+                serializer=serializer,
+            )
             return func
 
         return decorator(func_or_key) if callable(func_or_key) else decorator

--- a/next/pages/manager.py
+++ b/next/pages/manager.py
@@ -9,7 +9,6 @@ application-wide singleton. `context` is a convenience alias for
 from __future__ import annotations
 
 import contextlib
-import inspect
 import logging
 import time
 from dataclasses import dataclass
@@ -23,7 +22,7 @@ from django.urls import URLPattern, path
 from next.checks.common import get_router_manager, iter_scanned_page_pairs
 from next.conf import next_framework_settings
 from next.deps import DependencyResolver, resolver
-from next.utils import caller_source_path
+from next.utils import defining_file
 
 from .loaders import (
     LayoutTemplateLoader,
@@ -107,14 +106,6 @@ class Page:
         self._compiled_registry.pop(file_path, None)
         template_loaded.send(sender=Page, file_path=file_path)
 
-    def _get_caller_path(self, back_count: int = 1) -> Path:
-        """Return the filesystem path of the user caller outside this module."""
-        return caller_source_path(
-            back_count=back_count,
-            max_walk=10,
-            skip_while_filename_endswith=("manager.py",),
-        )
-
     @overload
     def context[C: Callable[..., Any]](self, func_or_key: C, /) -> C: ...
     @overload
@@ -145,9 +136,8 @@ class Page:
 
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             if callable(func_or_key):
-                caller_path = self._get_caller_path(2)
                 self._context_manager.register_context(
-                    caller_path,
+                    defining_file(func),
                     None,
                     func_or_key,
                     inherit_context=inherit_context,
@@ -155,9 +145,8 @@ class Page:
                     serializer=serializer,
                 )
             else:
-                caller_path = self._get_caller_path(1)
                 self._context_manager.register_context(
-                    caller_path,
+                    defining_file(func),
                     func_or_key,
                     func,
                     inherit_context=inherit_context,
@@ -591,9 +580,6 @@ class Page:
         return self._create_virtual_page_pattern(
             file_path, django_pattern, parameters, clean_name
         )
-
-
-_ = inspect  # keep `inspect` import reachable for test-time patching
 
 
 page: Page = Page()

--- a/next/pages/registry.py
+++ b/next/pages/registry.py
@@ -13,7 +13,7 @@ import logging
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from next.deps import DependencyResolver, get_request_dep_cache, resolver
-from next.utils import callable_name
+from next.utils import MisattributedContext, MisattributionLog, callable_name
 
 from .context import ContextResult
 from .signals import context_registered
@@ -84,6 +84,7 @@ class PageContextRegistry:
         # Keyless callables share the `None` slot, so the registry keeps only
         # the last. Retain the overwritten names for the `next.E018` diagnostic.
         self._keyless_conflicts: dict[Path, list[str]] = {}
+        self._misattributions = MisattributionLog()
         self._resolver = resolver
 
     def _get_resolver(self) -> DependencyResolver:
@@ -100,6 +101,28 @@ class PageContextRegistry:
         """
         self._context_registry.clear()
         self._keyless_conflicts.clear()
+        self._misattributions.clear()
+
+    def misattributed(self) -> tuple[MisattributedContext, ...]:
+        """Return every registration bound to a file other than the one running it."""
+        return self._misattributions.entries()
+
+    def note_misattribution(
+        self, registered_from: Path, declared_in: Path, func: Callable[..., Any]
+    ) -> None:
+        """Record a `@context` whose callable was declared outside the running file.
+
+        The registration binds to `declared_in`, which no render of
+        `registered_from` reads, so the pair feeds the `next.E074` diagnostic.
+        """
+        self._misattributions.record(registered_from, declared_in, func)
+
+    def registered_names(self) -> dict[Path, tuple[str, ...]]:
+        """Return the callable names registered per file, for the diagnostics."""
+        return {
+            file_path: tuple(callable_name(entry.func) for entry in entries.values())
+            for file_path, entries in self._context_registry.items()
+        }
 
     def register_context(
         self,

--- a/next/pages/registry.py
+++ b/next/pages/registry.py
@@ -13,6 +13,7 @@ import logging
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from next.deps import DependencyResolver, get_request_dep_cache, resolver
+from next.utils import callable_name
 
 from .context import ContextResult
 from .signals import context_registered
@@ -114,14 +115,13 @@ class PageContextRegistry:
         bucket = self._context_registry.setdefault(file_path, {})
         existing = bucket.get(None)
         # Compare by name so a re-executed module (same name) is not a conflict.
-        if (
-            key is None
-            and existing is not None
-            and existing.func.__name__ != func.__name__
-        ):
-            self._keyless_conflicts.setdefault(
-                file_path, [existing.func.__name__]
-            ).append(func.__name__)
+        if key is None and existing is not None:
+            existing_name = callable_name(existing.func)
+            new_name = callable_name(func)
+            if existing_name != new_name:
+                self._keyless_conflicts.setdefault(file_path, [existing_name]).append(
+                    new_name
+                )
         bucket[key] = PageContextEntry(
             func=func,
             inherit_context=inherit_context,

--- a/next/utils.py
+++ b/next/utils.py
@@ -1,4 +1,4 @@
-"""Filesystem path helpers."""
+"""Filesystem path helpers and the declaration-site attribution they back."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import functools
 import inspect
 from pathlib import Path
 from types import CodeType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from django.conf import settings
 
@@ -75,10 +75,38 @@ def classify_dirs_entries(
     return path_roots, frozenset(segments)
 
 
-def _code_filename(func: Callable[..., Any]) -> str | None:
+_CLASS_BODY_MEMBERS: tuple[str, ...] = ("__call__", "__init__")
+
+
+def _code_filename(func: object) -> str | None:
     """Return the source file behind ``func.__code__``, or ``None`` when it has none."""
-    code = getattr(inspect.unwrap(func), "__code__", None)
+    target = func
+    if callable(func):
+        try:
+            target = inspect.unwrap(func)
+        except ValueError:
+            # A ``__wrapped__`` cycle names no innermost function, so the
+            # outermost wrapper answers rather than the registration failing.
+            target = func
+    code = getattr(target, "__code__", None)
     return code.co_filename if isinstance(code, CodeType) else None
+
+
+def _class_filename(cls: type) -> str | None:
+    """Return the file declaring ``cls``, reading its own body when the module is gone.
+
+    The file router execs a ``page.py`` from a spec it never registers, so
+    ``sys.modules`` names no file for classes declared there. A method written
+    in the class body still carries the path in its code object.
+    """
+    try:
+        return inspect.getfile(cls)
+    except (OSError, TypeError):
+        for name in _CLASS_BODY_MEMBERS:
+            filename = _code_filename(cls.__dict__.get(name))
+            if filename is not None:
+                return filename
+    return None
 
 
 def defining_file(obj: object) -> Path:
@@ -86,18 +114,19 @@ def defining_file(obj: object) -> Path:
 
     Wrappers stay transparent only while they set ``__wrapped__`` through
     :func:`functools.wraps`, and a class built by ``type()`` inside foreign
-    code keeps no link to the file that asked for it. A callable instance
-    answers through the code object of its ``__call__``, which names the
-    file even for a module absent from ``sys.modules``.
+    code keeps no link to the file that asked for it. Where ``sys.modules``
+    names no file, a code object from the object's own body answers instead.
     """
-    if inspect.isclass(obj):
-        return Path(inspect.getfile(obj))
     if isinstance(obj, functools.partial):
         return defining_file(obj.func)
-    if callable(obj):
+    if inspect.isclass(obj):
+        filename = _class_filename(obj)
+    elif callable(obj):
         filename = _code_filename(obj) or _code_filename(type(obj).__call__)
-        if filename is not None:
-            return Path(filename)
+    else:
+        filename = None
+    if filename is not None:
+        return Path(filename)
     msg = (
         f"next.dj could not determine the file where {obj!r} was declared, "
         "so the registration has no page or component to belong to. Declare a "
@@ -116,3 +145,44 @@ def callable_name(obj: object) -> str:
         return callable_name(obj.func)
     name = getattr(obj, "__name__", None)
     return name if isinstance(name, str) else type(obj).__name__
+
+
+class MisattributedContext(NamedTuple):
+    """One registration whose callable was declared outside the file running it.
+
+    Both files are kept because a diagnostic has to name the file that
+    expected the value and the one the registration landed on.
+    """
+
+    registered_from: Path
+    declared_in: Path
+    name: str
+
+
+class MisattributionLog:
+    """Collect registrations bound to a file other than the one running them."""
+
+    def __init__(self) -> None:
+        """Start with no recorded registration."""
+        # Keyed by the whole record so a module executed more than once
+        # reports one diagnostic rather than one per execution.
+        self._records: dict[MisattributedContext, None] = {}
+
+    def record(
+        self, registered_from: Path, declared_in: Path, func: Callable[..., Any]
+    ) -> None:
+        """Note that `func` bound to `declared_in` while `registered_from` ran."""
+        entry = MisattributedContext(
+            registered_from=registered_from,
+            declared_in=declared_in,
+            name=callable_name(func),
+        )
+        self._records[entry] = None
+
+    def entries(self) -> tuple[MisattributedContext, ...]:
+        """Return every recorded registration, in the order first seen."""
+        return tuple(self._records)
+
+    def clear(self) -> None:
+        """Drop every recorded registration."""
+        self._records.clear()

--- a/next/utils.py
+++ b/next/utils.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import functools
 import inspect
 from pathlib import Path
+from types import CodeType
 from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
 
 
 if TYPE_CHECKING:
-    from types import FrameType
+    from collections.abc import Callable
 
 
 def resolve_base_dir() -> Path | None:
@@ -73,85 +75,44 @@ def classify_dirs_entries(
     return path_roots, frozenset(segments)
 
 
-_CALLER_PATH_ERROR = "Could not determine caller file path"
+def _code_filename(func: Callable[..., Any]) -> str | None:
+    """Return the source file behind ``func.__code__``, or ``None`` when it has none."""
+    code = getattr(inspect.unwrap(func), "__code__", None)
+    return code.co_filename if isinstance(code, CodeType) else None
 
 
-def caller_source_path(
-    *,
-    back_count: int = 1,
-    max_walk: int = 15,
-    skip_while_filename_endswith: tuple[str, ...] | None = None,
-    skip_framework_file: tuple[str, str] | None = None,
-) -> Path:
-    """Resolve ``Path`` of the caller module's ``__file__`` for decorator registration.
+def defining_file(obj: object) -> Path:
+    """Return the file where ``obj`` was declared, for decorator registration.
 
-    ``back_count`` is how many frames to step up before scanning. Use this to skip
-    past a decorator wrapper.
-
-    For pages and forms pass ``skip_while_filename_endswith``, for example
-    ``("pages.py",)``. Walk frames until ``__file__`` is missing or no longer ends
-    with one of those suffixes. Then return that path.
-
-    For components pass ``skip_framework_file`` as ``(basename, parent_dir_name)``,
-    for example ``("components.py", "next")``. Only ``str`` paths ending in ``.py``
-    are considered. The resolved framework module path is skipped.
+    Wrappers stay transparent only while they set ``__wrapped__`` through
+    :func:`functools.wraps`, and a class built by ``type()`` inside foreign
+    code keeps no link to the file that asked for it. A callable instance
+    answers through the code object of its ``__call__``, which names the
+    file even for a module absent from ``sys.modules``.
     """
-    if skip_while_filename_endswith is not None and skip_framework_file is not None:
-        msg = "Specify only one of skip_while_filename_endswith or skip_framework_file"
-        raise ValueError(msg)
-    if skip_while_filename_endswith is None and skip_framework_file is None:
-        msg = "Specify skip_while_filename_endswith or skip_framework_file"
-        raise ValueError(msg)
-
-    frame = _walk_back(inspect.currentframe(), back_count)
-    if skip_while_filename_endswith is not None:
-        return _scan_by_suffix(frame, skip_while_filename_endswith, max_walk)
-    if skip_framework_file is None:  # pragma: no cover
-        raise RuntimeError(_CALLER_PATH_ERROR)
-    return _scan_framework_file(frame, skip_framework_file, max_walk)
-
-
-def _walk_back(frame: FrameType | None, back_count: int) -> FrameType | None:
-    """Step up ``back_count`` frames before scanning, raising when they run out."""
-    for _ in range(back_count):
-        if not frame or not frame.f_back:
-            raise RuntimeError(_CALLER_PATH_ERROR)
-        frame = frame.f_back
-    return frame
+    if inspect.isclass(obj):
+        return Path(inspect.getfile(obj))
+    if isinstance(obj, functools.partial):
+        return defining_file(obj.func)
+    if callable(obj):
+        filename = _code_filename(obj) or _code_filename(type(obj).__call__)
+        if filename is not None:
+            return Path(filename)
+    msg = (
+        f"next.dj could not determine the file where {obj!r} was declared, "
+        "so the registration has no page or component to belong to. Declare a "
+        "function with 'def' in the file that uses it and decorate that."
+    )
+    raise TypeError(msg)
 
 
-def _scan_by_suffix(
-    frame: FrameType | None, suffixes: tuple[str, ...], max_walk: int
-) -> Path:
-    """Return the first caller frame whose ``__file__`` is not a framework suffix."""
-    for _ in range(max_walk):
-        if not frame:
-            break
-        raw = frame.f_globals.get("__file__")
-        if raw and isinstance(raw, str):
-            if any(raw.endswith(sfx) for sfx in suffixes):
-                frame = frame.f_back
-                continue
-            return Path(raw)
-        frame = frame.f_back
-    raise RuntimeError(_CALLER_PATH_ERROR)
+def callable_name(obj: object) -> str:
+    """Return the name a registration reports for ``obj`` in diagnostics.
 
-
-def _scan_framework_file(
-    frame: FrameType | None, skip_framework_file: tuple[str, str], max_walk: int
-) -> Path:
-    """Return the first caller frame outside the named framework module file."""
-    base, parent = skip_framework_file
-    err_components = f"{_CALLER_PATH_ERROR}: no __file__ in caller frames"
-    for _ in range(max_walk):
-        if not frame:
-            break
-        raw = frame.f_globals.get("__file__")
-        if isinstance(raw, str) and raw.endswith(".py"):
-            path = Path(raw).resolve()
-            if path.name == base and path.parent.name == parent:
-                frame = frame.f_back
-                continue
-            return path
-        frame = frame.f_back
-    raise RuntimeError(err_components)
+    A partial and a callable instance carry no ``__name__``, so the name of
+    the wrapped function or of the class stands in for one.
+    """
+    if isinstance(obj, functools.partial):
+        return callable_name(obj.func)
+    name = getattr(obj, "__name__", None)
+    return name if isinstance(name, str) else type(obj).__name__

--- a/tests/benchmarks/components/test_bench_registry.py
+++ b/tests/benchmarks/components/test_bench_registry.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from next.components.context import ComponentContextManager
 from next.components.registry import ComponentRegistry, ComponentVisibilityResolver
 from tests.benchmarks.factories import build_component_info_list
 
@@ -39,6 +40,22 @@ class TestBenchComponentRegistry:
     ) -> None:
         registry, _root = populated_component_registry
         benchmark(registry.__contains__, "not_registered")
+
+
+class TestBenchComponentContext:
+    @pytest.mark.benchmark(group="components.registry")
+    def test_context_decorator(self, benchmark) -> None:
+        """Import-time cost of `@component.context` attributing each callable."""
+
+        def ctx() -> dict[str, int]:
+            return {"count": 1}
+
+        def run() -> None:
+            manager = ComponentContextManager()
+            for i in range(20):
+                manager.context(f"k_{i}")(ctx)
+
+        benchmark(run)
 
 
 class TestBenchComponentVisibility:

--- a/tests/benchmarks/forms/test_bench_registration.py
+++ b/tests/benchmarks/forms/test_bench_registration.py
@@ -1,9 +1,30 @@
 from __future__ import annotations
 
+import importlib
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 import pytest
 
 from next.forms import Form
 from next.forms.manager import form_action_manager
+from next.pages.loaders import _load_python_module
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from types import ModuleType
+
+
+_ROUTER_PAGE_SOURCE = "from next.forms import Form\n\n\n" + "\n".join(
+    f"class BenchRouted{i}(Form):\n    pass\n" for i in range(20)
+)
+
+_IMPORTED_MODULE_NAME = "bench_imported_forms"
+_IMPORTED_MODULE_SOURCE = "from next.forms import Form\n\n\n" + "\n".join(
+    f"class BenchImported{i}(Form):\n    pass\n" for i in range(20)
+)
 
 
 @pytest.fixture()
@@ -25,18 +46,43 @@ def _restore_action_registry():
     backend._url_cache.update(url_cache)
 
 
+@pytest.fixture()
+def router_page_file(settings, tmp_path: Path) -> Path:
+    """Write a `page.py` inside a BASE_DIR the registration gate accepts."""
+    settings.BASE_DIR = tmp_path
+    page_file = tmp_path / "page.py"
+    page_file.write_text(_ROUTER_PAGE_SOURCE, encoding="utf-8")
+    return page_file
+
+
+@pytest.fixture()
+def imported_forms_module(settings, tmp_path: Path) -> Iterator[ModuleType]:
+    """Import a forms module normally, so it owns a `sys.modules` entry."""
+    settings.BASE_DIR = tmp_path
+    (tmp_path / f"{_IMPORTED_MODULE_NAME}.py").write_text(
+        _IMPORTED_MODULE_SOURCE, encoding="utf-8"
+    )
+    sys.path.insert(0, str(tmp_path))
+    importlib.invalidate_caches()
+    try:
+        yield importlib.import_module(_IMPORTED_MODULE_NAME)
+    finally:
+        sys.modules.pop(_IMPORTED_MODULE_NAME, None)
+        sys.path.remove(str(tmp_path))
+
+
 class TestBenchFormRegistration:
     """Import-time cost of declaring auto-registered Form subclasses.
 
-    Each declaration runs `__init_subclass__`, the registration gate,
-    and the `_find_definition_frame` stack walk. Class names repeat on
-    every round so the registry overwrites in place and stays
-    size-stable across rounds.
+    Each declaration runs `__init_subclass__`, the registration gate and
+    `_definition_file_of`. Class names repeat on every round, so the registry
+    overwrites in place and stays size-stable.
     """
 
     @pytest.mark.benchmark(group="forms.registration")
     @pytest.mark.usefixtures("_restore_action_registry")
     def test_define_form_subclasses(self, benchmark) -> None:
+        """20 subclasses built straight through the metaclass."""
         metaclass = type(Form)
 
         def run() -> None:
@@ -44,3 +90,38 @@ class TestBenchFormRegistration:
                 metaclass(f"BenchDeclared{i}", (Form,), {})
 
         benchmark(run)
+
+        backend = form_action_manager.default_backend
+        assert backend.get_meta("bench_declared0") is not None
+
+    @pytest.mark.benchmark(group="forms.registration")
+    @pytest.mark.usefixtures("_restore_action_registry")
+    def test_define_form_subclasses_in_router_module(
+        self, benchmark, router_page_file: Path
+    ) -> None:
+        """20 subclasses in a page.py the router execs, attributed via the stack."""
+
+        def run() -> None:
+            _load_python_module(router_page_file)
+
+        benchmark(run)
+
+        backend = form_action_manager.default_backend
+        assert backend.get_meta("bench_routed0", str(router_page_file)) is not None
+
+    @pytest.mark.benchmark(group="forms.registration")
+    @pytest.mark.usefixtures("_restore_action_registry")
+    def test_define_form_subclasses_in_imported_module(
+        self, benchmark, imported_forms_module: ModuleType
+    ) -> None:
+        """20 subclasses in an imported module, attributed via inspect."""
+
+        def run() -> None:
+            importlib.reload(imported_forms_module)
+
+        benchmark(run)
+
+        backend = form_action_manager.default_backend
+        meta = backend.get_meta("bench_imported0")
+        assert meta is not None
+        assert meta["file_path"] == str(Path(imported_forms_module.__file__).resolve())

--- a/tests/benchmarks/pages/test_bench_registry.py
+++ b/tests/benchmarks/pages/test_bench_registry.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from next.pages import Page
 from next.pages.registry import PageContextRegistry
 
 
@@ -24,6 +25,17 @@ class TestBenchPageContextRegistry:
             registry = PageContextRegistry(None)
             for i in range(20):
                 registry.register_context(page_path, f"k_{i}", _context_func)
+
+        benchmark(run)
+
+    @pytest.mark.benchmark(group="pages.registry")
+    def test_context_decorator(self, benchmark) -> None:
+        """Import-time cost of `@context`, which attributes each callable to a file."""
+
+        def run() -> None:
+            page = Page()
+            for i in range(20):
+                page.context(f"k_{i}")(_context_func)
 
         benchmark(run)
 

--- a/tests/checks/test_common.py
+++ b/tests/checks/test_common.py
@@ -10,9 +10,11 @@ from django.test import override_settings
 
 from next.checks import NEXT, register_all
 from next.checks.common import (
+    RegistrationSubject,
     get_components_manager,
     get_router_manager,
     iter_scanned_page_pairs,
+    registration_file_errors,
     reset_components_manager_cache,
     reset_router_manager_cache,
 )
@@ -291,3 +293,74 @@ class TestNextTag:
         ]
         assert next_checks
         assert all("compatibility" not in check.tags for check in next_checks)
+
+
+class TestRegistrationFileErrors:
+    """`registration_file_errors` turns registry state into check messages."""
+
+    subject = RegistrationSubject(
+        decorator="@context",
+        anchor_name="page.py",
+        render="page render",
+        code="next.E074",
+    )
+
+    def test_anchor_file_registration_reports_nothing(self, tmp_path: Path) -> None:
+        errors = registration_file_errors(
+            self.subject,
+            registrations={tmp_path / "page.py": ("greeting",)},
+            misattributed=[],
+        )
+        assert errors == []
+
+    def test_helper_file_registration_reports_the_dead_binding(
+        self, tmp_path: Path
+    ) -> None:
+        helper = tmp_path / "helpers.py"
+        errors = registration_file_errors(
+            self.subject,
+            registrations={helper: ("greeting", "farewell")},
+            misattributed=[],
+        )
+        assert [e.id for e in errors] == ["next.E074"]
+        assert "farewell, greeting" in errors[0].msg
+
+    def test_misattributed_name_is_not_repeated_by_the_helper_arm(
+        self, tmp_path: Path
+    ) -> None:
+        helper = tmp_path / "helpers.py"
+        page_file = tmp_path / "page.py"
+        errors = registration_file_errors(
+            self.subject,
+            registrations={helper: ("greeting", "farewell")},
+            misattributed=[(page_file, helper, "greeting")],
+        )
+        assert [e.id for e in errors] == ["next.E074", "next.E074"]
+        assert "greeting" in errors[0].msg
+        assert errors[1].msg.count("farewell") == 1
+        assert "greeting" not in errors[1].msg
+
+    def test_fully_misattributed_helper_reports_once(self, tmp_path: Path) -> None:
+        helper = tmp_path / "helpers.py"
+        page_file = tmp_path / "page.py"
+        errors = registration_file_errors(
+            self.subject,
+            registrations={helper: ("greeting",)},
+            misattributed=[(page_file, helper, "greeting")],
+        )
+        assert len(errors) == 1
+        assert str(page_file) in errors[0].msg
+
+    def test_records_are_ordered_by_their_paths(self, tmp_path: Path) -> None:
+        helper = tmp_path / "helpers.py"
+        first = tmp_path / "a" / "page.py"
+        second = tmp_path / "b" / "page.py"
+        errors = registration_file_errors(
+            self.subject,
+            registrations={},
+            misattributed=[(second, helper, "later"), (first, helper, "earlier")],
+        )
+        assert [str(first) in errors[0].msg, str(second) in errors[1].msg] == [
+            True,
+            True,
+        ]

--- a/tests/components/test_checks.py
+++ b/tests/components/test_checks.py
@@ -13,6 +13,7 @@ from next.checks import (
 from next.components import ComponentInfo, FileComponentsBackend
 from next.components.context import ComponentContextRegistry, component
 from tests.support import (
+    importable_dir,
     next_framework_settings_for_checks_backends_value as _next_framework_settings_for_checks_backends_value,
     patch_checks_components_manager,
 )
@@ -133,10 +134,10 @@ class TestChecks:
             errors = check_component_py_no_pages_context()
         assert any(e.id == "next.E021" for e in errors)
 
-    def test_component_context_on_imported_helper_is_e078(
+    def test_component_context_on_imported_helper_is_e075(
         self, tmp_path: Path, min_component_config: dict
     ) -> None:
-        """A component context bound to a helper module is reported as E078."""
+        """A component context bound to a helper module is reported as E075."""
         module_path = tmp_path / "component.py"
         module_path.write_text(
             "from next.components import context\n"
@@ -155,9 +156,43 @@ class TestChecks:
         ):
             errors = check_component_context_registration_files()
 
-        assert [e.id for e in errors] == ["next.E078"]
+        assert [e.id for e in errors] == ["next.E075"]
         assert "attribution.py" in errors[0].msg
         assert "handler_declared_here" in errors[0].msg
+        assert str(module_path) in errors[0].msg
+
+    def test_component_context_from_another_component_py_is_e075(
+        self, tmp_path: Path, min_component_config: dict
+    ) -> None:
+        """A callable imported from a sibling component.py is still reported."""
+        donor_dir = tmp_path / "donor"
+        donor_dir.mkdir()
+        (donor_dir / "__init__.py").write_text("")
+        (donor_dir / "component.py").write_text(
+            "def donated() -> str:\n    return 'hi'\n"
+        )
+        module_path = tmp_path / "component.py"
+        module_path.write_text(
+            "from next.components import context\n"
+            "from donor.component import donated\n\n"
+            "context('greeting')(donated)\n"
+        )
+        fake_backend = FileComponentsBackend(dict(min_component_config))
+        fake_backend._registry.register(
+            ComponentInfo("card", tmp_path, "", None, module_path, False)
+        )
+        fake_backend._loaded = True
+
+        with (
+            patch.object(component, "_registry", ComponentContextRegistry()),
+            patch_checks_components_manager(fake_backend),
+            importable_dir(tmp_path),
+        ):
+            errors = check_component_context_registration_files()
+
+        assert [e.id for e in errors] == ["next.E075"]
+        assert "donated" in errors[0].msg
+        assert str(donor_dir / "component.py") in errors[0].msg
 
     def test_component_context_declared_in_component_py_reports_nothing(
         self, tmp_path: Path, min_component_config: dict

--- a/tests/components/test_checks.py
+++ b/tests/components/test_checks.py
@@ -4,12 +4,14 @@ from unittest.mock import patch
 import pytest
 
 from next.checks import (
+    check_component_context_registration_files,
     check_component_py_no_pages_context,
     check_cross_root_component_name_conflicts,
     check_duplicate_component_names,
     reset_check_caches,
 )
 from next.components import ComponentInfo, FileComponentsBackend
+from next.components.context import ComponentContextRegistry, component
 from tests.support import (
     next_framework_settings_for_checks_backends_value as _next_framework_settings_for_checks_backends_value,
     patch_checks_components_manager,
@@ -130,3 +132,52 @@ class TestChecks:
         with patch_checks_components_manager(fake_backend):
             errors = check_component_py_no_pages_context()
         assert any(e.id == "next.E021" for e in errors)
+
+    def test_component_context_on_imported_helper_is_e078(
+        self, tmp_path: Path, min_component_config: dict
+    ) -> None:
+        """A component context bound to a helper module is reported as E078."""
+        module_path = tmp_path / "component.py"
+        module_path.write_text(
+            "from next.components import context\n"
+            "from tests.support.attribution import handler_declared_here\n\n"
+            "context('greeting')(handler_declared_here)\n"
+        )
+        fake_backend = FileComponentsBackend(dict(min_component_config))
+        fake_backend._registry.register(
+            ComponentInfo("card", tmp_path, "", None, module_path, False)
+        )
+        fake_backend._loaded = True
+
+        with (
+            patch.object(component, "_registry", ComponentContextRegistry()),
+            patch_checks_components_manager(fake_backend),
+        ):
+            errors = check_component_context_registration_files()
+
+        assert [e.id for e in errors] == ["next.E078"]
+        assert "attribution.py" in errors[0].msg
+        assert "handler_declared_here" in errors[0].msg
+
+    def test_component_context_declared_in_component_py_reports_nothing(
+        self, tmp_path: Path, min_component_config: dict
+    ) -> None:
+        """A component context declared in the component.py raises nothing."""
+        module_path = tmp_path / "component.py"
+        module_path.write_text(
+            "from next.components import context\n\n"
+            "@context('greeting')\n"
+            "def greeting() -> str:\n"
+            "    return 'hi'\n"
+        )
+        fake_backend = FileComponentsBackend(dict(min_component_config))
+        fake_backend._registry.register(
+            ComponentInfo("card", tmp_path, "", None, module_path, False)
+        )
+        fake_backend._loaded = True
+
+        with (
+            patch.object(component, "_registry", ComponentContextRegistry()),
+            patch_checks_components_manager(fake_backend),
+        ):
+            assert check_component_context_registration_files() == []

--- a/tests/components/test_context.py
+++ b/tests/components/test_context.py
@@ -1,7 +1,6 @@
+import functools
 import importlib.util
-import inspect
 import textwrap
-import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -20,6 +19,7 @@ from next.components import (
 )
 from next.components.context import iter_serialized_component_context_keys
 from next.static import StaticCollector
+from tests.support import handler_declared_here
 
 
 class TestComponentContextManager:
@@ -145,53 +145,35 @@ class TestComponentContextRegistryInternals:
         reg.register(p, "y", fy)
         assert len(reg) == 2
 
-    def test_duplicate_after_getsourcefile_oserror(self, tmp_path: Path) -> None:
-        """When inspect.getsourcefile fails, different functions are not 'same'."""
+    def test_same_name_from_another_file_is_a_duplicate(self, tmp_path: Path) -> None:
+        """Two callables sharing a name but not a file are different functions."""
         reg = ComponentContextRegistry()
         p = (tmp_path / "d" / "component.py").resolve()
         p.parent.mkdir(parents=True)
 
-        def f1() -> int:
+        def local() -> int:
             return 1
 
-        def f2() -> int:
-            return 2
+        local.__name__ = handler_declared_here.__name__
 
-        reg.register(p, "slot", f1)
-        nope = OSError("nope")
-        with (
-            patch.object(inspect, "getsourcefile", side_effect=nope),
-            pytest.raises(ValueError, match="Duplicate"),
-        ):
-            reg.register(p, "slot", f2)
+        reg.register(p, "slot", local)
+        with pytest.raises(ValueError, match="Duplicate"):
+            reg.register(p, "slot", handler_declared_here)
 
-    def test_is_same_function_false_when_sourcefile_missing(
-        self, tmp_path: Path
-    ) -> None:
-        """Same __name__ but getsourcefile returns None leads to duplicate error."""
+    def test_unattributable_callable_is_a_duplicate(self, tmp_path: Path) -> None:
+        """A callable with no declaring file can never match the registered one."""
         reg = ComponentContextRegistry()
         p = (tmp_path / "e" / "component.py").resolve()
         p.parent.mkdir(parents=True)
 
-        def g1() -> int:
+        def local() -> int:
             return 1
 
-        def g2() -> int:
-            return 2
+        local.__name__ = "len"
 
-        g1.__name__ = "g"
-        g2.__name__ = "g"
-
-        reg.register(p, "slot", g1)
-
-        def gs(_: object) -> str | None:
-            return None
-
-        with (
-            patch.object(inspect, "getsourcefile", gs),
-            pytest.raises(ValueError, match="Duplicate"),
-        ):
-            reg.register(p, "slot", g2)
+        reg.register(p, "slot", local)
+        with pytest.raises(ValueError, match="Duplicate"):
+            reg.register(p, "slot", len)
 
     def test_is_same_function_true_same_file_same_name(self, tmp_path: Path) -> None:
         """An identical name and source file counts as the same function."""
@@ -205,58 +187,42 @@ class TestComponentContextRegistryInternals:
         reg.register(p, "x", h)
         reg.register(p, "x", h)
 
-    def test_is_same_function_path_compare_raises_typeerror(
+    def test_equivalent_partial_reregisters_without_raising(
         self, tmp_path: Path
     ) -> None:
-        """If Path.resolve raises, _is_same_function returns False (except branch)."""
+        """A re-executed module rebuilds its partial, which is not a duplicate."""
         reg = ComponentContextRegistry()
         p = (tmp_path / "g" / "component.py").resolve()
         p.parent.mkdir(parents=True)
 
-        def u1() -> int:
+        def bound(value: int) -> dict[str, int]:
+            return {"value": value}
+
+        reg.register(p, "slot", functools.partial(bound, 1))
+        reg.register(p, "slot", functools.partial(bound, 1))
+
+        assert len(reg) == 1
+
+
+class TestComponentContextManagerAttribution:
+    """How ComponentContextManager attributes a decorated callable to a file."""
+
+    def test_context_decorator_registers_declaring_test_module(self) -> None:
+        """A callable declared here registers under this test module."""
+        mgr = ComponentContextManager()
+
+        @mgr.context("here")
+        def get_here() -> int:
             return 1
 
-        def u2() -> int:
-            return 2
-
-        u1.__name__ = "u"
-        u2.__name__ = "u"
-        reg.register(p, "slot", u1)
-
-        def gs(fn: object) -> object:
-            return str(p) if fn is u1 else 123
-
-        with (
-            patch.object(inspect, "getsourcefile", gs),
-            pytest.raises(ValueError, match="Duplicate"),
-        ):
-            reg.register(p, "slot", u2)
-
-
-class TestComponentContextManagerFrames:
-    """How ComponentContextManager finds the caller's file."""
-
-    def test_get_caller_path_raises_when_back_count_too_large(self) -> None:
-        """Exceeding frame chain raises RuntimeError."""
-        mgr = ComponentContextManager()
-        with pytest.raises(RuntimeError, match="Could not determine caller"):
-            mgr._get_caller_path(10_000)
-
-    def test_get_caller_path_raises_when_no_python_file_in_chain(self) -> None:
-        """Walk stops if no frame exposes a ``.py`` __file__."""
-        inner = types.SimpleNamespace(f_back=None, f_globals={"__file__": "/x.txt"})
-        start = types.SimpleNamespace(f_back=inner, f_globals={"__file__": "/y.txt"})
-        mgr = ComponentContextManager()
-        with (
-            patch("next.utils.inspect.currentframe", return_value=start),
-            pytest.raises(RuntimeError, match="no __file__ in caller frames"),
-        ):
-            mgr._get_caller_path(1)
+        funcs = mgr.get_functions(Path(__file__))
+        assert len(funcs) == 1
+        assert funcs[0].func is get_here
 
     def test_context_decorator_without_key_registers_caller(
         self, tmp_path: Path
     ) -> None:
-        """@mgr.context on a function registers unkeyed context at caller file."""
+        """@mgr.context on a function registers unkeyed context at its own file."""
         script = tmp_path / "comp" / "component.py"
         script.parent.mkdir(parents=True)
         script.write_text(
@@ -282,7 +248,7 @@ class TestComponentContextManagerFrames:
         assert funcs[0].key is None
 
     def test_context_decorator_with_string_key_registers(self, tmp_path: Path) -> None:
-        """@mgr.context('key') uses _get_caller_path(1) and keyed register branch."""
+        """@mgr.context('key') registers a keyed context for the component module."""
         script = tmp_path / "keyed" / "component.py"
         script.parent.mkdir(parents=True)
         script.write_text(

--- a/tests/components/test_context.py
+++ b/tests/components/test_context.py
@@ -19,7 +19,7 @@ from next.components import (
 )
 from next.components.context import iter_serialized_component_context_keys
 from next.static import StaticCollector
-from tests.support import handler_declared_here
+from tests.support import attribution, handler_declared_here
 
 
 class TestComponentContextManager:
@@ -218,6 +218,23 @@ class TestComponentContextManagerAttribution:
         funcs = mgr.get_functions(Path(__file__))
         assert len(funcs) == 1
         assert funcs[0].func is get_here
+        assert mgr._registry.misattributed() == ()
+
+    def test_helper_from_another_module_is_recorded_once(self) -> None:
+        """Decorating an imported helper records the pair of files it spans."""
+        mgr = ComponentContextManager()
+
+        mgr.context("greeting")(handler_declared_here)
+        mgr.context("greeting_again")(handler_declared_here)
+
+        records = mgr._registry.misattributed()
+        assert [(r.registered_from, r.declared_in, r.name) for r in records] == [
+            (
+                Path(__file__),
+                Path(attribution.__file__).resolve(),
+                "handler_declared_here",
+            )
+        ]
 
     def test_context_decorator_without_key_registers_caller(
         self, tmp_path: Path

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,5 @@
 from collections.abc import Generator
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 from django.http import HttpRequest
@@ -81,13 +80,6 @@ def context_manager():
 
 
 @pytest.fixture()
-def mock_frame():
-    """Mock inspect.currentframe for testing."""
-    with patch("next.pages.manager.inspect.currentframe") as mock_frame:
-        yield mock_frame
-
-
-@pytest.fixture()
 def test_file_path():
     """Create a test file path for render tests."""
     return Path("/test/path/page.py")
@@ -103,13 +95,6 @@ def global_file_path():
 def temp_python_file():
     """Create a temporary Python file for testing."""
     with named_temp_py('template = "test template"') as path:
-        yield path
-
-
-@pytest.fixture()
-def context_temp_file():
-    """Create a temporary file for context decorator tests."""
-    with named_temp_py("def test_func(): pass") as path:
         yield path
 
 

--- a/tests/forms/test_base.py
+++ b/tests/forms/test_base.py
@@ -1,6 +1,8 @@
 import importlib.util
+import os
 import sys
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -18,17 +20,19 @@ from next.forms import (
     wizard as forms_wizard,
 )
 from next.forms.base import (
+    _DJANGO_FORMS_ROOT,
     _FRAMEWORK_ROOT,
     _auto_register_form_class,
     _compute_scope,
-    _find_definition_frame,
-    _is_framework_file,
+    _definition_file_of,
     _is_self_registered,
     _record_invalid_meta_scope,
     _to_snake_case,
 )
 from next.forms.diagnostics import registration_diagnostics
 from next.forms.manager import form_action_manager
+from next.pages.loaders import _load_python_module
+from next.utils import defining_file
 
 
 class TestAutoRegistration:
@@ -43,7 +47,7 @@ class TestAutoRegistration:
         fake_path = str(app_dir / "forms.py")
         Path(fake_path).write_text("")
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class SharedRegistrationForm(Form):
                 title = django_forms.CharField()
@@ -61,7 +65,7 @@ class TestAutoRegistration:
         fake_path = str(page_dir / "page.py")
         Path(fake_path).write_text("")
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class PageScopeForm(Form):
                 title = django_forms.CharField()
@@ -81,7 +85,7 @@ class TestAutoRegistration:
         fake_path = str(comp_dir / "component.py")
         Path(fake_path).write_text("")
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class ComponentScopeForm(Form):
                 title = django_forms.CharField()
@@ -99,7 +103,7 @@ class TestAutoRegistration:
         fake_path = str(app_dir / "other.py")
         Path(fake_path).write_text("")
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class MetaPageForm(Form):
                 title = django_forms.CharField()
@@ -120,7 +124,7 @@ class TestAutoRegistration:
         fake_path = str(page_dir / "page.py")
         Path(fake_path).write_text("")
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class MetaSharedForm(Form):
                 title = django_forms.CharField()
@@ -142,7 +146,7 @@ class TestAutoRegistration:
         Path(fake_path).write_text("")
 
         registration_diagnostics.clear()
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class BadMetaScopeForm(Form):
                 title = django_forms.CharField()
@@ -167,7 +171,7 @@ class TestAutoRegistration:
         Path(fake_path).write_text("")
 
         registration_diagnostics.clear()
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class OutsideForm(Form):
                 title = django_forms.CharField()
@@ -179,9 +183,48 @@ class TestAutoRegistration:
         backend = form_action_manager.default_backend
         assert backend.get_meta("outside_form") is None
 
+    def test_sibling_of_base_dir_records_warning(self, settings, tmp_path) -> None:
+        """A directory whose name extends BASE_DIR is outside it."""
+        settings.BASE_DIR = tmp_path / "project"
+        sibling = tmp_path / "project-extra"
+        sibling.mkdir()
+        fake_path = str(sibling / "forms.py")
+        Path(fake_path).write_text("")
+
+        registration_diagnostics.clear()
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
+
+            class SiblingOfBaseDirForm(Form):
+                title = django_forms.CharField()
+
+        assert any(
+            "SiblingOfBaseDirForm" in name
+            for name, _ in registration_diagnostics.outside_base_dir
+        )
+        backend = form_action_manager.default_backend
+        assert backend.get_meta("sibling_of_base_dir_form") is None
+
+    def test_filesystem_root_base_dir_contains_every_path(
+        self, settings, tmp_path
+    ) -> None:
+        """A BASE_DIR that already ends in a separator still contains its files."""
+        settings.BASE_DIR = os.sep
+        app_dir = tmp_path / "myapp"
+        app_dir.mkdir()
+        fake_path = str(app_dir / "forms.py")
+        Path(fake_path).write_text("")
+
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
+
+            class RootBaseDirForm(Form):
+                title = django_forms.CharField()
+
+        backend = form_action_manager.default_backend
+        assert backend.get_meta("root_base_dir_form") is not None
+
     def test_virtual_path_skipped(self) -> None:
         """Files with paths starting with '<' (interactive/virtual) are skipped."""
-        with patch("next.forms.base._find_definition_frame", return_value="<stdin>"):
+        with patch("next.forms.base._definition_file_of", return_value="<stdin>"):
 
             class VirtualForm(Form):
                 title = django_forms.CharField()
@@ -190,28 +233,14 @@ class TestAutoRegistration:
         assert backend.get_meta("virtual_form") is None
 
     def test_empty_path_skipped(self) -> None:
-        """Empty file path from _find_definition_frame is skipped."""
-        with patch("next.forms.base._find_definition_frame", return_value=""):
+        """Empty file path from _definition_file_of is skipped."""
+        with patch("next.forms.base._definition_file_of", return_value=""):
 
             class EmptyPathForm(Form):
                 title = django_forms.CharField()
 
         backend = form_action_manager.default_backend
         assert backend.get_meta("empty_path_form") is None
-
-    def test_framework_file_skipped(self) -> None:
-        """Forms inside the next framework package itself are not registered."""
-        framework_path = str(_FRAMEWORK_ROOT / "forms" / "base.py")
-
-        with patch(
-            "next.forms.base._find_definition_frame", return_value=framework_path
-        ):
-
-            class FrameworkInternalForm(Form):
-                title = django_forms.CharField()
-
-        backend = form_action_manager.default_backend
-        assert backend.get_meta("framework_internal_form") is None
 
     def test_duplicate_name_same_scope_records_collision(
         self, settings, tmp_path
@@ -255,7 +284,7 @@ class TestAutoRegistration:
         fake_path = str(app_dir / "forms.py")
         Path(fake_path).write_text("")
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class NoDirForm(Form):
                 title = django_forms.CharField()
@@ -265,18 +294,40 @@ class TestAutoRegistration:
         assert meta is not None
 
 
-def _exec_module_from_file(module_name: str, module_file: Path) -> None:
+def _exec_module_from_file(module_name: str, module_file: Path) -> ModuleType:
+    """Execute a file as a module the way the import system does."""
     spec = importlib.util.spec_from_file_location(module_name, module_file)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
+    # The entry must exist before the body runs, otherwise classes declared
+    # there cannot resolve their own module.
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def user_module():
+    """Load user files as modules and drop their sys.modules entries afterwards."""
+    names: list[str] = []
+
+    def load(module_name: str, module_file: Path) -> ModuleType:
+        names.append(module_name)
+        return _exec_module_from_file(module_name, module_file)
+
+    yield load
+
+    for name in names:
+        sys.modules.pop(name, None)
 
 
 class TestUserFormsPackageRegistration:
-    """Forms declared in a user forms/ package register via the real frame walk."""
+    """Forms declared in a user forms/ package register under their own file."""
 
-    def test_form_in_forms_package_module_registers(self, settings, tmp_path) -> None:
+    def test_form_in_forms_package_module_registers(
+        self, settings, tmp_path, user_module
+    ) -> None:
         """A Form in myapp/forms/models.py registers with its own file_path."""
         settings.BASE_DIR = tmp_path
         forms_pkg = tmp_path / "myapp" / "forms"
@@ -292,7 +343,7 @@ class TestUserFormsPackageRegistration:
             "    title = CharField()\n"
         )
 
-        _exec_module_from_file("user_forms_pkg_models", module_file)
+        user_module("user_forms_pkg_models", module_file)
 
         backend = form_action_manager.default_backend
         meta = backend.get_meta("packaged_models_form")
@@ -300,7 +351,9 @@ class TestUserFormsPackageRegistration:
         assert meta["file_path"] == str(module_file.resolve())
         assert meta["scope"] == "shared"
 
-    def test_form_in_forms_package_init_registers(self, settings, tmp_path) -> None:
+    def test_form_in_forms_package_init_registers(
+        self, settings, tmp_path, user_module
+    ) -> None:
         """A Form in myapp/forms/__init__.py registers with its own file_path."""
         settings.BASE_DIR = tmp_path
         forms_pkg = tmp_path / "myapp" / "forms"
@@ -315,7 +368,7 @@ class TestUserFormsPackageRegistration:
             "    title = CharField()\n"
         )
 
-        _exec_module_from_file("user_forms_pkg_init", module_file)
+        user_module("user_forms_pkg_init", module_file)
 
         backend = form_action_manager.default_backend
         meta = backend.get_meta("packaged_init_form")
@@ -324,24 +377,91 @@ class TestUserFormsPackageRegistration:
         assert meta["scope"] == "shared"
 
 
-class TestFindDefinitionFrame:
-    """_find_definition_frame walks the call stack to find the definition site."""
+class TestRouterLoadedPageRegistration:
+    """A page.py the file router execs registers its forms under that page."""
 
-    def test_returns_string(self) -> None:
-        """_find_definition_frame returns a string (the caller's filename)."""
-        result = _find_definition_frame()
-        assert isinstance(result, str)
+    def test_form_in_router_loaded_page_registers_under_that_page(
+        self, settings, tmp_path
+    ) -> None:
+        """A Form declared in a router-loaded page.py registers with that page's path."""
+        settings.BASE_DIR = tmp_path
+        page_file = tmp_path / "page.py"
+        page_file.write_text(
+            "from next.forms import CharField, Form\n"
+            "\n"
+            "\n"
+            "class RouterLoadedForm(Form):\n"
+            "    title = CharField()\n"
+        )
 
-    def test_does_not_return_framework_file(self) -> None:
-        """The returned path is not the framework's own base.py."""
-        result = _find_definition_frame()
-        if result:
-            assert not _is_framework_file(result)
+        module = _load_python_module(page_file)
 
-    def test_returns_empty_when_stack_exhausted(self) -> None:
-        """When sys._getframe raises ValueError, _find_definition_frame returns ''."""
+        assert module is not None
+        # The router leaves no sys.modules entry, so only the stack names the file.
+        assert sys.modules.get("page_module") is None
+        backend = form_action_manager.default_backend
+        meta = backend.get_meta("router_loaded_form", str(page_file))
+        assert meta is not None
+        assert meta["file_path"] == str(page_file.resolve())
+        assert meta["scope"] == "page"
+
+
+class TestDefinitionFileOf:
+    """_definition_file_of attributes a form class to its declaration site."""
+
+    @pytest.mark.parametrize(
+        ("file_name", "class_name"),
+        [("page.py", "AnchoredForm"), ("shared_forms.py", "SharedModuleForm")],
+        ids=["anchor_file", "shared_module"],
+    )
+    def test_class_declared_in_imported_module(
+        self, tmp_path, user_module, file_name, class_name
+    ) -> None:
+        """A Form is attributed to the module file declaring it."""
+        module_file = tmp_path / file_name
+        module_file.write_text(
+            "from next.forms import CharField, Form\n"
+            "\n"
+            "\n"
+            f"class {class_name}(Form):\n"
+            "    title = CharField()\n"
+        )
+
+        module = user_module(f"attribution_{module_file.stem}", module_file)
+
+        assert _definition_file_of(getattr(module, class_name)) == str(module_file)
+
+    def test_class_from_unimportable_module_falls_back_to_stack(self) -> None:
+        """A class whose module is absent from sys.modules falls back to the stack."""
+
+        class Detached:
+            pass
+
+        Detached.__module__ = "next_dj_virtual_module"
+        assert _definition_file_of(Detached) == __file__
+
+    def test_class_from_main_without_file_falls_back_to_stack(self) -> None:
+        """A __main__ class with no __file__ falls back to the stack."""
+
+        class Detached:
+            pass
+
+        Detached.__module__ = "__main__"
+        with patch.dict(sys.modules, {"__main__": ModuleType("__main__")}):
+            assert _definition_file_of(Detached) == __file__
+
+    def test_class_built_inside_django_forms_falls_back_to_stack(self) -> None:
+        """A class attributed to django.forms falls back to the stack."""
+        assert _definition_file_of(django_forms.models.ModelForm) == __file__
+
+    def test_class_built_inside_framework_falls_back_to_stack(self) -> None:
+        """A class attributed to next.forms falls back to the stack."""
+        assert _definition_file_of(Form) == __file__
+
+    def test_fallback_returns_empty_when_stack_exhausted(self) -> None:
+        """The fallback returns '' once sys._getframe runs out of frames."""
+        # Every frame reports a framework file, so the walk never accepts one.
         framework_file = str(_FRAMEWORK_ROOT / "forms" / "fake.py")
-
         call_count = {"n": 0}
 
         def mock_getframe(depth: int) -> object:
@@ -354,9 +474,39 @@ class TestFindDefinitionFrame:
             return frame
 
         with patch.object(sys, "_getframe", side_effect=mock_getframe):
-            result = _find_definition_frame()
+            assert _definition_file_of(django_forms.models.ModelForm) == ""
 
-        assert result == ""
+
+class TestModelFormFactoryAttribution:
+    """A class built by modelform_factory keeps the caller's file, not Django's."""
+
+    def test_factory_built_class_registers_under_calling_module(
+        self, settings, tmp_path, user_module
+    ) -> None:
+        """The registered file_path is the calling module, not Django's."""
+        settings.BASE_DIR = tmp_path
+        module_file = tmp_path / "admin_forms.py"
+        module_file.write_text(
+            "from django.contrib.auth.models import User\n"
+            "\n"
+            "from next.forms import ModelForm, modelform_factory\n"
+            "\n"
+            "\n"
+            "def user_form_factory():\n"
+            "    return modelform_factory(User, form=ModelForm, fields=['username'])\n"
+        )
+        module = user_module("attribution_factory_module", module_file)
+
+        form_class = module.user_form_factory()
+
+        backend = form_action_manager.default_backend
+        meta = backend.get_meta("user_form")
+        assert meta is not None
+        assert meta["file_path"] == str(module_file.resolve())
+        # Plain attribution lands in Django, so registration used the stack fallback.
+        assert (
+            Path(defining_file(form_class)).resolve().is_relative_to(_DJANGO_FORMS_ROOT)
+        )
 
 
 class TestModelFormAutoRegistration:
@@ -373,7 +523,7 @@ class TestModelFormAutoRegistration:
         fake_path = str(app_dir / "forms.py")
         Path(fake_path).write_text("")
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class AuthorModelForm(ModelForm):
                 class Meta:
@@ -395,7 +545,7 @@ class TestModelFormAutoRegistration:
         fake_path = str(page_dir / "page.py")
         Path(fake_path).write_text("")
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class PageModelForm(ModelForm):
                 class Meta:
@@ -428,7 +578,7 @@ class TestAutoRegisterFormClassDirectly:
         class DirectForm(Form):
             title = django_forms.CharField()
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
             _auto_register_form_class(DirectForm)
 
         backend = form_action_manager.default_backend
@@ -523,7 +673,7 @@ class TestAbstractForms:
         fake_path = str(app_dir / "forms.py")
         Path(fake_path).write_text("")
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class AbstractTenantForm(Form):
                 class Meta:
@@ -547,7 +697,7 @@ class TestAbstractForms:
         fake_path = str(app_dir / "forms.py")
         Path(fake_path).write_text("")
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class RegisteredBaseForm(Form):
                 title = django_forms.CharField()
@@ -613,17 +763,35 @@ def test_to_snake_case(name: str, expected: str) -> None:
     assert _to_snake_case(name) == expected
 
 
-class TestIsFrameworkFileUsed:
-    """_is_framework_file detects paths inside the framework root."""
+class TestIsForeignFile:
+    """_is_foreign_file detects paths inside django.forms or the framework."""
 
-    def test_framework_file_detected(self) -> None:
-        """A path inside the framework root is recognised as a framework file."""
-        framework_path = str(_FRAMEWORK_ROOT / "forms" / "base.py")
-        assert _is_framework_file(framework_path) is True
+    @pytest.mark.parametrize(
+        "root", [_DJANGO_FORMS_ROOT, _FRAMEWORK_ROOT], ids=["django", "framework"]
+    )
+    def test_file_under_foreign_root_detected(self, root: Path) -> None:
+        """A path inside either foreign root is foreign."""
+        assert forms_base._is_foreign_file(str(root / "widgets.py")) is True
 
-    def test_non_framework_file_not_detected(self, tmp_path) -> None:
-        """A path outside the framework root is not a framework file."""
-        assert _is_framework_file(str(tmp_path / "myapp" / "forms.py")) is False
+    @pytest.mark.parametrize(
+        "root", [_DJANGO_FORMS_ROOT, _FRAMEWORK_ROOT], ids=["django", "framework"]
+    )
+    def test_sibling_root_with_shared_prefix_not_detected(self, root: Path) -> None:
+        """A sibling directory whose name extends a foreign root is outside it."""
+        sibling = root.parent / f"{root.name}-extra"
+        assert forms_base._is_foreign_file(str(sibling / "widgets.py")) is False
+
+    def test_decision_is_memoised(self, tmp_path) -> None:
+        """The second call answers from the cache instead of resolving the path."""
+        user_path = str(tmp_path / "myapp" / "forms.py")
+        forms_base._foreign_file_cache.pop(user_path, None)
+
+        assert forms_base._is_foreign_file(user_path) is False
+        assert forms_base._foreign_file_cache[user_path] is False
+
+        # A poisoned entry can only win if the second call skips resolution.
+        forms_base._foreign_file_cache[user_path] = True
+        assert forms_base._is_foreign_file(user_path) is True
 
 
 class TestComputeScope:

--- a/tests/forms/test_base.py
+++ b/tests/forms/test_base.py
@@ -1,3 +1,4 @@
+import importlib
 import importlib.util
 import os
 import sys
@@ -21,6 +22,7 @@ from next.forms import (
 )
 from next.forms.base import (
     _DJANGO_FORMS_ROOT,
+    _FOREIGN_ROOTS,
     _FRAMEWORK_ROOT,
     _auto_register_form_class,
     _compute_scope,
@@ -33,6 +35,7 @@ from next.forms.diagnostics import registration_diagnostics
 from next.forms.manager import form_action_manager
 from next.pages.loaders import _load_python_module
 from next.utils import defining_file
+from tests.support import importable_dir
 
 
 class TestAutoRegistration:
@@ -221,6 +224,34 @@ class TestAutoRegistration:
 
         backend = form_action_manager.default_backend
         assert backend.get_meta("root_base_dir_form") is not None
+
+    def test_form_declared_inside_the_framework_never_registers(
+        self, settings, tmp_path
+    ) -> None:
+        """A Form declared in a framework file registers nowhere when imported."""
+        settings.BASE_DIR = tmp_path
+        module_file = tmp_path / "framework_internal_forms.py"
+        module_file.write_text(
+            "from next.forms import CharField, Form\n"
+            "\n"
+            "\n"
+            "class FrameworkInternalForm(Form):\n"
+            "    title = CharField()\n"
+        )
+        # Treating tmp_path as a framework root makes the import behave like one
+        # of next's own modules, which the stack walk answers with an importlib
+        # frame rather than a user file.
+        foreign_roots = (*_FOREIGN_ROOTS, (str(tmp_path), str(tmp_path) + os.sep))
+
+        with (
+            patch.object(forms_base, "_FOREIGN_ROOTS", foreign_roots),
+            patch.dict(forms_base._foreign_file_cache, {}, clear=True),
+            importable_dir(tmp_path),
+        ):
+            importlib.import_module("framework_internal_forms")
+
+        backend = form_action_manager.default_backend
+        assert backend.get_meta("framework_internal_form") is None
 
     def test_virtual_path_skipped(self) -> None:
         """Files with paths starting with '<' (interactive/virtual) are skipped."""
@@ -447,7 +478,10 @@ class TestDefinitionFileOf:
             pass
 
         Detached.__module__ = "__main__"
-        with patch.dict(sys.modules, {"__main__": ModuleType("__main__")}):
+        interactive = ModuleType("__main__")
+        # The module binds the class, so only its missing __file__ can refuse.
+        interactive.Detached = Detached
+        with patch.dict(sys.modules, {"__main__": interactive}):
             assert _definition_file_of(Detached) == __file__
 
     def test_class_built_inside_django_forms_falls_back_to_stack(self) -> None:
@@ -457,6 +491,23 @@ class TestDefinitionFileOf:
     def test_class_built_inside_framework_falls_back_to_stack(self) -> None:
         """A class attributed to next.forms falls back to the stack."""
         assert _definition_file_of(Form) == __file__
+
+    def test_module_holding_another_class_of_that_name_is_ignored(
+        self, tmp_path, user_module
+    ) -> None:
+        """A same-named module that never declared the class does not answer for it."""
+        impostor_file = tmp_path / "impostor.py"
+        impostor_file.write_text("class Shadowed:\n    pass\n")
+        impostor = user_module("attribution_impostor", impostor_file)
+
+        class Shadowed:
+            pass
+
+        Shadowed.__module__ = impostor.__name__
+        # The impostor binds a different class under that name, which is the
+        # collision the attribution has to notice.
+        assert impostor.Shadowed is not Shadowed
+        assert _definition_file_of(Shadowed) == __file__
 
     def test_fallback_returns_empty_when_stack_exhausted(self) -> None:
         """The fallback returns '' once sys._getframe runs out of frames."""

--- a/tests/forms/test_decorators.py
+++ b/tests/forms/test_decorators.py
@@ -12,6 +12,7 @@ from next.forms.decorators import action as action_decorator
 from next.forms.diagnostics import registration_diagnostics
 from next.forms.dispatch import _form_action_context_callable
 from next.forms.manager import build_form_namespace_for_action, form_action_manager
+from tests.support import attribution, handler_declared_here
 
 
 class TestBuildFormNamespaceForAction:
@@ -127,6 +128,19 @@ class TestActionDecoratorBareForm:
         assert (
             form_action_manager.default_backend.get_meta("bare_decorated_class") is None
         )
+
+
+class TestActionDecoratorAttribution:
+    """Where ``@action`` attributes a handler declared in another module."""
+
+    def test_imported_function_keys_on_declaring_file_not_call_site(self) -> None:
+        """An imported handler keys on its own module, not on the decorating file."""
+        action_decorator(name="imported_handler_action")(handler_declared_here)
+
+        meta = form_action_manager.default_backend.get_meta("imported_handler_action")
+        assert meta is not None
+        assert meta["file_path"] == str(Path(attribution.__file__).resolve())
+        assert meta["file_path"] != str(Path(__file__).resolve())
 
 
 class TestActionDecoratorScope:

--- a/tests/forms/test_instance_from_url.py
+++ b/tests/forms/test_instance_from_url.py
@@ -255,7 +255,7 @@ class TestValidateInstanceFromUrlE049:
         fake_path = str(app_dir / "forms.py")
         Path(fake_path).write_text("")
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class PlainFormWithSpec(Form):
                 class Meta:

--- a/tests/forms/test_wizard.py
+++ b/tests/forms/test_wizard.py
@@ -17,7 +17,6 @@ from django.test import RequestFactory, override_settings
 
 from next.conf import next_framework_settings
 from next.forms import Form, ModelForm, PermissionOutcome
-from next.forms.base import _FRAMEWORK_ROOT
 from next.forms.diagnostics import registration_diagnostics
 from next.forms.manager import form_action_manager
 from next.forms.wizard import (
@@ -212,7 +211,7 @@ class TestWizardRegistration:
 
     def test_virtual_path_skips_registration(self) -> None:
         """A wizard defined in a virtual frame is not registered."""
-        with patch("next.forms.base._find_definition_frame", return_value="<stdin>"):
+        with patch("next.forms.base._definition_file_of", return_value="<stdin>"):
 
             class VirtualWizard(FormWizard):
                 class Meta:
@@ -222,26 +221,13 @@ class TestWizardRegistration:
 
     def test_empty_path_skips_registration(self) -> None:
         """A wizard whose definition frame is empty is not registered."""
-        with patch("next.forms.base._find_definition_frame", return_value=""):
+        with patch("next.forms.base._definition_file_of", return_value=""):
 
             class EmptyPathWizard(FormWizard):
                 class Meta:
                     steps: ClassVar = [("identity", IdentityStep)]
 
         assert form_action_manager.default_backend.get_meta("empty_path_wizard") is None
-
-    def test_framework_file_skips_registration(self) -> None:
-        """A wizard defined inside the framework package is not registered."""
-        framework_path = str(_FRAMEWORK_ROOT / "forms" / "wizard.py")
-        with patch(
-            "next.forms.base._find_definition_frame", return_value=framework_path
-        ):
-
-            class FrameworkWizard(FormWizard):
-                class Meta:
-                    steps: ClassVar = [("identity", IdentityStep)]
-
-        assert form_action_manager.default_backend.get_meta("framework_wizard") is None
 
     def test_outside_base_dir_records_warning(self, settings, tmp_path) -> None:
         """A wizard outside BASE_DIR is flagged for W046 and not registered."""
@@ -251,7 +237,7 @@ class TestWizardRegistration:
         fake_path = str(outside / "wizards.py")
         Path(fake_path).write_text("")
 
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class OutsideWizard(FormWizard):
                 class Meta:
@@ -474,7 +460,7 @@ class TestWizardStorageScopeIsolation:
     """Same-named wizards from different modules use distinct storage buckets."""
 
     def _make_wizard(self, fake_path: str) -> type[FormWizard]:
-        with patch("next.forms.base._find_definition_frame", return_value=fake_path):
+        with patch("next.forms.base._definition_file_of", return_value=fake_path):
 
             class CheckoutWizard(FormWizard):
                 class Meta:
@@ -539,7 +525,7 @@ class TestWizardStorageScopeIsolation:
 
     def test_unregistered_wizard_falls_back_to_module_scope(self) -> None:
         """An unregistered wizard derives its storage scope from its module."""
-        with patch("next.forms.base._find_definition_frame", return_value="<stdin>"):
+        with patch("next.forms.base._definition_file_of", return_value="<stdin>"):
 
             class GhostWizard(FormWizard):
                 class Meta:

--- a/tests/pages/conftest.py
+++ b/tests/pages/conftest.py
@@ -1,7 +1,6 @@
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
 
 import pytest
 
@@ -44,13 +43,6 @@ def context_manager():
 
 
 @pytest.fixture()
-def mock_frame():
-    """Mock inspect.currentframe for testing."""
-    with patch("next.pages.manager.inspect.currentframe") as mock_frame:
-        yield mock_frame
-
-
-@pytest.fixture()
 def test_file_path():
     """Create a test file path for render tests."""
     return Path("/test/path/page.py")
@@ -66,13 +58,6 @@ def global_file_path():
 def temp_python_file():
     """Create a temporary Python file for testing."""
     with named_temp_py('template = "test template"') as path:
-        yield path
-
-
-@pytest.fixture()
-def context_temp_file():
-    """Create a temporary file for context decorator tests."""
-    with named_temp_py("def test_func(): pass") as path:
         yield path
 
 

--- a/tests/pages/test_checks.py
+++ b/tests/pages/test_checks.py
@@ -15,7 +15,13 @@ from next.checks import (
     reset_check_caches,
 )
 from next.conf import next_framework_settings as s
-from next.pages.checks import check_context_processor_signature, check_template_loaders
+from next.pages.checks import (
+    check_context_processor_signature,
+    check_context_registration_files,
+    check_template_loaders,
+)
+from next.pages.manager import page
+from next.pages.registry import PageContextRegistry
 from tests.support import (
     patch_checks_router_manager,
     patch_checks_router_manager_with_routers,
@@ -857,3 +863,63 @@ class TestContextChecksDeduplicate:
         with patch_checks_router_manager_with_routers(routers=routers):
             messages = check_context_functions(None)
         assert [m.id for m in messages] == ["next.E029"]
+
+
+class TestContextRegistrationFileCheck:
+    """`check_context_registration_files` catches a context bound to a helper module."""
+
+    def test_context_on_imported_helper_is_e077(self, tmp_path) -> None:
+        page_file = tmp_path / "page.py"
+        page_file.write_text(
+            "from next.pages import context\n"
+            "from tests.support.attribution import handler_declared_here\n\n"
+            "context('greeting')(handler_declared_here)\n"
+        )
+        loaders_module._MODULE_MEMO.pop(page_file, None)
+        with (
+            patch.object(page, "_context_manager", PageContextRegistry(None)),
+            patch_checks_router_manager(
+                pages_directory=tmp_path, scan_routes=[("test", page_file)]
+            ),
+        ):
+            messages = check_context_registration_files(None)
+        assert [m.id for m in messages] == ["next.E077"]
+        assert "attribution.py" in messages[0].msg
+        assert "handler_declared_here" in messages[0].msg
+
+    def test_e077_names_the_function_behind_a_partial(self, tmp_path) -> None:
+        page_file = tmp_path / "page.py"
+        page_file.write_text(
+            "import functools\n\n"
+            "from next.pages import context\n"
+            "from tests.support.attribution import handler_declared_here\n\n"
+            "context('greeting')(functools.partial(handler_declared_here))\n"
+        )
+        loaders_module._MODULE_MEMO.pop(page_file, None)
+        with (
+            patch.object(page, "_context_manager", PageContextRegistry(None)),
+            patch_checks_router_manager(
+                pages_directory=tmp_path, scan_routes=[("test", page_file)]
+            ),
+        ):
+            messages = check_context_registration_files(None)
+        assert [m.id for m in messages] == ["next.E077"]
+        assert "handler_declared_here" in messages[0].msg
+
+    def test_context_declared_in_the_page_file_reports_nothing(self, tmp_path) -> None:
+        page_file = tmp_path / "page.py"
+        page_file.write_text(
+            "from next.pages import context\n\n"
+            "@context('greeting')\n"
+            "def greeting() -> str:\n"
+            "    return 'hi'\n"
+        )
+        loaders_module._MODULE_MEMO.pop(page_file, None)
+        with (
+            patch.object(page, "_context_manager", PageContextRegistry(None)),
+            patch_checks_router_manager(
+                pages_directory=tmp_path, scan_routes=[("test", page_file)]
+            ),
+        ):
+            messages = check_context_registration_files(None)
+        assert messages == []

--- a/tests/pages/test_checks.py
+++ b/tests/pages/test_checks.py
@@ -23,6 +23,7 @@ from next.pages.checks import (
 from next.pages.manager import page
 from next.pages.registry import PageContextRegistry
 from tests.support import (
+    importable_dir,
     patch_checks_router_manager,
     patch_checks_router_manager_with_routers,
 )
@@ -866,9 +867,9 @@ class TestContextChecksDeduplicate:
 
 
 class TestContextRegistrationFileCheck:
-    """`check_context_registration_files` catches a context bound to a helper module."""
+    """`check_context_registration_files` catches a context bound to another file."""
 
-    def test_context_on_imported_helper_is_e077(self, tmp_path) -> None:
+    def test_context_on_imported_helper_is_e074(self, tmp_path) -> None:
         page_file = tmp_path / "page.py"
         page_file.write_text(
             "from next.pages import context\n"
@@ -883,11 +884,36 @@ class TestContextRegistrationFileCheck:
             ),
         ):
             messages = check_context_registration_files(None)
-        assert [m.id for m in messages] == ["next.E077"]
+        assert [m.id for m in messages] == ["next.E074"]
         assert "attribution.py" in messages[0].msg
         assert "handler_declared_here" in messages[0].msg
+        assert str(page_file) in messages[0].msg
 
-    def test_e077_names_the_function_behind_a_partial(self, tmp_path) -> None:
+    def test_context_from_another_page_py_is_e074(self, tmp_path) -> None:
+        donor_dir = tmp_path / "donor"
+        donor_dir.mkdir()
+        (donor_dir / "__init__.py").write_text("")
+        (donor_dir / "page.py").write_text("def donated() -> str:\n    return 'hi'\n")
+        page_file = tmp_path / "page.py"
+        page_file.write_text(
+            "from next.pages import context\n"
+            "from donor.page import donated\n\n"
+            "context('greeting')(donated)\n"
+        )
+        loaders_module._MODULE_MEMO.pop(page_file, None)
+        with (
+            patch.object(page, "_context_manager", PageContextRegistry(None)),
+            patch_checks_router_manager(
+                pages_directory=tmp_path, scan_routes=[("test", page_file)]
+            ),
+            importable_dir(tmp_path),
+        ):
+            messages = check_context_registration_files(None)
+        assert [m.id for m in messages] == ["next.E074"]
+        assert "donated" in messages[0].msg
+        assert str(donor_dir / "page.py") in messages[0].msg
+
+    def test_e074_names_the_function_behind_a_partial(self, tmp_path) -> None:
         page_file = tmp_path / "page.py"
         page_file.write_text(
             "import functools\n\n"
@@ -903,7 +929,7 @@ class TestContextRegistrationFileCheck:
             ),
         ):
             messages = check_context_registration_files(None)
-        assert [m.id for m in messages] == ["next.E077"]
+        assert [m.id for m in messages] == ["next.E074"]
         assert "handler_declared_here" in messages[0].msg
 
     def test_context_declared_in_the_page_file_reports_nothing(self, tmp_path) -> None:

--- a/tests/pages/test_manager.py
+++ b/tests/pages/test_manager.py
@@ -19,7 +19,11 @@ from next.pages.loaders import (
 from next.pages.manager import iter_serialized_page_context_keys
 from next.pages.registry import PageContextRegistry
 from next.static import default_manager as static_default_manager
-from tests.support import patch_checks_router_manager
+from tests.support import (
+    attribution,
+    handler_declared_here,
+    patch_checks_router_manager,
+)
 
 
 class TestPage:
@@ -610,6 +614,41 @@ class TestGlobalPageInstance:
         assert script in registry
         assert "from_page_module" in registry[script]
         assert "from_page_module" not in registry.get(Path(__file__), {})
+
+
+class TestContextMisattribution:
+    """A decorator run on a callable declared elsewhere is recorded as such."""
+
+    def test_declaring_file_matching_the_caller_records_nothing(self) -> None:
+        """A callable declared where the decorator runs is attributed cleanly."""
+        instance = Page()
+
+        @instance.context("here")
+        def declared_here() -> str:
+            return "value"
+
+        assert instance._context_manager.misattributed() == ()
+
+    def test_helper_from_another_module_is_recorded_once(self) -> None:
+        """Decorating an imported helper records the pair of files it spans."""
+        instance = Page()
+
+        instance.context("greeting")(handler_declared_here)
+        instance.context("greeting_again")(handler_declared_here)
+
+        records = instance._context_manager.misattributed()
+        assert [(r.registered_from, r.declared_in, r.name) for r in records] == [
+            (Path(__file__), Path(attribution.__file__), "handler_declared_here")
+        ]
+
+    def test_reset_drops_recorded_misattributions(self) -> None:
+        """A registry reset clears the diagnostic along with the registrations."""
+        instance = Page()
+        instance.context("greeting")(handler_declared_here)
+
+        instance._context_manager.reset()
+
+        assert instance._context_manager.misattributed() == ()
 
 
 class TestLayoutIntegration:

--- a/tests/pages/test_manager.py
+++ b/tests/pages/test_manager.py
@@ -1,3 +1,4 @@
+import importlib.util
 import textwrap
 from pathlib import Path
 from unittest import mock
@@ -41,29 +42,18 @@ class TestPage:
         assert page_instance._template_registry[file_path] == template_str
 
     @pytest.mark.parametrize(
-        ("decorator_type", "expected_key", "frame_chain"),
+        ("decorator_type", "expected_key"),
         [
-            ("with_key", "user_name", "f_back"),
-            ("without_key", None, "f_back.f_back"),
-            ("without_parentheses", None, "f_back.f_back"),
+            ("with_key", "user_name"),
+            ("without_key", None),
+            ("without_parentheses", None),
         ],
         ids=["with_key", "without_key", "without_parentheses"],
     )
     def test_context_decorator_variations(
-        self,
-        page_instance,
-        context_temp_file,
-        mock_frame,
-        decorator_type,
-        expected_key,
-        frame_chain,
+        self, page_instance, decorator_type, expected_key
     ) -> None:
-        """``@context`` keys on the caller file whether or not a key and parentheses are given."""
-        frame = mock_frame.return_value
-        for attr in frame_chain.split("."):
-            frame = getattr(frame, attr)
-        frame.f_globals = {"__file__": str(context_temp_file)}
-
+        """``@context`` keys on the declaring file whether or not a key is given."""
         if decorator_type == "with_key":
 
             @page_instance.context("user_name")
@@ -71,67 +61,55 @@ class TestPage:
                 return "John Doe"
 
             func = get_user_name
-        else:
+        elif decorator_type == "without_key":
 
-            @page_instance.context
+            @page_instance.context()
             def get_context_data():
                 return {"key1": "value1", "key2": "value2"}
 
             func = get_context_data
+        else:
 
-        assert context_temp_file in page_instance._context_manager._context_registry
-        assert (
-            expected_key
-            in page_instance._context_manager._context_registry[context_temp_file]
-        )
-        entry = page_instance._context_manager._context_registry[context_temp_file][
-            expected_key
-        ]
+            @page_instance.context
+            def get_context_data_bare():
+                return {"key1": "value1", "key2": "value2"}
+
+            func = get_context_data_bare
+
+        registry = page_instance._context_manager._context_registry
+        assert Path(__file__) in registry
+        assert expected_key in registry[Path(__file__)]
+        entry = registry[Path(__file__)][expected_key]
         assert entry.func == func
         assert entry.inherit_context is False
         assert entry.serialize is False
 
-    def test_context_decorator_with_inherit_context(
-        self, page_instance, context_temp_file, mock_frame
-    ) -> None:
+    def test_context_decorator_with_inherit_context(self, page_instance) -> None:
         """A keyed ``@context`` records ``inherit_context`` on the registry entry."""
-        mock_frame.return_value.f_back.f_globals = {"__file__": str(context_temp_file)}
 
         @page_instance.context("inherited_key", inherit_context=True)
         def get_inherited_value() -> str:
             return "inherited_value"
 
-        assert context_temp_file in page_instance._context_manager._context_registry
-        assert (
-            "inherited_key"
-            in page_instance._context_manager._context_registry[context_temp_file]
-        )
-        entry = page_instance._context_manager._context_registry[context_temp_file][
-            "inherited_key"
-        ]
+        registry = page_instance._context_manager._context_registry
+        assert Path(__file__) in registry
+        assert "inherited_key" in registry[Path(__file__)]
+        entry = registry[Path(__file__)]["inherited_key"]
         assert entry.func == get_inherited_value
         assert entry.inherit_context is True
         assert entry.serialize is False
 
-    def test_context_decorator_without_key_inherit_context(
-        self, page_instance, context_temp_file, mock_frame
-    ) -> None:
+    def test_context_decorator_without_key_inherit_context(self, page_instance) -> None:
         """A dict-merge ``@context`` registers under the ``None`` key and keeps inheritance."""
-        mock_frame.return_value.f_back.f_back.f_globals = {
-            "__file__": str(context_temp_file)
-        }
 
         @page_instance.context(inherit_context=True)
         def get_context_data():
             return {"key1": "value1", "key2": "value2"}
 
-        assert context_temp_file in page_instance._context_manager._context_registry
-        assert (
-            None in page_instance._context_manager._context_registry[context_temp_file]
-        )
-        entry = page_instance._context_manager._context_registry[context_temp_file][
-            None
-        ]
+        registry = page_instance._context_manager._context_registry
+        assert Path(__file__) in registry
+        assert None in registry[Path(__file__)]
+        entry = registry[Path(__file__)][None]
         assert entry.func == get_context_data
         assert entry.inherit_context is True
         assert entry.serialize is False
@@ -570,87 +548,68 @@ class TestGlobalPageInstance:
         assert global_file_path in page._template_registry
         assert page._template_registry[global_file_path] == template_str
 
-    def test_global_page_context_registration(
-        self, global_file_path, mock_frame
-    ) -> None:
+    def test_global_page_context_registration(self) -> None:
         """A context function registered on the singleton lands in its registry."""
-        mock_frame.return_value.f_back.f_globals = {"__file__": str(global_file_path)}
 
         @page.context("global_key")
         def get_global_value() -> str:
             return "global_value"
 
-        assert global_file_path in page._context_manager._context_registry
-        assert "global_key" in page._context_manager._context_registry[global_file_path]
+        registry = page._context_manager._context_registry
+        assert Path(__file__) in registry
+        assert "global_key" in registry[Path(__file__)]
 
-    def test_global_page_render(self, global_file_path, mock_frame) -> None:
+    def test_global_page_render(self) -> None:
         """The singleton renders a registered template with its own context."""
-        template_str = "Global: {{ key }}"
-        page.register_template(global_file_path, template_str)
-
-        mock_frame.return_value.f_back.f_globals = {"__file__": str(global_file_path)}
+        page.register_template(Path(__file__), "Global: {{ key }}")
 
         @page.context("key")
         def get_key() -> str:
             return "value"
 
-        result = page.render(global_file_path)
+        result = page.render(Path(__file__))
         assert result == "Global: value"
 
-    def test_context_decorator_with_global_page(
-        self, global_file_path, mock_frame
-    ) -> None:
-        """The exported ``context`` decorator registers against the calling file."""
-        mock_frame.return_value.f_back.f_globals = {"__file__": str(global_file_path)}
+    def test_context_decorator_with_global_page(self) -> None:
+        """The exported ``context`` decorator registers against the declaring file."""
 
         @context("test_key")
         def test_function() -> str:
             return "test_value"
 
-        assert global_file_path in page._context_manager._context_registry
-        assert "test_key" in page._context_manager._context_registry[global_file_path]
-        entry = page._context_manager._context_registry[global_file_path]["test_key"]
+        registry = page._context_manager._context_registry
+        assert Path(__file__) in registry
+        assert "test_key" in registry[Path(__file__)]
+        entry = registry[Path(__file__)]["test_key"]
         assert entry.func == test_function
         assert entry.inherit_context is False
         assert entry.serialize is False
 
-    @pytest.mark.parametrize(
-        ("test_case", "frame_setup"),
-        [
-            (
-                "frame_none",
-                lambda mock_frame: setattr(mock_frame.return_value, "f_back", None),
-            ),
-            (
-                "final_none",
-                lambda mock_frame: setattr(mock_frame, "return_value", None),
-            ),
-            (
-                "no_file",
-                lambda mock_frame: setattr(
-                    mock_frame.return_value.f_back, "f_globals", {"__file__": None}
-                ),
-            ),
-            (
-                "exhausted_frames",
-                lambda mock_frame: setattr(
-                    mock_frame.return_value.f_back, "f_back", None
-                ),
-            ),
-        ],
-        ids=["frame_none", "final_none", "no_file", "exhausted_frames"],
-    )
-    def test_get_caller_path_error_cases(
-        self, page_instance, test_case, frame_setup
+    def test_context_registered_from_another_module_keys_on_that_module(
+        self, tmp_path
     ) -> None:
-        """A frame chain with no usable ``__file__`` raises instead of guessing a path."""
-        with patch("next.pages.manager.inspect.currentframe") as mock_frame:
-            frame_setup(mock_frame)
+        """A page module registers under its own file, not under this test file."""
+        script = tmp_path / "page.py"
+        script.write_text(
+            textwrap.dedent(
+                """
+                from next.pages import context
 
-            with pytest.raises(
-                RuntimeError, match="Could not determine caller file path"
-            ):
-                page_instance._get_caller_path(1)
+                @context("from_page_module")
+                def get_value():
+                    return "value"
+                """
+            ).lstrip()
+        )
+        spec = importlib.util.spec_from_file_location("dyn_page_ctx", script)
+        assert spec is not None
+        assert spec.loader is not None
+        spec.loader.exec_module(importlib.util.module_from_spec(spec))
+
+        registry = page._context_manager._context_registry
+        assert script in registry
+        assert "from_page_module" in registry[script]
+        assert "from_page_module" not in registry.get(Path(__file__), {})
 
 
 class TestLayoutIntegration:

--- a/tests/pages/test_registry.py
+++ b/tests/pages/test_registry.py
@@ -1,3 +1,4 @@
+import functools
 from unittest.mock import MagicMock
 
 import pytest
@@ -406,6 +407,20 @@ class TestKeylessConflicts:
         context_manager.register_context(test_file_path, None, get_context_data)
 
         assert context_manager._keyless_conflicts == {}
+
+    def test_partial_and_function_conflict_records_unwrapped_names(
+        self, context_manager, test_file_path
+    ) -> None:
+        def bound() -> dict:
+            return {}
+
+        def plain() -> dict:
+            return {}
+
+        context_manager.register_context(test_file_path, None, functools.partial(bound))
+        context_manager.register_context(test_file_path, None, plain)
+
+        assert context_manager._keyless_conflicts[test_file_path] == ["bound", "plain"]
 
     def test_reset_clears_keyless_conflicts(
         self, context_manager, test_file_path

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from tests.support.attribution import (
+    handler_declared_here,
+    unwrapped_decorator,
+    wraps_decorator,
+)
 from tests.support.cases import (
     COERCE_URL_VALUE_CASES,
     URL_BY_ANNOTATION_RESOLVE_CASES,
@@ -69,6 +74,7 @@ __all__ = [
     "default_page_router_config",
     "file_router_backend_from_params",
     "file_router_config_entry",
+    "handler_declared_here",
     "inspect_parameter",
     "named_temp_py",
     "next_framework_settings_component_backends_list",
@@ -88,4 +94,6 @@ __all__ = [
     "tick_scenario_route_set_grows",
     "tick_scenario_route_set_unchanged",
     "tick_scenario_watch_raises",
+    "unwrapped_decorator",
+    "wraps_decorator",
 ]

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -37,6 +37,7 @@ from tests.support.partial_requests import (
     plain_request,
 )
 from tests.support.patches import (
+    importable_dir,
     patch_checks_components_manager,
     patch_checks_router_manager,
     patch_checks_router_manager_with_routers,
@@ -75,6 +76,7 @@ __all__ = [
     "file_router_backend_from_params",
     "file_router_config_entry",
     "handler_declared_here",
+    "importable_dir",
     "inspect_parameter",
     "named_temp_py",
     "next_framework_settings_component_backends_list",

--- a/tests/support/attribution.py
+++ b/tests/support/attribution.py
@@ -1,0 +1,29 @@
+import functools
+from collections.abc import Callable
+from typing import Any
+
+from django.http import HttpRequest, HttpResponse
+
+
+def wraps_decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap ``func`` with ``functools.wraps``, keeping the ``__wrapped__`` link."""
+
+    @functools.wraps(func)
+    def wrapper(*args: object, **kwargs: object) -> object:
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def unwrapped_decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap ``func`` without ``functools.wraps``, leaving no ``__wrapped__`` link."""
+
+    def wrapper(*args: object, **kwargs: object) -> object:
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def handler_declared_here(request: HttpRequest) -> HttpResponse:
+    """Answer with the request method, from a module that never applies ``@action``."""
+    return HttpResponse(request.method)

--- a/tests/support/patches.py
+++ b/tests/support/patches.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,19 @@ from tests.support.helpers import next_framework_settings_for_checks
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
     from pathlib import Path
+
+
+@contextmanager
+def importable_dir(directory: Path) -> Generator[None, None, None]:
+    """Put `directory` on `sys.path` and drop the modules imported from it."""
+    before = set(sys.modules)
+    sys.path.insert(0, str(directory))
+    try:
+        yield
+    finally:
+        sys.path.remove(str(directory))
+        for name in set(sys.modules) - before:
+            del sys.modules[name]
 
 
 @contextmanager

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import functools
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from next.utils import caller_source_path, resolve_base_dir
+from next.utils import callable_name, defining_file, resolve_base_dir
+from tests.support import attribution, unwrapped_decorator, wraps_decorator
 
 
 class TestResolveBaseDir:
@@ -40,32 +42,112 @@ class TestResolveBaseDir:
             assert resolve_base_dir() is None
 
 
-class TestCallerSourcePath:
-    """Tests for ``caller_source_path``."""
+class TestDefiningFile:
+    """Tests for ``defining_file``."""
 
-    def test_raises_when_no_mode_specified(self) -> None:
-        """Callers must pass exactly one of the two skip strategies."""
-        with pytest.raises(ValueError, match="Specify skip_while_filename_endswith"):
-            caller_source_path()
+    def test_plain_function_returns_its_own_file(self) -> None:
+        """A function declared here is attributed to this test module."""
 
-    def test_raises_when_both_modes_specified(self) -> None:
-        """Passing both strategies at once raises ValueError."""
-        with pytest.raises(ValueError, match="only one of"):
-            caller_source_path(
-                skip_while_filename_endswith=("a.py",),
-                skip_framework_file=("b.py", "next"),
-            )
+        def handler() -> None:
+            pass
 
-    def test_skip_while_filename_endswith_returns_caller_file(self) -> None:
-        """``skip_while_filename_endswith`` skips pytest internals and returns this file."""
-        result = caller_source_path(skip_while_filename_endswith=("_pytest/python.py",))
-        assert result.exists()
-        assert result.suffix == ".py"
+        assert defining_file(handler) == Path(__file__)
 
-    def test_skip_framework_file_returns_caller_file(self) -> None:
-        """``skip_framework_file`` skips the named framework module and returns this file."""
-        result = caller_source_path(
-            skip_framework_file=("_pytest/python.py", "_pytest")
-        )
-        assert result.exists()
-        assert result.suffix == ".py"
+    def test_function_wrapped_with_functools_wraps_returns_user_file(self) -> None:
+        """A wrapper built with ``functools.wraps`` is unwrapped to the user file."""
+
+        @wraps_decorator
+        def handler() -> None:
+            pass
+
+        assert defining_file(handler) == Path(__file__)
+
+    def test_function_wrapped_without_functools_wraps_returns_wrapper_file(
+        self,
+    ) -> None:
+        """Without ``functools.wraps`` the wrapper's own file wins."""
+
+        @unwrapped_decorator
+        def handler() -> None:
+            pass
+
+        assert defining_file(handler) == Path(attribution.__file__)
+
+    def test_class_returns_the_file_it_was_declared_in(self) -> None:
+        """A class is attributed to the file declaring it."""
+
+        class Marker:
+            pass
+
+        assert defining_file(Marker) == Path(__file__)
+
+    def test_partial_returns_the_file_of_the_wrapped_function(self) -> None:
+        """A ``functools.partial`` is attributed to the function it binds."""
+
+        def handler(value: int) -> int:
+            return value
+
+        assert defining_file(functools.partial(handler, 1)) == Path(__file__)
+
+    def test_nested_partial_unwraps_to_the_innermost_function(self) -> None:
+        """Stacked partials resolve through to the declaring file."""
+
+        def handler(first: int, second: int) -> int:
+            return first + second
+
+        stacked = functools.partial(functools.partial(handler, 1), 2)
+        assert defining_file(stacked) == Path(__file__)
+
+    def test_partial_of_a_builtin_raises_type_error(self) -> None:
+        """A partial binding a builtin has no declaring file either."""
+        with pytest.raises(TypeError, match=r"could not determine the file where"):
+            defining_file(functools.partial(len))
+
+    def test_callable_instance_returns_the_file_of_its_class(self) -> None:
+        """An instance with ``__call__`` is attributed through that method."""
+
+        class Handler:
+            def __call__(self) -> None:
+                pass
+
+        assert defining_file(Handler()) == Path(__file__)
+
+    def test_callable_without_code_object_raises_type_error(self) -> None:
+        """A builtin has no ``__code__`` and raises ``TypeError``."""
+        with pytest.raises(TypeError, match=r"could not determine the file where"):
+            defining_file(len)
+
+    def test_non_callable_object_raises_type_error_naming_the_object(self) -> None:
+        """A non-callable value raises ``TypeError`` naming the value."""
+        with pytest.raises(TypeError, match=r"'not a callable'"):
+            defining_file("not a callable")
+
+
+class TestCallableName:
+    """Tests for ``callable_name``."""
+
+    def test_function_keeps_its_own_name(self) -> None:
+        """A plain function reports ``__name__``."""
+
+        def handler() -> None:
+            pass
+
+        assert callable_name(handler) == "handler"
+
+    def test_partial_reports_the_wrapped_function(self) -> None:
+        """A partial has no ``__name__``, so the bound function names it."""
+
+        def handler(value: int) -> int:
+            return value
+
+        stacked = functools.partial(functools.partial(handler, 1))
+        assert callable_name(stacked) == "handler"
+
+    def test_callable_instance_reports_its_class(self) -> None:
+        """An instance with ``__call__`` reports the class name."""
+
+        class Handler:
+            def __call__(self) -> None:
+                pass
+
+        assert callable_name(Handler()) == "Handler"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from next.pages.loaders import _load_python_module
 from next.utils import callable_name, defining_file, resolve_base_dir
 from tests.support import attribution, unwrapped_decorator, wraps_decorator
 
@@ -121,6 +122,42 @@ class TestDefiningFile:
         """A non-callable value raises ``TypeError`` naming the value."""
         with pytest.raises(TypeError, match=r"'not a callable'"):
             defining_file("not a callable")
+
+    def test_wrapper_loop_falls_back_to_the_outer_function(self, tmp_path) -> None:
+        """A ``__wrapped__`` cycle answers with the file of the outer wrapper."""
+        module_file = tmp_path / "page.py"
+        module_file.write_text("def inner() -> None:\n    pass\n")
+        module = _load_python_module(module_file)
+
+        def outer() -> None:
+            pass
+
+        outer.__wrapped__ = module.inner
+        module.inner.__wrapped__ = outer
+
+        assert defining_file(outer) == Path(__file__)
+
+    @pytest.mark.parametrize("member", ["__call__", "__init__"], ids=["call", "init"])
+    def test_class_without_a_registered_module_reads_its_own_body(
+        self, tmp_path, member
+    ) -> None:
+        """A class the loader execs without sys.modules answers through its body."""
+        module_file = tmp_path / "page.py"
+        module_file.write_text(
+            f"class Declared:\n    def {member}(self) -> None:\n        pass\n"
+        )
+        module = _load_python_module(module_file)
+
+        assert defining_file(module.Declared) == module_file
+
+    def test_class_without_a_module_or_body_raises_type_error(self, tmp_path) -> None:
+        """A body-less class outside sys.modules names no file at all."""
+        module_file = tmp_path / "page.py"
+        module_file.write_text("class Declared:\n    marker = 1\n")
+        module = _load_python_module(module_file)
+
+        with pytest.raises(TypeError, match=r"could not determine the file where"):
+            defining_file(module.Declared)
 
 
 class TestCallableName:


### PR DESCRIPTION
## Description

Decorator registration stopped guessing the caller from the call stack. `next.utils.defining_file` now reads the decorated object itself — `inspect.getfile` for a class, `__code__.co_filename` after `inspect.unwrap` for a callable — so `@context`, `@component.context`, `@action` and form auto-registration all key on the file that *declares* the callable rather than the file that *runs* the decorator. The old `caller_source_path` frame walk, with its `back_count` / `max_walk` / skip-suffix knobs, is gone.

What this buys: a wrapper built with `functools.wraps` stays transparent (`@action` stacked over `transaction.atomic` still lands on its `page.py`), a class built by `next.forms.modelform_factory` is attributed to the module that called the factory instead of to `django/forms/models.py`, and a `functools.partial` or a callable instance registers at all — the frame walk raised `TypeError` for both, which escaped the page loader and blew up URLconf construction.

**Breaking:** the documented "direct registration" form `context("key")(imported_helper)` no longer binds the helper to the page. It now registers under the module that declares `imported_helper`, where no render collects it. Wrap the helper in a thin function inside the `page.py` (or `component.py`) that needs it — `examples/feature-flags`, `examples/shortener` and `docs/content/topics/context.rst` show the shape. `@action` on an imported function keeps working but registers as a shared-scope action rather than a page-scoped one.

Two new system checks make that failure loud instead of silent, since a wrong-file registration otherwise renders as an empty variable with `manage.py check` reporting zero issues:

- `next.E077` — a `@context` callable keyed on a file that is not a `page.py`, naming the file and the callables it holds.
- `next.E078` — the same for `@component.context` and `component.py`.

Two bugs found while wiring this up and fixed here: `callable_name` replaces the raw `__name__` reads in the page context registry (`next.E018`), in `next.E029` and in both new checks, because a partial and a callable instance have no `__name__` and raised `AttributeError` at `page.py` import time; and `ComponentContextRegistry._is_same_function` now compares through `callable_name` plus `defining_file` instead of `inspect.getsourcefile`, which made a re-executed `component.py` holding a partial context raise a bogus `ValueError: Duplicate component context registration` once the 128-entry module LRU evicted it.

Forms registration also rewrites the BASE_DIR and foreign-root membership tests from `Path.relative_to` in a `try` block to memoised string prefix checks, and drops the framework-file arm of the registration gate that `_definition_file_of` already made unreachable, together with the three tests that only kept it covered by patching `_definition_file_of`. Three `inspect.getsourcefile` mocks in the component context tests went away with it, replaced by real callables.

The second commit repairs the kanban example, whose React layer was dead in both of its modes. Vite 8 refuses to serve any path holding a colon before it consults `server.fs.allow`, and a typed route segment is spelled `[int:id]`, so every co-located `.jsx` asset under the board route answered 403 — `vite.config.ts` now drops that guard the way `vitest.config.ts` already did for the test files sitting in the same directory. `DEV_ORIGIN` was hardcoded, so the manifest branch of `ViteManifestBackend` never ran and the documented build flow still resolved to dev-server URLs that nothing answered, so it reads `VITE_ORIGIN` now and the HMR receiver takes the origin from the backend options instead of the environment. A hot update re-evaluates `page.jsx` and left its `WeakMap` guard empty, so a second `createRoot` claimed an element the first root still owned, and the registry moved onto `window` to outlive the re-evaluation.

## How to test

Gates run green locally: `uv run pytest` (3117 passed, 15 skipped, 100% coverage on `next/`), `make lint`, `make type-check`, `make test-examples` (every example suite at 100%), `make docs` with `-W`, and `doc8 docs/`. `manage.py check` is clean in `examples/feature-flags`, `examples/shortener` and `examples/kanban`, which exercise the new checks against real page trees. The forms registration benchmarks gained cases for router-exec'd and normally imported modules — worth a paired `make bench` run against `main` since the registration path changed. The JS toolchain steps of `make ci` were run only for kanban (`npm run test`, `npm run build`, prettier), and `make test-compat` was not part of this change.

Every example was also driven through a browser: the shortener pending-clicks panel, the feature-flags metrics counters, the audit-forms wizard, the search-catalog facets, both multi-tenant accents, the live-polls SSE vote, the observability filter dispatch, the admin login and add form, and the kanban board with a real drag between columns.

To see `next.E077` fire, decorate an imported helper directly in a `page.py` (`context("stats")(shared_stats)`) and run `manage.py check`.

## Related issues

None.

## Checklist

- [ ] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [x] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable
