### PR TITLE
feat(core): curated lazy top-level api and honest next.components surface

### DIFF
--- a/docs/content/howto/add-a-page.rst
+++ b/docs/content/howto/add-a-page.rst
@@ -26,7 +26,7 @@ Create the page module.
 .. code-block:: python
    :caption: notes/pages/about/page.py
 
-   from next.pages import context
+   from next import context
 
    @context("body")
    def about_body() -> str:

--- a/docs/content/howto/build-a-composite-component.rst
+++ b/docs/content/howto/build-a-composite-component.rst
@@ -37,7 +37,7 @@ Create the folder ``notes/pages/_components/info_card/`` with three files.
 .. code-block:: python
    :caption: notes/pages/_components/info_card/component.py
 
-   from next.components import component
+   from next import component
 
    @component.context("subtitle")
    def subtitle(subtitle: str = "") -> str:

--- a/docs/content/howto/customize-error-pages.rst
+++ b/docs/content/howto/customize-error-pages.rst
@@ -120,7 +120,7 @@ The exception propagates out of the page to Django's URL resolver, which then in
    :caption: notes/pages/notes/[int:note_id]/page.py
 
    from django.http import Http404
-   from next.pages import context
+   from next import context
    from next.urls import DUrl
    from notes.models import Note
 

--- a/docs/content/howto/integrate-django-admin.rst
+++ b/docs/content/howto/integrate-django-admin.rst
@@ -80,7 +80,7 @@ Use ``reverse`` from inside the file router.
    :caption: notes/pages/page.py
 
    from django.urls import reverse
-   from next.pages import context
+   from next import context
 
    @context("admin_url")
    def admin_url() -> str:

--- a/docs/content/howto/integrate-django-allauth-forms.rst
+++ b/docs/content/howto/integrate-django-allauth-forms.rst
@@ -74,7 +74,7 @@ The factory passes the request into the allauth constructor, and the handler han
    from allauth.account.forms import LoginForm
    from django.http import HttpRequest, HttpResponse
 
-   from next.forms import action
+   from next import action
 
    def login_form_factory(request: HttpRequest) -> tuple[type[LoginForm], dict[str, HttpRequest]]:
        return LoginForm, {"request": request}
@@ -110,7 +110,7 @@ The neutral ``{"initial": {}}`` keeps construction on the factory path, the same
    from allauth.account.utils import complete_signup
    from django.http import HttpRequest, HttpResponse
 
-   from next.forms import action
+   from next import action
 
    def signup_form_factory() -> tuple[type[SignupForm], dict[str, dict[str, object]]]:
        return SignupForm, {"initial": {}}
@@ -135,7 +135,7 @@ Password Reset
    from allauth.account.forms import ResetPasswordForm
    from django.http import HttpRequest, HttpResponseRedirect
 
-   from next.forms import action
+   from next import action
 
    def reset_form_factory() -> tuple[type[ResetPasswordForm], dict[str, dict[str, object]]]:
        return ResetPasswordForm, {"initial": {}}

--- a/docs/content/howto/internationalize-routes.rst
+++ b/docs/content/howto/internationalize-routes.rst
@@ -97,7 +97,7 @@ A ``@context`` callable returns the already-translated string.
    :caption: shop/routes/page.py
 
    from django.utils.translation import gettext as _
-   from next.pages import context
+   from next import context
 
    @context("heading")
    def heading() -> str:

--- a/docs/content/howto/override-the-js-context-serializer.rst
+++ b/docs/content/howto/override-the-js-context-serializer.rst
@@ -35,7 +35,7 @@ Context functions can now return Pydantic models directly.
    :caption: notes/pages/page.py
 
    from pydantic import BaseModel
-   from next.pages import context
+   from next import context
 
    class NoteOut(BaseModel):
        id: int

--- a/docs/content/howto/read-query-parameters.rst
+++ b/docs/content/howto/read-query-parameters.rst
@@ -29,7 +29,7 @@ The default is used when the key is absent from the query string.
    :caption: storefront/page.py
 
    from catalog.models import Product
-   from next.pages import context
+   from next import context
    from next.urls import DQuery
 
    DEFAULT_FEATURED = 3
@@ -99,7 +99,7 @@ Each annotation drives its own coercion.
 .. code-block:: python
    :caption: storefront/catalog/page.py
 
-   from next.pages import context
+   from next import context
    from next.urls import DQuery
 
    @context("results")
@@ -178,7 +178,7 @@ Child callables then ask for ``category`` by parameter name and never re-query.
 
    from catalog.models import Category
    from django.http import Http404
-   from next.pages import context
+   from next import context
 
    @context("category", inherit_context=True)
    def category(category: object) -> Category:
@@ -195,7 +195,7 @@ A descendant page reads the resolved instance back through its parameter name.
    :caption: storefront/catalog/[category]/products/page.py
 
    from catalog.models import Category, Product
-   from next.pages import context
+   from next import context
 
    @context("products")
    def products(category: Category) -> list[Product]:

--- a/docs/content/howto/require-login-on-pages.rst
+++ b/docs/content/howto/require-login-on-pages.rst
@@ -89,7 +89,7 @@ A ``@context`` callable asks for the request by annotation and reads ``request.u
    :caption: notes/pages/page.py
 
    from django.http import HttpRequest
-   from next.pages import context
+   from next import context
 
    @context("greeting")
    def greeting(request: HttpRequest) -> str:
@@ -110,7 +110,7 @@ A branded 403 page needs a ``403.html`` template or a ``handler403`` in the root
 
    from django.core.exceptions import PermissionDenied
    from django.http import HttpRequest
-   from next.pages import context
+   from next import context
 
    @context("notes")
    def notes(request: HttpRequest) -> list:

--- a/docs/content/howto/reverse-urls.rst
+++ b/docs/content/howto/reverse-urls.rst
@@ -86,7 +86,7 @@ Use Inside a Component
 .. code-block:: python
    :caption: _components/note_link/component.py
 
-   from next.components import component
+   from next import component
    from next.urls import page_reverse
    from notes.models import Note
 

--- a/docs/content/howto/scope-requests-per-tenant.rst
+++ b/docs/content/howto/scope-requests-per-tenant.rst
@@ -134,7 +134,7 @@ Keep real annotations in these modules, because the resolver compares parameter 
 
    from notes.models import Note
    from notes.providers import DTenant
-   from next.pages import context
+   from next import context
 
    @context("notes")
    def notes(active_tenant: DTenant) -> list[Note]:
@@ -151,7 +151,7 @@ A ``@context(..., inherit_context=True)`` callable on the workspace root publish
 
    from notes.models import Note
    from notes.providers import DTenant
-   from next.pages import context
+   from next import context
 
    @context("tenant", inherit_context=True)
    def tenant(active_tenant: DTenant) -> "Tenant":

--- a/docs/content/howto/share-context-across-pages.rst
+++ b/docs/content/howto/share-context-across-pages.rst
@@ -21,7 +21,7 @@ Add the context function to the segment's ``page.py``.
 .. code-block:: python
    :caption: notes/pages/page.py
 
-   from next.pages import context
+   from next import context
    from notes.models import Note
 
    @context("note_count", inherit_context=True)
@@ -53,7 +53,7 @@ Drop the flag for values that should stay local to the current page only.
 .. code-block:: python
    :caption: notes/pages/page.py (local only)
 
-   from next.pages import context
+   from next import context
 
    @context("nav_links")
    def nav_links() -> list:

--- a/docs/content/howto/use-formsets.rst
+++ b/docs/content/howto/use-formsets.rst
@@ -47,7 +47,8 @@ Register the action.
    from django.forms.formsets import BaseFormSet
    from django.http import HttpRequest, HttpResponseRedirect
 
-   from next.forms import action, redirect_to_origin
+   from next import action
+   from next.forms import redirect_to_origin
    from notes.forms import NoteFormSet
 
    def build_bulk_formset() -> tuple[type[BaseFormSet], dict]:
@@ -102,8 +103,8 @@ Use ``cleanup_extra_initial`` to clear initial values from blank extra rows befo
 
    from types import SimpleNamespace
 
+   from next import context
    from next.forms import cleanup_extra_initial
-   from next.pages import context
    from notes.forms import NoteFormSet
 
    @context("bulk_create")

--- a/docs/content/internals/contributing-notes.rst
+++ b/docs/content/internals/contributing-notes.rst
@@ -47,7 +47,7 @@ Public Callables
 ~~~~~~~~~~~~~~~~
 
 Names exposed through ``@page.context``, ``@component.context``, ``@action``, and through provider classes never start with an underscore.
-``@context`` imported from ``next.pages`` is the documented alias for ``@page.context`` used in page modules.
+``@context`` imported from ``next`` is the documented alias for ``@page.context`` used in page modules.
 Names prefixed with ``_`` stay module internal.
 
 System Checks

--- a/docs/content/intro/install.rst
+++ b/docs/content/intro/install.rst
@@ -136,7 +136,7 @@ Create one page in the ``notes`` application to confirm the wiring.
 .. code-block:: python
    :caption: notes/pages/page.py
 
-   from next.pages import context
+   from next import context
 
    @context("title")
    def page_title() -> str:

--- a/docs/content/intro/tutorial01.rst
+++ b/docs/content/intro/tutorial01.rst
@@ -70,7 +70,7 @@ A captioned code block holds the complete content of the named file unless the p
    :caption: notes/pages/page.py
 
    from notes.models import Note
-   from next.pages import context
+   from next import context
 
    @context("notes")
    def recent_notes() -> list[Note]:

--- a/docs/content/intro/tutorial02.rst
+++ b/docs/content/intro/tutorial02.rst
@@ -77,7 +77,7 @@ Pass ``inherit_context=True`` so every descendant page can read the value too.
 .. code-block:: python
    :caption: notes/pages/page.py
 
-   from next.pages import context
+   from next import context
 
    @context("site_name", inherit_context=True)
    def site_name() -> str:
@@ -104,7 +104,7 @@ The typed ``[int:id]`` directory form rejects non-numeric URLs at routing time b
 
    from django.shortcuts import get_object_or_404
    from notes.models import Note
-   from next.pages import context
+   from next import context
    from next.urls import DUrl
 
    @context("note")

--- a/docs/content/intro/tutorial03.rst
+++ b/docs/content/intro/tutorial03.rst
@@ -167,7 +167,7 @@ Add a ``component.py`` next to the template.
    :caption: notes/pages/_components/note_card/component.py
 
    from notes.models import Note
-   from next.components import component
+   from next import component
 
    @component.context("preview")
    def preview(note: Note) -> str:

--- a/docs/content/intro/tutorial04.rst
+++ b/docs/content/intro/tutorial04.rst
@@ -66,7 +66,7 @@ The ``inherit_context=True`` flag on the three layout-scope callables stays from
    :caption: notes/pages/page.py
 
    from notes.models import Note
-   from next.pages import context
+   from next import context
 
    @context("site_name", inherit_context=True)
    def site_name() -> str:
@@ -146,8 +146,7 @@ It receives the same DI-resolved parameters as any other callable, including URL
    from django.urls import reverse
    from notes.forms import CreateNoteForm
    from notes.models import Note
-   from next.forms import action
-   from next.pages import context
+   from next import action, context
    from next.urls import DUrl
 
    @context("note")
@@ -240,7 +239,7 @@ The detail ``page.py`` only needs to add its own context.
    from django.shortcuts import get_object_or_404
    from django.urls import reverse
    from notes.models import Note
-   from next.pages import context
+   from next import context
    from next.urls import DUrl
 
    @context("note")

--- a/docs/content/intro/tutorial05.rst
+++ b/docs/content/intro/tutorial05.rst
@@ -211,7 +211,7 @@ Add the two page files.
 .. code-block:: python
    :caption: notes/pages/about/page.py
 
-   from next.pages import context
+   from next import context
 
    @context("body")
    def about_body() -> str:

--- a/docs/content/intro/tutorial06.rst
+++ b/docs/content/intro/tutorial06.rst
@@ -76,7 +76,7 @@ Update ``notes/pages/page.py`` so the ``notes`` context honours ``q``, and publi
 
    from django.http import HttpRequest
    from notes.models import Note
-   from next.pages import context
+   from next import context
 
    @context("site_name", inherit_context=True)
    def site_name() -> str:

--- a/docs/content/ref/components.rst
+++ b/docs/content/ref/components.rst
@@ -12,7 +12,6 @@ The names in this reference are grouped by their intended audience.
 .. note::
 
    The Application Imports, Framework Extension, and Internal Infrastructure tiers follow the public-surface rules in :ref:`faq-safe-symbols`.
-   Underscore-prefixed render helpers under *Internal Infrastructure* are hooks for tests and framework code, not for everyday imports in applications.
 
 Application Imports
 -------------------
@@ -146,15 +145,6 @@ Use it to test factory wiring.
 .. autoclass:: next.components.BoomBackend
    :members:
 
-The underscore-prefixed render helpers exported from this module are internal hooks.
-Do not use them in application code.
-
-.. autofunction:: next.components._inject_component_context
-
-.. autofunction:: next.components._merge_csrf_context
-
-.. autofunction:: next.components._render_template_string
-
 Signals
 -------
 
@@ -181,8 +171,6 @@ The module ``next.components.signals`` exposes four ``django.dispatch.Signal`` i
    * - ``component_rendered``
      - ``ComponentsManager``
      - ``info`` (``ComponentInfo``), ``template_path`` (``Path`` or ``None``)
-
-The package ``__init__`` re-exports ``next_framework_settings`` from :doc:`/content/ref/conf` as a convenience for backend code that reads ``LAZY_COMPONENT_MODULES``.
 
 See Also
 --------

--- a/docs/content/ref/index.rst
+++ b/docs/content/ref/index.rst
@@ -26,6 +26,9 @@ Import them from the package root with ``from next import Depends, action, compo
 ``next.Depends``
    The dependency marker for injected values, re-exported from :doc:`deps`.
 
+``next.VERSION``
+   The framework version string, the sixth and only eager name in ``next.__all__``.
+
 Each of the five resolves from its owning subpackage on first attribute access, so ``import next`` on its own pulls in no Django module.
 Anything outside the five stays a deep import, such as ``from next.urls import DUrl`` or ``from next.forms import Form``.
 The subsystem pages below are the reference for that wider surface.

--- a/docs/content/ref/index.rst
+++ b/docs/content/ref/index.rst
@@ -6,6 +6,44 @@ API Reference
 Module by module reference for the next.dj public API.
 Each page lists the public surface plus configuration and signal entries that belong to the subsystem.
 
+.. rubric:: Top-Level API
+
+The ``next`` package itself exports five curated names, the ones that page modules, component modules, and form handlers use most often.
+Import them from the package root with ``from next import Depends, action, component, context, page``.
+
+``next.page``
+   The page manager that owns template registration and rendering, re-exported from :doc:`pages`.
+
+``next.context``
+   The page context decorator, re-exported from :doc:`pages` and documented in :doc:`decorators`.
+
+``next.component``
+   The component context manager behind ``@component.context``, re-exported from :doc:`components`.
+
+``next.action``
+   The form action decorator, re-exported from :doc:`forms`.
+
+``next.Depends``
+   The dependency marker for injected values, re-exported from :doc:`deps`.
+
+Each of the five resolves from its owning subpackage on first attribute access, so ``import next`` on its own pulls in no Django module.
+Anything outside the five stays a deep import, such as ``from next.urls import DUrl`` or ``from next.forms import Form``.
+The subsystem pages below are the reference for that wider surface.
+
+.. warning::
+
+   ``next.page`` and ``next.pages`` differ by one letter and name different things.
+   ``next.page`` is the manager object re-exported at the package root, while ``next.pages`` is the subpackage that owns it together with the rest of the pages API.
+
+.. note::
+
+   The curated ``context`` is the decorator, not the ``Context`` and ``ContextResult`` classes that share the word.
+   Those classes belong to the same subpackage and stay behind ``from next.pages import Context, ContextResult``.
+
+The laziness covers the package root, not the subsystems it fronts.
+Reading ``Depends`` imports ``next.deps``, which pulls in a small set of modules from ``django.dispatch`` and ``django.utils``.
+Reading ``page``, ``context``, ``component``, or ``action`` loads a much larger part of Django.
+
 .. rubric:: Subsystems
 
 :doc:`pages`

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -172,7 +172,7 @@ Errors
      - A component name is registered more than once within the same scope.
      - ``next.components.checks``
    * - ``next.E021``
-     - A ``component.py`` imports ``context`` from ``next.pages`` instead of ``next.components``.
+     - A ``component.py`` reaches for the page ``context`` decorator instead of the component one, under any spelling: ``next.pages``, the ``next`` package root, or ``next.page.context``.
      - ``next.components.checks``
    * - ``next.E022``
      - ``PAGE_BACKENDS`` is empty.

--- a/docs/content/security/di-and-untrusted-input.rst
+++ b/docs/content/security/di-and-untrusted-input.rst
@@ -42,7 +42,7 @@ Always validate the string before passing it into ORM lookups or external servic
 
    from django.shortcuts import get_object_or_404
    from notes.models import Note
-   from next.pages import context
+   from next import context
    from next.urls import DUrl
 
    @context("note")
@@ -80,7 +80,7 @@ Validate the resulting values against business rules.
 .. code-block:: python
    :caption: notes/pages/page.py
 
-   from next.pages import context
+   from next import context
    from next.urls import DQuery
 
    @context("page")

--- a/docs/content/topics/components.rst
+++ b/docs/content/topics/components.rst
@@ -303,7 +303,7 @@ Use ``@component.context("key")`` to publish a value under that key for the temp
    :caption: _components/note_card/component.py
 
    from notes.models import Note
-   from next.components import component
+   from next import component
 
    @component.context("preview")
    def preview(note: Note) -> str:
@@ -461,7 +461,7 @@ The components subsystem contributes Django system checks.
 
 - ``next.E020`` reports two components with the same name in the same scope.
   Rename one of the colliding components or move it to a different scope root.
-- ``next.E021`` reports a ``component.py`` that uses ``context`` from ``next.pages``.
+- ``next.E021`` reports a ``component.py`` that uses the page ``context`` decorator, whether it comes from ``next.pages`` or from the curated ``next`` root.
   Use ``@component.context`` from ``next.components`` instead.
 - ``next.E034`` reports one component name used at the root route scope of more than one page tree.
   Rename one of the colliding components or move it to a different scope root.

--- a/docs/content/topics/context.rst
+++ b/docs/content/topics/context.rst
@@ -69,7 +69,7 @@ The decorator takes a single key and the function returns the value.
 .. code-block:: python
    :caption: notes/pages/page.py
 
-   from next.pages import context
+   from next import context
    from notes.models import Note
 
    @context("notes")
@@ -86,7 +86,7 @@ Decorating a function with bare ``@context`` and returning a dict merges every k
 .. code-block:: python
    :caption: shared dependency
 
-   from next.pages import context
+   from next import context
 
    @context
    def post_context(post: Post) -> dict[str, object]:
@@ -106,7 +106,7 @@ The inherit_context Flag
 .. code-block:: python
    :caption: notes/pages/page.py
 
-   from next.pages import context
+   from next import context
 
    @context("site_name", inherit_context=True)
    def site_name() -> str:
@@ -124,7 +124,7 @@ A helper that lives in a shared module therefore needs a thin wrapper in the pag
 .. code-block:: python
    :caption: notes/pages/dashboard/page.py
 
-   from next.pages import context
+   from next import context
    from notes.cache import pending_clicks
 
    @context("pending_clicks")
@@ -165,7 +165,8 @@ The factory takes its own dependency-injected arguments, so it can ask for the r
 .. code-block:: python
    :caption: notes/pages/notes/[int:note_id]/page.py
 
-   from next.pages import Context, context
+   from next import context
+   from next.pages import Context
    from next.urls import DUrl
    from notes.models import Note
 
@@ -229,7 +230,7 @@ Leave the parameter untyped and return early when it is already a model instance
 .. code-block:: python
    :caption: notes/pages/notes/[category]/page.py
 
-   from next.pages import context
+   from next import context
    from notes.models import Category
 
    @context("category", inherit_context=True)
@@ -303,7 +304,7 @@ Publish the page title from each page.
 .. code-block:: python
    :caption: notes/pages/notes/[id]/page.py
 
-   from next.pages import context
+   from next import context
    from next.urls import DUrl
    from notes.models import Note
 
@@ -332,7 +333,7 @@ Combine a context function with the ``DQuery[T]`` marker to read filters from th
 .. code-block:: python
    :caption: notes/pages/page.py
 
-   from next.pages import context
+   from next import context
    from next.urls import DQuery
 
    @context("active_tag")

--- a/docs/content/topics/dependency-injection.rst
+++ b/docs/content/topics/dependency-injection.rst
@@ -83,7 +83,7 @@ The URL path provider coerces the captured segment to the requested type.
    :caption: notes/pages/notes/[int:note_id]/page.py
 
    from notes.models import Note
-   from next.pages import context
+   from next import context
    from next.urls import DUrl
 
    @context("note")
@@ -158,7 +158,7 @@ The query provider reads from ``request.GET``.
    :caption: notes/pages/search/page.py
 
    from notes.models import Note
-   from next.pages import context
+   from next import context
    from next.urls import DQuery
 
    @context("results")
@@ -235,8 +235,8 @@ See :doc:`/content/internals/di-resolver` for the cycle and cache mechanics.
 .. code-block:: python
    :caption: consuming context and depends
 
-   from next.deps import Depends
-   from next.pages import Context, context
+   from next import Depends, context
+   from next.pages import Context
 
    @context("ready_message")
    def ready_message(
@@ -271,7 +271,8 @@ When two of them ask for each other, directly or through a longer chain, resolut
 .. code-block:: python
    :caption: notes/deps.py
 
-   from next.deps import Depends, resolver
+   from next import Depends
+   from next.deps import resolver
 
    @resolver.dependency("profile")
    def profile(settings: dict = Depends("settings")) -> dict:
@@ -299,7 +300,8 @@ Here ``settings`` does not need ``profile`` at all, so the fix is to drop that p
 .. code-block:: python
    :caption: notes/deps.py
 
-   from next.deps import Depends, resolver
+   from next import Depends
+   from next.deps import resolver
 
    @resolver.dependency("settings")
    def settings() -> dict:
@@ -356,7 +358,7 @@ Use the new marker.
 
    from notes.models import Note
    from notes.providers import DNote
-   from next.pages import context
+   from next import context
 
    @context("note")
    def current_note(note: DNote[Note]) -> Note:

--- a/docs/content/topics/file-router.rst
+++ b/docs/content/topics/file-router.rst
@@ -107,7 +107,7 @@ Name your directories without hyphens when you want the parameter name and the d
 .. code-block:: python
    :caption: routes/posts/[int:post_id]/page.py
 
-   from next.pages import context
+   from next import context
    from next.urls import DUrl
    from notes.models import Note
 

--- a/docs/content/topics/forms/actions.rst
+++ b/docs/content/topics/forms/actions.rst
@@ -187,7 +187,8 @@ A bare ``@action`` or an empty ``@action()`` registers the function under its ow
    :caption: page.py
 
    from django.http import HttpRequest
-   from next.forms import action, redirect_to_origin
+   from next import action
+   from next.forms import redirect_to_origin
    from next.urls import DUrl
 
    @action("delete_note")
@@ -222,7 +223,8 @@ Keep ``@action`` outermost when other decorators apply to the same handler.
 
    from django.db import transaction
    from django.http import HttpRequest
-   from next.forms import action, redirect_to_origin
+   from next import action
+   from next.forms import redirect_to_origin
    from next.urls import DUrl
 
    @action("publish_note")
@@ -253,7 +255,7 @@ Mark such a class abstract, or move the handler logic into its ``on_valid``.
    from django.shortcuts import redirect
 
    import next.forms
-   from next.forms import action
+   from next import action
    from next.forms.markers import DForm
 
    class ContactForm(next.forms.ModelForm):
@@ -290,7 +292,7 @@ A ``(FormClass, init_kwargs)`` tuple.
    :caption: page.py — a factory returning the tuple form
 
    from django.shortcuts import get_object_or_404, redirect
-   from next.forms import action
+   from next import action
    from next.urls import DUrl
 
    def edit_form_factory(note_id: DUrl["id", int]) -> tuple:
@@ -346,7 +348,8 @@ Declare the access requirements on the action itself.
    from django.http import HttpRequest
 
    import next.forms
-   from next.forms import action, redirect_to_origin
+   from next import action
+   from next.forms import redirect_to_origin
    from next.urls import DUrl
 
    class NoteDeleteForm(next.forms.Form):
@@ -423,7 +426,7 @@ Declare ``request`` to read the user, and any further parameter the injector res
    from notes.models import Note
 
    import next.forms
-   from next.deps import Depends
+   from next import Depends
    from next.urls import DUrl
 
    class WorkspaceNoteForm(next.forms.ModelForm):
@@ -544,7 +547,8 @@ Call ``messages.success`` in the handler body instead.
 
    from django.contrib import messages
    from django.http import HttpRequest
-   from next.forms import action, redirect_to_origin
+   from next import action
+   from next.forms import redirect_to_origin
    from next.urls import DUrl
 
    @action("archive_note")

--- a/docs/content/topics/forms/formsets.rst
+++ b/docs/content/topics/forms/formsets.rst
@@ -51,7 +51,7 @@ Without the flag, ``__init_subclass__`` registers ``NoteRowForm`` as a standalon
    from django.forms.formsets import BaseFormSet
    from django.http import HttpResponseRedirect
    from django.urls import reverse
-   from next.forms import action
+   from next import action
    from notes.forms import NoteFormSet
 
    def build_bulk_formset() -> tuple[type[BaseFormSet], dict]:
@@ -115,8 +115,8 @@ Build the formset inside a ``@context`` callable named after the action and retu
    :caption: notes/pages/notes/bulk/page.py
 
    from types import SimpleNamespace
+   from next import context
    from next.forms import cleanup_extra_initial
-   from next.pages import context
    from notes.forms import NoteFormSet
 
    def build_formset(initial: list[dict]) -> NoteFormSet:
@@ -159,8 +159,7 @@ Use ``modelformset_factory`` for editing several existing instances.
    from django.forms.formsets import BaseFormSet
    from django.http import HttpResponseRedirect
    from django.urls import reverse
-   from next.forms import action
-   from next.pages import context
+   from next import action, context
    from notes.forms import NoteEditFormSet
    from notes.models import Note
 
@@ -231,7 +230,7 @@ The parent form is ``abstract`` because it dispatches only through the ``update_
 
    from django.http import HttpResponseRedirect
    from django.shortcuts import get_object_or_404
-   from next.forms import action
+   from next import action
    from next.urls import DUrl
    from notes.forms import NoteForm
    from notes.models import Note

--- a/docs/content/topics/forms/overview.rst
+++ b/docs/content/topics/forms/overview.rst
@@ -128,7 +128,8 @@ A bare ``@action`` registers the function under its own name.
    :caption: page.py
 
    from django.http import HttpRequest
-   from next.forms import action, redirect_to_origin
+   from next import action
+   from next.forms import redirect_to_origin
    from next.urls import DUrl
 
    @action("delete_article")

--- a/docs/content/topics/forms/validation-rerender.rst
+++ b/docs/content/topics/forms/validation-rerender.rst
@@ -140,7 +140,8 @@ The ``redirect_to_origin`` helper sends the user back to whichever page rendered
    :caption: notes/pages/page.py
 
    from django.http import HttpRequest
-   from next.forms import action, redirect_to_origin
+   from next import action
+   from next.forms import redirect_to_origin
    from next.urls import DUrl
 
    @action("toggle_favourite")

--- a/docs/content/topics/forms/wizard.rst
+++ b/docs/content/topics/forms/wizard.rst
@@ -147,7 +147,7 @@ Beyond the reserved names, ``done`` declares markers and named dependencies like
 .. code-block:: python
    :caption: pulling a named dependency into the finaliser
 
-   from next.deps import Depends
+   from next import Depends
 
    def done(self, request: HttpRequest, cleaned_data, tenant=Depends("active_tenant")):
        AccessRequest.objects.create(tenant=tenant, **cleaned_data)
@@ -261,7 +261,7 @@ A progress bar reads the step status in Python and iterates the precomputed list
 
    from typing import Any
 
-   from next.components import component
+   from next import component
    from next.forms import FormWizard
 
    @component.context("steps")

--- a/docs/content/topics/layouts.rst
+++ b/docs/content/topics/layouts.rst
@@ -101,7 +101,7 @@ Use it to publish values that the layout markup needs and, with ``inherit_contex
 .. code-block:: python
    :caption: notes/pages/page.py
 
-   from next.pages import context
+   from next import context
    from notes.models import Note
 
    @context("site_name", inherit_context=True)

--- a/docs/content/topics/pages.rst
+++ b/docs/content/topics/pages.rst
@@ -135,7 +135,7 @@ A ``@context`` decorator publishes one or more values into the template scope.
 .. code-block:: python
    :caption: keyed single value
 
-   from next.pages import context
+   from next import context
 
    @context("notes")
    def all_notes() -> list:
@@ -170,7 +170,7 @@ Pass ``serializer=`` with a ``JsContextSerializer`` instance to use a per-key se
 .. code-block:: python
    :caption: page.py
 
-   from next.pages import context
+   from next import context
 
    @context("featured", serialize=True)
    def featured_payload() -> dict:
@@ -179,7 +179,7 @@ Pass ``serializer=`` with a ``JsContextSerializer`` instance to use a per-key se
 .. code-block:: python
    :caption: unkeyed dict
 
-   from next.pages import context
+   from next import context
 
    @context
    def post_context(post: Post) -> dict[str, object]:

--- a/docs/content/topics/partial-rendering/extending.rst
+++ b/docs/content/topics/partial-rendering/extending.rst
@@ -89,7 +89,7 @@ A value is pushed by the name of a registered ``serialize=True`` provider on the
 
    from django.http import HttpRequest
 
-   from next.pages import context
+   from next import context
    from next.partial import Patches
 
 

--- a/docs/content/topics/static-assets/js-context.rst
+++ b/docs/content/topics/static-assets/js-context.rst
@@ -89,7 +89,7 @@ The override applies only to that key.
 .. code-block:: python
    :caption: per key serializer
 
-   from next.pages import context
+   from next import context
    from next.static import PydanticJsContextSerializer
 
    @context("featured", serialize=True, serializer=PydanticJsContextSerializer())
@@ -217,7 +217,7 @@ Register the key server-side with ``serialize=True``.
 .. code-block:: python
    :caption: notes/pages/page.py
 
-   from next.pages import context
+   from next import context
    from notes.models import Note
 
    @context("note_count", serialize=True)

--- a/docs/content/topics/url-reversing.rst
+++ b/docs/content/topics/url-reversing.rst
@@ -208,7 +208,7 @@ A component can compute a URL through ``@component.context``.
 .. code-block:: python
    :caption: _components/note_link/component.py
 
-   from next.components import component
+   from next import component
    from next.urls import page_reverse
    from notes.models import Note
 

--- a/examples/_shared/_components/alert/component.py
+++ b/examples/_shared/_components/alert/component.py
@@ -1,4 +1,4 @@
-from next.components import component
+from next import component
 
 
 BASE = "relative w-full rounded-lg border p-4 text-sm"

--- a/examples/_shared/_components/badge/component.py
+++ b/examples/_shared/_components/badge/component.py
@@ -1,4 +1,4 @@
-from next.components import component
+from next import component
 
 
 BASE = (

--- a/examples/_shared/_components/button/component.py
+++ b/examples/_shared/_components/button/component.py
@@ -1,4 +1,4 @@
-from next.components import component
+from next import component
 
 
 BASE = (

--- a/examples/_shared/_components/markdown_preview/component.py
+++ b/examples/_shared/_components/markdown_preview/component.py
@@ -1,6 +1,6 @@
 from django.utils.safestring import SafeString
 
-from next.components import component
+from next import component
 
 
 scripts = ["https://cdn.jsdelivr.net/npm/marked/marked.min.js"]

--- a/examples/_shared/_components/nav_link/component.py
+++ b/examples/_shared/_components/nav_link/component.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sequence
 from django.http import HttpRequest
 from django.urls import NoReverseMatch, reverse
 
-from next.components import component
+from next import component
 
 
 _HOVER_ACCENT = "hover:bg-accent hover:text-accent-foreground"

--- a/examples/_template/myapp/routes/page.py
+++ b/examples/_template/myapp/routes/page.py
@@ -1,4 +1,4 @@
-from next.pages import context
+from next import context
 
 
 @context("greeting")

--- a/examples/admin/shadcn_admin/_panels/admin_form/component.py
+++ b/examples/admin/shadcn_admin/_panels/admin_form/component.py
@@ -3,8 +3,7 @@ from typing import Any
 from django.http import HttpRequest
 from shadcn_admin.forms import AdminFormSpec, AdminInlineSpec, build_inline_formsets
 
-from next.components import component
-from next.deps import Depends
+from next import Depends, component
 from next.forms import form_spec, formset_spec
 
 

--- a/examples/admin/shadcn_admin/_panels/flash_messages/component.py
+++ b/examples/admin/shadcn_admin/_panels/flash_messages/component.py
@@ -3,7 +3,7 @@ from typing import Any
 from django.contrib.messages import get_messages
 from django.http import HttpRequest
 
-from next.components import component
+from next import component
 
 
 _LEVEL_TO_VARIANT = {

--- a/examples/admin/shadcn_admin/forms.py
+++ b/examples/admin/shadcn_admin/forms.py
@@ -18,8 +18,9 @@ from django.http import (
 )
 from django.template import Context, Template
 
-from next.deps import Depends, resolver
-from next.forms import BaseModelForm, action, cleanup_extra_initial, form_spec
+from next import Depends, action
+from next.deps import resolver
+from next.forms import BaseModelForm, cleanup_extra_initial, form_spec
 from next.partial import Patches, is_partial_request
 from shadcn_admin import utils
 

--- a/examples/admin/shadcn_admin/surfaces/[str:app_label]/[str:model_name]/[int:pk]/delete/page.py
+++ b/examples/admin/shadcn_admin/surfaces/[str:app_label]/[str:model_name]/[int:pk]/delete/page.py
@@ -6,8 +6,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from shadcn_admin import utils
 
-from next.forms import action
-from next.pages import context
+from next import action, context
 
 
 @context("delete_state")

--- a/examples/admin/shadcn_admin/surfaces/[str:app_label]/[str:model_name]/[int:pk]/history/page.py
+++ b/examples/admin/shadcn_admin/surfaces/[str:app_label]/[str:model_name]/[int:pk]/history/page.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.http import HttpRequest
 from shadcn_admin import utils
 
-from next.pages import context
+from next import context
 
 
 _ACTION_LABELS = {1: "Added", 2: "Changed", 3: "Deleted"}

--- a/examples/admin/shadcn_admin/surfaces/[str:app_label]/[str:model_name]/page.py
+++ b/examples/admin/shadcn_admin/surfaces/[str:app_label]/[str:model_name]/page.py
@@ -14,8 +14,8 @@ from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.utils.safestring import SafeString, mark_safe
 from shadcn_admin import utils
 
-from next.forms import action, redirect_to_origin
-from next.pages import context
+from next import action, context
+from next.forms import redirect_to_origin
 from next.urls import with_query
 
 

--- a/examples/admin/shadcn_admin/surfaces/activity/page.py
+++ b/examples/admin/shadcn_admin/surfaces/activity/page.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from admin_audit.models import AdminActivityLog
 
-from next.pages import context
+from next import context
 
 
 _LIMIT = 50

--- a/examples/admin/shadcn_admin/surfaces/login/page.py
+++ b/examples/admin/shadcn_admin/surfaces/login/page.py
@@ -6,8 +6,7 @@ from django.contrib.auth.forms import AuthenticationForm
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from shadcn_admin import utils
 
-from next.forms import action
-from next.pages import context
+from next import action, context
 
 
 def admin_login_form_factory(

--- a/examples/admin/shadcn_admin/surfaces/page.py
+++ b/examples/admin/shadcn_admin/surfaces/page.py
@@ -6,7 +6,7 @@ from django.contrib import admin
 from django.http import HttpRequest
 from shadcn_admin import utils
 
-from next.pages import context
+from next import context
 
 
 _AUTH_PREFIXES = (utils.LOGIN_URL, utils.LOGOUT_URL)

--- a/examples/audit-forms/access/views/_blocks/audit_row/component.py
+++ b/examples/audit-forms/access/views/_blocks/audit_row/component.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from access.models import AuditEntry
 
-from next.components import component
+from next import component
 
 
 _KIND_CLASS = {

--- a/examples/audit-forms/access/views/admin/audit/page.py
+++ b/examples/audit-forms/access/views/admin/audit/page.py
@@ -1,7 +1,7 @@
 from access.models import AuditEntry
 from django.http import HttpRequest
 
-from next.pages import context
+from next import context
 from next.partial import zone_requested
 
 

--- a/examples/audit-forms/access/views/page.py
+++ b/examples/audit-forms/access/views/page.py
@@ -1,6 +1,6 @@
 from access.models import AccessRequest, AuditEntry
 
-from next.pages import context
+from next import context
 
 
 @context("recent_requests")

--- a/examples/audit-forms/access/views/request/[int:request_id]/audit/page.py
+++ b/examples/audit-forms/access/views/request/[int:request_id]/audit/page.py
@@ -1,7 +1,7 @@
 from access.models import AccessRequest, AuditEntry
 from django.http import Http404, HttpRequest
 
-from next.pages import context
+from next import context
 
 
 @context("access_request")

--- a/examples/audit-forms/access/views/request/[step]/_blocks/progress_bar/component.py
+++ b/examples/audit-forms/access/views/request/[step]/_blocks/progress_bar/component.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from next.components import component
+from next import component
 from next.forms import FormWizard
 
 

--- a/examples/feature-flags/flags/panels/_chunks/toggle_preview/component.py
+++ b/examples/feature-flags/flags/panels/_chunks/toggle_preview/component.py
@@ -1,7 +1,7 @@
 from flags.models import Flag
 from flags.providers import DFlag
 
-from next.components import component
+from next import component
 
 
 @component.context("state")

--- a/examples/feature-flags/flags/panels/admin/metrics/page.py
+++ b/examples/feature-flags/flags/panels/admin/metrics/page.py
@@ -1,7 +1,7 @@
 from flags.metrics import render_counts
 from flags.receivers import access_denied_count, feature_guard_count
 
-from next.pages import context
+from next import context
 
 
 @context("render_counts")

--- a/examples/feature-flags/flags/panels/admin/page.py
+++ b/examples/feature-flags/flags/panels/admin/page.py
@@ -5,9 +5,8 @@ from django.http import HttpRequest, HttpResponseRedirect
 from flags.models import Flag
 from flags.providers import WRITE_GATE_FLAG, FlagService
 
-from next.deps import Depends
+from next import Depends, context
 from next.forms import Form
-from next.pages import context
 
 
 class BulkToggleForm(Form):

--- a/examples/feature-flags/flags/panels/demo/page.py
+++ b/examples/feature-flags/flags/panels/demo/page.py
@@ -1,6 +1,6 @@
 from flags.models import Flag
 
-from next.pages import context
+from next import context
 
 
 DEMO_FLAG_NAMES = ("beta_checkout", "dark_sidebar", "ai_suggestions")

--- a/examples/feature-flags/flags/panels/page.py
+++ b/examples/feature-flags/flags/panels/page.py
@@ -1,6 +1,6 @@
 from flags.models import Flag
 
-from next.pages import context
+from next import context
 
 
 @context("active_flags")

--- a/examples/kanban/kanban/boards/board/[int:id]/_pieces/card/component.py
+++ b/examples/kanban/kanban/boards/board/[int:id]/_pieces/card/component.py
@@ -1,6 +1,6 @@
 from kanban.models import Card
 
-from next.components import component
+from next import component
 
 
 @component.context("excerpt")

--- a/examples/kanban/kanban/boards/board/[int:id]/_pieces/column/component.py
+++ b/examples/kanban/kanban/boards/board/[int:id]/_pieces/column/component.py
@@ -1,7 +1,7 @@
 from django.db.models import QuerySet
 from kanban.models import Card, Column
 
-from next.components import component
+from next import component
 
 
 @component.context("cards")

--- a/examples/kanban/kanban/boards/board/[int:id]/page.py
+++ b/examples/kanban/kanban/boards/board/[int:id]/page.py
@@ -4,8 +4,8 @@ from django.middleware.csrf import get_token
 from kanban.models import Board, Card, Column
 from kanban.providers import DBoard
 
+from next import context
 from next.forms.manager import form_action_manager
-from next.pages import context
 
 
 @context("board_object", inherit_context=True)

--- a/examples/kanban/kanban/boards/board/[int:id]/settings/page.py
+++ b/examples/kanban/kanban/boards/board/[int:id]/settings/page.py
@@ -1,4 +1,4 @@
-from next.pages import context
+from next import context
 
 
 @context("settings_active")

--- a/examples/kanban/kanban/boards/page.py
+++ b/examples/kanban/kanban/boards/page.py
@@ -1,6 +1,6 @@
 from kanban.models import Board
 
-from next.pages import context
+from next import context
 
 
 @context("boards")

--- a/examples/live-polls/polls/screens/polls/[int:id]/_widgets/poll_chart/component.py
+++ b/examples/live-polls/polls/screens/polls/[int:id]/_widgets/poll_chart/component.py
@@ -1,7 +1,7 @@
 from django.db.models import Sum
 from polls.models import Poll
 
-from next.components import component
+from next import component
 
 
 @component.context("results", serialize=True)

--- a/examples/live-polls/polls/screens/polls/[int:id]/page.py
+++ b/examples/live-polls/polls/screens/polls/[int:id]/page.py
@@ -2,7 +2,7 @@ from polls.broker import build_snapshot
 from polls.models import Poll
 from polls.providers import DPoll
 
-from next.pages import context
+from next import context
 
 
 @context("poll", inherit_context=True)

--- a/examples/live-polls/polls/screens/polls/page.py
+++ b/examples/live-polls/polls/screens/polls/page.py
@@ -2,7 +2,7 @@ from django.db.models import Count, QuerySet, Sum, Value
 from django.db.models.functions import Coalesce
 from polls.models import Poll
 
-from next.pages import context
+from next import context
 
 
 @context("polls")

--- a/examples/markdown-blog/README.md
+++ b/examples/markdown-blog/README.md
@@ -119,7 +119,8 @@ Thanks to the loader, each post module is **tiny**:
 from pathlib import Path
 
 from blog.markdown_template import post_metadata, read_post_body, reading_minutes
-from next.pages import context
+
+from next import context
 
 
 _POST = Path(__file__).parent / "template.md"

--- a/examples/markdown-blog/blog/screens/page.py
+++ b/examples/markdown-blog/blog/screens/page.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from blog.markdown_template import post_metadata
 
-from next.pages import context
+from next import context
 
 
 POSTS_DIR = Path(__file__).parent / "posts"

--- a/examples/markdown-blog/blog/screens/posts/hello-world/page.py
+++ b/examples/markdown-blog/blog/screens/posts/hello-world/page.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from blog.markdown_template import post_metadata, read_post_body, reading_minutes
 
-from next.pages import context
+from next import context
 
 
 _POST = Path(__file__).parent / "template.md"

--- a/examples/markdown-blog/blog/screens/posts/welcome/page.py
+++ b/examples/markdown-blog/blog/screens/posts/welcome/page.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from blog.markdown_template import post_metadata, read_post_body, reading_minutes
 
-from next.pages import context
+from next import context
 
 
 _POST = Path(__file__).parent / "template.md"

--- a/examples/multi-tenant/notes/workspaces/notes/[int:note_id]/edit/page.py
+++ b/examples/multi-tenant/notes/workspaces/notes/[int:note_id]/edit/page.py
@@ -9,8 +9,8 @@ from notes.markdown_render import render_markdown
 from notes.models import Note
 from notes.providers import DTenant
 
+from next import context
 from next.forms import ComponentWidget, ModelForm, PermissionOutcome
-from next.pages import context
 
 
 def get_owned_note(tenant: object, note_id: int) -> Note:

--- a/examples/multi-tenant/notes/workspaces/notes/_blocks/note_card/component.py
+++ b/examples/multi-tenant/notes/workspaces/notes/_blocks/note_card/component.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from notes.models import Note
 
-from next.components import component
+from next import component
 
 
 EXCERPT_LIMIT = 140

--- a/examples/multi-tenant/notes/workspaces/notes/new/page.py
+++ b/examples/multi-tenant/notes/workspaces/notes/new/page.py
@@ -6,8 +6,8 @@ from notes.markdown_render import render_markdown
 from notes.models import Note
 from notes.providers import DTenant
 
+from next import context
 from next.forms import ComponentWidget, Form
-from next.pages import context
 
 
 class NoteCreateForm(Form):

--- a/examples/multi-tenant/notes/workspaces/notes/page.py
+++ b/examples/multi-tenant/notes/workspaces/notes/page.py
@@ -1,7 +1,7 @@
 from notes.models import Note
 from notes.providers import DTenant
 
-from next.pages import context
+from next import context
 
 
 @context("notes")

--- a/examples/multi-tenant/notes/workspaces/page.py
+++ b/examples/multi-tenant/notes/workspaces/page.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from notes.models import Note
 from notes.providers import DTenant
 
-from next.pages import context
+from next import context
 
 
 if TYPE_CHECKING:

--- a/examples/observability/obs/dashboards/_widgets/busiest_pages/component.py
+++ b/examples/observability/obs/dashboards/_widgets/busiest_pages/component.py
@@ -1,6 +1,6 @@
 from obs import metrics
 
-from next.components import component
+from next import component
 
 
 @component.context("busiest_pages")

--- a/examples/observability/obs/dashboards/_widgets/render_chart/component.py
+++ b/examples/observability/obs/dashboards/_widgets/render_chart/component.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from next.components import component
+from next import component
 
 
 # The Chart.js CDN URL lives in the page-level `scripts` list of

--- a/examples/observability/obs/dashboards/_widgets/sparkline/component.py
+++ b/examples/observability/obs/dashboards/_widgets/sparkline/component.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from obs.serializers import WrappedJsContextSerializer
 
-from next.components import component
+from next import component
 
 
 # React and Babel-standalone are declared at the page level

--- a/examples/observability/obs/dashboards/_widgets/stats_nav/component.py
+++ b/examples/observability/obs/dashboards/_widgets/stats_nav/component.py
@@ -1,4 +1,4 @@
-from next.components import component
+from next import component
 
 
 NAV_ITEMS = (

--- a/examples/observability/obs/dashboards/page.py
+++ b/examples/observability/obs/dashboards/page.py
@@ -1,6 +1,6 @@
 from obs import metrics
 
-from next.pages import context
+from next import context
 
 
 scripts = [

--- a/examples/observability/obs/dashboards/stats/components/page.py
+++ b/examples/observability/obs/dashboards/stats/components/page.py
@@ -1,6 +1,6 @@
 from obs import metrics
 
-from next.pages import context
+from next import context
 
 
 @context("counters")

--- a/examples/observability/obs/dashboards/stats/forms/page.py
+++ b/examples/observability/obs/dashboards/stats/forms/page.py
@@ -1,6 +1,6 @@
 from obs import metrics
 
-from next.pages import context
+from next import context
 
 
 @context("dispatched")

--- a/examples/observability/obs/dashboards/stats/page.py
+++ b/examples/observability/obs/dashboards/stats/page.py
@@ -5,7 +5,7 @@ from obs import metrics
 from obs.forms import DEFAULT_WINDOW
 from obs.serializers import WrappedJsContextSerializer
 
-from next.pages import context
+from next import context
 
 
 # Chart.js is declared at the page level rather than next to the

--- a/examples/observability/obs/dashboards/stats/pages/page.py
+++ b/examples/observability/obs/dashboards/stats/pages/page.py
@@ -1,6 +1,6 @@
 from obs import metrics
 
-from next.pages import context
+from next import context
 
 
 @context("counters")

--- a/examples/observability/obs/dashboards/stats/static/page.py
+++ b/examples/observability/obs/dashboards/stats/static/page.py
@@ -1,6 +1,6 @@
 from obs import metrics
 
-from next.pages import context
+from next import context
 
 
 @context("dedup")

--- a/examples/search-catalog/README.md
+++ b/examples/search-catalog/README.md
@@ -45,7 +45,7 @@ Search is idempotent. A bookmark of `?q=iphone&brand=Acme&page=2` should reprodu
 [`next/urls/markers.py`](../../next/urls/markers.py) ships a marker that mirrors `DUrl[T]` and reads `request.GET`. Any GET listing page can declare a typed parameter and skip the `request.GET.get(...)` plumbing.
 
 ```python
-from next.pages import context
+from next import context
 from next.urls import DQuery
 
 @context("results")

--- a/examples/search-catalog/catalog/storefront/_cards/product_card/component.py
+++ b/examples/search-catalog/catalog/storefront/_cards/product_card/component.py
@@ -1,7 +1,7 @@
 from catalog.models import Product
 from django.urls import reverse
 
-from next.components import component
+from next import component
 
 
 @component.context("detail_url")

--- a/examples/search-catalog/catalog/storefront/catalog/[category]/[slug]/page.py
+++ b/examples/search-catalog/catalog/storefront/catalog/[category]/[slug]/page.py
@@ -1,7 +1,7 @@
 from catalog.models import Category, Product
 from django.http import Http404
 
-from next.pages import context
+from next import context
 
 
 @context("product")

--- a/examples/search-catalog/catalog/storefront/catalog/[category]/page.py
+++ b/examples/search-catalog/catalog/storefront/catalog/[category]/page.py
@@ -3,7 +3,7 @@ from catalog.providers import DFilters, DPage
 from catalog.queries import cached_search
 from django.http import Http404
 
-from next.pages import context
+from next import context
 
 
 @context("category", inherit_context=True)

--- a/examples/search-catalog/catalog/storefront/catalog/_cards/filter_panel/component.py
+++ b/examples/search-catalog/catalog/storefront/catalog/_cards/filter_panel/component.py
@@ -2,7 +2,7 @@ from catalog.models import Category
 from catalog.providers import DFilters, Filters
 from django.urls import reverse
 
-from next.components import component
+from next import component
 
 
 @component.context("submit_url")

--- a/examples/search-catalog/catalog/storefront/catalog/page.py
+++ b/examples/search-catalog/catalog/storefront/catalog/page.py
@@ -2,7 +2,7 @@ from catalog.models import Category, Product
 from catalog.providers import DFilters, DPage
 from catalog.queries import cached_search
 
-from next.pages import context
+from next import context
 
 
 @context("page_obj")

--- a/examples/search-catalog/catalog/storefront/page.py
+++ b/examples/search-catalog/catalog/storefront/page.py
@@ -1,6 +1,6 @@
 from catalog.models import Category, Product
 
-from next.pages import context
+from next import context
 from next.urls import DQuery
 
 

--- a/examples/shortener/shortener/routes/_widgets/link_card/component.py
+++ b/examples/shortener/shortener/routes/_widgets/link_card/component.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from shortener.models import Link
 
-from next.components import component
+from next import component
 
 
 @component.context("short_url")

--- a/examples/shortener/shortener/routes/admin/links/[slug]/page.py
+++ b/examples/shortener/shortener/routes/admin/links/[slug]/page.py
@@ -3,8 +3,7 @@ from shortener.cache import CLICK_PREFIX, reset_clicks
 from shortener.models import Link
 from shortener.providers import DLink
 
-from next.forms import action
-from next.pages import context
+from next import action, context
 from next.partial import Patches
 
 

--- a/examples/shortener/shortener/routes/admin/page.py
+++ b/examples/shortener/shortener/routes/admin/page.py
@@ -2,8 +2,8 @@ from django.http import Http404, HttpRequest, HttpResponse
 from shortener.cache import pending_clicks
 from shortener.models import Link
 
-from next.forms import ModelForm, action
-from next.pages import context
+from next import action, context
+from next.forms import ModelForm
 from next.partial import Patches
 
 

--- a/examples/shortener/shortener/routes/admin/stats/page.py
+++ b/examples/shortener/shortener/routes/admin/stats/page.py
@@ -3,7 +3,7 @@ from shortener.cache import pending_clicks
 from shortener.models import Link
 from shortener.receivers import action_counts
 
-from next.pages import context
+from next import context
 
 
 @context("totals")

--- a/examples/shortener/shortener/routes/page.py
+++ b/examples/shortener/shortener/routes/page.py
@@ -9,8 +9,8 @@ from django.template import Context, Template
 from shortener.cache import pending_clicks
 from shortener.models import Link
 
+from next import context
 from next.forms import ComponentWidget, Form
-from next.pages import context
 from next.partial import Patches, is_partial_request
 
 

--- a/examples/wiki/wiki/routes/articles/edit/[slug]/page.py
+++ b/examples/wiki/wiki/routes/articles/edit/[slug]/page.py
@@ -7,8 +7,8 @@ from wiki.markdown_render import render_markdown
 from wiki.models import RESERVED_SLUGS, Article
 from wiki.providers import DArticle
 
+from next import context
 from next.forms import ComponentWidget, ModelForm, PermissionOutcome
-from next.pages import context
 
 
 class ArticleEditForm(ModelForm):

--- a/examples/wiki/wiki/routes/articles/new/page.py
+++ b/examples/wiki/wiki/routes/articles/new/page.py
@@ -4,8 +4,8 @@ from django.utils.safestring import SafeString
 from wiki.markdown_render import render_markdown
 from wiki.models import RESERVED_SLUGS, Article
 
+from next import context
 from next.forms import ComponentWidget, Form
-from next.pages import context
 
 
 class ArticleCreateForm(Form):

--- a/examples/wiki/wiki/routes/docs/components/page.py
+++ b/examples/wiki/wiki/routes/docs/components/page.py
@@ -1,4 +1,4 @@
-from next.pages import context
+from next import context
 
 
 @context("section")

--- a/examples/wiki/wiki/routes/docs/routing/page.py
+++ b/examples/wiki/wiki/routes/docs/routing/page.py
@@ -1,4 +1,4 @@
-from next.pages import context
+from next import context
 
 
 @context("section")

--- a/examples/wiki/wiki/routes/page.py
+++ b/examples/wiki/wiki/routes/page.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from wiki.models import Article
 
-from next.pages import context
+from next import context
 
 
 @context("file_pages")

--- a/examples/wiki/wiki/routes/search/page.py
+++ b/examples/wiki/wiki/routes/search/page.py
@@ -3,7 +3,7 @@ from django.http import HttpRequest
 from django.urls import reverse
 from wiki.models import Article
 
-from next.pages import context
+from next import context
 
 
 FILE_DOC_CATALOGUE = (

--- a/examples/wiki/wiki/routes/wiki/[slug]/page.py
+++ b/examples/wiki/wiki/routes/wiki/[slug]/page.py
@@ -3,7 +3,7 @@ from wiki.markdown_render import render_markdown
 from wiki.models import Article
 from wiki.providers import DArticle
 
-from next.pages import context
+from next import context
 
 
 @context("article")

--- a/next/__init__.py
+++ b/next/__init__.py
@@ -11,8 +11,50 @@ r"""                  __           __
 A next-gen framework based on Django without the tears.
 """
 
+import importlib
+from typing import TYPE_CHECKING
+
+
+# No annotation here references these names, so the module does without
+# `from __future__ import annotations` and the import cost it adds to `import next`.
+if TYPE_CHECKING:
+    from next.components import component
+    from next.deps import Depends
+    from next.forms import action
+    from next.pages import context, page
+
+
+__all__ = ["VERSION", "Depends", "action", "component", "context", "page"]
+
 __title__ = "Next Django Framework"
 __version__ = "0.8.0"
 __author__ = "paqstd-dev"
 
 VERSION = __version__
+
+
+_LAZY_ATTRIBUTES: dict[str, str] = {
+    "page": "next.pages",
+    "context": "next.pages",
+    "component": "next.components",
+    "action": "next.forms",
+    "Depends": "next.deps",
+}
+
+
+def __getattr__(name: str) -> object:
+    """Resolve a curated top-level name from its owning subpackage on demand.
+
+    Importing any subpackage pulls in Django, so the facade stays lazy to keep
+    `import next` free of Django imports.
+    """
+    module_name = _LAZY_ATTRIBUTES.get(name)
+    if module_name is None:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+    return getattr(importlib.import_module(module_name), name)
+
+
+def __dir__() -> list[str]:
+    """List the version constant plus every lazily resolved curated name."""
+    return sorted({"VERSION", *_LAZY_ATTRIBUTES})

--- a/next/__init__.py
+++ b/next/__init__.py
@@ -11,12 +11,12 @@ r"""                  __           __
 A next-gen framework based on Django without the tears.
 """
 
+# Every annotation here is a builtin, so the module skips
+# `from __future__ import annotations` and the import it would add to `import next`.
 import importlib
 from typing import TYPE_CHECKING
 
 
-# No annotation here references these names, so the module does without
-# `from __future__ import annotations` and the import cost it adds to `import next`.
 if TYPE_CHECKING:
     from next.components import component
     from next.deps import Depends
@@ -42,7 +42,7 @@ _LAZY_ATTRIBUTES: dict[str, str] = {
 }
 
 
-def __getattr__(name: str) -> object:
+def _resolve(name: str) -> object:
     """Resolve a curated top-level name from its owning subpackage on demand.
 
     Importing any subpackage pulls in Django, so the facade stays lazy to keep
@@ -55,6 +55,13 @@ def __getattr__(name: str) -> object:
     return getattr(importlib.import_module(module_name), name)
 
 
+# A visible module `__getattr__` would make any name typecheck, so only the binding
+# hides from type checkers and `_resolve` stays outside the guard to keep its body
+# checked.
+if not TYPE_CHECKING:
+    __getattr__ = _resolve
+
+
 def __dir__() -> list[str]:
-    """List the version constant plus every lazily resolved curated name."""
-    return sorted({"VERSION", *_LAZY_ATTRIBUTES})
+    """List the curated names alongside the live module namespace."""
+    return sorted(set(__all__) | set(globals()))

--- a/next/components/__init__.py
+++ b/next/components/__init__.py
@@ -12,8 +12,6 @@ of the form `from next.components.registry import ComponentRegistry`.
 
 from __future__ import annotations
 
-from next.conf import next_framework_settings
-
 from . import checks, signals
 from .backends import (
     BoomBackend,
@@ -41,9 +39,6 @@ from .renderers import (
     ComponentTemplateLoader,
     CompositeComponentRenderer,
     SimpleComponentRenderer,
-    _inject_component_context,
-    _merge_csrf_context,
-    _render_template_string,
 )
 from .scanner import ComponentScanner, component_extra_roots_from_config
 from .watch import get_component_paths_for_watch
@@ -70,9 +65,6 @@ __all__ = [
     "ModuleCache",
     "ModuleLoader",
     "SimpleComponentRenderer",
-    "_inject_component_context",
-    "_merge_csrf_context",
-    "_render_template_string",
     "checks",
     "component",
     "component_extra_roots_from_config",
@@ -81,7 +73,6 @@ __all__ = [
     "get_component",
     "get_component_paths_for_watch",
     "load_component_template",
-    "next_framework_settings",
     "register_components_folder_from_router_walk",
     "render_component",
     "signals",

--- a/next/components/checks.py
+++ b/next/components/checks.py
@@ -38,6 +38,11 @@ _COMPONENT_CONTEXT_SUBJECT = RegistrationSubject(
 
 _FILE_COMPONENT_BACKEND_CONFIG_KEYS = frozenset({"BACKEND", "COMPONENTS_DIR", "DIRS"})
 
+# The curated root re-exports the page decorator, so every spelling below names
+# the same wrong `context` inside a component.py.
+_PAGE_CONTEXT_MODULES = frozenset({"next", "next.pages"})
+_PAGE_CONTEXT_OWNERS = frozenset({"next", "page", "next.page", "next.pages"})
+
 
 def _validate_single_component_backend(
     config: dict[str, object], index: int
@@ -197,8 +202,18 @@ def check_cross_root_component_name_conflicts(*args, **kwargs) -> list[CheckMess
     return errors
 
 
+def _dotted_owner(node: ast.expr) -> str | None:
+    """Spell an attribute owner back as a dotted name, or None when it is computed."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _dotted_owner(node.value)
+        return None if parent is None else f"{parent}.{node.attr}"
+    return None
+
+
 def _component_py_uses_pages_context(file_path: Path) -> bool:
-    """Return True if `component.py` imports `context` from `next.pages`."""
+    """Return True if `component.py` reaches for the page `context` decorator."""
     try:
         source = file_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
@@ -208,18 +223,14 @@ def _component_py_uses_pages_context(file_path: Path) -> bool:
     except SyntaxError:
         return False
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.ImportFrom)
-            and getattr(node, "module", None) == "next.pages"
-        ):
+        if isinstance(node, ast.ImportFrom) and node.module in _PAGE_CONTEXT_MODULES:
             for alias in node.names:
                 if getattr(alias, "name", None) == "context":
                     return True
         if (
             isinstance(node, ast.Attribute)
-            and isinstance(node.value, ast.Name)
-            and node.value.id == "page"
             and node.attr == "context"
+            and _dotted_owner(node.value) in _PAGE_CONTEXT_OWNERS
         ):
             return True
     return False
@@ -246,8 +257,9 @@ def check_component_py_no_pages_context(*args, **kwargs) -> list[CheckMessage]:
             if _component_py_uses_pages_context(info.module_path):
                 errors.append(
                     Error(
-                        "component.py must not use context from next.pages. "
-                        "Use component context from next.components instead.",
+                        "component.py must not use context from next.pages or "
+                        "the next package root. Use component context from "
+                        "next.components instead.",
                         obj=str(info.module_path),
                         id="next.E021",
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,7 +266,7 @@ mark-parentheses = true
 fixture-parentheses = true
 
 [tool.ruff.lint.flake8-bugbear]
-extend-immutable-calls = ["next.deps.Depends"]
+extend-immutable-calls = ["next.Depends", "next.deps.Depends"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,9 +186,6 @@ exclude = [
     "*.egg-info",
     "migrations",
 
-    # Project annotation file
-    "next/__init__.py",
-
     # Sphinx configuration
     "docs/conf.py",
 ]
@@ -211,6 +208,8 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+# The ASCII banner is the package docstring, so summary-line rules cannot hold there
+"next/__init__.py" = ["D205", "D210", "D400", "D415"]
 "examples/*" = [
     "ARG002",
     "D100", "D101", "D103", "D104", "D105", "D106",

--- a/tests/components/test_checks.py
+++ b/tests/components/test_checks.py
@@ -118,11 +118,23 @@ class TestChecks:
             errors = check_cross_root_component_name_conflicts()
         assert any(e.id == "next.E034" for e in errors)
 
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "from next.pages import context\n",
+            "from next import context\n",
+            "from next import context as page_context\n",
+            "from next import page\n\n@page.context\ndef data():\n    return {}\n",
+            "import next\n\n@next.context\ndef data():\n    return {}\n",
+            "import next\n\n@next.page.context\ndef data():\n    return {}\n",
+            "import next.pages\n\n@next.pages.context\ndef data():\n    return {}\n",
+        ],
+    )
     def test_check_component_py_no_pages_context_reports_import(
-        self, tmp_path: Path, min_component_config: dict
+        self, source: str, tmp_path: Path, min_component_config: dict
     ) -> None:
-        """check_component_py_no_pages_context reports when component.py imports context from next.pages."""
-        (tmp_path / "component.py").write_text("from next.pages import context\n")
+        """Every spelling of the page context decorator in component.py is reported."""
+        (tmp_path / "component.py").write_text(source)
         fake_backend = FileComponentsBackend(dict(min_component_config))
 
         fake_backend._registry.register(
@@ -133,6 +145,31 @@ class TestChecks:
         with patch_checks_components_manager(fake_backend):
             errors = check_component_py_no_pages_context()
         assert any(e.id == "next.E021" for e in errors)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "from next import component\n\n@component.context\ndef data():\n    return {}\n",
+            "from next.components import context\n",
+            "from next import component\n\n@component.page.context\ndef data():\n    return {}\n",
+            "def loader():\n    return None\n\n@loader().context\ndef data():\n    return {}\n",
+        ],
+    )
+    def test_check_component_py_no_pages_context_allows_component_context(
+        self, source: str, tmp_path: Path, min_component_config: dict
+    ) -> None:
+        """The component context decorator stays clean under either spelling."""
+        (tmp_path / "component.py").write_text(source)
+        fake_backend = FileComponentsBackend(dict(min_component_config))
+
+        fake_backend._registry.register(
+            ComponentInfo("good", tmp_path, "", None, tmp_path / "component.py", False)
+        )
+        fake_backend._loaded = True
+
+        with patch_checks_components_manager(fake_backend):
+            errors = check_component_py_no_pages_context()
+        assert errors == []
 
     def test_component_context_on_imported_helper_is_e075(
         self, tmp_path: Path, min_component_config: dict

--- a/tests/components/test_context.py
+++ b/tests/components/test_context.py
@@ -13,11 +13,11 @@ from next.components import (
     ContextFunction,
     DummyBackend,
     FileComponentsBackend,
-    _inject_component_context,
     component,
     render_component,
 )
 from next.components.context import iter_serialized_component_context_keys
+from next.components.renderers import _inject_component_context
 from next.static import StaticCollector
 from tests.support import attribution, handler_declared_here
 

--- a/tests/components/test_manager.py
+++ b/tests/components/test_manager.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 from django.test import RequestFactory, override_settings
 
-import next.components as next_components_mod
 from next.components import (
     ComponentInfo,
     ComponentRenderer,
@@ -15,7 +14,6 @@ from next.components import (
     FileComponentsBackend,
     ModuleLoader,
     SimpleComponentRenderer,
-    _inject_component_context,
     components_manager,
     get_component,
     get_component_paths_for_watch,
@@ -23,6 +21,7 @@ from next.components import (
     register_components_folder_from_router_walk,
     render_component,
 )
+from next.components.renderers import _inject_component_context, _merge_csrf_context
 from next.conf import next_framework_settings
 from tests.support import (
     next_framework_settings_component_backends_list as _next_framework_settings_component_backends_list,
@@ -374,7 +373,7 @@ class TestComponentRenderers:
     def test_merge_csrf_context_no_op_without_request(self) -> None:
         """Early return when ``request`` is None (defensive API)."""
         ctx: dict[str, object] = {}
-        next_components_mod._merge_csrf_context(ctx, None)
+        _merge_csrf_context(ctx, None)
         assert "csrf_token" not in ctx
 
     def test_merge_csrf_context_skips_when_csrf_token_present(self) -> None:
@@ -382,7 +381,7 @@ class TestComponentRenderers:
         req = RequestFactory().get("/")
         existing = "__test_merge_csrf_existing__"
         ctx: dict[str, object] = {"csrf_token": existing}
-        next_components_mod._merge_csrf_context(ctx, req)
+        _merge_csrf_context(ctx, req)
         assert ctx["csrf_token"] == existing
 
     def test_render_with_template_returns_empty_when_no_template_string(

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,81 @@
+import pkgutil
+import subprocess
+import sys
+
+import pytest
+
+import next as next_dj
+from next import _LAZY_ATTRIBUTES
+from next.components import component
+from next.deps import Depends
+from next.forms import action
+from next.pages import context, page
+
+
+_CURATED = frozenset({"Depends", "action", "component", "context", "page"})
+
+
+class TestCuratedSurface:
+    """`next.__all__` is the curated top-level facade plus the version constant."""
+
+    def test_all_matches_curated_set(self) -> None:
+        assert frozenset(next_dj.__all__) == _CURATED | {"VERSION"}
+
+    def test_all_has_no_duplicates(self) -> None:
+        assert len(next_dj.__all__) == len(set(next_dj.__all__))
+
+    def test_lazy_map_covers_every_curated_name(self) -> None:
+        assert set(_LAZY_ATTRIBUTES) == _CURATED
+
+    @pytest.mark.parametrize("name", sorted(_CURATED))
+    def test_every_curated_name_resolves(self, name: str) -> None:
+        assert getattr(next_dj, name) is not None
+
+    def test_curated_names_are_the_subpackage_objects(self) -> None:
+        assert next_dj.page is page
+        assert next_dj.context is context
+        assert next_dj.component is component
+        assert next_dj.action is action
+        assert next_dj.Depends is Depends
+
+    def test_unknown_name_raises_attribute_error(self) -> None:
+        with pytest.raises(AttributeError, match="no attribute 'nonexistent'"):
+            next_dj.__getattr__("nonexistent")
+
+    def test_hasattr_contract_stays_honest(self) -> None:
+        assert hasattr(next_dj, "page")
+        assert not hasattr(next_dj, "nonexistent")
+
+    def test_lazy_names_do_not_shadow_subpackages(self) -> None:
+        subpackages = {info.name for info in pkgutil.iter_modules(next_dj.__path__)}
+        assert _CURATED & subpackages == frozenset()
+
+
+class TestDirContract:
+    """Module __dir__ lists the version constant and every curated name."""
+
+    def test_dir_matches_all(self) -> None:
+        assert set(next_dj.__dir__()) == set(next_dj.__all__)
+
+    def test_dir_is_sorted(self) -> None:
+        listed = next_dj.__dir__()
+        assert listed == sorted(listed)
+
+
+class TestImportStaysDjangoFree:
+    """Importing next must not drag Django into a fresh interpreter."""
+
+    def test_no_django_modules_after_import(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys\n"
+                "import next\n"
+                "print(len([m for m in sys.modules if m.startswith('django')]))",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert result.stdout.strip() == "0"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,3 +1,4 @@
+import importlib
 import pkgutil
 import subprocess
 import sys
@@ -52,14 +53,25 @@ class TestCuratedSurface:
 
 
 class TestDirContract:
-    """Module __dir__ lists the version constant and every curated name."""
+    """Module __dir__ lists the curated names on top of the live namespace."""
 
-    def test_dir_matches_all(self) -> None:
-        assert set(next_dj.__dir__()) == set(next_dj.__all__)
+    def test_dir_covers_all(self) -> None:
+        assert set(next_dj.__all__) <= set(next_dj.__dir__())
 
     def test_dir_is_sorted(self) -> None:
         listed = next_dj.__dir__()
         assert listed == sorted(listed)
+
+    def test_dir_has_no_duplicates(self) -> None:
+        listed = next_dj.__dir__()
+        assert len(listed) == len(set(listed))
+
+    def test_dir_lists_the_metadata_globals(self) -> None:
+        assert {"__title__", "__version__", "__author__"} <= set(next_dj.__dir__())
+
+    def test_dir_lists_an_imported_subpackage(self) -> None:
+        importlib.import_module("next.deps")
+        assert "deps" in next_dj.__dir__()
 
 
 class TestImportStaysDjangoFree:


### PR DESCRIPTION
## Description

`next/__init__.py` carried only the banner and the metadata, so writing a first page meant knowing the subpackage layout: `context` and `page` in `next.pages`, `component` in `next.components`, `action` in `next.forms`, `Depends` in `next.deps`. The package root now exports those five curated names directly, so `from next import page, context, component, action, Depends` is the short path and the subpackages stay the deep import for everything else.

Resolution goes through a PEP 562 `__getattr__` that loads each name from its owning subpackage on first attribute access, the same pattern `next/checks/__init__.py` has run in production for a long time. Laziness is the whole point: an eager top-level import would pull 168 Django modules into `import next` and break the contract that the package root is importable without `django.setup()`. A subprocess test guards it, since an in-process count is meaningless once `tests/conftest.py` has already called `django.setup()`. Measured on this branch: `import next` still loads zero Django modules, and the module costs about 135 µs to import, slightly less than before this PR because the facade deliberately skips `from __future__ import annotations` (no annotation in the file references the names behind `TYPE_CHECKING`, and importing `__future__` costs more than the rest of the module).

`next/__init__.py` also leaves the ruff `exclude` list, where it sat as an "annotation file" and would have kept the new code unlinted forever. A per-file ignore covers the four docstring rules the ASCII banner can never satisfy.

**BREAKING: `next.components` no longer re-exports `_inject_component_context`, `_merge_csrf_context`, `_render_template_string` and `next_framework_settings`.** The three underscore helpers were private render hooks and `next_framework_settings` is a symbol from `next.conf` that the package body never touches. `from next.components import <any of the four>` and `from next.components import *` stop resolving. The helpers stay reachable as `next.components.renderers`, the settings accessor as `next.conf`. Nothing in `next/` or `examples/` depended on the re-export, only tests, and they now import from the owning module. `docs/content/ref/components.rst` drops the `autofunction` entries that documented the helpers as public.

The curated set is exactly five names and stays that way on purpose. `partial`, `zone`, `render_zone`, `Form`, `ModelForm`, `FormWizard`, `Context`, `ContextResult`, `ComponentWidget`, `form_spec` and the providers are not promoted, so the root is an onboarding surface and not a mirror of the subpackages. Adding a name later is one line in `_LAZY_ATTRIBUTES`, one in `__all__` and one test case.

The four commits are independent and readable on their own: the facade with its tests, the `next.components` surface break with its docs and test updates, the `examples/` migration, and the documentation sync.

## How to test

`make ci` passes locally on this branch (lint, type-check, the full JS chain, `make test`, `make test-examples`, `make test-compat`), exit code 0, working tree clean afterwards.

Beyond the suite, the behaviour was checked by hand rather than only through tests:

- `from next import page, context, component, action, Depends` returns the same objects as the deep imports, verified with `is` comparisons.
- `import next` in a clean interpreter reports zero `django.*` modules in `sys.modules`. The guard test was proven to catch a regression: inserting an eager `from next.pages import page` makes it fail with 168 modules, removing it makes it pass again.
- mypy strict resolves real signatures through the facade, not `object`: `page` reveals as `next.pages.manager.Page`, `context` and `action` reveal their full overloads.
- `hatchling` still reads `__version__` out of `next/__init__.py`, the lazy facade does not interfere with the build-time version source.
- All four removed `next.components` names raise `ImportError` on import and `hasattr` returns `False`, while `next.components.renderers` still exposes the three helpers.
- Live rendering outside the test suite: the feature-flags example serves `/`, `/admin/`, `/admin/metrics/` and `/demo/` with 200 after the migration, so DI resolution of `Depends("flag_service")` works through the top-level import.
- `make docs` builds with `-W` and `doc8` reports zero errors across 147 files.
- `make bench` was run after the facade landed: 151 benchmarks pass with no regression, as expected since `__getattr__` fires only on explicit attribute access and no runtime path changed.

## Related issues

No linked issue. The work comes from the top-level API RFC of the core audit.

## Checklist

- [x] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [x] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable

## Notes for review

`docs/content/ref/index.rst` gains a new "Top-Level API" section inserted between the intro paragraph and the "Subsystems" rubric. The docs-honesty work touches the same file, so whichever of the two merges second should check that the two sections did not double up.

`docs/content/intro/tutorial03` through `tutorial06`, `howto/*` and `topics/*` deliberately keep the deep imports. Those chapters demonstrate one specific subpackage, so the deep import carries information there. The trade-off is that `notes/pages/page.py` appears with `from next import context` in tutorial02 and with `from next.pages import context` in tutorial04 and tutorial05, which a reader going through the series in order will notice. Say the word and the rest of the series follows in one pass.

`pyproject.toml` gains `next.Depends` in the bugbear `extend-immutable-calls` allowlist. The rule resolves B008 by the qualified import path, so `param = Depends("...")` in argument defaults started failing the moment the examples switched to the root import. The old `next.deps.Depends` entry stays, since tests and the rest of the documentation still use the deep import.

---

Full guidelines: [CONTRIBUTING.md](https://github.com/next-dj/next-dj/blob/main/CONTRIBUTING.md)
