### PR TITLE
refactor(core): shared backend loading for the settings-driven families

### DIFF
--- a/docs/content/contributing/index.rst
+++ b/docs/content/contributing/index.rst
@@ -7,7 +7,7 @@ This section covers documentation contributions.
 It explains how to write and structure new pages.
 
 Code contributions cover setup, testing, benchmarks, and the pull request process.
-Read `CONTRIBUTING.md <https://github.com/next-dj/next-dj/blob/main/CONTRIBUTING.md>`_ in the repository root for that workflow.
+Read :repo:`CONTRIBUTING.md <blob/main/CONTRIBUTING.md>` in the repository root for that workflow.
 
 For **internal framework conventions** (module layout, naming, signal and system-check rules) read :doc:`/content/internals/contributing-notes`.
 

--- a/docs/content/contributing/style-guide.rst
+++ b/docs/content/contributing/style-guide.rst
@@ -1,6 +1,6 @@
 .. _contributing-style-guide:
 
-Documentation Style Guide
+Documentation style guide
 =========================
 
 Every documentation page follows the rules on this page.
@@ -10,7 +10,7 @@ Reviewers cite this guide during pull request review.
    :local:
    :depth: 2
 
-Language and Tone
+Language and tone
 -----------------
 
 The documentation is written in English.
@@ -31,7 +31,7 @@ Forbidden in running prose.
 Allowed everywhere.
    These characters belong in code, paths, RST role syntax, headings, frontmatter, and inside list items that name two parallel items.
 
-ASCII Art and Pipes
+ASCII art and pipes
 -------------------
 
 ASCII art is forbidden in running prose.
@@ -62,10 +62,12 @@ Headings
 
 RST underlines use ``=``, ``-``, ``~``, ``^``.
 One H1 per file.
-Title Case for every heading.
+Sentence case for every heading.
+Capitalize the first word, proper nouns (Django, Python, Sphinx, Vite), and acronyms (URL, DI, CSRF).
+Code identifiers in headings keep their exact spelling.
 A heading never ends with punctuation.
 
-Code Blocks
+Code blocks
 -----------
 
 Use ``.. code-block:: <language>`` with an explicit language.
@@ -83,7 +85,7 @@ Forbidden inside code blocks meant to be runnable.
    ``...`` ellipses.
    Shell prompts (``$``, ``>>>``) except in transcript blocks.
 
-Cross References
+Cross references
 ----------------
 
 Use ``:doc:`` for whole page links.
@@ -94,7 +96,7 @@ Admonitions
 -----------
 
 Do not use ``.. versionadded::`` or ``.. versionchanged::`` in user-facing documentation.
-Release history belongs in the project changelog, not in the manual.
+Release history belongs in the release notes of each pull request, not in the manual.
 This matches the version policy in :doc:`writing-documentation`.
 
 Allowed types.
@@ -105,7 +107,7 @@ Allowed types.
 
 Each admonition holds one paragraph.
 
-Inline Code
+Inline code
 -----------
 
 Double back ticks for code, paths, configuration keys, and signal names.
@@ -116,13 +118,13 @@ Lists
 Each list item is a complete sentence ending in a period.
 Items in one list share grammar (all noun phrases, all verb phrases, all complete sentences).
 
-Page Templates
+Page templates
 --------------
 
 Read :doc:`writing-documentation` for the section specific templates.
 Templates apply consistently inside each section.
 
-Pull Request Checklist
+Pull request checklist
 ----------------------
 
 A documentation pull request lands when.
@@ -144,7 +146,7 @@ Running prose paragraphs avoid em dashes and semicolons, the same as RST prose.
 Semicolons do not join independent clauses in any context.
 Each independent clause begins a new sentence.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/contributing/writing-documentation.rst
+++ b/docs/content/contributing/writing-documentation.rst
@@ -1,6 +1,6 @@
 .. _contributing-writing-documentation:
 
-Writing Documentation
+Writing documentation
 =====================
 
 This page describes how to write new documentation pages for next.dj and how to review pull requests that touch the docs.
@@ -9,7 +9,7 @@ This page describes how to write new documentation pages for next.dj and how to 
    :local:
    :depth: 2
 
-Where Pages Live
+Where pages live
 ----------------
 
 The documentation tree lives under ``docs/content/``.
@@ -42,7 +42,7 @@ The layout follows the Django convention.
    * - ``contributing/``
      - Contribution workflow and writing guidance.
 
-Picking the Right Section
+Picking the right section
 -------------------------
 
 Use this decision tree when you are unsure where a new page belongs.
@@ -64,31 +64,31 @@ I am explaining how a subsystem works inside.
 
 If still in doubt, ask in a draft pull request.
 
-Page Templates
+Page templates
 --------------
 
 Each section uses a consistent template.
 
 Tutorial.
-   Goal, Prerequisites, Walkthrough, Checkpoint, Next Steps.
+   Goal, Prerequisites, Walkthrough, Checkpoint, Next steps.
 
 Topic.
-   Overview, Concepts, Usage, Common Patterns, See Also.
+   Overview, Concepts, Usage, Common patterns, See also.
    Starts with a leading paragraph and ``.. contents:: :local:``.
 
 How-To.
-   Problem, Solution, Walkthrough, Verification, See Also.
+   Problem, Solution, Walkthrough, Verification, See also.
    Aim for under 150 lines.
    Multi-part integrations (streaming, admin shell, cross-cutting security) may exceed that when splitting the flow would hurt verification steps.
 
 Reference.
-   Module Summary, Public API, Configuration, Signals, See Also.
+   Module summary, Public API, Configuration, Signals, See also.
    Body is generated through ``autodoc`` directives.
 
 Internals.
-   Overview, Pipeline (with a mermaid diagram), Implementation Notes, Extension Points, See Also.
+   Overview, Pipeline (with a mermaid diagram), Implementation notes, Extension points, See also.
 
-One Canonical Source Per Fact
+One canonical source per fact
 ------------------------------
 
 Each technical fact has one canonical home in the documentation tree.
@@ -103,13 +103,13 @@ Checklist for settings and system checks.
    This prevents the divergence where ``ref/`` and ``deployment/`` describe the same flag with different meanings.
    When you add or change a ``next.*.checks`` error or warning id, update the tables in ``ref/system-checks.rst`` in the same change.
 
-Version Numbers and Compatibility Notes
+Version numbers and compatibility notes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Do not mention the framework's current version number in user-facing pages.
 Do not include backward-compatibility notes, migration guidance, or phrases like "as of version X" or "this was changed in Y".
 The documentation describes how the framework works now.
-Historical context belongs in the changelog, not in the docs.
+Release history belongs in the release notes of each pull request, not in the manual.
 Do not use Sphinx ``.. versionadded::`` or ``.. versionchanged::`` directives in user-facing pages.
 They duplicate the same problem under a different syntax.
 
@@ -120,7 +120,7 @@ The *Requirements* section of :doc:`/content/intro/install` documents supported 
 On other pages link back with a short sentence such as "Use a supported Python and Django release (see :doc:`/content/intro/install`)" instead of copying the bullet list.
 Fragmented matrices drift out of sync with ``pyproject.toml`` and CI.
 
-Examples and Code Blocks
+Examples and code blocks
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Keep filenames aligned with the Notes tutorial unless the page names another sample project.
@@ -129,7 +129,7 @@ Paste runnable snippets when practical.
 
 Prefer adapting excerpts from ``examples/`` over speculative shortcuts.
 
-Style Rules
+Style rules
 -----------
 
 Read :doc:`style-guide` before writing.
@@ -153,13 +153,13 @@ A typical change goes through three steps.
 A green build is a hard precondition for merge.
 Local builds reveal anchor and cross reference issues quickly.
 
-System Checks
+System checks
 -------------
 
 Run ``uv run python manage.py check`` after every change that affects the API surface or the system checks.
 The output makes sure that no contributed check broke during development.
 
-Linting the Docs
+Linting the docs
 ----------------
 
 The project uses ``doc8`` for RST style.
@@ -171,13 +171,13 @@ The project uses ``doc8`` for RST style.
 
 The linter catches trailing whitespace, lines that exceed 200 characters, and inconsistent indentation.
 
-Translation Notes
+Translation notes
 -----------------
 
 The documentation is written in English.
 Translations are not part of the project at this time.
 
-Coverage Map
+Coverage map
 ------------
 
 When you change ``next/`` code, check whether the corresponding documentation needs updating.
@@ -245,7 +245,7 @@ Cross references
 
 Prefer absolute paths from the manual root (for example ``:doc:`/content/topics/pages```) in new prose so links remain valid if a page moves between toctrees.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/deployment/checklist.rst
+++ b/docs/content/deployment/checklist.rst
@@ -1,6 +1,6 @@
 .. _deployment-checklist:
 
-Deployment Checklist
+Deployment checklist
 ====================
 
 Use this checklist before pushing a next.dj project to production.
@@ -9,7 +9,7 @@ Use this checklist before pushing a next.dj project to production.
    :local:
    :depth: 2
 
-Django Settings
+Django settings
 ---------------
 
 - ``DEBUG`` is ``False``.
@@ -27,25 +27,25 @@ Run the standard :doc:`Django deployment check <django:howto/deployment/checklis
 
 Resolve every warning before deploying.
 
-next.dj Settings
+next.dj settings
 ----------------
 
 Tune ``NEXT_FRAMEWORK`` using :doc:`settings` (production-oriented commentary and patterns).
 Canonical semantics for each key live in :doc:`/content/ref/settings`.
 
-Wizard Drafts
+Wizard drafts
 -------------
 
 Review these when the project ships a ``FormWizard``.
 
 - The default ``SessionFormWizardBackend`` shares drafts wherever the session engine does, so confirm the session store is durable and shared across workers.
 - When using ``CacheFormWizardBackend``, point it at a cache shared across workers, not local memory, and set a short ``TIMEOUT`` for drafts, especially when a step collects personal data.
-- Use a signed or encrypted backend for sensitive flows, and re-check invariants in ``done``.
+- Use a signed or encrypted backend for sensitive flows.
 - Validate cross-step invariants in ``done`` so a stale draft value fails with a friendly message, not an integrity error.
 
 See :doc:`/content/topics/forms/wizard-backend` for the backend trade-offs.
 
-Static Files
+Static files
 ------------
 
 - Run ``uv run python manage.py collectstatic`` during the build.
@@ -79,7 +79,7 @@ Monitoring
 - Track ``router_reloaded`` if the project mounts a dynamic router.
 - Forward ``sse_stream_opened``, ``sse_stream_closed``, and ``zone_rendered`` when the project uses partial rendering.
 
-System Checks
+System checks
 -------------
 
 Run the framework system checks as part of CI and as part of the deployment script.
@@ -91,7 +91,7 @@ Run the framework system checks as part of CI and as part of the deployment scri
 
 A clean exit is required for the deployment to proceed.
 
-Smoke Tests
+Smoke tests
 -----------
 
 Hit at least three URLs after the deploy.
@@ -102,7 +102,7 @@ Hit at least three URLs after the deploy.
 
 The smoke tests confirm that the file router is mounted, the database is reachable, and the dispatcher resolves URLs.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/deployment/index.rst
+++ b/docs/content/deployment/index.rst
@@ -7,7 +7,7 @@ This section covers production deployment of a next.dj project.
 The pages assume an existing Django project that runs locally.
 They walk through the checklist, the static file pipeline, the server choice, and the recommended settings.
 
-.. rubric:: Preparing a Release
+.. rubric:: Preparing a release
 
 :doc:`checklist`
    Pre-flight checklist before shipping.
@@ -15,7 +15,7 @@ They walk through the checklist, the static file pipeline, the server choice, an
 :doc:`settings`
    Production-tuned values for ``NEXT_FRAMEWORK``.
 
-.. rubric:: Pipeline and Server
+.. rubric:: Pipeline and server
 
 :doc:`static-files`
    How ``collectstatic`` and the static pipeline behave in production.

--- a/docs/content/deployment/settings.rst
+++ b/docs/content/deployment/settings.rst
@@ -1,6 +1,6 @@
 .. _deployment-settings:
 
-Production Settings
+Production settings
 ===================
 
 This page lists recommended ``NEXT_FRAMEWORK`` values for production.
@@ -11,7 +11,7 @@ Each snippet below sets one key on an existing ``NEXT_FRAMEWORK`` dict.
 Declare ``NEXT_FRAMEWORK = {}`` once before the first override, or merge the keys into a single literal as shown under :ref:`combining-keys`.
 Keys left unset keep their framework default because the framework merges :doc:`/content/ref/settings` defaults under the user dict.
 
-Strict Context
+Strict context
 --------------
 
 .. code-block:: python
@@ -23,7 +23,7 @@ Strict Context
 Use ``STRICT_CONTEXT: True`` in production so a misconfigured context processor fails loudly.
 See :ref:`ref-settings` for behaviour and exception types.
 
-Eager Component Loading
+Eager component loading
 -----------------------
 
 .. code-block:: python
@@ -38,7 +38,7 @@ With the default ``False``, every ``component.py`` is imported during startup, s
 With ``True``, a ``component.py`` is imported on the first render that resolves the component rather than during startup.
 See :ref:`ref-settings` and :doc:`/content/topics/testing` for lazy behaviour and testing helpers.
 
-Static Backend
+Static backend
 --------------
 
 .. code-block:: python
@@ -51,7 +51,7 @@ Static Backend
 Point at a CDN aware backend in production.
 The default ``StaticFilesBackend`` is appropriate for single host deployments where the same process serves both HTML and static files.
 
-JS Context Serializer
+JS context serializer
 ---------------------
 
 .. code-block:: python
@@ -68,7 +68,7 @@ Set the serializer when context values include types beyond the standard JSON se
    Install it separately (``pip install pydantic``) before enabling this serializer.
    If ``pydantic`` is not installed, the first render that serializes context raises ``ImportError``.
 
-Page Backends With Context Processors
+Page backends with context processors
 -------------------------------------
 
 .. code-block:: python
@@ -87,7 +87,7 @@ Page Backends With Context Processors
 Use ``extend_default_backend`` to patch the default page backend entry with production context processors.
 The ``OPTIONS`` dict is merged, so the other default keys survive.
 
-Form Action Backend
+Form action backend
 -------------------
 
 .. code-block:: python
@@ -102,7 +102,7 @@ See :doc:`/content/howto/write-a-form-action-backend`.
 
 .. _combining-keys:
 
-Combining Keys
+Combining keys
 --------------
 
 When several recommendations apply at once, merge them into a single ``NEXT_FRAMEWORK`` literal.
@@ -134,13 +134,13 @@ When several recommendations apply at once, merge them into a single ``NEXT_FRAM
 Keep only the keys the deployment changes.
 The framework supplies the default for every key left out, so there is no need to duplicate the full default structures documented on :doc:`/content/ref/settings`.
 
-Runtime Script Overrides
+Runtime script overrides
 ------------------------
 
 Strict content security policies sometimes need nonces or manual ordering for the bundled ``next.min.js`` shell.
 ``NEXT_FRAMEWORK["NEXT_JS_OPTIONS"]`` accepts template overrides and ``ScriptInjectionPolicy`` values described on :ref:`ref-settings` and in :doc:`/content/topics/static-assets/js-context`.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/deployment/static-files.rst
+++ b/docs/content/deployment/static-files.rst
@@ -1,6 +1,6 @@
 .. _deployment-static-files:
 
-Static Files in Production
+Static files in production
 ==========================
 
 This page covers how to serve next.dj static assets in production.
@@ -18,7 +18,7 @@ The finder exposes every co-located asset to Django's :doc:`standard staticfiles
 ``NextFrameworkConfig.ready`` appends it to ``STATICFILES_FINDERS`` automatically, so no manual configuration is required.
 Production deployments use :doc:`collectstatic <django:ref/contrib/staticfiles>` exactly as they would for any other Django project.
 
-Verify the Finder
+Verify the finder
 ~~~~~~~~~~~~~~~~~
 
 To confirm the finder is active, run the command below with a path that matches a component the project actually ships.
@@ -30,7 +30,7 @@ To confirm the finder is active, run the command below with a path that matches 
 
 If the file is not found, check that ``next`` is in ``INSTALLED_APPS`` and that the component named in the path exists.
 
-Build Step
+Build step
 ----------
 
 Run ``collectstatic`` during the deployment build.
@@ -59,7 +59,7 @@ Stable hashes make long lived browser cache lifetimes safe.
 
 Configure the web server or the CDN to honour long ``Cache-Control`` headers on the static origin.
 
-Manifest Storage
+Manifest storage
 ----------------
 
 For projects that use Django ``ManifestStaticFilesStorage`` the framework cooperates without extra configuration.
@@ -98,7 +98,7 @@ Use a CDN aware backend to point asset URLs at a CDN host.
 
 Register the backend in ``STATIC_BACKENDS`` and configure the CDN to pull from the static origin.
 
-Pre Compressed Files
+Pre compressed files
 --------------------
 
 For Brotli or gzip support, generate the compressed files during the build.
@@ -112,19 +112,19 @@ For Brotli or gzip support, generate the compressed files during the build.
 The ``./staticfiles`` path stands for the directory configured as ``STATIC_ROOT``.
 Configure the web server or CDN to serve the pre compressed copies based on the ``Accept-Encoding`` header.
 
-Service Workers
+Service workers
 ---------------
 
 A service worker that caches assets must invalidate when the content hash changes.
 Read the rendered URL and key the cache on the full path, which already carries the content hash in the filename.
 
-System Checks
+System checks
 -------------
 
 Run ``uv run python manage.py check --deploy`` before shipping.
 The Django deployment checks cover ``STATIC_ROOT`` and ``STATIC_URL``, and the framework static checks validate that the static backend chain is well formed.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/deployment/wsgi-asgi.rst
+++ b/docs/content/deployment/wsgi-asgi.rst
@@ -9,7 +9,7 @@ This page covers the choice between WSGI and ASGI, the configuration each requir
    :local:
    :depth: 2
 
-Which to Choose
+Which to choose
 ---------------
 
 WSGI is the default and suits most projects.
@@ -25,7 +25,7 @@ ASGI is the right choice when the project uses any of these features.
 Both servers run the same next.dj pipeline.
 The difference lies in how Django dispatches the request.
 
-WSGI Configuration
+WSGI configuration
 ------------------
 
 A standard ``config/wsgi.py`` works without modification.
@@ -40,7 +40,7 @@ See Django's :doc:`WSGI deployment guide <django:howto/deployment/wsgi/index>`.
    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
    application = get_wsgi_application()
 
-A project that split its settings into a package defaults this to ``config.settings.prod`` for the deployed process.
+A project that split its settings into a package keeps the ``config.settings.dev`` default here and exports ``DJANGO_SETTINGS_MODULE=config.settings.prod`` for the deployed process.
 See :doc:`/content/howto/split-settings-per-environment`.
 
 Run with a production WSGI server such as ``gunicorn`` or ``uwsgi``.
@@ -53,7 +53,7 @@ Run with a production WSGI server such as ``gunicorn`` or ``uwsgi``.
 The example passes ``--workers 4``.
 Start from a heuristic such as ``(2 * num_cores) + 1`` and tune against the measured concurrency and request duration.
 
-ASGI Configuration
+ASGI configuration
 ------------------
 
 A standard ``config/asgi.py`` works without modification.
@@ -68,7 +68,7 @@ See Django's :doc:`ASGI deployment guide <django:howto/deployment/asgi/index>`.
    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
    application = get_asgi_application()
 
-A project that split its settings into a package defaults this to ``config.settings.prod`` for the deployed process.
+A project that split its settings into a package keeps the ``config.settings.dev`` default here and exports ``DJANGO_SETTINGS_MODULE=config.settings.prod`` for the deployed process.
 See :doc:`/content/howto/split-settings-per-environment`.
 
 Run with an ASGI server such as ``daphne`` or ``uvicorn``.
@@ -78,7 +78,7 @@ Run with an ASGI server such as ``daphne`` or ``uvicorn``.
 
    uv run uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --workers 4
 
-Worker Sizing
+Worker sizing
 -------------
 
 WSGI workers are blocking.
@@ -90,14 +90,14 @@ A single worker handles many concurrent SSE or websocket connections.
 A patch stream (see :doc:`/content/topics/partial-rendering/sse`) holds its connection open until the source ends or the client disconnects, which outlives any reasonable sync worker timeout.
 Serve those streams from ASGI workers rather than raising the WSGI worker timeout.
 
-Reverse Proxy
+Reverse proxy
 -------------
 
 Place a reverse proxy in front of either server for TLS termination and connection handling.
 The most common choice is ``nginx`` or ``caddy``.
 The next.dj pipeline does not require any special configuration on the proxy beyond standard Django requirements.
 
-Health Checks
+Health checks
 -------------
 
 Add a health check page that returns ``200`` quickly.
@@ -113,7 +113,7 @@ A pure ``render`` function avoids the layout chain and the static collector.
 
 Configure the load balancer or container orchestrator to hit ``/healthz/`` for liveness.
 
-Concurrency Notes
+Concurrency notes
 -----------------
 
 Form dispatch reuses the request scoped dependency cache so a re-render after validation failure is cheap.
@@ -123,7 +123,7 @@ The router manager and the components registry are process scoped.
 Hot reload through ``router_manager.reload`` updates the running worker.
 A multi worker deployment must trigger the reload from every worker or restart the process group.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/faq/general.rst
+++ b/docs/content/faq/general.rst
@@ -1,6 +1,6 @@
 .. _faq-general:
 
-General Questions
+General questions
 =================
 
 This page answers high-level questions about the project, its scope, and its lifecycle.
@@ -9,33 +9,32 @@ This page answers high-level questions about the project, its scope, and its lif
    :local:
    :depth: 2
 
-What Is next.dj and Is It a Django Replacement
+What is next.dj and is it a Django replacement
 ----------------------------------------------
 
 next.dj is a framework built on Django, not a replacement for it.
 It adds file-based routing, a layout system, reusable components, form dispatch, and partial rendering on top of a regular Django project.
 See :doc:`/content/intro/overview`, especially :ref:`intro-overview-django-unchanged`, for what stays stock Django versus what the framework adds.
 
-Which Django and Python Versions Are Supported
+Which Django and Python versions are supported
 ----------------------------------------------
 
 The :doc:`/content/intro/install` *Requirements* list names the tested Python and Django combinations.
 
-Is next.dj Production Ready
+Is next.dj production ready
 ---------------------------
 
-next.dj is used in production.
 Run ``manage.py check`` to confirm a deployment matches framework expectations, and pin a supported Python and Django release (see :doc:`/content/intro/install`).
 See :ref:`faq-safe-symbols` below for guidance on the public API surface.
 
-How Do I Follow the Project
+How do I follow the project
 ---------------------------
 
 Watch the repository on GitHub.
 Releases ship through PyPI under the distribution name ``next.dj``, imported as ``next`` (see :doc:`/content/intro/install`).
 Discussions and feature requests live on GitHub Discussions.
 
-How Is This Different From Plain Django Forms
+How is this different from plain Django forms
 ---------------------------------------------
 
 A next.dj form needs no URL entry and no view.
@@ -43,20 +42,20 @@ Subclassing ``next.forms.Form`` or ``next.forms.ModelForm`` registers it and att
 A failed submission re-renders the origin page with the entered values and field errors instead of an error page, so you write no re-render code (see :doc:`/content/topics/forms/validation-rerender`).
 A ``next.forms.FormWizard`` persists per-step data through a configured backend rather than hand-managed session keys (see :doc:`/content/topics/forms/wizard`).
 
-When To Use FormWizard Versus Rolling Your Own Session Logic
+When to use FormWizard versus rolling your own session logic
 ------------------------------------------------------------
 
 Use ``next.forms.FormWizard`` when a flow spans several steps that share a final commit, where you would otherwise stash partial data in the session and wire step routing, back-navigation, and conditional branching by hand.
 A single form, or two independent forms with no shared finalisation, does not need a wizard.
 
-What About Plugins
+What about plugins
 ------------------
 
 The project does not ship a plugin registry.
 The five extension mechanisms in :doc:`/content/topics/extending` cover the common cases.
 Distribute your customisations as ordinary Python packages.
 
-What About a CLI
+What about a CLI
 ----------------
 
 The framework does not add a new CLI.
@@ -64,7 +63,7 @@ Django's ``manage.py`` plus the framework system checks cover the operational su
 
 .. _faq-safe-symbols:
 
-Which Symbols Are Safe to Depend On
+Which symbols are safe to depend on
 -----------------------------------
 
 Two rules define the public surface.
@@ -73,7 +72,7 @@ Second, symbols whose names start with a single underscore are internal and may 
 The underscore rule is binding and overrides any incidental re-export.
 See :doc:`/content/ref/forms` for a concrete example of how the API tiers apply to ``next.forms``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/faq/index.rst
+++ b/docs/content/faq/index.rst
@@ -1,6 +1,6 @@
 .. _faq:
 
-Frequently Asked Questions
+Frequently asked questions
 ==========================
 
 The FAQ section answers common questions in three buckets.

--- a/docs/content/faq/troubleshooting.rst
+++ b/docs/content/faq/troubleshooting.rst
@@ -14,7 +14,7 @@ Run ``uv run python manage.py check --tag next`` to filter out the built-in Djan
 Pages
 -----
 
-Page Does Not Appear at the Expected URL
+Page does not appear at the expected URL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Confirm that the directory contains a ``page.py`` plus at least one body source, a ``render`` function, a ``template`` attribute, a ``template.djx``, or a sibling ``layout.djx``.
@@ -23,7 +23,7 @@ Confirm that the application is listed in ``INSTALLED_APPS`` and ``APP_DIRS=True
 Run ``uv run python manage.py check`` and resolve every warning.
 The command runs Django's :doc:`system check framework <django:ref/checks>` together with the next.dj checks.
 
-Page Renders Without Layout
+Page renders without layout
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A layout must contain the placeholder block ``{% block template %}{% endblock template %}`` or its short form ``{% block template %}{% endblock %}``.
@@ -32,35 +32,35 @@ Without the placeholder the framework skips that layout during composition, so i
 
 Confirm that ``layout.djx`` sits in the same directory as ``page.py`` or in an ancestor directory.
 
-next.W043 Warning
+next.W043 warning
 ~~~~~~~~~~~~~~~~~
 
 A page module declares more than one body source.
 Keep exactly one body source.
 The choices are a ``render`` function, a ``template`` module attribute, or a sibling ``template.djx`` file.
 
-``render`` Raised ``TypeError``
+``render`` raised ``TypeError``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``render`` must return ``str`` or a Django :class:`~django.http.HttpResponseBase` subclass.
 Other values raise ``TypeError`` naming the ``page.py`` path.
 See :doc:`/content/topics/pages`.
 
-next.E017 on a page.py That Fails to Import
+next.E017 on a page.py that fails to import
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A ``page.py`` raised while importing, so the framework loads it as nothing.
 Its ``render``, ``template``, and ``@context`` declarations never take effect, and a sibling ``template.djx`` can otherwise hide the failure.
 Fix the syntax or import error named in the report so the module loads.
 
-next.E018 on Multiple Keyless Context Functions
+next.E018 on multiple keyless context functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A ``page.py`` registers more than one keyless ``@context`` callable.
 Keyless callables share one slot, so only the last one runs and the earlier ones are ignored.
 Give each callable a key such as ``@context("name")``, or merge them into a single callable.
 
-next.E029 on a Keyless Context Function
+next.E029 on a keyless context function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A keyless context callable must be annotated as returning a dict.
@@ -74,7 +74,7 @@ Alternatively give the decorator a key, for example ``@context("name")``, which 
 Forms
 -----
 
-HTTP 400 From Form Submission
+HTTP 400 from form submission
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The dispatcher rejected the request because ``_next_form_origin`` is missing or does not resolve against the URLconf.
@@ -94,7 +94,7 @@ An authenticated user missing a ``Meta.permission_required`` permission gets ``P
 A dynamic permission hook, ``check_permissions`` or ``has_object_permission``, returning ``False`` or raising ``PermissionDenied`` produces the same bare 403, see :ref:`topics-forms-actions-dynamic-guards`.
 See :ref:`topics-forms-actions-guards`.
 
-Form POST Redirects to the Login Page
+Form POST redirects to the login page
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The action declares ``Meta.login_required`` or ``login_required=True`` on ``@action``, and the submission came from an anonymous session.
@@ -102,27 +102,27 @@ The dispatcher answers with a 302 to ``LOGIN_URL`` carrying ``next`` set to the 
 This is the declared behaviour, not an error.
 Sign in, or hide the form from anonymous visitors in the template, since the guard protects the mutation and not the markup.
 
-``MessageFailure`` on a Valid Submission
+``MessageFailure`` on a valid submission
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The form declares ``Meta.success_message`` but the messages framework is not fully installed.
 Add ``django.contrib.messages`` to ``INSTALLED_APPS`` and ``django.contrib.messages.middleware.MessageMiddleware`` to ``MIDDLEWARE``.
 The framework raises rather than dropping the requested message silently, and ``manage.py check`` reports the gap upfront as :ref:`next.W061 <ref-system-checks>`.
 
-next.E041 Collision
+next.E041 collision
 ~~~~~~~~~~~~~~~~~~~
 
 Two actions are registered under the same name by different handlers.
 Rename one of them or move one to a different scope to avoid the collision.
 
-Unknown Form Action
+Unknown form action
 ~~~~~~~~~~~~~~~~~~~
 
 ``{% form "name" %}``, ``{% action_url "name" %}``, ``NextClient.post_action``, ``resolve_action_url``, and ``build_form_for`` raise ``next.forms.FormActionNotFoundError`` when no registered action matches the name.
 The message ends with ``Closest matches: ...`` listing the nearest registered names, so a typo is usually visible in the error itself.
 Check the name against the suggestions, confirm the declaring module was imported before the lookup, and remember that a page-scoped action resolves only from its own page.
 
-Wizard Draft Disappears Between Steps
+Wizard draft disappears between steps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The default ``SessionFormWizardBackend`` stores drafts in the session, so a lost draft means the session itself did not survive.
@@ -131,7 +131,7 @@ Confirm that ``django.contrib.sessions`` is in ``INSTALLED_APPS`` and ``SessionM
 With ``CacheFormWizardBackend`` the usual cause is a local-memory cache under a multi-worker server, where each worker holds its own copy of the draft.
 Point that backend at a shared cache such as Redis, and check that its ``TIMEOUT`` does not expire mid-flow.
 
-``ImproperlyConfigured`` From a Wizard Step Save
+``ImproperlyConfigured`` from a wizard step save
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Both bundled wizard backends raise ``ImproperlyConfigured`` when a step is saved on a request without session support, see the previous entry.
@@ -142,19 +142,19 @@ See :doc:`/content/topics/forms/wizard-backend` for the codec rules.
 Components
 ----------
 
-next.E020 or next.E034 Collision
+next.E020 or next.E034 collision
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Two components share the same name in the same scope.
 Rename one or move one to a different page tree.
 
-Component Does Not Render
+Component does not render
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Confirm that ``COMPONENTS_DIR`` is set on ``COMPONENT_BACKENDS``.
 Confirm that the component folder name matches the string argument to ``{% component %}``.
 
-Component Prop Does Not Resolve
+Component prop does not resolve
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``{% component "card" title=some_var %}`` resolves ``some_var`` from the parent template context.
@@ -164,40 +164,40 @@ Pick the form that matches the value you want to pass.
 Static
 ------
 
-CSS or JS Not Loaded
+CSS or JS not loaded
 ~~~~~~~~~~~~~~~~~~~~
 
 Confirm that ``{% collect_styles %}`` sits in the layout ``<head>`` and ``{% collect_scripts %}`` sits at the bottom of ``<body>``.
 Confirm that the asset filename matches a registered stem and a registered kind.
 
-Hashed URL Does Not Change
+Hashed URL does not change
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Restart the development server.
-The watcher picks up file content changes but a URL memoised at startup can go stale during long sessions.
+Hashed URLs come from the staticfiles manifest, so re-run ``collectstatic`` after the file content changes.
+The backend memoises each resolved asset URL for the life of the process, so restart the development server to pick up the new hash.
 
-next.W030 Empty Static Backends
+next.W030 empty static backends
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``manage.py check`` warns when ``STATIC_BACKENDS`` is empty.
 The framework falls back to the bundled ``StaticFilesBackend``, but you should either restore an explicit backend entry or accept that no custom chain is configured.
 
-next.E038 Duplicate BACKEND Entries
+next.E038 duplicate BACKEND entries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Two identical ``BACKEND`` dotted paths appear in ``STATIC_BACKENDS``.
 Remove or rename one entry so each backend class appears once.
 
-next.W042 Unusable JS_CONTEXT_SERIALIZER
+next.W042 unusable JS_CONTEXT_SERIALIZER
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``JS_CONTEXT_SERIALIZER`` is set but does not resolve to a class that implements the ``JsContextSerializer`` protocol (a ``dumps`` method).
 Fix the dotted path or install optional dependencies such as ``pydantic`` when using ``PydanticJsContextSerializer``.
 
-Partial Rendering
+Partial rendering
 -----------------
 
-Zone GET Returns HTTP 400
+Zone GET returns HTTP 400
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A response body of ``unknown zone`` means the requested name matches no ``{% zone %}`` in the composed page.
@@ -205,34 +205,34 @@ Check that ``data-next-target`` names the same string as the zone tag on the pag
 A response body of ``zone in dynamic body`` means the page body comes from a ``render`` function returning a string, so there is no compiled template source to render the slice standalone.
 Move the zone to a page whose body comes from a template source.
 
-Zone GET Returns HTTP 409
+Zone GET returns HTTP 409
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The client asserted an asset version that no longer matches the server's, which usually happens right after a deploy.
 The empty-bodied 409 tells the runtime to perform a full visit of the current URL, so the page reloads once with fresh assets.
 No action is needed beyond the reload the runtime already performs.
 
-Inline Script in a Patch Does Not Run
+Inline script in a patch does not run
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The applier strips every ``<script>`` element from patch HTML before the markup reaches the document.
 With the runtime's dev mode on, that is with Django ``DEBUG``, the runtime prints a ``console.warn`` for each neutralised script, so the removal is visible rather than silent.
 Move the behaviour into a co-located module, see :doc:`/content/topics/partial-rendering/co-located-js`.
 
-next.W071 Extra PARTIAL_BACKENDS Entries
+next.W071 extra PARTIAL_BACKENDS entries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``PARTIAL_BACKENDS`` lists more than one entry.
 Partial rendering activates only the first entry and ignores the rest, so remove the extra entries or merge their options into one.
 
-next.E067 PARTIAL_BACKENDS Is Not a List
+next.E067 PARTIAL_BACKENDS is not a list
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``PARTIAL_BACKENDS`` holds a tuple, a bare dict, or a dotted path rather than a list of config dicts.
 The framework merges the key only from a list, so the configured backend never loads and the default protocol backend serialises the wire format instead.
 Wrap the entry in a list.
 
-Dependency Injection
+Dependency injection
 --------------------
 
 DependencyCycleError
@@ -242,7 +242,7 @@ The resolver raises ``DependencyCycleError`` when two providers depend on each o
 Read the chain printed on the exception, remove one ``Depends`` edge, or merge providers.
 See :doc:`/content/topics/dependency-injection` for request-cache interactions during form re-renders.
 
-DI Parameter Resolves to None
+DI parameter resolves to None
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Three common causes explain this.
@@ -251,8 +251,7 @@ Three common causes explain this.
   Drop that import in ``page.py``, the ``page.py`` modules that declare inherited context, ``component.py``, and provider modules if markers stop resolving.
 
 - No registered provider covers the marker type.
-  The resolver leaves the parameter unset.
-  Depending on the callable signature this surfaces as ``None`` or a normal Python ``TypeError``.
+  The resolver passes ``None``, or the declared default when one exists, so the callable receives the parameter and fails only when its body cannot handle ``None``.
 
 - The callable asks for data that is not in the request-scoped cache yet (for example the wrong phase of a form re-render).
   Compare your scenario with the lifecycle discussion in :doc:`/content/topics/dependency-injection`.
@@ -275,13 +274,13 @@ Import the real ``fetch_note`` directly when the page module sits at an importab
 ``resolve_call`` returns the kwargs dict the resolver would pass to the callable.
 Use ``make_resolution_context`` when you need finer control over the request, form, URL kwargs, or context data supplied to the resolver.
 
-Custom Marker Not Handled
+Custom marker not handled
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Confirm that the provider class is imported during ``AppConfig.ready``.
 ``RegisteredParameterProvider`` registers at class creation, so the import must happen before the resolver caches the provider list.
 
-Testing With Custom Providers
+Testing with custom providers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``reset_registries()`` resets the form-action and component backends.
@@ -290,6 +289,8 @@ To swap a provider for the duration of a test, use ``override_provider`` from ``
 The context manager prepends the provider to the resolver list on entry and removes it on exit.
 
 .. code-block:: python
+
+   from django.test import TestCase
 
    from next.testing import override_provider
    from myapp.providers import TenantProvider
@@ -302,25 +303,25 @@ The context manager prepends the provider to the resolver list on entry and remo
 
 See :doc:`/content/howto/test-a-component-in-isolation` for the full isolation-test setup.
 
-URL Resolution
+URL resolution
 --------------
 
-Virtual Routes and Bracket Directories
+Virtual routes and bracket directories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A plain directory that contains only a ``template.djx`` and no ``page.py`` is a virtual route.
 The router still maps it to a URL.
 
-Captured-parameter directories (names in brackets) must contain ``page.py``, ``layout.djx``, ``template.djx``, or a child directory whose subtree includes ``page.py``.
+Captured-parameter directories (names in brackets) must contain ``page.py``, ``layout.djx``, ``template.djx``, or a direct child directory that contains ``page.py``.
 Otherwise ``manage.py check`` reports :ref:`next.E010 <ref-system-checks>`.
 
-URL Name Not Found
+URL name not found
 ~~~~~~~~~~~~~~~~~~
 
 Run ``uv run python manage.py shell`` and print ``reverse("next:page_<name>")``.
 If it raises ``NoReverseMatch``, verify that the directory contains at least one of ``page.py``, ``template.djx``, or a child page, and that it sits under an active ``PAGES_DIR`` root configured in ``PAGE_BACKENDS``.
 
-Captured Parameter Name Differs From Directory Name
+Captured parameter name differs from directory name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The router normalises hyphens in directory names to underscores.
@@ -328,37 +329,38 @@ A directory named ``[my-id]`` produces the parameter ``my_id``, not ``my-id``.
 Access it as ``DUrl[str]`` annotated ``my_id`` in your context function.
 Rename the directory to ``[my_id]`` to avoid confusion.
 
-Two Pages Collide Under the Same URL Pattern
+Two pages collide under the same URL pattern
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The system check :ref:`next.E015 <ref-system-checks>` reports when the same Django URL pattern is produced from multiple sources.
 This happens when two backends each walk a directory that maps to the same logical path.
 Verify that ``DIRS`` and ``APP_DIRS`` in your page backends do not overlap.
 
-Routes Do Not Refresh
+Routes do not refresh
 ~~~~~~~~~~~~~~~~~~~~~
 
 The bundled ``FileRouterBackend`` refreshes automatically when the dev server detects a filesystem change.
 The manual ``router_manager.reload()`` call is only for a custom backend that reads routes from a non-filesystem source such as a database.
 See :doc:`/content/howto/reload-routes-from-code`.
 
-Template Tags Look Undefined
+Template tags look undefined
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The framework registers ``{% form %}``, ``{% component %}``, ``{% collect_styles %}``, and related tags as Django builtins during ``AppConfig.ready``.
 You normally **do not** ``{% load %}`` the ``next.templatetags.*`` libraries.
 If the template engine reports ``Invalid block tag`` on one of these names, confirm ``next.apps.NextFrameworkConfig`` is listed in ``INSTALLED_APPS`` and run ``manage.py check`` before chasing import paths.
 
-``template.djx`` Edits and Hot Reload
+``template.djx`` edits and hot reload
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The dev watcher restarts the process when Python entrypoints such as ``page.py`` change.
-Editing only ``template.djx`` or other DJX files refreshes rendered output without a full restart, but long sessions occasionally benefit from a manual server bounce if templates look stale.
+Editing only ``template.djx`` or other DJX files refreshes rendered output without a full restart.
+The composed template cache is invalidated by file mtime.
 
-Settings Behaviour
+Settings behaviour
 ------------------
 
-STRICT_CONTEXT Causes Unexpected Exceptions
+STRICT_CONTEXT causes unexpected exceptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When ``STRICT_CONTEXT = True`` in ``NEXT_FRAMEWORK``, any context processor that raises ``TypeError``, ``ValueError``, ``AttributeError``, or ``KeyError`` re-raises the exception instead of logging a warning and continuing.
@@ -366,7 +368,7 @@ This is recommended in production to surface misconfigured processors immediatel
 To debug, disable ``STRICT_CONTEXT`` temporarily and read the logged warning to identify the offending processor.
 See :ref:`ref-settings` for the full description of this key.
 
-Components Are Not Available at Startup
+Components are not available at startup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default ``LAZY_COMPONENT_MODULES = False``, which means ``component.py`` modules under configured component roots are imported during ``AppConfig.ready``.
@@ -375,13 +377,13 @@ Set ``LAZY_COMPONENT_MODULES = True`` in ``NEXT_FRAMEWORK`` to defer imports for
 Components beside page routes may still load earlier when URL patterns are constructed.
 This hides some startup errors but surfaces them when the failing component or route branch is first touched.
 
-System Checks
+System checks
 -------------
 
 ``uv run python manage.py check`` runs every framework check and prints each one that fired with its code and a hint.
 The check codes referenced above are defined in full in :doc:`/content/ref/system-checks`.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/faq/troubleshooting.rst
+++ b/docs/content/faq/troubleshooting.rst
@@ -225,6 +225,13 @@ next.W071 Extra PARTIAL_BACKENDS Entries
 ``PARTIAL_BACKENDS`` lists more than one entry.
 Partial rendering activates only the first entry and ignores the rest, so remove the extra entries or merge their options into one.
 
+next.E067 PARTIAL_BACKENDS Is Not a List
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``PARTIAL_BACKENDS`` holds a tuple, a bare dict, or a dotted path rather than a list of config dicts.
+The framework merges the key only from a list, so the configured backend never loads and the default protocol backend serialises the wire format instead.
+Wrap the entry in a list.
+
 Dependency Injection
 --------------------
 

--- a/docs/content/faq/usage.rst
+++ b/docs/content/faq/usage.rst
@@ -1,6 +1,6 @@
 .. _faq-usage:
 
-Usage Questions
+Usage questions
 ===============
 
 This page answers questions that come up while building a project with next.dj.
@@ -9,90 +9,90 @@ This page answers questions that come up while building a project with next.dj.
    :local:
    :depth: 2
 
-How Do I Add a Page
+How do I add a page
 -------------------
 
 Create a directory under the page root and add a ``page.py`` plus a ``template.djx`` inside it.
 See :doc:`/content/howto/add-a-page` for a recipe.
 
-How Do I Pass Data to the Template
+How do I pass data to the template
 ----------------------------------
 
 Use ``@context("key")`` inside ``page.py`` to publish a value.
 The template renders the value as ``{{ key }}``.
 See :doc:`/content/topics/context`.
 
-How Do I Share Data Across Pages
+How do I share data across pages
 --------------------------------
 
 Declare the context in a ``page.py`` that sits in a directory above the consuming page, and pass ``inherit_context=True`` to the decorator.
 See :doc:`/content/howto/share-context-across-pages`.
 
-How Do I Capture URL Parameters
+How do I capture URL parameters
 -------------------------------
 
 Name the directory ``[param]`` for a string or ``[type:param]`` for a typed value.
 Inside the page module annotate the parameter with ``DUrl[T]``.
 See :doc:`/content/topics/file-router`.
 
-How Do I Render a Form
+How do I render a form
 ----------------------
 
 Subclass ``next.forms.Form`` or ``next.forms.ModelForm`` and render the form with ``{% form "name" %}``.
 The action name is derived automatically from the class name in ``snake_case``.
 See :doc:`/content/intro/tutorial04`.
 
-How Do I Update Part of a Page Without a Reload
+How do I update part of a page without a reload
 -----------------------------------------------
 
 Wrap the slice in ``{% zone "name" %}`` and point a form or a link at it with ``data-next-target="name"``.
 The server re-renders only that zone and the client runtime swaps it in place.
 See :doc:`/content/intro/tutorial06` for the walkthrough and :doc:`/content/topics/partial-rendering/index` for the full model.
 
-How Do I Customise the Static Output
+How do I customise the static output
 ------------------------------------
 
 Subclass a static backend, register its dotted path in ``STATIC_BACKENDS``, and override how tags or asset URLs are produced.
 See :doc:`/content/howto/write-a-static-backend`.
 
-How Do I Test a Page
+How do I test a page
 --------------------
 
-Use ``NextClient`` from ``next.testing.client``.
+Use ``NextClient`` from ``next.testing``.
 See :doc:`/content/topics/testing`.
 
-How Do I Run the Development Server
+How do I run the development server
 -----------------------------------
 
 Run ``uv run python manage.py runserver``.
 The autoreloader picks up new and changed page directories without a restart.
 
-How Do I Deploy in Production
+How do I deploy in production
 -----------------------------
 
 Serve the project through a WSGI or ASGI server and collect static files the same way as any Django project.
 See :doc:`/content/deployment/index` for the framework-specific checklist.
 
-How Do I Integrate Django Admin
+How do I integrate Django admin
 -------------------------------
 
 Mount ``admin.site.urls`` above ``include("next.urls")`` in ``config/urls.py``.
 See :doc:`/content/howto/integrate-django-admin`.
 
-How Do I Split Routes Across Applications
+How do I split routes across applications
 -----------------------------------------
 
 Use ``APP_DIRS=True`` so every application contributes its own page tree.
 Use ``DIRS`` to add project level page roots.
 See :doc:`/content/topics/file-router`.
 
-How Do I Share Components Across Projects
+How do I share components across projects
 -----------------------------------------
 
 Place the shared components in one folder and reference it through ``COMPONENT_BACKENDS["DIRS"]``.
 See :doc:`/content/howto/share-components-across-projects`.
 
-How Do I Add Context Processors to Pages
+How do I add context processors to pages
 ----------------------------------------
 
 Add a ``context_processors`` list to the ``OPTIONS`` dict of the relevant page backend entry.
@@ -100,7 +100,7 @@ The list merges with the processors from the first ``TEMPLATES`` entry in Django
 Duplicates are dropped.
 See :doc:`/content/topics/context` for the merge order and a full settings example.
 
-How Do I Keep Query Parameters After a Form Action Redirect
+How do I keep query parameters after a form action redirect
 -----------------------------------------------------------
 
 Build the redirect URL from the form's ``cleaned_data`` inside the action handler.
@@ -128,7 +128,7 @@ Use ``{% form "search_form" %}`` in the template.
 For filter forms with no side effects, use ``<form method="get">`` directly and skip the form action altogether.
 The ``DQuery`` marker then reads every filter from the query string on the GET request without a round-trip through the action endpoint.
 
-Can a Form Action Return a Custom HTTP Status Code
+Can a form action return a custom HTTP status code
 --------------------------------------------------
 
 Return any ``HttpResponseBase`` subclass.
@@ -151,7 +151,7 @@ Return any ``HttpResponseBase`` subclass.
 
 Common choices are ``HttpResponse(status=204)`` for no-content responses, ``HttpResponse(status=201)`` for created resources, and ``HttpResponseRedirect(url, status=303)`` for POST-redirect-GET flows.
 
-How Do I Translate URLs or Templates
+How do I translate URLs or templates
 ------------------------------------
 
 Internationalisation stays on Django's stack.
@@ -161,7 +161,7 @@ next.dj does not ship a separate translation mechanism for ``page.py`` files bey
 
 See Django's :doc:`translation overview <django:topics/i18n/index>`.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/add-a-custom-stem.rst
+++ b/docs/content/howto/add-a-custom-stem.rst
@@ -1,6 +1,6 @@
 .. _howto-custom-stem:
 
-Add a Custom Stem
+Add a custom stem
 =================
 
 Problem
@@ -45,7 +45,7 @@ Ship a file with the new stem.
 
 Discovery now records ``page.css`` as a ``css`` asset owned by the page, because ``page`` is a registered stem under the ``template`` role and ``.css`` is the extension of the ``css`` kind.
 
-Stem and Kind Pairing
+Stem and kind pairing
 ~~~~~~~~~~~~~~~~~~~~~
 
 A new stem participates in every registered kind.
@@ -68,7 +68,7 @@ The finder maps a template-directory asset to ``next/<logical_name><suffix>``.
 The logical name is the template directory relative to its page root, and a root template has the logical name ``index``.
 The stem does not appear in the static path, so ``page.css`` next to the root ``template.djx`` resolves under ``next/index.css``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/add-a-custom-template-loader.rst
+++ b/docs/content/howto/add-a-custom-template-loader.rst
@@ -1,6 +1,6 @@
 .. _howto-custom-template-loader:
 
-Add a Custom Template Loader
+Add a custom template loader
 ============================
 
 Problem
@@ -68,7 +68,7 @@ Run ``uv run python manage.py check`` to validate import paths and loader subcla
 
 Request the page in the browser or through ``NextClient`` and confirm the Markdown body renders through your layout chain.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/add-a-new-asset-kind.rst
+++ b/docs/content/howto/add-a-new-asset-kind.rst
@@ -1,6 +1,6 @@
 .. _howto-asset-kind:
 
-Add a New Asset Kind
+Add a new asset kind
 ====================
 
 Problem
@@ -47,13 +47,13 @@ Ship the file.
 
 Discovery picks up ``component.jsx`` because ``component`` is a registered stem and ``.jsx`` is now a registered extension.
 
-Emit the Asset
+Emit the asset
 ~~~~~~~~~~~~~~
 
 The kind sits in the ``scripts`` slot, so ``{% collect_scripts %}`` in the layout emits the tag.
 No template change is needed.
 
-Custom Renderer
+Custom renderer
 ~~~~~~~~~~~~~~~
 
 When the new kind needs a tag shape that the bundled methods do not produce, add a renderer method on a custom backend.
@@ -103,7 +103,7 @@ A script tag points at the JSX file.
 Run ``uv run python manage.py check``.
 The walkthrough registration reports no warnings, and the custom-renderer variant reports ``next.W074`` for the ``jsx`` kind.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/add-a-page.rst
+++ b/docs/content/howto/add-a-page.rst
@@ -1,6 +1,6 @@
 .. _howto-add-a-page:
 
-Add a Page
+Add a page
 ==========
 
 Problem
@@ -74,7 +74,7 @@ Run system checks.
 The output reports no errors.
 Adding a second body source to the same directory reports the ``next.W043`` warning.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/build-a-composite-component.rst
+++ b/docs/content/howto/build-a-composite-component.rst
@@ -1,6 +1,6 @@
 .. _howto-composite-component:
 
-Build a Composite Component
+Build a composite component
 ===========================
 
 Problem
@@ -56,7 +56,7 @@ The function reads its own ``subtitle`` prop through dependency injection and re
    }
    .info-card__head { margin-bottom: 0.5rem; }
 
-Use the Component
+Use the component
 ~~~~~~~~~~~~~~~~~
 
 Call the component in block form and fill the slot.
@@ -78,7 +78,7 @@ Verification
 Open the page and confirm the card renders with the slot content.
 View the HTML source and confirm a ``<link>`` to ``info_card/component.css`` appears in ``<head>``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/build-a-custom-asset-backend.rst
+++ b/docs/content/howto/build-a-custom-asset-backend.rst
@@ -1,6 +1,6 @@
 .. _howto-build-a-custom-asset-backend:
 
-Resolve Asset URLs Through a Custom Backend
+Resolve asset URLs through a custom backend
 ===========================================
 
 Pick this page when the asset URL must come from an external source such as a Vite manifest.
@@ -83,6 +83,7 @@ Read the Vite manifest
 A production build writes hashed filenames into ``dist/.vite/manifest.json``.
 The backend reads that file once, caches it, and looks up the built output.
 A missing manifest logs one warning and falls back to staticfiles so the dev workflow stays unblocked.
+Add these methods to ``ViteManifestBackend``.
 
 .. code-block:: python
    :caption: kanban/backends.py
@@ -126,7 +127,7 @@ A missing manifest logs one warning and falls back to staticfiles so the dev wor
 ``_manifest_key`` builds the lookup key relative to ``VITE_ROOT`` and falls back to the bare filename.
 URL resolution delegates to ``staticfiles_storage`` so manifest storage, S3 storage, and CDN settings still apply to the hashed output.
 
-Register the Kind
+Register the kind
 ~~~~~~~~~~~~~~~~~
 
 Register the ``jsx`` kind in ``AppConfig.ready``.
@@ -158,7 +159,7 @@ The ``scripts`` slot means ``{% collect_scripts %}`` in the layout emits the tag
 The manager looks the renderer up on the active backend with ``getattr`` per asset.
 A subclass that needs a tag shape the bundled methods do not produce can add its own renderer method and name it here.
 
-Register the Backend
+Register the backend
 ~~~~~~~~~~~~~~~~~~~~
 
 List the subclass in ``STATIC_BACKENDS``.
@@ -182,7 +183,7 @@ Every key under ``OPTIONS`` reaches the backend through the ``config`` property.
        ],
    }
 
-Ship the Asset
+Ship the asset
 ~~~~~~~~~~~~~~
 
 Drop a ``component.jsx`` file next to the ``component.py`` it belongs to.
@@ -227,7 +228,7 @@ In production, add an explicit entry.
        },
    }
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/build-a-multi-step-wizard.rst
+++ b/docs/content/howto/build-a-multi-step-wizard.rst
@@ -1,6 +1,6 @@
 .. _howto-multi-step-wizard:
 
-Build a Multi-Step Wizard
+Build a multi-step wizard
 =========================
 
 Problem
@@ -18,7 +18,7 @@ Implement ``done`` to create the row from the merged cleaned data.
 Walkthrough
 -----------
 
-Declare the Steps and Wizard
+Declare the steps and wizard
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Each data step is an ordinary ``ModelForm`` over the target model, and the final step only confirms the merged request.
@@ -68,13 +68,13 @@ Every step form subclasses ``django.forms`` directly because a step is not a sta
 A step built on a ``next.forms`` base would register as its own form action, whose default ``on_valid`` saves a partial row outside the wizard flow, unless it sets ``Meta.abstract = True``.
 :doc:`/content/topics/forms/wizard` covers the registration, scope, and ``Meta.steps`` semantics in depth.
 
-Route Through the Step Segment
+Route through the step segment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The page directory is ``request/[step]/``, so the route captures a ``step`` kwarg that the wizard reads to pick the current step and swaps when it advances.
 See :doc:`/content/topics/forms/wizard` for the routing and back-navigation rules.
 
-Render the Wizard
+Render the wizard
 ~~~~~~~~~~~~~~~~~~
 
 The ``{% form %}`` tag publishes ``form`` for the current step and ``wizard`` for navigation.
@@ -93,7 +93,7 @@ A valid step saves its draft and advances, the final step calls ``done``, and an
 Per-step drafts persist through the configured wizard backend (see :doc:`/content/topics/forms/wizard-backend`).
 A back link or a progress indicator builds on ``wizard.goto`` and ``wizard.step_names``, see the wizard template API in :doc:`/content/topics/forms/wizard`.
 
-Finalise the Wizard
+Finalise the wizard
 ~~~~~~~~~~~~~~~~~~~~
 
 ``done`` receives the merged cleaned data of every step, so for ModelForm steps over one model the dict maps straight onto the constructor.
@@ -133,7 +133,7 @@ The dispatcher resolves it against the URLconf, the ``[step]`` segment yields th
 Each ``post_step`` targets one step through its ``origin`` path.
 The final step's submission triggers ``done`` and the row appears.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/customize-error-pages.rst
+++ b/docs/content/howto/customize-error-pages.rst
@@ -1,6 +1,6 @@
 .. _howto-customize-error-pages:
 
-Customize 404 and 500 Pages
+Customize 404 and 500 pages
 ===========================
 
 Problem
@@ -20,7 +20,7 @@ The file router include stays unchanged.
 Walkthrough
 -----------
 
-Turn Off Debug
+Turn off debug
 ~~~~~~~~~~~~~~
 
 Custom error pages render only when ``DEBUG`` is off.
@@ -33,7 +33,7 @@ With ``DEBUG`` on, Django shows its own traceback page instead.
 
    ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
 
-Add the Error Templates
+Add the error templates
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Django looks for ``404.html`` and ``500.html`` at the root of a configured template directory.
@@ -76,7 +76,7 @@ A ``500.html`` template renders with an empty context because the failure may ha
      </body>
    </html>
 
-Point the Handlers at a View
+Point the handlers at a view
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For full control, name a :doc:`custom error handler <django:topics/http/views>` in the root URLconf.
@@ -110,7 +110,7 @@ A ``handler500`` view receives only the request.
        """Render the branded 500 page."""
        return render(request, "500.html", status=500)
 
-Raise Http404 From a Page
+Raise http404 from a page
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A ``render`` function or a ``@context`` callable can raise :exc:`~django.http.Http404` when a record is missing.
@@ -144,7 +144,7 @@ Run the server with ``DEBUG`` off and request a route that does not exist.
 Visiting an unknown path returns the branded ``404`` page with status ``404``.
 A view that raises an unhandled exception returns the branded ``500`` page with status ``500``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/drive-form-actions-with-htmx.rst
+++ b/docs/content/howto/drive-form-actions-with-htmx.rst
@@ -1,6 +1,6 @@
 .. _howto-htmx:
 
-Drive Form Actions With htmx
+Drive form actions with htmx
 ============================
 
 Problem
@@ -22,7 +22,7 @@ The dispatcher answers an invalid submission with the complete origin page, not 
 Walkthrough
 -----------
 
-Boost the Form
+Boost the form
 ~~~~~~~~~~~~~~
 
 A boosted form submits to its own ``action`` attribute over AJAX, and the tag has already pointed ``action`` at the dispatch endpoint.
@@ -47,7 +47,7 @@ Invalid submission.
 Valid submission.
    The handler answers with a redirect, the request machinery follows it before htmx sees the response, and the selected fragment of the destination page lands in the target.
 
-Post Explicitly With ``{% action_url %}``
+Post explicitly with ``{% action_url %}``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``{% action_url %}`` tag returns the dispatch endpoint for an action name, resolved with the same page scoping as ``{% form %}``.
@@ -68,7 +68,7 @@ htmx serialises the form on submit, so the hidden ``csrfmiddlewaretoken`` and ``
 Keep ``hx-post`` on the ``<form>`` element for that reason.
 An ``hx-post`` on an element outside the form would post without those fields and the dispatcher could not validate or re-render.
 
-Address the Form From Scripts
+Address the form from scripts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The opening tag carries ``data-next-action`` with the action UID, the registry identity that also names the dispatch URL.
@@ -79,7 +79,7 @@ Client-side code selects the form through that attribute instead of parsing the 
 
    const form = document.querySelector('form[data-next-action]');
 
-Distinguish Re-Render From Redirect
+Distinguish re-render from redirect
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 An invalid submission answers with the headers ``X-Next-Form: invalid`` and ``X-Next-Action: <uid>``.
@@ -99,7 +99,7 @@ An htmx event listener reads the headers to tell the two outcomes apart.
      });
    </script>
 
-Branch on ``request.htmx`` With django-htmx
+Branch on ``request.htmx`` with django-htmx
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The django-htmx middleware coexists with the dispatcher and annotates every request, so ``on_valid`` and action handlers branch on ``request.htmx``.
@@ -153,7 +153,7 @@ A ``NextClient`` test asserts the server side of the same flow.
        assert resp["X-Next-Form"] == "invalid"
        assert 'value="Ada"' in resp.content.decode()
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/enforce-object-level-permissions.rst
+++ b/docs/content/howto/enforce-object-level-permissions.rst
@@ -1,6 +1,6 @@
 .. _howto-enforce-object-level-permissions:
 
-Enforce Object-Level Permissions
+Enforce object-level permissions
 =================================
 
 Problem
@@ -21,7 +21,7 @@ A ``False`` return denies with HTTP 403 and the row is never saved.
 Walkthrough
 -----------
 
-Load the Row From the URL
+Load the row from the URL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The edit form loads its instance from a captured URL segment through ``Meta.instance_from_url``.
@@ -48,14 +48,14 @@ The default ``get_initial`` loads ``Note.objects.get(slug=<captured slug>)`` thr
 The dispatcher binds the form against that instance, then resolves ``has_object_permission``.
 At that point ``self.instance`` is the loaded ``Note``, so the hook compares its owner against the current user.
 
-Combine It With a Login Requirement
+Combine it with a login requirement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The object-level hook compares ``request.user``, so the request needs an authenticated user.
 Pair the hook with the static ``Meta.login_required`` so an anonymous POST is redirected to the login page before the hook runs.
 
 .. code-block:: python
-   :caption: notes/pages/notes/edit/[slug]/page.py — with a login requirement
+   :caption: notes/pages/notes/edit/[slug]/page.py
 
    class NoteEditForm(next.forms.ModelForm):
        class Meta:
@@ -70,7 +70,7 @@ Pair the hook with the static ``Meta.login_required`` so an anonymous POST is re
 The static guard runs first and pre-database.
 An anonymous visitor is redirected before any application code runs, and the object-level hook only ever sees an authenticated user.
 
-Render the Form
+Render the form
 ~~~~~~~~~~~~~~~
 
 The template renders the form by name.
@@ -128,7 +128,7 @@ Django renders the denial as a bare HTTP 403 without re-rendering the origin, so
 A ``form_access_denied`` signal fires on the denial with ``layer="object"`` and ``reason="denied"``.
 Connect a receiver to audit refused edits, see :ref:`topics-forms-signals-form-access-denied`.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/extend-a-default-backend.rst
+++ b/docs/content/howto/extend-a-default-backend.rst
@@ -1,6 +1,6 @@
 .. _howto-extend-backend:
 
-Extend a Default Backend Entry
+Extend a default backend entry
 ==============================
 
 Problem
@@ -56,7 +56,7 @@ Call the helper with the setting name and the keys to override.
 
 The helper returns the default ``PAGE_BACKENDS`` list with the first entry ``PAGES_DIR`` set to ``routes`` and every other key kept.
 
-Override a Nested OPTIONS Key
+Override a nested OPTIONS key
 -----------------------------
 
 Nested dicts such as ``OPTIONS`` are merged, not replaced.
@@ -74,7 +74,7 @@ Adjacent keys survive.
        )
    }
 
-Patch a Specific Entry
+Patch a specific entry
 ----------------------
 
 The ``index`` keyword selects which entry of the default list to patch.
@@ -85,7 +85,7 @@ The default is ``0``, the first entry.
 
    extend_default_backend("PAGE_BACKENDS", index=0, APP_DIRS=False)
 
-When to Write the List by Hand
+When to write the list by hand
 ------------------------------
 
 ``extend_default_backend`` patches an existing default entry.
@@ -119,7 +119,7 @@ Print the resolved setting from a Django shell.
 
 The list shows the default entry with your overrides applied.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/handle-file-uploads.rst
+++ b/docs/content/howto/handle-file-uploads.rst
@@ -1,6 +1,6 @@
 .. _howto-file-uploads:
 
-Handle File Uploads
+Handle file uploads
 ===================
 
 Problem
@@ -143,7 +143,7 @@ Without a resolvable origin the invalid submission is rejected with HTTP 400, se
        assert response.status_code == 200
        assert b"This field is required" in response.content
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/index.rst
+++ b/docs/content/howto/index.rst
@@ -1,6 +1,6 @@
 .. _howto:
 
-How-To Guides
+How-to guides
 =============
 
 How-to guides answer task-shaped questions.

--- a/docs/content/howto/integrate-django-admin.rst
+++ b/docs/content/howto/integrate-django-admin.rst
@@ -1,6 +1,6 @@
 .. _howto-django-admin:
 
-Integrate Django Admin
+Integrate Django admin
 ======================
 
 Problem
@@ -56,7 +56,7 @@ A project that split its settings places this in ``config/settings/base.py`` ins
        "notes",
    ]
 
-Register Models
+Register models
 ~~~~~~~~~~~~~~~
 
 Standard Django admin registration applies.
@@ -71,7 +71,7 @@ Standard Django admin registration applies.
    class NoteAdmin(admin.ModelAdmin):
        list_display = ("title", "created_at")
 
-Link to Admin From the Site
+Link to admin from the site
 ---------------------------
 
 Use ``reverse`` from inside the file router.
@@ -86,7 +86,7 @@ Use ``reverse`` from inside the file router.
    def admin_url() -> str:
        return reverse("admin:notes_note_changelist")
 
-Use Frozen Form Specs Inside Admin
+Use frozen form specs inside admin
 ----------------------------------
 
 When the admin renders a custom form, ``next.forms.form_spec`` produces a frozen descriptor that admin templates can render without touching the standard Django widgets.
@@ -107,7 +107,7 @@ Run migrations and create a superuser.
 Start the server and visit ``/admin/``.
 The admin renders, the existing next.dj routes continue to work, and there is no overlap between the two URL spaces.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/integrate-django-allauth-forms.rst
+++ b/docs/content/howto/integrate-django-allauth-forms.rst
@@ -1,6 +1,6 @@
 .. _howto-allauth:
 
-Integrate django-allauth Forms
+Integrate django-allauth forms
 ==============================
 
 Problem
@@ -62,7 +62,7 @@ Beyond the allauth system checks, it publishes the current request through ``all
 ``allauth.urls`` must stay mounted even when no allauth view is linked directly.
 The reset email reverses ``account_reset_password_from_key``, and mandatory email verification redirects to ``/accounts/confirm-email/``, so both flows break without the URLconf entry.
 
-Login Through a Factory
+Login through a factory
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 The recommended pattern is a factory plus a handler.
@@ -95,7 +95,7 @@ The ``init_kwargs`` reach both the POST constructor and the GET render, so the d
 Wrong credentials answer with HTTP 200, ``X-Next-Form: invalid``, the allauth error message, and the entered login preserved.
 Valid credentials answer with the allauth redirect to ``LOGIN_REDIRECT_URL`` and an authenticated session.
 
-Signup and the ``{"initial": {}}`` Idiom
+Signup and the ``{"initial": {}}`` idiom
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``SignupForm`` takes no ``request`` kwarg, but the factory must still return non-empty ``init_kwargs``.
@@ -124,7 +124,7 @@ The neutral ``{"initial": {}}`` keeps construction on the factory path, the same
 
 ``try_save`` returns an early response when allauth intervenes, for example the enumeration-prevention flow, and the handler passes it through unchanged.
 
-Password Reset
+Password reset
 ~~~~~~~~~~~~~~
 
 ``ResetPasswordForm.save`` sends the email and returns the address string rather than a response, so the handler answers with its own redirect.
@@ -145,7 +145,7 @@ Password Reset
        form.save(request)
        return HttpResponseRedirect("/password-reset/sent/")
 
-Alternative: a Thin Subclass
+Alternative: a thin subclass
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A subclass keeps the next-forms style with auto-registration and ``on_valid``.
@@ -187,7 +187,7 @@ The GET render works without the line, the crash fires only on submit.
    No origin re-render, no ``X-Next-Form`` header, and no visible errors.
    Register the form through ``form_class`` so the dispatcher owns the invalid path.
 
-Sharp Edges
+Sharp edges
 ~~~~~~~~~~~
 
 Rate limits need a cache.
@@ -239,7 +239,7 @@ Verification
        assert resp["Location"] == "/welcome/"
        assert client.session.get("_auth_user_id") == str(user.pk)
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/internationalize-routes.rst
+++ b/docs/content/howto/internationalize-routes.rst
@@ -1,6 +1,6 @@
 .. _howto-internationalize-routes:
 
-Internationalize Routes
+Internationalize routes
 =======================
 
 Problem
@@ -18,7 +18,7 @@ Add :class:`~django.middleware.locale.LocaleMiddleware` so the prefix sets the a
 Walkthrough
 -----------
 
-Enable i18n in Settings
+Enable i18n in settings
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Turn on :doc:`translation <django:topics/i18n/translation>`, list the offered languages, and point at a locale directory.
@@ -37,7 +37,7 @@ Turn on :doc:`translation <django:topics/i18n/translation>`, list the offered la
 
    LOCALE_PATHS = [BASE_DIR / "locale"]
 
-Add the Locale Middleware
+Add the locale middleware
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Place :class:`~django.middleware.locale.LocaleMiddleware` after the session middleware and before :class:`~django.middleware.common.CommonMiddleware`.
@@ -57,7 +57,7 @@ It reads the URL prefix and sets the active language for the request.
        "django.middleware.clickjacking.XFrameOptionsMiddleware",
    ]
 
-Mount the Router Under a Language Prefix
+Mount the router under a language prefix
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Wrap the file router include in :func:`~django.conf.urls.i18n.i18n_patterns`.
@@ -75,7 +75,7 @@ Every routed URL now resolves under ``/en/`` and ``/de/``, and the prefix-free U
 
 Keep URLs that must not carry a prefix, such as a health check, in a plain ``urlpatterns`` list outside the ``i18n_patterns`` call.
 
-Translate In-Page Text
+Translate in-page text
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Mark template strings with the standard Django i18n tags.
@@ -104,7 +104,7 @@ A ``@context`` callable returns the already-translated string.
        """Return the localized page heading."""
        return _("Featured products")
 
-Compile the Catalogs
+Compile the catalogs
 ~~~~~~~~~~~~~~~~~~~~
 
 Extract the marked strings and compile the binary catalogs.
@@ -134,7 +134,7 @@ Once the router include is wrapped in ``i18n_patterns``, ``page_reverse`` return
 URL names are unchanged.
 ``page_reverse`` reverses the same ``next:page_<segments>`` name, and ``i18n_patterns`` applies the active prefix at resolve time.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/move-from-django-formtools.rst
+++ b/docs/content/howto/move-from-django-formtools.rst
@@ -1,6 +1,6 @@
 .. _howto-from-formtools:
 
-Move From django-formtools
+Move from django-formtools
 ==========================
 
 Problem
@@ -16,7 +16,7 @@ The step forms move unchanged, the wizard hooks keep the formtools vocabulary, a
 Declare the ordered steps under ``Meta.steps``, place the wizard on a route with a ``[step]`` segment, and move the finalising code into ``done``.
 :doc:`build-a-multi-step-wizard` walks through a complete wizard from scratch.
 
-Method Map
+Method map
 ----------
 
 The wizard API deliberately reuses the formtools names where the semantics match.
@@ -44,21 +44,21 @@ The wizard API deliberately reuses the formtools names where the semantics match
    * - ``storage_name`` with the session and cookie storages
      - The ``FORM_WIZARD_BACKEND`` setting with the session and cache backends.
    * - ``file_storage``
-     - No equivalent, see `Files in Steps`_.
+     - No equivalent, see `Files in steps`_.
    * - ``as_view()`` mounted in ``urlpatterns``
      - Auto-registration on subclassing, no URLconf entry.
 
-What Changes in Substance
+What changes in substance
 -------------------------
 
-No URL Plumbing
+No URL plumbing
 ~~~~~~~~~~~~~~~
 
 A ``WizardView`` is a class-based view mounted with ``as_view`` in ``urlpatterns``.
 A ``FormWizard`` registers itself the moment Python runs the ``class`` statement and lives on a routed page, where the ``[step]`` directory captures the current step.
 See :doc:`/content/topics/forms/wizard` for the registration and scope rules.
 
-Steps Live in the URL
+Steps live in the URL
 ~~~~~~~~~~~~~~~~~~~~~
 
 The base ``WizardView`` keeps the current step in storage behind a single URL, and only ``NamedUrlWizardView`` exposes it.
@@ -66,7 +66,7 @@ The ``FormWizard`` always resolves the current step from the URL segment, so boo
 There is no ``{{ wizard.management_form }}`` and no ``wizard_goto_step`` POST field.
 Navigation to an earlier step is a plain link to its URL, built with ``wizard.goto(step)``.
 
-``done`` Receives Data, Not Forms
+``done`` receives data, not forms
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 formtools revalidates every form at the end and passes the instances into ``done``.
@@ -74,13 +74,13 @@ The ``FormWizard`` persists each step's cleaned data through the backend as it v
 Per-step access goes through ``get_cleaned_data_for_step``.
 A field declared by two steps merges to the last stored value, and the ``next.W059`` system check warns about such collisions.
 
-Validation Re-Render Is Free
+Validation re-render is free
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 An invalid step re-renders the page with the bound failing form under the same ``form`` variable the template already uses.
 There is no per-step template selection and no ``{{ wizard.form }}`` indirection, the one ``{% form %}`` block covers every step.
 
-Files in Steps
+Files in steps
 ~~~~~~~~~~~~~~
 
 formtools supports uploads inside steps through ``file_storage``.
@@ -103,7 +103,7 @@ Run the system checks after the port.
 Then walk the flow once.
 Fill the first step, use the browser back button to confirm the draft reappears, and finish to confirm ``done`` runs exactly once.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/observe-framework-signals.rst
+++ b/docs/content/howto/observe-framework-signals.rst
@@ -1,6 +1,6 @@
 .. _howto-observe-framework-signals:
 
-Observe Framework Signals
+Observe framework signals
 =========================
 
 Problem
@@ -22,7 +22,7 @@ Use :doc:`/content/topics/signals` when you need the full catalog with payload t
 Walkthrough
 -----------
 
-Wire One Receiver Per Signal Group
+Wire one receiver per signal group
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Keep handlers thin.
@@ -85,7 +85,7 @@ It fires only when a dynamic permission hook denies a request, never on the stat
 See :ref:`topics-forms-signals-form-access-denied` for the full contract.
 The ``request`` value is the live ``HttpRequest`` of the dispatch, so a receiver reads it synchronously and never stores it past the call.
 
-Cover the Static Pipeline
+Cover the static pipeline
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The static subsystem emits ``asset_registered``, ``backend_loaded``, ``collector_finalized``, and ``html_injected``.
@@ -122,7 +122,7 @@ The ``html_injected`` payload carries ``injected_bytes``, which is useful as a p
    def on_static_backend_loaded(**kwargs) -> None:
        incr("static", "backend_loaded")
 
-Cover the Router
+Cover the router
 ~~~~~~~~~~~~~~~~
 
 The URL subsystem emits ``route_registered`` for each route discovered during a file router scan and ``router_reloaded`` for each rebuild.
@@ -144,7 +144,7 @@ The URL subsystem emits ``route_registered`` for each route discovered during a 
    def on_router_reloaded(**kwargs) -> None:
        incr("urls", "router_reloaded")
 
-Connect Receivers at Startup
+Connect receivers at startup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Import the receivers module from ``AppConfig.ready`` so the ``@receiver`` decorators run once at startup.
@@ -168,7 +168,7 @@ The ``pages.rendered``, ``components.rendered``, and ``forms.action_dispatched``
 
 In a test, assert the same wiring with ``SignalRecorder`` from ``next.testing``, which records every framework signal without a production backend.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/override-the-js-context-serializer.rst
+++ b/docs/content/howto/override-the-js-context-serializer.rst
@@ -1,6 +1,6 @@
 .. _howto-js-serializer:
 
-Override the JS Context Serializer
+Override the JS context serializer
 ==================================
 
 Problem
@@ -16,7 +16,7 @@ Point ``NEXT_FRAMEWORK["JS_CONTEXT_SERIALIZER"]`` at a serializer class, or pass
 Walkthrough
 -----------
 
-Use the Bundled Pydantic Serializer
+Use the bundled pydantic serializer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The framework ships ``PydanticJsContextSerializer``.
@@ -45,18 +45,18 @@ Context functions can now return Pydantic models directly.
    def featured() -> NoteOut:
        return NoteOut(id=1, title="Hello")
 
-Write a Custom Serializer
+Write a custom serializer
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A serializer is any class with a ``dumps`` method that returns a JSON string.
 See :doc:`/content/topics/static-assets/js-context` for the protocol and a minimal ``CompactSerializer`` example, then point ``JS_CONTEXT_SERIALIZER`` at your dotted path.
 
-Per Key Override
+Per key override
 ~~~~~~~~~~~~~~~~
 
 Pass ``serializer=`` on a single ``@context`` so only that key uses a different encoder.
 Everything else keeps the project default.
-See the Per-Key Serializer section in :doc:`/content/topics/static-assets/js-context` for a concrete snippet.
+See the Per-key serializer section in :doc:`/content/topics/static-assets/js-context` for a concrete snippet.
 
 Verification
 ------------
@@ -64,7 +64,7 @@ Verification
 Reload a page and inspect ``window.Next.context`` in the browser console.
 The values that could not serialise before now appear as proper JSON.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/read-query-parameters.rst
+++ b/docs/content/howto/read-query-parameters.rst
@@ -1,6 +1,6 @@
 .. _howto-read-query-parameters:
 
-Read Query Parameters
+Read query parameters
 =====================
 
 Problem
@@ -19,7 +19,7 @@ The framework reads :attr:`request.GET <django:django.http.HttpRequest.GET>`, co
 Walkthrough
 -----------
 
-Read a Single Parameter
+Read a single parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Declare the parameter with a type and a default.
@@ -47,7 +47,7 @@ The default is used when the key is absent from the query string.
 A request to ``/?show=8`` injects ``show=8`` as an ``int``.
 A request to ``/`` injects the default ``3``.
 
-Type Coercion
+Type coercion
 ~~~~~~~~~~~~~
 
 The annotation drives coercion of the raw query string.
@@ -90,7 +90,7 @@ The annotation drives coercion of the raw query string.
 A scalar parameter that is absent from the query string receives the declared default, or ``None`` when no default is given.
 A ``DQuery[list[T]]`` parameter that is absent in all three wire formats returns the declared default, or an empty list when no default is given.
 
-Read Several Typed Parameters
+Read several typed parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A single callable can mix scalar and list parameters.
@@ -111,9 +111,9 @@ Each annotation drives its own coercion.
    ) -> dict:
        return {"q": q, "page": page, "in_stock": in_stock, "brands": list(brand)}
 
-List elements follow the same three wire formats described above under *Type Coercion*.
+List elements follow the same three wire formats described above under *Type coercion*.
 
-Build a Typed Snapshot With a Provider
+Build a typed snapshot with a provider
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When several callables need the same filter set, parse it once into a frozen dataclass.
@@ -141,7 +141,7 @@ When several callables need the same filter set, parse it once into a frozen dat
            sort=g.get("sort") or "newest",
        )
 
-Render the Form
+Render the form
 ~~~~~~~~~~~~~~~~
 
 Search is idempotent, so the filter form uses ``method="get"`` and posts back to the same page.
@@ -163,7 +163,7 @@ Reserve ``@action`` for POST side effects such as creating or deleting rows.
      {% component "button" type="submit" text="Apply filters" variant="default" %}
    </form>
 
-Share the Snapshot Across a Layout Chain
+Share the snapshot across a layout chain
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Register a resolved value with ``inherit_context=True`` so nested pages receive the same instance through DI.
@@ -214,7 +214,7 @@ Open the listing page with a faceted query string and confirm the response refle
 Visiting ``/catalog/?q=iphone&brand=Acme&brand=Globex&in_stock=1&page=2`` filters by search term, two brands, and stock, on the second page.
 The bracket form ``?brand[]=Acme&brand[]=Globex`` and the comma form ``?brand=Acme,Globex`` produce the same listing.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/reload-routes-from-code.rst
+++ b/docs/content/howto/reload-routes-from-code.rst
@@ -1,6 +1,6 @@
 .. _howto-reload-routes:
 
-Reload Routes From Code
+Reload routes from code
 =======================
 
 Problem
@@ -52,7 +52,7 @@ Import the receivers module from ``AppConfig.ready`` so the decorators run at st
 Each call rebuilds the backend list from the current ``NEXT_FRAMEWORK`` configuration, clears Django's URL caches, and emits ``router_reloaded``.
 Receivers should tolerate being invoked more than once when several writes batch into one task.
 
-Observe the Reload
+Observe the reload
 ------------------
 
 Long lived processes that cache URL references can listen to ``router_reloaded``.
@@ -72,7 +72,7 @@ Verification
 
 Add a row to the underlying table and confirm that the next request resolves the new URL without restarting the server.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/require-login-on-pages.rst
+++ b/docs/content/howto/require-login-on-pages.rst
@@ -1,6 +1,6 @@
 .. _howto-require-login-on-pages:
 
-Require Login on File-Routed Pages
+Require login on file-routed pages
 ==================================
 
 Problem
@@ -19,7 +19,7 @@ A page or component callable that needs the user reads it back through the reque
 Walkthrough
 -----------
 
-Write the Guard Middleware
+Write the guard middleware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The middleware lets the login page and static assets through, and redirects every other anonymous request to the login URL with a ``next`` parameter.
@@ -62,7 +62,7 @@ See :doc:`/content/topics/url-reversing` for the full reversing surface.
        "notes.middleware.LoginRequiredMiddleware",
    ]
 
-Wire the Login Route
+Wire the login route
 ~~~~~~~~~~~~~~~~~~~~~
 
 Mount Django's :doc:`auth views <django:topics/auth/default>` before the file router include so ``/login/`` resolves before the router claims the path.
@@ -79,7 +79,7 @@ Mount Django's :doc:`auth views <django:topics/auth/default>` before the file ro
        path("", include("next.urls")),
    ]
 
-Read the User in a Page
+Read the user in a page
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Past the guard every request carries an authenticated user.
@@ -96,7 +96,7 @@ A ``@context`` callable asks for the request by annotation and reads ``request.u
        """Return a greeting for the signed-in user."""
        return f"Signed in as {request.user.get_username()}"
 
-Guard One Page Without Middleware
+Guard one page without middleware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When only a few pages need protection, skip the middleware and raise :exc:`~django.core.exceptions.PermissionDenied` from the page itself.
@@ -119,7 +119,7 @@ A branded 403 page needs a ``403.html`` template or a ``handler403`` in the root
            raise PermissionDenied
        return list(request.user.note_set.all())
 
-Guard Form Actions
+Guard form actions
 ~~~~~~~~~~~~~~~~~~
 
 Form actions dispatch at ``/_next/form/<uid>/``, outside the page URL space.
@@ -160,7 +160,7 @@ Start the server and request a protected page while signed out.
 Visiting ``/notes/`` while anonymous redirects to ``/login/?next=/notes/``.
 After signing in the same path renders the page and the greeting names the user.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/resolve-feature-flags-with-di.rst
+++ b/docs/content/howto/resolve-feature-flags-with-di.rst
@@ -1,6 +1,6 @@
 .. _howto-resolve-feature-flags-with-di:
 
-Resolve Feature Flags With DI
+Resolve feature flags with DI
 =============================
 
 Problem
@@ -229,7 +229,7 @@ A second context function that also asks for ``DFlag[Flag]`` triggers the provid
 ``get_cached_flag`` shares Django's :class:`~django.core.cache.backends.locmem.LocMemCache` entry, so the lookup is served from process memory rather than the database.
 The framework's per-resolution cache only memoises ``Depends("name")`` callables, so identity across calls comes from the LocMem cache the helper builds.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/reverse-urls.rst
+++ b/docs/content/howto/reverse-urls.rst
@@ -17,7 +17,7 @@ Use ``with_query`` to add, replace, or remove query string parameters.
 Walkthrough
 -----------
 
-Reverse a Static Page
+Reverse a static page
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
@@ -29,7 +29,7 @@ Reverse a Static Page
    url = page_reverse("blog")       # "/blog/"
    url = page_reverse("about/team") # "/about/team/"
 
-Reverse a Captured Page
+Reverse a captured page
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
@@ -46,7 +46,7 @@ Reverse a Captured Page
 The path template uses the same bracket syntax that the file router uses.
 The parameter name in the template matches the keyword argument.
 
-Add Query Parameters
+Add query parameters
 ~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
@@ -60,7 +60,7 @@ Add Query Parameters
 Pass ``None`` to remove a key.
 Pass a list or tuple to repeat a key in the output.
 
-Use Inside an Action Handler
+Use inside an action handler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
@@ -80,7 +80,7 @@ Use Inside an Action Handler
            note = self.save()
            return HttpResponseRedirect(page_reverse("notes/[id]", id=note.id))
 
-Use Inside a Component
+Use inside a component
 ~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
@@ -109,7 +109,7 @@ Print the URL from a Django shell.
 
 The shell prints ``/notes/1/``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/scope-requests-per-tenant.rst
+++ b/docs/content/howto/scope-requests-per-tenant.rst
@@ -1,6 +1,6 @@
 .. _howto-scope-requests-per-tenant:
 
-Scope Requests Per Tenant
+Scope requests per tenant
 =========================
 
 Problem
@@ -20,7 +20,7 @@ See :doc:`/content/misc/examples`.
 Walkthrough
 -----------
 
-Resolve The Tenant In Middleware
+Resolve the tenant in middleware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The middleware parses the ``X-Tenant`` header, looks up the matching row, and attaches it to ``request.tenant``.
@@ -65,7 +65,7 @@ Register it last in ``MIDDLEWARE`` so it runs after sessions and authentication.
        "notes.middleware.TenantMiddleware",
    ]
 
-Read The Tenant Through One Helper
+Read the tenant through one helper
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Every consumer reads the tenant through a single accessor instead of touching ``request.tenant`` directly.
@@ -78,7 +78,7 @@ On error pages where the middleware short-circuited, the attribute is absent and
        """Return the tenant attached to `request` by `TenantMiddleware`."""
        return getattr(request, "tenant", None)
 
-Inject The Tenant Into Pages
+Inject the tenant into pages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A ``DDependencyBase`` marker plus a ``RegisteredParameterProvider`` lets page and action callables ask for the tenant by type.
@@ -141,7 +141,7 @@ Keep real annotations in these modules, because the resolver compares parameter 
        """Return every note that belongs to the active tenant."""
        return list(Note.objects.filter(tenant=active_tenant))
 
-Lift The Tenant To Every Descendant Page
+Lift the tenant to every descendant page
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A ``@context(..., inherit_context=True)`` callable on the workspace root publishes the tenant once, and every nested page reads it without re-resolving.
@@ -158,7 +158,7 @@ A ``@context(..., inherit_context=True)`` callable on the workspace root publish
        """Expose the active tenant under `tenant` to every workspace page."""
        return active_tenant
 
-Theme The Chrome With A Context Processor
+Theme the chrome with a context processor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A context processor turns the tenant's color into a CSS variable for every template.
@@ -198,7 +198,7 @@ List it in the page backend ``OPTIONS`` so the file router runs it.
        ],
    }
 
-Prefix Asset URLs Per Tenant
+Prefix asset URLs per tenant
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Scope the static backend the same way.
@@ -206,7 +206,7 @@ Subclass ``StaticFilesBackend`` and override the renderer methods.
 Read the tenant from the ``request`` keyword argument that the static manager passes to every renderer, then prepend the tenant slug to each collected URL.
 Register the subclass in ``STATIC_BACKENDS``.
 
-See :doc:`write-a-static-backend` under *Tenant URL Prefix* for the full implementation.
+See :doc:`write-a-static-backend` under *Tenant URL prefix* for the full implementation.
 
 Verification
 ------------
@@ -223,7 +223,7 @@ The Acme response lists only Acme notes.
 The Globex response lists only Globex notes.
 A request with no header returns ``400``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/share-components-across-projects.rst
+++ b/docs/content/howto/share-components-across-projects.rst
@@ -1,6 +1,6 @@
 .. _howto-share-components-across-projects:
 
-Share Components Across Projects
+Share components across projects
 ================================
 
 Problem
@@ -66,7 +66,7 @@ Add the shared directory to each project.
 Repeat the same block in ``projects/site/config/settings.py``.
 Each project now sees ``button``, ``card``, and every other component in the shared folder.
 
-Use the Components
+Use the components
 ~~~~~~~~~~~~~~~~~~
 
 .. code-block:: jinja
@@ -76,7 +76,7 @@ Use the Components
 
 The framework resolves the component by name through the component visibility resolver.
 
-Per Project Overrides
+Per project overrides
 ~~~~~~~~~~~~~~~~~~~~~
 
 A project can override a shared component by placing a component with the same name in its own components root.
@@ -89,7 +89,7 @@ A project can override a shared component by placing a component with the same n
 The project-local version wins because the visibility resolver scores the project's page-tree root and a global ``DIRS`` root equally, then breaks the tie in favour of the page-tree component.
 A page-tree component shadows a same-name ``DIRS`` component at equal score, so the project's own copy overrides the shared one regardless of which root was registered first.
 
-Static Files
+Static files
 ~~~~~~~~~~~~
 
 Add the shared static directory to ``STATICFILES_DIRS`` if the components ship CSS or images outside the co-located stems.
@@ -108,7 +108,7 @@ Verification
 Run each project independently with ``uv run python manage.py runserver`` from inside the project directory.
 Confirm that the shared component renders in both projects.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/share-context-across-pages.rst
+++ b/docs/content/howto/share-context-across-pages.rst
@@ -1,6 +1,6 @@
 .. _howto-share-context-across-pages:
 
-Share Context Across Pages
+Share context across pages
 ==========================
 
 Problem
@@ -45,7 +45,7 @@ The value is injected into the shared context dict for that request, so both the
 
    <p>{{ note_count }} notes in total.</p>
 
-Limit Inheritance to a Subtree
+Limit inheritance to a subtree
 ------------------------------
 
 Drop the flag for values that should stay local to the current page only.
@@ -71,7 +71,7 @@ Verification
 Visit two pages under the directory that hosts the ``page.py`` and confirm the value renders on both.
 Visit a page outside that directory and confirm the value is undefined.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/split-settings-per-environment.rst
+++ b/docs/content/howto/split-settings-per-environment.rst
@@ -1,6 +1,6 @@
 .. _howto-split-settings-per-environment:
 
-Split Settings per Environment
+Split settings per environment
 ==============================
 
 Problem
@@ -19,7 +19,7 @@ The ``DJANGO_SETTINGS_MODULE`` environment variable selects one per process.
 Walkthrough
 -----------
 
-Create the Settings Package
+Create the settings package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Delete ``config/settings.py`` and create a ``config/settings/`` directory with an empty ``__init__.py``.
@@ -37,7 +37,7 @@ Place ``base.py``, ``dev.py``, and ``prod.py`` beside it.
      urls.py
      wsgi.py
 
-Define the Shared Base
+Define the shared base
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ``base.py`` holds every value common to all environments.
@@ -72,7 +72,7 @@ Define ``NEXT_FRAMEWORK`` here in full so the framework configuration has one so
        ],
    }
 
-Override for Development
+Override for development
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``dev.py`` imports everything from ``base`` with a star import, then overrides the values that differ.
@@ -98,7 +98,7 @@ Development keeps the framework defaults, so ``dev.py`` leaves ``NEXT_FRAMEWORK`
 The default ``STRICT_CONTEXT`` value ``False`` keeps local rendering alive when a context processor fails.
 The copy-and-patch pattern for a per-environment key is shown in the production module below.
 
-Override for Production
+Override for production
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 ``prod.py`` follows the same shape.
@@ -125,7 +125,7 @@ A flat key such as ``STRICT_CONTEXT`` is copied and reassigned as shown here.
 For nested backend lists use ``extend_default_backend`` or ``copy.deepcopy``.
 See :doc:`extend-a-default-backend` for the backend-list case.
 
-Select a Module per Process
+Select a module per process
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``manage.py`` and ``wsgi.py`` read ``DJANGO_SETTINGS_MODULE`` from the environment.
@@ -161,7 +161,7 @@ Both runs report no errors.
 The development run has ``DEBUG`` on and the production run has it off.
 The production run carries the ``STRICT_CONTEXT`` override, the development run keeps the default.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/stream-live-updates-with-sse.rst
+++ b/docs/content/howto/stream-live-updates-with-sse.rst
@@ -1,6 +1,6 @@
 .. _howto-stream-live-updates-with-sse:
 
-Stream Live Updates With SSE
+Stream live updates with SSE
 ============================
 
 Problem
@@ -25,7 +25,7 @@ For the WSGI and ASGI contract, the echo suppression, and why the fan-out uses `
 Walkthrough
 -----------
 
-Build the Broker
+Build the broker
 ~~~~~~~~~~~~~~~~
 
 The broker keeps one :class:`threading.Condition` and one monotonic revision counter per poll.
@@ -90,7 +90,7 @@ A :class:`threading.Event` with ``clear()`` would drop events under fan-out, bec
 A wake timeout loops without yielding.
 A sync source under WSGI sends no keepalive on its own, a documented limitation of the stream, so an idle keepalive is the source's job if a deployment needs one.
 
-Stream From a Page Module
+Stream from a page module
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Place a page module at the ``stream/`` route and return a ``PatchEventStream`` from ``render``.
@@ -128,7 +128,7 @@ The pairing is a contract.
 An async source requires ASGI and a sync source requires WSGI.
 A mismatch raises :exc:`~django.core.exceptions.ImproperlyConfigured` rather than silently hanging the stream.
 
-Fan Out From the Vote Signal
+Fan out from the vote signal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The vote handler runs the atomic ``UPDATE`` and returns its result.
@@ -165,7 +165,7 @@ The signal carries the bound form after validation and the request, so the recei
 
 Threading the mutation's ``X-Next-Request-Id`` to ``publish`` lets the stream echo it, so the voter's own tab drops the fan-out and applies only the morph from its own POST response.
 
-Connect From the Browser
+Connect from the browser
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The vote page wraps its results in a zone and connects the stream with a ``data-next-sse`` element.
@@ -195,7 +195,7 @@ Peek at the stream from a second terminal while a server runs.
 The ``-N`` flag disables curl output buffering so frames appear as the server flushes them.
 Vote in the browser and a ``next-patches`` event arrives within milliseconds, with every open tab re-fetching its zone at the same time.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/style-forms-with-crispy-and-widget-tweaks.rst
+++ b/docs/content/howto/style-forms-with-crispy-and-widget-tweaks.rst
@@ -1,6 +1,6 @@
 .. _howto-crispy-widget-tweaks:
 
-Style Forms With crispy-forms and widget-tweaks
+Style forms with crispy-forms and widget-tweaks
 ===============================================
 
 Problem
@@ -19,7 +19,7 @@ Verified with django-crispy-forms 2.5 and later plus the crispy-bootstrap5 templ
 Walkthrough
 -----------
 
-Install the Packages
+Install the packages
 ~~~~~~~~~~~~~~~~~~~~
 
 Add the apps and pick a template pack.
@@ -37,7 +37,7 @@ Add the apps and pick a template pack.
    CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
    CRISPY_TEMPLATE_PACK = "bootstrap5"
 
-Render Through the ``|crispy`` Filter
+Render through the ``|crispy`` filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The filter is the zero-configuration path.
@@ -69,7 +69,7 @@ It renders the fields with the template pack's markup and never emits a ``<form>
 
 The output carries the Bootstrap 5 markup (``div_id_*`` wrappers, ``form-control`` classes) with exactly one ``<form>`` element and exactly one CSRF token, both owned by the tag.
 
-Render Through the ``{% crispy %}`` Tag
+Render through the ``{% crispy %}`` tag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``{% crispy %}`` tag drives the layout from a ``FormHelper``, and a helper defaults to rendering its own ``<form>`` element and its own CSRF node.
@@ -117,7 +117,7 @@ Both helper lines are required, and they cover two different leaks.
 Define the helper as a ``@property`` rather than assigning it in ``__init__``.
 The constructor of a registered form participates in the dispatch pipeline, and the property keeps its signature untouched and adds no per-instance state.
 
-Restyle Single Fields With widget-tweaks
+Restyle single fields with widget-tweaks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When the markup is hand-written and only the widget attributes need adjusting, the widget-tweaks filters apply to the pushed ``form`` variable directly.
@@ -132,7 +132,7 @@ When the markup is hand-written and only the widget attributes need adjusting, t
      <button type="submit">Send</button>
    {% endform %}
 
-Validation Re-Render
+Validation re-render
 ~~~~~~~~~~~~~~~~~~~~
 
 An invalid submission re-renders the origin page with the bound failing form in place of ``form``, see :doc:`/content/topics/forms/validation-rerender`.
@@ -148,7 +148,7 @@ The output contains exactly one ``<form>`` element and exactly one ``csrfmiddlew
 Submit an invalid value.
 The page re-renders with the crispy error markup, and the entered values stay in the fields.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/test-a-component-in-isolation.rst
+++ b/docs/content/howto/test-a-component-in-isolation.rst
@@ -1,6 +1,6 @@
 .. _howto-test-a-component-in-isolation:
 
-Test a Component in Isolation
+Test a component in isolation
 =============================
 
 Problem
@@ -17,7 +17,7 @@ It resolves a component by name as seen from a given template path, renders it w
 Walkthrough
 -----------
 
-Load the Components
+Load the components
 ~~~~~~~~~~~~~~~~~~~
 
 Component discovery is a side effect, so import the components before a test resolves one.
@@ -38,7 +38,7 @@ Component folders inside a page tree register during the URL router walk instead
 A suite whose other tests issue ``NextClient`` requests has already triggered the walk.
 A suite that renders components without any HTTP triggers it by reversing one route in the same fixture, for example with ``page_reverse()`` from ``next.urls``.
 
-Render the Component
+Render the component
 ~~~~~~~~~~~~~~~~~~~~
 
 ``render_component_by_name`` takes the component name and the ``at`` path the component is referenced from.
@@ -61,7 +61,7 @@ The ``context`` mapping fills the values the component template reads.
 
 The helper raises ``LookupError`` when no visible component matches the name from the ``at`` path.
 
-Assert on the Markup
+Assert on the markup
 ~~~~~~~~~~~~~~~~~~~~
 
 The return value is a plain string, so any HTML assertion works.
@@ -89,7 +89,7 @@ The ``assert_has_class`` and ``find_anchor`` helpers from ``next.testing`` keep 
        anchor = find_anchor(html, href="/notes/1/", text="Quick start")
        assert 'href="/notes/1/"' in anchor
 
-Pass a Request When the Component Needs One
+Pass a request when the component needs one
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When a component callable reads the request, build one with :class:`~django.test.RequestFactory` and pass it through the ``request`` keyword.
@@ -124,7 +124,7 @@ Run the component tests.
 Every test passes.
 Each component rendered on its own, with no page or route involved.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/test-a-page-with-actions.rst
+++ b/docs/content/howto/test-a-page-with-actions.rst
@@ -1,6 +1,6 @@
 .. _howto-test-actions:
 
-Test a Page With Actions
+Test a page with actions
 ========================
 
 Problem
@@ -62,7 +62,7 @@ Write the test.
 
 ``NextClient`` does not enforce CSRF by default, matching Django's test client, so the POST needs no token.
 
-Test the Failure Path
+Test the failure path
 ~~~~~~~~~~~~~~~~~~~~~
 
 A failing validation re-renders the origin page, so the test names the origin.
@@ -90,7 +90,7 @@ Without a resolvable origin the invalid branch cannot re-render and answers HTTP
        response = NextClient().post_action("create_note", {"title": ""})
        assert response.status_code == 400
 
-Render the Page Without HTTP
+Render the page without HTTP
 ----------------------------
 
 For tests that focus on template output, render the page directly.
@@ -120,7 +120,7 @@ Run the suite.
 Every test passes.
 The dispatch ran through the signal, the model row exists, the failure path stayed on the origin page.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/use-formsets.rst
+++ b/docs/content/howto/use-formsets.rst
@@ -1,6 +1,6 @@
 .. _howto-formsets:
 
-Use Formsets
+Use formsets
 ============
 
 Problem
@@ -37,7 +37,7 @@ Define the row form and the formset.
 Without it, subclassing ``ModelForm`` would register ``NoteRowForm`` as the standalone action ``note_row_form`` through ``__init_subclass__``.
 That is a live endpoint that saves a single row through the default ``on_valid``, even though only the formset action is intended.
 The flag suppresses that registration, and ``formset_factory`` still builds the formset from the abstract class as usual.
-See :ref:`Preventing Registration <topics-forms-actions-abstract>` for the ``Meta.abstract`` semantics.
+See :ref:`Preventing registration <topics-forms-actions-abstract>` for the ``Meta.abstract`` semantics.
 
 Register the action.
 
@@ -90,7 +90,7 @@ Render the formset.
 Always render ``{{ form.management_form }}`` before the row loop.
 ``can_delete=True`` adds the ``DELETE`` checkbox to every row, and the handler skips the rows the user marked, so the template renders it alongside the fields.
 
-Clean Up Empty Rows
+Clean up empty rows
 -------------------
 
 A formset with ``extra=3`` ships three blank rows.
@@ -125,7 +125,7 @@ Submit the formset with two filled rows and one blank row.
 The handler saves the two filled rows and skips the blank one.
 A row that fails validation re-renders with errors on that row only.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/use-modelform-for-crud.rst
+++ b/docs/content/howto/use-modelform-for-crud.rst
@@ -18,7 +18,7 @@ The same class drives the create page, where the kwarg is absent and the form re
 Walkthrough
 -----------
 
-Declare the Form Once
+Declare the form once
 ~~~~~~~~~~~~~~~~~~~~~
 
 The class lives outside ``page.py``, so it registers with shared scope.
@@ -40,7 +40,7 @@ Autodiscovery imports ``notes/forms.py`` on startup, so neither page module impo
 A copy declared in each ``page.py`` would be page-scoped instead, keeping the shared action name but giving every per-file registration its own action URL.
 See :doc:`/content/topics/forms/modelforms` for that distinction and :doc:`/content/topics/forms/actions` for the scope rules.
 
-Edit Page
+Edit page
 ~~~~~~~~~
 
 The edit page lives under a route that captures the lookup field.
@@ -66,7 +66,7 @@ See :ref:`topics-forms-actions-success` for both options.
 The ``{% form %}`` tag resolves the action by name, opens the ``<form>`` element, injects the CSRF token, and publishes ``form`` inside the block.
 It also emits a hidden ``_next_form_origin`` field with the page URL, so the dispatcher recovers the captured ``slug`` by resolving that path and the submission re-attaches to the same row.
 
-Create Page
+Create page
 ~~~~~~~~~~~
 
 The create page renders the same form on a route with no captured kwarg.
@@ -84,7 +84,7 @@ The create page renders the same form on a route with no captured kwarg.
 With no ``slug`` in the URL, ``get_initial`` returns an empty dict and the form renders fresh.
 ``self.save()`` then inserts a new row.
 
-URL names follow the ``page_{path}`` convention where path segments are joined with underscores and captured-parameter brackets are dropped.
+URL names follow the ``page_{name}`` convention where path segments are joined with underscores and captured-parameter brackets are dropped.
 See :doc:`/content/topics/file-router` for the full naming rules.
 
 Verification
@@ -119,7 +119,7 @@ Resolving the edit-page path yields the ``slug`` kwarg, ``instance_from_url`` lo
 
 The recovered kwargs come through the URL converters of the resolved route, so a ``[int:id]`` kwarg arrives as an integer on both the initial render and the re-render, while a slug stays a string.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/write-a-form-action-backend.rst
+++ b/docs/content/howto/write-a-form-action-backend.rst
@@ -1,6 +1,6 @@
 .. _howto-form-backend:
 
-Write a Form Action Backend
+Write a form action backend
 ===========================
 
 Problem
@@ -59,7 +59,7 @@ Register the backend.
 
 The custom backend replaces ``RegistryFormActionBackend`` because it already inherits every default behaviour.
 
-Block a Dispatch
+Block a dispatch
 ~~~~~~~~~~~~~~~~
 
 Return an ``HttpResponse`` before calling ``super().dispatch`` to short circuit.
@@ -79,7 +79,7 @@ Return an ``HttpResponse`` before calling ``super().dispatch`` to short circuit.
        def _over_limit(self, request) -> bool:
            return False
 
-Read an Option
+Read an option
 ~~~~~~~~~~~~~~
 
 A backend reads its own settings from the ``OPTIONS`` dict of its config entry.
@@ -111,7 +111,7 @@ The factory passes the whole config entry to the constructor, so declare ``__ini
 
 Forward ``config`` to ``super().__init__`` so the registry is set up before you read any option.
 
-Change the Invalid Envelope
+Change the invalid envelope
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The default backend answers an invalid submission with HTTP 200, the re-rendered origin page, and the ``X-Next-Form``/``X-Next-Action`` headers.
@@ -142,7 +142,7 @@ See :doc:`/content/topics/forms/backends` for the two customisation layers and t
    ``FormActionBackend.shape_response`` routes partial requests through the patch-envelope shaping first, so this override restamps patch envelopes too.
    Gate the status change on ``not is_partial_request(request)`` from ``next.partial`` to keep the partial wire contract at 200.
 
-Surface Actions to the System Checks
+Surface actions to the system checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The forms system checks collect action metadata from every configured backend through ``iter_actions()``, which yields one ``ActionMeta`` per stored action.
@@ -186,7 +186,7 @@ Run the system checks.
 A misconfigured ``FORM_ACTION_BACKENDS`` entry fires ``next.E044``.
 A backend class that does not subclass ``FormActionBackend`` fires ``next.E045``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/write-a-router-backend.rst
+++ b/docs/content/howto/write-a-router-backend.rst
@@ -1,6 +1,6 @@
 .. _howto-write-a-router-backend:
 
-Write a Router Backend
+Write a router backend
 ======================
 
 Problem
@@ -53,7 +53,7 @@ Its only contract is ``generate_urls``, which returns the patterns the backend c
 The call to ``super().generate_urls()`` keeps every file route intact.
 The subclass only adds patterns.
 
-Reuse the File Route View
+Reuse the file route view
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The database URLs do not need their own view.
@@ -63,19 +63,21 @@ Locate that catchall :doc:`URLPattern <django:ref/urls>` by its reverse name and
 .. code-block:: python
    :caption: wiki/backends.py
 
-   def _find_catchall(self, urls: list[URLPattern | URLResolver]) -> URLPattern | None:
-       """Locate the file pattern that handles every article slug."""
-       target = next_framework_settings.URL_NAME_TEMPLATE.format(name="wiki_slug")
-       for url in urls:
-           if isinstance(url, URLPattern) and getattr(url, "name", None) == target:
-               return url
-       return None
+       def _find_catchall(
+           self, urls: list[URLPattern | URLResolver]
+       ) -> URLPattern | None:
+           """Locate the file pattern that handles every article slug."""
+           target = next_framework_settings.URL_NAME_TEMPLATE.format(name="wiki_slug")
+           for url in urls:
+               if isinstance(url, URLPattern) and getattr(url, "name", None) == target:
+                   return url
+           return None
 
 The reverse name follows ``URL_NAME_TEMPLATE``, which defaults to ``page_{name}``.
 A dynamic segment named ``[slug]`` yields the route name ``wiki_slug``.
 A typed segment such as ``[int:slug]`` would instead yield ``wiki_int_slug`` because the converter token survives into the name.
 
-Append One Pattern Per Row
+Append one pattern per row
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Read the slugs from the model and build a :func:`django.urls.path` for each.
@@ -85,28 +87,30 @@ Catch ``django.db.utils.DatabaseError`` because the backend can run before migra
 .. code-block:: python
    :caption: wiki/backends.py
 
-   def _build_article_aliases(self, view: Callable[..., object]) -> list[URLPattern]:
-       """Materialise one named URL per existing article slug."""
-       article_model = django_apps.get_model("wiki", "Article")
-       try:
-           slugs = list(article_model.objects.values_list("slug", flat=True))
-       except DatabaseError:
-           return []
-       return [
-           path(
-               f"{PUBLIC_PREFIX}/{slug}/",
-               view,
-               kwargs={"slug": slug},
-               name=f"wiki_article_{slug}",
-           )
-           for slug in slugs
-       ]
+       def _build_article_aliases(
+           self, view: Callable[..., object]
+       ) -> list[URLPattern]:
+           """Materialise one named URL per existing article slug."""
+           article_model = django_apps.get_model("wiki", "Article")
+           try:
+               slugs = list(article_model.objects.values_list("slug", flat=True))
+           except DatabaseError:
+               return []
+           return [
+               path(
+                   f"{PUBLIC_PREFIX}/{slug}/",
+                   view,
+                   kwargs={"slug": slug},
+                   name=f"wiki_article_{slug}",
+               )
+               for slug in slugs
+           ]
 
 Each alias gets a unique reverse name of ``wiki_article_<slug>`` so templates can call :func:`~django.urls.reverse` per article.
 Patterns mounted through ``include("next.urls")`` carry the ``next`` application namespace, so the lookup is ``reverse("next:wiki_article_<slug>")``.
 Names a custom backend registers land in the same ``next`` namespace.
 
-Register the Backend
+Register the backend
 ~~~~~~~~~~~~~~~~~~~~~
 
 List the dotted path of the subclass under ``PAGE_BACKENDS``.
@@ -131,7 +135,7 @@ List the dotted path of the subclass under ``PAGE_BACKENDS``.
        ],
    }
 
-Reload When the Table Changes
+Reload when the table changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``generate_urls`` runs once per router build, so a new row stays invisible until the router rebuilds.
@@ -161,7 +165,7 @@ The next request resolves ``/wiki/<slug>/`` and ``reverse("next:wiki_article_<sl
 
 Run ``uv run python manage.py check`` and confirm the backend is registered.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/howto/write-a-static-backend.rst
+++ b/docs/content/howto/write-a-static-backend.rst
@@ -1,6 +1,6 @@
 .. _howto-static-backend:
 
-Customise Rendered Static Tags
+Customise rendered static tags
 ==============================
 
 Pick this page when the tag markup must change, for example to add ``crossorigin`` or load from a CDN host.
@@ -20,10 +20,10 @@ For URL rewriting, subclass ``StaticFilesBackend`` and override the renderer met
 Walkthrough
 -----------
 
-Attributes Through Options
+Attributes through options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The simplest customisation needs no Python.
+This customisation needs no Python.
 Bake the attributes into the tag format strings.
 
 .. code-block:: python
@@ -44,7 +44,7 @@ Bake the attributes into the tag format strings.
 
 The format string must contain the ``{url}`` placeholder.
 
-Subclass for URL Rewriting
+Subclass for URL rewriting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When the URL itself must change, subclass ``StaticFilesBackend`` and override the renderer methods.
@@ -79,7 +79,7 @@ Register the backend.
        ]
    }
 
-Request Aware Output
+Request aware output
 ~~~~~~~~~~~~~~~~~~~~
 
 A renderer can read the request to vary its output per visitor.
@@ -96,7 +96,7 @@ A renderer can read the request to vary its output per visitor.
 
 The static manager passes the current request to every renderer call.
 
-Tenant URL Prefix
+Tenant URL prefix
 ~~~~~~~~~~~~~~~~~
 
 A common multi-tenant pattern is to prefix every collected URL with a tenant slug so static files are scoped per tenant.
@@ -148,7 +148,7 @@ Every ``<link>`` and ``<script>`` tag carries the new attributes or the CDN host
 
 Run ``uv run python manage.py check`` and confirm the backend is registered.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/internals/action-dispatch.rst
+++ b/docs/content/internals/action-dispatch.rst
@@ -87,7 +87,8 @@ Modules
    Manages the bound form, the dependency cache reuse, and the response selection.
 
 ``next.forms.backends``.
-   ``FormActionBackend`` abstract contract, ``RegistryFormActionBackend`` default implementation, ``FormActionFactory``, and the ``FormActionNotFoundError`` exception.
+   ``FormActionBackend`` abstract contract, ``RegistryFormActionBackend`` default implementation, and the ``FormActionNotFoundError`` exception.
+   Turning the configured entries into instances is not the module's job: ``FormActionManager`` delegates that to the shared ``load_backends`` helper every backend family uses.
 
 ``next.forms.uid``.
    ``redirect_to_origin``, ``reverse_form_action``, and ``validated_origin_path`` helpers for the origin page round trip, plus the ``ORIGIN_FIELD_NAME`` wire constant and the ``FORM_ORIGIN_OVERRIDE_KEY`` render-context key the partial shaping layer sets on a wizard advance.
@@ -96,7 +97,7 @@ Modules
    Resolution of the posted origin path into the page module and the typed URL kwargs, memoised per request.
 
 ``next.forms.wizard``.
-   ``FormWizard`` base class, the ``FormWizardBackend`` contract with the session and cache implementations, and the ``WizardBackendManager`` holder.
+   ``FormWizard`` base class, the ``FormWizardBackend`` contract with the session and cache implementations, and the ``wizard_backend_manager`` holder.
 
 ``next.forms.widgets``.
    ``ComponentWidget`` and the ``bind_component_widgets`` binder the ``{% form %}`` tag calls before rendering.

--- a/docs/content/internals/action-dispatch.rst
+++ b/docs/content/internals/action-dispatch.rst
@@ -1,6 +1,6 @@
 .. _internals-action-dispatch:
 
-Action Dispatch
+Action dispatch
 ===============
 
 This page covers the form dispatch pipeline.
@@ -114,7 +114,7 @@ Modules
 ``next.forms.formsets``.
    ``cleanup_extra_initial`` helper for blank extra rows.
 
-Access Guard
+Access guard
 ------------
 
 An action that declares ``login_required`` or ``permission_required`` carries an ``ActionGuard`` in its registry metadata under the ``guard`` key.
@@ -122,7 +122,7 @@ The shared pipeline enforces this static guard right after the method check, ahe
 An anonymous user receives a redirect to ``LOGIN_URL`` whose ``next`` is the validated posted origin, and an authenticated user missing a permission raises ``PermissionDenied``.
 Every backend that delegates to ``FormActionDispatch.dispatch`` inherits the enforcement.
 
-Dynamic Permission Hooks
+Dynamic permission hooks
 ------------------------
 
 Two opt-in hooks layer per-request permission decisions on top of the static guard, and unlike the static guard they intentionally run application code.
@@ -143,7 +143,7 @@ A wizard enforces ``check_permissions`` once per step POST before the step binds
 A wizard step binds without ``get_initial`` or ``Meta.instance_from_url``, so a ``ModelForm`` step reads an unbound ``self.instance`` in that hook, not the URL-addressed target the standalone path loads.
 The guide covers the authoring contract at :ref:`topics-forms-actions-dynamic-guards`.
 
-Validate-Only Short Circuit
+Validate-only short circuit
 ---------------------------
 
 A partial request whose intent carries validate fields short-circuits the pipeline on the already bound form.
@@ -152,7 +152,7 @@ The dispatcher answers with the validation envelope, the handler never runs, the
 A request without validate fields falls through to the normal submit path.
 See :doc:`/content/topics/partial-rendering/scenarios` for the client-side flow.
 
-Origin Resolution
+Origin resolution
 -----------------
 
 The hidden ``_next_form_origin`` field on every rendered form carries the URL path of the origin page.
@@ -178,7 +178,7 @@ Its ``dispatch`` method resolves the UID to an action and forwards the request t
 A project customises dispatch by subclassing ``RegistryFormActionBackend`` and overriding ``dispatch``.
 The override calls ``super().dispatch`` to keep the standard pipeline.
 
-Shared Dependency Cache
+Shared dependency cache
 -----------------------
 
 The dispatcher creates a fresh dependency cache on every POST and shares it across each stage of the dispatch.
@@ -214,7 +214,7 @@ All five request-time signals carry ``uid`` and ``request``.
 ``uid`` is the registry identity also stamped on the ``data-next-action`` markup attribute, ``None`` for a backend whose meta stores no uid.
 ``request`` is the live ``HttpRequest`` and receivers must not retain it past the call.
 
-Extension Points
+Extension points
 ----------------
 
 - Subclass ``RegistryFormActionBackend`` and override ``dispatch`` to wrap the standard pipeline.
@@ -224,7 +224,7 @@ Extension Points
 - Subscribe to ``action_dispatched`` for audit and cache invalidation.
 - Subscribe to ``form_validation_failed`` for alerting on failure rates.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/internals/autoreload.rst
+++ b/docs/content/internals/autoreload.rst
@@ -30,7 +30,7 @@ Pipeline
        Diff -- changed --> Notify[notify_file_changed]
        Notify --> ProcessRestart
 
-Startup Integration
+Startup integration
 -------------------
 
 The pipeline is wired by ``next.apps.autoreload.install()``, which ``NextFrameworkConfig.ready`` calls at application startup.
@@ -55,7 +55,9 @@ Installer
 
 ``next.apps.autoreload``.
    ``install()`` swaps ``StatReloader`` and connects the watch signal.
-   ``uninstall()`` restores the previous reloader. Test suites that call ``AppConfig.ready`` multiple times use it to avoid double-patching.
+   ``uninstall()`` restores the previous reloader.
+   Test suites that patched the reloader through ``AppConfig.ready`` call it to put the original class back.
+   Repeated ``ready`` calls need no such cleanup because ``install()`` itself is idempotent.
 
 Runtime
 ~~~~~~~
@@ -71,9 +73,9 @@ Runtime
    ``get_framework_filesystem_roots_for_linking`` returns the canonical page and component directory roots for build tooling.
 
 ``next.server.signals``.
-   ``watch_specs_ready`` fires once after ``iter_all_autoreload_watch_specs`` finishes building the spec list.
+   ``watch_specs_ready`` fires on every call to ``iter_all_autoreload_watch_specs`` after the spec list is built.
 
-Watch Specs
+Watch specs
 -----------
 
 A watch spec is a tuple of a root path and one glob pattern.
@@ -90,7 +92,7 @@ Only Python entrypoints are watched.
 ``iter_all_autoreload_watch_specs`` appends the specs registered through ``register_autoreload_watch_spec``.
 It deduplicates the combined list by resolved path and glob, then emits ``watch_specs_ready`` with the final list.
 
-Reload Decisions
+Reload decisions
 ----------------
 
 Two kinds of changes trigger a reload.
@@ -113,13 +115,12 @@ A saved edit shows up on the next request without a process restart.
 Signals
 -------
 
-The autoreload pipeline fires ``watch_specs_ready`` after the watch-spec aggregation completes.
+The autoreload pipeline fires ``watch_specs_ready`` on every call to ``iter_all_autoreload_watch_specs`` after the watch-spec aggregation completes.
 The sender is the ``iter_all_autoreload_watch_specs`` function itself, so a receiver connected with ``sender=iter_all_autoreload_watch_specs`` fires only for that aggregation.
 
 Receivers subscribe to ``watch_specs_ready`` to log or assert on the resolved spec set.
-Registration goes through ``register_autoreload_watch_spec``.
 
-Extension Points
+Extension points
 ----------------
 
 - Register extra ``(path, glob)`` pairs from ``AppConfig.ready`` through ``register_autoreload_watch_spec``.
@@ -129,27 +130,10 @@ Extension Points
 Registering extra watch directories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Packages that generate templates or routes outside the usual page trees can register additional ``(path, glob)`` pairs without forking the framework.
+Packages that generate templates or routes outside the usual page trees register additional ``(path, glob)`` pairs by calling ``register_autoreload_watch_spec`` inside ``AppConfig.ready``, as the worked example in :ref:`topics-extending` shows.
+Registered pairs merge into the list returned by ``iter_all_autoreload_watch_specs`` and receive the same deduplication pass as built-in specs.
 
-Call ``register_autoreload_watch_spec`` from ``next.server`` inside ``AppConfig.ready``.
-
-.. code-block:: python
-   :caption: myapp/apps.py
-
-   from pathlib import Path
-   from django.apps import AppConfig
-   from next.server import register_autoreload_watch_spec
-
-   class MyAppConfig(AppConfig):
-       name = "myapp"
-
-       def ready(self) -> None:
-           register_autoreload_watch_spec(Path("/var/cache/myapp/templates"), "**/*.djx")
-
-Pairs merge into the list returned by ``iter_all_autoreload_watch_specs`` and receive the same deduplication pass as built-in specs.
-Subscribe to ``watch_specs_ready`` if you need to assert on the effective list during development.
-
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/internals/component-pipeline.rst
+++ b/docs/content/internals/component-pipeline.rst
@@ -65,10 +65,11 @@ Modules
 ``next.components.backends``.
    ``ComponentsBackend`` contract.
    ``FileComponentsBackend`` default implementation.
-   ``ComponentsFactory`` instantiates a backend from its ``BACKEND`` dotted path.
 
 ``next.components.manager``.
-   ``ComponentsManager`` orchestrates the backends, shares one render pipeline between them, and rebuilds on ``settings_reloaded``.
+   ``ComponentsManager`` orchestrates the backends, shares one render pipeline between them, and builds the list with the shared ``load_backends`` helper.
+   A ``settings_reloaded`` drops the cached backends, and the next access rebuilds them.
+   ``next.components.watch`` resolves the same entries with ``resolve_backend_class`` and never instantiates them, because its scan is read-only.
 
 ``next.components.checks``.
    The components system checks, including ``next.E020`` and ``next.E034``.
@@ -123,7 +124,7 @@ The pipeline fires four signals.
 
 - ``component_registered`` once per component on startup or reload.
 - ``components_registered`` once per bulk discovery cycle with the full list.
-- ``component_backend_loaded`` once per backend instance.
+- ``component_backend_loaded`` once per backend instance, sent by the backend class with ``config`` and ``instance``.
 - ``component_rendered`` after each render, carrying the ``ComponentInfo`` and its ``template_path``.
 
 Extension Points

--- a/docs/content/internals/component-pipeline.rst
+++ b/docs/content/internals/component-pipeline.rst
@@ -1,6 +1,6 @@
 .. _internals-component-pipeline:
 
-Component Pipeline
+Component pipeline
 ==================
 
 This page covers how the components backend discovers component folders, loads their Python modules, resolves their context, and renders the final HTML fragment.
@@ -77,7 +77,7 @@ Modules
 ``next.components.watch``.
    Watch specs exposed to the autoreloader.
 
-Resolution Order
+Resolution order
 ----------------
 
 A component reference resolves through the visibility resolver.
@@ -96,7 +96,7 @@ Across backends, the order of entries in ``COMPONENT_BACKENDS`` decides which ba
 Two components in the same scope with the same name are reported by ``next.E020``.
 ``next.E034`` reports one component name used at the root route scope of more than one page tree.
 
-Filter Expression Props
+Filter expression props
 -----------------------
 
 The ``{% component %}`` template tag accepts dynamic props through Django ``FilterExpression``.
@@ -105,13 +105,14 @@ A prop like ``title="Hello"`` stays a literal string.
 
 The renderer parses the props into a dict and forwards both the literal values and the surrounding scope into the component template.
 
-Component Context Resolution
+Component context resolution
 ----------------------------
 
 Each ``@component.context("key")`` function runs once per component render.
 When a component's ``component.py`` fails to import, the renderer falls back to plain template rendering and the ``@component.context`` callables in that module do not run.
 On the template render path the resolver shares the request-scoped dependency cache through ``get_request_dep_cache``.
-DI parameters resolved earlier in the request are reused inside the component callables.
+Named ``Depends("name")`` values resolved earlier in the dispatch are reused inside the component callables.
+Provider-resolved parameters are recomputed per call.
 Page context values reach the component through the template scope, not through the DI cache.
 A component whose ``component.py`` defines a ``render`` function uses a fresh ``DependencyCache`` for that call instead of the shared request cache.
 The surrounding template scope (props and page context variables) is still forwarded to the resolver as DI parameters.
@@ -127,14 +128,14 @@ The pipeline fires four signals.
 - ``component_backend_loaded`` once per backend instance, sent by the backend class with ``config`` and ``instance``.
 - ``component_rendered`` after each render, carrying the ``ComponentInfo`` and its ``template_path``.
 
-Extension Points
+Extension points
 ----------------
 
 - Subclass ``ComponentsBackend`` to serve components from another source.
 - Subclass ``ComponentRenderStrategy`` for non standard rendering, for example a JSX bridge.
 - Subscribe to ``components_registered`` to keep caches in sync with the registry.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/internals/contributing-notes.rst
+++ b/docs/content/internals/contributing-notes.rst
@@ -1,6 +1,6 @@
 .. _internals-contributing:
 
-Contributor Notes
+Contributor notes
 =================
 
 This page collects the conventions that the framework code itself follows.
@@ -30,7 +30,7 @@ A patch passes through a fixed set of gates before it merges.
 Conventions
 -----------
 
-Module Layout
+Module layout
 ~~~~~~~~~~~~~
 
 Each subsystem keeps a flat layout where every submodule is small.
@@ -43,14 +43,14 @@ Modules that participate in dependency resolution never use ``from __future__ im
 This applies to ``page.py``, ``component.py``, ``providers.py``, every action handler, and every ``get_initial`` callable.
 The DI resolver inspects real annotations, not strings, and ``typing.get_origin`` returns ``None`` on stringified generics.
 
-Public Callables
+Public callables
 ~~~~~~~~~~~~~~~~
 
 Names exposed through ``@page.context``, ``@component.context``, ``@action``, and through provider classes never start with an underscore.
 ``@context`` imported from ``next`` is the documented alias for ``@page.context`` used in page modules.
 Names prefixed with ``_`` stay module internal.
 
-System Checks
+System checks
 ~~~~~~~~~~~~~
 
 Every check lives next to the subsystem it validates.
@@ -64,11 +64,11 @@ Every signal lives in a ``signals`` submodule of its subsystem.
 The aggregator ``next.signals`` re-exports each name.
 A new signal adds an entry to the aggregator and to the topic catalog in ``docs/content/topics/signals.rst``.
 
-Module Docstrings
+Module docstrings
 ~~~~~~~~~~~~~~~~~
 
 Test modules carry no module-level docstring.
-Production modules may include a one-line summary at the top.
+Every production module opens with a one-line summary at the top.
 
 Imports
 ~~~~~~~
@@ -82,7 +82,7 @@ Docstrings
 A docstring is one summary line, or at most a short paragraph.
 Examples, enumerations, and historical notes belong in the guide documentation, not in docstrings.
 
-Prose Punctuation
+Prose punctuation
 ~~~~~~~~~~~~~~~~~
 
 The same punctuation rules that bind the documentation also bind every docstring, comment, and log message in ``next/``.
@@ -90,13 +90,13 @@ No semicolon joins two clauses.
 No em or en dash separates one statement from the next.
 The full rule set lives in :doc:`/content/contributing/style-guide`.
 
-Decorative Separators
+Decorative separators
 ~~~~~~~~~~~~~~~~~~~~~
 
 CSS, JavaScript, and Jinja files in ``docs/_static`` and ``docs/_templates`` carry no decorative ``/* ---- section ---- */`` banners.
 A comment explains a non-obvious choice and nothing else.
 
-Testing the Framework
+Testing the framework
 ---------------------
 
 The repository ships its own pytest suite plus a per example suite under ``examples/``.
@@ -106,17 +106,17 @@ The repository ships its own pytest suite plus a per example suite under ``examp
 
    uv run pytest
    uv run pytest examples/admin
-   uv run python manage.py check
+   uv run python examples/admin/manage.py check
 
+The system checks run through an example project because the framework itself ships no ``manage.py``.
 Always run the framework suite and the system checks before opening a pull request.
 
-Documentation Tests
+Documentation tests
 -------------------
 
-When introducing a new public API or removing one, add or update an import-presence test in the matching ``tests/<area>/`` suite so an accidental removal fails CI.
-The test imports the name and confirms its presence in the reference.
+When introducing or removing a public API, update the import-presence coverage in ``tests/test_public_api.py`` or the matching area suite so an accidental removal fails CI.
 
-Code Style
+Code style
 ----------
 
 The project uses ``ruff`` for linting and ``mypy`` for static type checks.
@@ -128,7 +128,7 @@ Run both before submitting.
    uv run ruff check
    uv run mypy
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/internals/di-resolver.rst
+++ b/docs/content/internals/di-resolver.rst
@@ -1,6 +1,6 @@
 .. _internals-di-resolver:
 
-Dependency Resolver
+Dependency resolver
 ===================
 
 This page covers how the dependency resolver inspects a callable, picks providers, fills parameters, and caches results across a request.
@@ -60,7 +60,7 @@ Modules
 ``next.deps.markers``.
    ``Depends``, ``DDependencyBase``, and the ``DependsProvider`` that resolves ``Depends`` markers.
 
-Provider Order
+Provider order
 --------------
 
 The resolver iterates providers in ascending ``priority`` order.
@@ -79,16 +79,10 @@ Custom providers register through ``RegisteredParameterProvider``.
 A subclass that does not set ``priority`` inherits the default ``100``, so it is consulted after every built-in provider.
 The resolver sorts the registry by ``priority`` as the primary key and by subclass definition order as the stable tie-break.
 
-Depends Forms
+Depends forms
 -------------
 
-``DependsProvider`` handles a parameter whose default is a ``Depends`` marker.
-The ``dependency`` argument of ``Depends`` selects one of four forms.
-
-- ``Depends("name")``. The argument is a string. The resolver looks up the callable registered under that name and invokes it with its own parameters resolved.
-- ``Depends(callable)``. The argument is a callable. The resolver resolves the callable's own parameters and calls it as a factory.
-- ``Depends(value)``. The argument is any other object. That object is injected directly as a constant.
-- ``Depends()``. No argument. The marker falls back to the parameter name and resolves it as the named form.
+``DependsProvider`` handles a parameter whose default is a ``Depends`` marker, see :doc:`/content/topics/dependency-injection` for the four marker forms.
 
 ResolutionContext
 -----------------
@@ -115,14 +109,14 @@ An ordinary page request that does not pass through the form dispatcher never se
 
 Two consequences flow from the cache.
 
-Idempotent providers.
-   Custom providers must not depend on producing a fresh value between two invocations within the same request.
-   The cache holds the first result.
+Provider results are never cached.
+   The framework cache memoises only named ``Depends("name")`` values.
+   A provider that must return one value per request keeps its own request-scoped store.
 
 Shared across the dispatch.
    The dispatch cache attaches on every form-dispatch POST and is consumed on the validation-failure re-render to keep the second pass cheap.
 
-Cycle Detection
+Cycle detection
 ---------------
 
 ``DependencyCycleError`` is raised when a named dependency re-enters a name already being resolved, directly or through a longer ``Depends`` chain.
@@ -134,14 +128,14 @@ Signals
 ``provider_registered`` fires once per provider when the subclass enters the ``RegisteredParameterProvider`` registry.
 Subscribe to track custom providers across reloads.
 
-Extension Points
+Extension points
 ----------------
 
 - Subclass ``DDependencyBase`` to introduce a typed marker.
 - Subclass ``RegisteredParameterProvider`` to handle a custom marker or a custom annotation.
 - Use ``resolver.dependency("name")`` to register a callable for ``Depends("name")``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/internals/overview.rst
+++ b/docs/content/internals/overview.rst
@@ -1,6 +1,6 @@
 .. _internals-overview:
 
-Internals Overview
+Internals overview
 ==================
 
 next.dj is built from the subsystems mapped below, which share one settings layer, one dependency resolver, and one signal bus.
@@ -70,7 +70,7 @@ The hooks wire autoreload, templates, staticfiles, components, and form autodisc
 The final hook ``autodiscover_forms()`` registers shared forms before the first request arrives.
 See :doc:`/content/ref/apps` for the canonical ordering and the full API.
 
-How They Compose
+How they compose
 ----------------
 
 A request passes from ``next.urls`` through ``next.pages`` and ``next.deps`` to ``next.static`` and ``next.components`` before the final HTML returns to the client.
@@ -79,7 +79,7 @@ Partial requests take a zone-patch path through ``next.partial``, which renders 
 :doc:`request-lifecycle` traces the render and form paths end to end.
 :doc:`/content/topics/partial-rendering/how-it-works` traces the zone-patch path.
 
-Signals Fan Out
+Signals fan out
 ---------------
 
 Most cross subsystem coordination happens through signals.
@@ -118,24 +118,24 @@ The diagram below shows which subsystem emits each signal and the typical receiv
    The diagram is a coordination sketch.
    :doc:`/content/topics/signals` is the canonical catalog of signal names, senders, and payloads.
 
-Subsystem Dependencies
+Subsystem dependencies
 ----------------------
 
 The dependency graph between subsystems is shallow.
 
 - ``next.conf`` has no internal dependencies and sits at the bottom.
-- ``next.deps`` depends only on ``next.conf``.
+- ``next.deps`` imports nothing from the framework and sits at the bottom next to ``next.conf``.
 - ``next.pages`` and ``next.components`` depend on ``next.conf`` and ``next.deps``.
-- ``next.static`` depends on ``next.conf``, ``next.deps``, ``next.pages``, and ``next.components``, whose trees its discovery and staticfiles finder walk.
-- ``next.forms`` depends on ``next.pages``, ``next.deps``, ``next.components``, and ``next.static``, the last two through the component-widget binding.
+- ``next.static`` depends on ``next.conf``, ``next.pages``, and ``next.components``, whose trees its discovery and staticfiles finder walk.
+- ``next.forms`` depends on ``next.conf``, ``next.pages``, ``next.deps``, ``next.components``, and ``next.static``, the last two through the component-widget binding.
 - ``next.urls`` depends on ``next.conf``, ``next.deps``, ``next.pages``, ``next.components``, and ``next.forms``.
-- ``next.partial`` depends on ``next.conf``, ``next.deps``, ``next.pages``, ``next.components``, ``next.static``, ``next.forms``, and ``next.urls`` to render zones and shape patches.
+- ``next.partial`` depends on ``next.conf``, ``next.pages``, ``next.components``, ``next.static``, and ``next.forms`` to render zones and shape patches, and touches ``next.urls`` only in its system checks.
 - ``next.server`` depends on ``next.conf``, ``next.pages``, ``next.urls``, and ``next.components``, the subsystems whose trees it watches.
-- ``next.testing`` depends on the page, component, form, dependency, and static subsystems to drive isolation and rendering helpers.
+- ``next.testing`` depends on the page, component, form, dependency, static, and partial subsystems to drive isolation and rendering helpers.
 - ``next.apps`` depends on every subsystem.
   It is the Django-facing entry point that calls each subsystem's startup hook.
 
-Module Map
+Module map
 ----------
 
 Each subsystem keeps a flat module layout.
@@ -151,7 +151,7 @@ Each subsystem keeps a flat module layout.
    * - ``next.components``
      - ``manager``, ``registry``, ``scanner``, ``loading``, ``renderers``, ``context``, ``facade``, ``info``, ``backends``, ``watch``, ``checks``, ``signals``.
    * - ``next.urls``
-     - ``manager``, ``backends``, ``dispatcher``, ``parser``, ``markers``, ``reverse``, ``checks``, ``signals``.
+     - ``manager``, ``backends``, ``dispatcher``, ``parser``, ``resolver``, ``markers``, ``reverse``, ``checks``, ``signals``.
    * - ``next.forms``
      - ``manager``, ``dispatch``, ``backends``, ``decorators``, ``base``, ``markers``, ``serializers``, ``formsets``,
        ``uid``, ``rendering``, ``autodiscover``, ``wizard``, ``widgets``, ``origin``, ``diagnostics``, ``checks``, ``signals``.
@@ -160,21 +160,23 @@ Each subsystem keeps a flat module layout.
    * - ``next.partial``
      - ``manager``, ``registry``, ``backends``, ``zone``, ``render``, ``patches``, ``shaping``, ``sse``, ``view``, ``headers``, ``keys``, ``origin``, ``checks``, ``signals``.
    * - ``next.deps``
-     - ``resolver``, ``providers``, ``cache``, ``context``, ``markers``, ``signals``. The ``checks`` module is a reserved stub with no checks registered yet.
+     - ``resolver``, ``providers``, ``cache``, ``context``, ``markers``, ``signals``.
    * - ``next.server``
-     - ``autoreload``, ``watcher``, ``roots``, ``checks``, ``signals``.
+     - ``autoreload``, ``watcher``, ``roots``, ``signals``.
    * - ``next.conf``
      - ``settings``, ``defaults``, ``helpers``, ``imports``, ``checks``, ``signals``.
    * - ``next.testing``
      - ``client``, ``signals``, ``isolation``, ``actions``, ``rendering``, ``loaders``, ``html``, ``patching``, ``deps``.
    * - ``next.apps``
-     - ``config``, ``autoreload``, ``templates``, ``staticfiles``, ``components``.
+     - ``config``, ``autoreload``, ``templates``, ``staticfiles``, ``components``, ``checks``.
+   * - ``next.backends``
+     - A single flat module that provides ``load_backends``, ``resolve_backend_class``, and ``SingleBackendManager`` for every settings-driven backend family.
    * - ``next.checks``
      - ``__init__`` aggregates system-check registration across every subpackage. ``common`` provides shared helpers used by individual ``checks`` modules.
    * - ``next.templatetags``
      - ``components``, ``forms``, ``next_static``, ``partial``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/internals/page-discovery.rst
+++ b/docs/content/internals/page-discovery.rst
@@ -1,6 +1,6 @@
 .. _internals-page-discovery:
 
-Page Discovery
+Page discovery
 ==============
 
 This page covers how the framework discovers pages from the filesystem, registers them, evaluates context, and composes the final body with the ancestor layout chain.
@@ -59,20 +59,20 @@ Modules
 ``next.pages.watch``.
    Returns the watch specs that the autoreloader uses to track page directories.
 
-Render Path
+Render path
 -----------
 
 1. The view loads the page module through the mtime-keyed module memo, reading from disk only when the file changed.
 2. The body source produces the page body string.
 3. The framework composes the ancestor layout chain, the innermost layout wrapping the page body first and each outer layout wrapping the result.
    Each layout substitutes the wrapped content into ``{% block template %}{% endblock template %}``.
-4. ``Page.build_render_context`` assembles the template scope, see `Context Resolution`_ below.
+4. ``Page.build_render_context`` assembles the template scope, see `Context resolution`_ below.
 5. The composed template string renders against the assembled scope.
 6. The static manager replaces the ``{% collect_styles %}`` and ``{% collect_scripts %}`` placeholder tokens with the rendered tags accumulated by the request-scoped ``StaticCollector``.
 
 When the body source is a ``render`` function that returns an ``HttpResponseBase``, the response is returned verbatim and steps 3 through 6 do not run.
 
-Composed-Template Cache
+Composed-template cache
 -----------------------
 
 ``Page`` keeps two parallel dicts that short-circuit layout composition for the callers of ``composed_template_for``.
@@ -88,7 +88,7 @@ The canonical full-page path never consults the cache and recomposes the body an
 On each cache read ``_is_template_stale`` compares the current mtimes against the snapshot.
 A change to any contributing file evicts the entry, the composition step rebuilds the template string, and the new snapshot is stored.
 
-Layout Composition
+Layout composition
 ------------------
 
 The framework reads each ancestor ``layout.djx`` from disk and replaces its ``{% block template %}{% endblock template %}`` region with the wrapped content.
@@ -97,13 +97,13 @@ Composition is string substitution, not Django template inheritance, so no page 
 
 The user-facing rules for layout discovery, the placeholder contract, and layout-level context live in :doc:`/content/topics/layouts`.
 
-Body Source Priority
+Body source priority
 --------------------
 
 ``Page._resolve_page_body`` and ``_load_static_body`` in ``next.pages.manager`` pick the highest priority body source.
 See :doc:`/content/topics/pages` for the full priority order and the ``next.W043`` conflict warning.
 
-Context Resolution
+Context resolution
 ------------------
 
 ``Page.build_render_context`` assembles the template scope in this order.
@@ -129,14 +129,14 @@ A cache that spans the page and its components exists only on the form-dispatch 
 The canonical description is in :doc:`/content/topics/context`.
 This page focuses on which module performs each step.
 
-Extension Points
+Extension points
 ----------------
 
 - Register a new template loader in ``NEXT_FRAMEWORK["TEMPLATE_LOADERS"]``.
 - Subclass ``Page`` to add metadata for rendering tools.
 - Add a context processor for global template variables.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/internals/request-lifecycle.rst
+++ b/docs/content/internals/request-lifecycle.rst
@@ -1,6 +1,6 @@
 .. _internals-request-lifecycle:
 
-Request Lifecycle
+Request lifecycle
 =================
 
 This page traces an HTTP request from the Django entry point through next.dj to the rendered response.
@@ -34,9 +34,9 @@ Pipeline
        StaticBody --> ZoneIntent
        ZoneIntent -- "zone request" --> ZoneResp["Zone response"]
        ZoneResp --> Response
-       ZoneIntent -- "full page" --> ContextCtx["Run context functions"]
-       ContextCtx --> LayoutChain["Compose layout chain"]
-       LayoutChain --> CollectAssets["Static collector"]
+       ZoneIntent -- "full page" --> LayoutChain["Compose layout chain"]
+       LayoutChain --> ContextCtx["Run context functions"]
+       ContextCtx --> CollectAssets["Static collector"]
        CollectAssets --> InjectTags["Emit collected tags"]
        InjectTags --> Response(["HTTP response"])
        FormDispatch --> Validation{"Form valid"}
@@ -44,16 +44,16 @@ Pipeline
        Handler --> Response
        Validation -- no --> Loader
 
-Implementation Notes
+Implementation notes
 --------------------
 
-Django Middleware
+Django middleware
 ~~~~~~~~~~~~~~~~~
 
 Django middleware runs first.
 Authentication, sessions, CSRF, common middleware, and any project specific middleware all see the request before the framework does.
 
-URL Resolver
+URL resolver
 ~~~~~~~~~~~~
 
 The framework registers its URL patterns through ``include("next.urls")`` in ``config/urls.py``, which mounts the framework's ``TrieURLResolver``.
@@ -61,7 +61,7 @@ The resolver narrows the request path to a few candidate patterns and matches th
 A file routed match dispatches to the page view.
 A match on ``/_next/form/<str:uid>/`` dispatches to the form dispatcher instead.
 
-Page View
+Page view
 ~~~~~~~~~
 
 The page view loads the page module and resolves the body source first.
@@ -71,35 +71,35 @@ When the body comes from the ``template`` attribute or a ``template.djx`` file t
 After the body is in hand the view builds the render context and runs every ``@context`` function in order.
 Captured URL kwargs from the matched route are seeded into the context dict before any ``@context`` function runs.
 
-Zone Requests
+Zone requests
 ~~~~~~~~~~~~~
 
 After the body source resolves, the view inspects the request for a partial intent.
 A request that targets named zones receives a zone response instead of the full page render.
 See :doc:`/content/topics/partial-rendering/how-it-works` for the zone request wire format and the patch envelope.
 
-Layout Chain
+Layout chain
 ~~~~~~~~~~~~
 
 The framework collects every ancestor ``layout.djx`` walking upward from the page directory through every ancestor, bounded at 64 levels.
 Each layout substitutes the wrapped content into its ``{% block template %}`` placeholder.
 The innermost layout wraps the page body, the outermost layout wraps everything.
 
-Static Collector
+Static collector
 ~~~~~~~~~~~~~~~~
 
 The collector accumulates assets touched during the render.
 Components contribute when they render through ``{% component %}``.
 The collector finalises before the template tags emit their slot.
 
-Tag Injection
+Tag injection
 ~~~~~~~~~~~~~
 
 ``{% collect_styles %}`` and ``{% collect_scripts %}`` emit placeholder tokens during template rendering.
 After the layout chain finishes, the static manager replaces every placeholder token with the rendered tags accumulated by the request-scoped ``StaticCollector``.
 The framework injects the ``Next`` JS context script before any other script in the page.
 
-Form Submission Path
+Form submission path
 --------------------
 
 A form submission enters at ``/_next/form/<str:uid>/``.
@@ -109,15 +109,15 @@ On invalid form the dispatcher loads the origin page and re-renders it through t
 
 The dependency cache is reused across the failure path so context functions and providers run at most once per request.
 
-Extension Points
+Extension points
 ----------------
 
 - Add an entry to ``MIDDLEWARE`` to intercept the request before next.dj sees it.
-- Subscribe to ``page_rendered`` to inspect the final HTML.
+- Subscribe to ``page_rendered`` to observe render duration, asset counts, and the context keys of each response.
 - Subclass ``StaticBackend`` to change how the collector renders.
 - Subclass ``RouterBackend`` to feed the resolver from a different source.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/internals/static-pipeline.rst
+++ b/docs/content/internals/static-pipeline.rst
@@ -80,7 +80,8 @@ Modules
    Also holds ``PlaceholderSlot``, ``PlaceholderRegistry``, and the ``default_placeholders`` instance.
 
 ``next.static.backends``.
-   ``StaticBackend`` abstract base class plus the bundled ``StaticFilesBackend`` and the ``StaticsFactory``.
+   ``StaticBackend`` abstract base class plus the bundled ``StaticFilesBackend``.
+   Instances come from ``load_backends``, the shared loader every backend family uses.
 
 ``next.static.manager``.
    ``StaticManager`` orchestrates discovery and the per request collector lifecycle.
@@ -121,7 +122,8 @@ The pipeline fires four signals.
   Module-level ``styles`` and ``scripts`` lists and inline ``{% #use_script %}`` and ``{% #use_style %}`` blocks call ``collector.add`` directly and do not emit it.
 - ``collector_finalized`` once per request after the collector closes its set.
 - ``html_injected`` once per request after the manager replaces the placeholder slots.
-- ``backend_loaded`` once per backend instance when the factory builds it.
+- ``backend_loaded`` once per backend instance when the manager builds it, including
+  the staticfiles backend it seeds when no entry survives.
 
 A standalone zone render runs the same discovery but ships the collected assets in the patch envelope, so ``collector_finalized`` and ``html_injected`` fire only on full-page renders.
 

--- a/docs/content/internals/static-pipeline.rst
+++ b/docs/content/internals/static-pipeline.rst
@@ -1,6 +1,6 @@
 .. _internals-static-pipeline:
 
-Static Pipeline
+Static pipeline
 ===============
 
 This page covers how the static subsystem discovers assets, collects them per request, deduplicates them, and emits the final HTML through the configured backend.
@@ -15,7 +15,7 @@ Overview
 The static pipeline runs entirely per request.
 ``AssetDiscovery`` walks the page and component trees on each render, builds ``StaticAsset`` records, and feeds them to the request ``StaticCollector``.
 
-Discovery and Injection
+Discovery and injection
 -----------------------
 
 .. mermaid::
@@ -31,7 +31,7 @@ Discovery and Injection
        Backend --> Tags["Render link or script tags"]
        Tags --> HTML["Final HTML"]
 
-Collector Slots
+Collector slots
 ---------------
 
 The collector keeps assets in named slots, one per registered slot, each backed by a placeholder token in templates.
@@ -46,7 +46,7 @@ Each slot matches the ``collector slot`` term in :doc:`/content/misc/glossary`.
        Finalize --> Emit["collect tag for each slot"]
        Emit --> Injected["html_injected"]
 
-Runtime Script Injection
+Runtime script injection
 ------------------------
 
 Under the ``AUTO`` script injection policy the static manager wraps the rendered page with the ``next.min.js`` runtime through ``NextScriptBuilder``.
@@ -99,7 +99,7 @@ Modules
 ``next.static.defaults``.
    ``register_defaults`` registers the built in ``css``, ``js``, and ``module`` kinds and the ``styles`` and ``scripts`` slots.
 
-Asset Kinds
+Asset kinds
 -----------
 
 Each kind maps an extension to a placeholder slot and a backend renderer method.
@@ -127,7 +127,7 @@ The pipeline fires four signals.
 
 A standalone zone render runs the same discovery but ships the collected assets in the patch envelope, so ``collector_finalized`` and ``html_injected`` fire only on full-page renders.
 
-Extension Points
+Extension points
 ----------------
 
 - Subclass ``StaticFilesBackend`` to change the rendered output.
@@ -136,7 +136,7 @@ Extension Points
 - Call ``default_stems.register`` in ``AppConfig.ready`` to recognise a new filename.
 - Subscribe to ``collector_finalized`` to inspect the collected set.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/internals/url-router.rst
+++ b/docs/content/internals/url-router.rst
@@ -1,6 +1,6 @@
 .. _internals-url-router:
 
-URL Router
+URL router
 ==========
 
 This page covers how the file router scans the filesystem, builds URL patterns, and reloads at runtime.
@@ -61,7 +61,7 @@ Modules
 ``next.urls.reverse``.
    ``page_reverse``, ``page_reverse_lazy``, and ``with_query`` helpers.
 
-URL Name Computation
+URL name computation
 --------------------
 
 Names follow ``next:page_<segments>`` where the segments come from the directory path.
@@ -76,7 +76,7 @@ The default ``page_{name}`` produces the names listed in :doc:`/content/topics/f
 The name computation collapses ``/``, brackets, ``:``, ``-``, and ``_`` into a single underscore, so distinct routes such as ``foo-bar`` and ``foo_bar`` can produce the same name.
 The ``check_reverse_name_collisions`` system check walks every page tree of every router, computes the reverse name of each route through the same parser, and fails with ``next.E039`` when two distinct routes collapse to one name, listing the conflicting paths.
 
-Resolution Algorithm
+Resolution algorithm
 --------------------
 
 ``include("next.urls")`` mounts a single ``TrieURLResolver`` that wraps the lazy router and form-action pattern sequence.
@@ -103,7 +103,7 @@ A 404 goes through the fallback, so its ``tried`` is identical to the linear sca
 Setting ``URL_RESOLVER`` in ``NEXT_FRAMEWORK`` to ``"django.urls.resolvers.URLResolver"`` replaces the trie resolver with the stock Django class and routes every call through the plain linear scan.
 The resolver is rebuilt on settings reload, so the swap takes effect without a restart.
 
-Reload Mechanics
+Reload mechanics
 ----------------
 
 ``router_manager.reload()`` does four things in order.
@@ -116,7 +116,7 @@ Reload Mechanics
 The next request observes the new patterns without a process restart.
 Long lived processes such as websocket subscribers listen for the signal to refresh cached URL references.
 
-Multiple Backends
+Multiple backends
 -----------------
 
 The settings list accepts more than one backend.
@@ -128,7 +128,7 @@ The comparison is string equality after bracket conversion, so semantic overlap 
 The same collection pass owns the duplicate parameter report, failing with ``next.E028`` and listing every conflicting name in one message, and reports a router whose collection raises as ``next.E016``.
 ``check_reverse_name_collisions`` reuses the collection but drops its errors, so ``next.E016`` and ``next.E028`` never appear twice.
 
-Extension Points
+Extension points
 ----------------
 
 - Subclass ``RouterBackend`` to feed the resolver from a different source, or subclass ``FileRouterBackend`` to add patterns or augment naming on the file-based backend.
@@ -137,7 +137,7 @@ Extension Points
   It fires once per discovered pattern with ``sender=FileRouterBackend`` and the ``url_path`` and ``file_path`` keyword arguments.
   See :doc:`/content/ref/signals`.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/intro/index.rst
+++ b/docs/content/intro/index.rst
@@ -1,6 +1,6 @@
 .. _intro:
 
-Getting Started
+Getting started
 ===============
 
 This section gets you from zero to a running next.dj project.
@@ -16,7 +16,7 @@ The six tutorial parts build a small Notes application from there.
 :doc:`install`
    Install the package, register it in Django, and serve a single page.
 
-.. rubric:: Build the Notes App
+.. rubric:: Build the Notes app
 
 :doc:`tutorial01`
    Create the Notes application, model the data, and serve the index page.

--- a/docs/content/intro/install.rst
+++ b/docs/content/intro/install.rst
@@ -11,12 +11,14 @@ Requirements
 
 - Python 3.12 or newer (3.12, 3.13, 3.14 tested).
 - Django 5.2 or newer (5.2, 6.0 supported).
+- Python 3.14 requires Django 6.0.
+  Django 5.2 supports Python 3.12 and 3.13.
 - An ASGI or WSGI server compatible with the Django version in use.
 
 next.dj extends Django.
 It does not replace the ORM, migrations, admin, or auth (:ref:`intro-overview-django-unchanged`).
 
-Install the Package
+Install the package
 -------------------
 
 Install the project package from PyPI.
@@ -31,7 +33,7 @@ Install the project package from PyPI.
 Some installers normalise dots to hyphens in wheel and cache paths.
 The import path is always ``next``.
 
-Create a Django Project
+Create a Django project
 -----------------------
 
 If you do not already have a Django project, scaffold one in an empty folder.
@@ -48,7 +50,7 @@ The same instructions work with any other names if you adapt the imports.
 Add next.dj to INSTALLED_APPS
 -----------------------------
 
-Open ``config/settings.py`` and register both ``next`` and your application in :doc:`INSTALLED_APPS <django:ref/applications>`.
+Open ``config/settings.py`` and register both ``next`` and your application in :doc:`INSTALLED_APPS <django:ref/settings>`.
 
 .. code-block:: python
    :caption: config/settings.py
@@ -105,7 +107,7 @@ A ``FileRouterBackend`` entry must carry an ``OPTIONS`` key, and ``manage.py che
 Keep ``django.template.context_processors.request`` in the ``OPTIONS`` of your ``TEMPLATES`` setting.
 A fresh ``django-admin startproject`` already includes it, and ``manage.py check`` reports ``next.E019`` if it is missing.
 
-Mount the Router
+Mount the router
 ----------------
 
 Forward all unmatched URLs to next.dj by replacing ``config/urls.py`` with the file below.
@@ -128,7 +130,7 @@ This replacement also removes the ``admin`` import that ``startproject`` generat
 URLs declared above the ``include`` keep working.
 Anything not matched by Django falls through to the file router, which resolves it against your ``pages/`` tree.
 
-Create Your First Page
+Create your first page
 ----------------------
 
 Create one page in the ``notes`` application to confirm the wiring.
@@ -155,7 +157,7 @@ Create one page in the ``notes`` application to confirm the wiring.
 The directory ``notes/pages/`` is the page root for the application.
 The ``page.py`` plus ``template.djx`` pair turns the empty path into a rendered URL.
 
-Run the Server
+Run the server
 --------------
 
 Apply Django migrations and start the development server.
@@ -169,7 +171,7 @@ A fresh ``startproject`` configures SQLite by default, so ``migrate`` creates th
 
 Open ``http://127.0.0.1:8000/`` and you should see the ``Notes`` heading.
 
-Verify the Install
+Verify the install
 ------------------
 
 Run the Django system checks once to confirm the configuration matches the framework expectations.
@@ -182,7 +184,7 @@ Run the Django system checks once to confirm the configuration matches the frame
 A clean check run prints ``System check identified no issues`` and exits with status zero.
 If a check fires, the message includes both the configuration key and the recommended fix.
 
-Next Steps
+Next steps
 ----------
 
 The environment is ready for the tutorial.

--- a/docs/content/intro/overview.rst
+++ b/docs/content/intro/overview.rst
@@ -9,7 +9,7 @@ It extends a regular Django project while leaving the ORM, admin, auth, and migr
 This page describes the mental model.
 Read it once before the tutorial, then refer back when the layout of a real project surprises you.
 
-What next.dj Adds
+What next.dj adds
 -----------------
 
 next.dj layers five things on top of a regular Django project.
@@ -41,7 +41,7 @@ Partial rendering.
 
 .. _intro-overview-django-unchanged:
 
-What next.dj Does Not Replace
+What next.dj does not replace
 -----------------------------
 
 The ORM, migrations, admin, auth, and middleware stay the same as in a stock Django project.
@@ -53,7 +53,7 @@ For the design principles behind that split, read :doc:`/content/misc/design-phi
 The nouns *page*, *layout*, *component*, *action*, and *context function* appear on every documentation page.
 :doc:`/content/misc/glossary` defines each one.
 
-A Minimal Project
+A minimal project
 -----------------
 
 Once installed, the smallest next.dj project is a ``page.py`` plus a ``template.djx`` under an app's ``pages/`` directory such as ``notes/pages/``.
@@ -61,12 +61,12 @@ It also needs the ``NEXT_FRAMEWORK`` block in ``config/settings.py`` and a one-l
 :doc:`install` shows the full three-file shape with each block spelled out.
 Every new directory under ``pages/`` then adds another page without touching the URL configuration.
 
-When to Read the Tutorial
+When to read the tutorial
 -------------------------
 
 If you have used Django before and want to feel the framework, jump to :doc:`tutorial01`.
 The six tutorial parts build a small Notes application that exercises every core subsystem.
-The first five wire up routing, layouts, components, forms, and editing, and the sixth makes the Notes index update in place with partial rendering.
+The first four wire up routing, layouts, components, and forms, the fifth adds tests and the development workflow, and the sixth makes the Notes index update in place with partial rendering.
 
 .. seealso::
 

--- a/docs/content/intro/tutorial01.rst
+++ b/docs/content/intro/tutorial01.rst
@@ -1,6 +1,6 @@
 .. _intro-tutorial01:
 
-Building the First Page
+Building the first page
 =======================
 
 Goal
@@ -20,7 +20,7 @@ If ``/`` does not respond, revisit :doc:`install`.
 Walkthrough
 -----------
 
-Model the Note
+Model the note
 ~~~~~~~~~~~~~~
 
 Create a single :doc:`Django model <django:topics/db/models>` that represents a note.
@@ -55,7 +55,7 @@ Apply the :doc:`migration <django:topics/migrations>` and seed two rows so the i
    Note.objects.create(title='Second note', body='Pages are directories.')
    PY
 
-Add the Index Page
+Add the index page
 ~~~~~~~~~~~~~~~~~~
 
 The file router treats the ``notes/pages/`` directory as the page root for the application.
@@ -100,7 +100,7 @@ Create the template.
 The framework composes the body of ``template.djx`` with any ancestor ``layout.djx``.
 You do not have a layout yet, so the page renders standalone.
 
-Run the Server
+Run the server
 ~~~~~~~~~~~~~~
 
 Start the development server.
@@ -113,7 +113,7 @@ Start the development server.
 Visit ``http://127.0.0.1:8000/`` and you should see the two seeded notes.
 The development server restarts itself on every Python edit, so reloading the browser page shows the change without a manual restart.
 
-Trace the URL Name
+Trace the URL name
 ~~~~~~~~~~~~~~~~~~
 
 Every file-routed page receives a stable URL name in the ``next`` namespace.
@@ -131,7 +131,7 @@ Open a Django shell and reverse it to confirm.
 The shell prints ``/``.
 You will use these names from templates through the standard ``{% url %}`` tag.
 
-Inspect Through System Checks
+Inspect through system checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 next.dj contributes Django system checks for the page configuration.
@@ -163,7 +163,7 @@ At the end of this part the project layout looks like this.
 The index page lists notes from the database.
 The URL ``/`` responds with HTML and the URL name ``next:page_`` reverses cleanly.
 
-Common Pitfalls
+Common pitfalls
 ---------------
 
 Page module is not discovered.
@@ -177,7 +177,7 @@ ImportError for ``Note``.
    The ``notes`` app must be installed and migrated.
    Re-run ``uv run python manage.py migrate``.
 
-Next Steps
+Next steps
 ----------
 
 You have a page that renders dynamic data.

--- a/docs/content/intro/tutorial02.rst
+++ b/docs/content/intro/tutorial02.rst
@@ -1,6 +1,6 @@
 .. _intro-tutorial02:
 
-Adding Layouts and Context
+Adding layouts and context
 ==========================
 
 Goal
@@ -18,11 +18,11 @@ The index page at ``/`` lists two seeded notes from the database.
 Walkthrough
 -----------
 
-Add a Root Layout
+Add a root layout
 ~~~~~~~~~~~~~~~~~
 
 A ``layout.djx`` placed in any directory wraps every page below it.
-For the Notes application the most common layout sits next to the page tree at ``notes/pages/layout.djx``.
+For the Notes application the most common layout sits at the root of the page tree, ``notes/pages/layout.djx``.
 
 .. code-block:: jinja
    :caption: notes/pages/layout.djx
@@ -66,7 +66,7 @@ Remove the now redundant HTML envelope from ``notes/pages/template.djx`` and kee
 
 Refresh ``http://127.0.0.1:8000/`` to confirm that the layout renders the title and the list now uses anchor tags.
 
-Share Site Context
+Share site context
 ~~~~~~~~~~~~~~~~~~
 
 The layout references ``site_name`` and ``tagline``, but no page module produces them yet.
@@ -91,7 +91,7 @@ Pass ``inherit_context=True`` so every descendant page can read the value too.
 Passing ``inherit_context=True`` publishes the value to every descendant page as well.
 Without that flag the layout would still render but pages further down the tree would not see them.
 
-Add the Detail Page
+Add the detail page
 ~~~~~~~~~~~~~~~~~~~
 
 Create a new directory ``notes/pages/notes/[id]/``.
@@ -135,7 +135,7 @@ Add the matching template.
 Click a note from the index and confirm that the detail page renders the captured note.
 The URL name ``next:page_notes_id`` reverses with a single keyword argument ``id`` and is generated from the directory shape.
 
-Trace the Layout Stack
+Trace the layout stack
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The detail page renders inside the same root layout because every ancestor ``layout.djx`` wraps every descendant page.
@@ -155,7 +155,7 @@ Reload ``/notes/1/`` and you should see both layouts at once.
 The root layout wraps the inner layout which wraps the detail template.
 Composition works by folding each descendant body into the parent ``{% block template %}`` placeholder, so adding ancestor layouts never requires changes to the inner templates.
 
-Use Counts Across Pages
+Use counts across pages
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Add a small bit of inherited context that the layout reads on every page.
@@ -169,6 +169,7 @@ Append the ``note_count`` function to the existing ``notes/pages/page.py`` and a
        return Note.objects.count()
 
 Reference the count in the layout.
+Update the ``<header>`` block inside ``notes/pages/layout.djx``, leaving the rest of the file unchanged.
 
 .. code-block:: jinja
    :caption: notes/pages/layout.djx
@@ -202,7 +203,7 @@ The index links to each note.
 The detail page renders a single note pulled from the URL.
 Inherited context flows from the root ``page.py`` down to every page.
 
-Common Pitfalls
+Common pitfalls
 ---------------
 
 A layout's markup does not appear on the page.
@@ -220,7 +221,7 @@ Inherited context not available in a descendant.
 
 See :doc:`/content/faq/troubleshooting` for the full catalog of errors and fixes.
 
-Next Steps
+Next steps
 ----------
 
 Pages are still inline HTML.

--- a/docs/content/intro/tutorial03.rst
+++ b/docs/content/intro/tutorial03.rst
@@ -1,12 +1,13 @@
 .. _intro-tutorial03:
 
-Components and Static Assets
+Components and static assets
 ============================
 
 Goal
 ----
 
-By the end of this part the index page renders each note through a reusable component, the component ships its own CSS and JS, and both files load through the static collector without any manual ``<link>`` or ``<script>`` plumbing.
+By the end of this part the index page renders each note through a reusable component.
+The component ships its own CSS and JS, and both files load through the static collector without any manual ``<link>`` or ``<script>`` plumbing.
 
 Prerequisites
 -------------
@@ -18,7 +19,7 @@ The detail page at ``/notes/<id>/`` renders one note from the URL.
 Walkthrough
 -----------
 
-Create the Component Folder
+Create the component folder
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`component </content/topics/components>` backend looks for component folders under the configured root.
@@ -42,7 +43,7 @@ Create the directory and a starter template.
 
 Components reference variables by name, so ``note`` resolves from the surrounding template context.
 
-Use the Component
+Use the component
 ~~~~~~~~~~~~~~~~~
 
 Replace the inline markup in the index template with a call to ``note_card``.
@@ -62,7 +63,7 @@ It resolves the component by name, runs any context functions declared in a ``co
 Reload ``/`` and confirm that the page still lists both notes.
 The HTML now uses an ``<article>`` per note instead of an ``<li>`` block.
 
-Add Co-located CSS
+Add co-located CSS
 ~~~~~~~~~~~~~~~~~~
 
 Place a CSS file next to ``component.djx`` and the :doc:`static pipeline </content/topics/static-assets/index>` picks it up automatically.
@@ -98,7 +99,7 @@ When a page renders a component that has co-located styles, the static collector
 Asset discovery picks up files co-located with the component folder.
 See :doc:`/content/topics/components` for the full component model.
 
-Wire the Collector Into the Layout
+Wire the collector into the layout
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Tell the layout where to emit the collected style and script tags.
@@ -130,7 +131,7 @@ Each asset is deduplicated by its URL, so the same file referenced from two comp
 
 Reload ``/`` and confirm that the served HTML now contains a ``<link>`` to ``note_card/component.css``.
 
-Add Co-located JavaScript
+Add co-located JavaScript
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Co-located scripts work the same way.
@@ -155,7 +156,7 @@ Add a small enhancement that toggles a class when the note title is clicked.
 
 The collector emits one ``<script>`` tag for the file at the location of ``{% collect_scripts %}``.
 
-Composite Components With Component Context
+Composite components with component context
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A component that pairs a template with a ``component.py`` is a composite component.
@@ -221,7 +222,7 @@ The index lists notes through the ``note_card`` component.
 The component carries its own template, Python context, CSS, and JS.
 The layout pulls both ``{% collect_styles %}`` and ``{% collect_scripts %}`` from the static pipeline.
 
-Common Pitfalls
+Common pitfalls
 ---------------
 
 Component renders nothing or is not found.
@@ -242,7 +243,7 @@ Component context not resolved.
    The framework forwards the parent template scope into the component, so ``note`` must be in scope where ``{% component "note_card" %}`` is called.
    Inside a ``{% for note in notes %}`` block the variable is in scope, outside the loop it is not.
 
-Next Steps
+Next steps
 ----------
 
 The notes are visible but not editable.

--- a/docs/content/intro/tutorial04.rst
+++ b/docs/content/intro/tutorial04.rst
@@ -1,6 +1,6 @@
 .. _intro-tutorial04:
 
-Forms and Actions
+Forms and actions
 =================
 
 Goal
@@ -20,7 +20,7 @@ Action handlers resolve ``request``, the form, and URL segments through the same
 Walkthrough
 -----------
 
-Declare the Note Forms
+Declare the note forms
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Forms in next.dj are Django forms with one extra base class.
@@ -55,7 +55,7 @@ See the :term:`origin page` glossary entry.
 ``next.forms`` re-exports the common Django form fields and widgets used in this tutorial, so ``BooleanField`` and the rest are importable from one place.
 Import other fields directly from :mod:`django.forms` when you need them.
 
-Register Context for the Index Page
+Register context for the index page
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The index page publishes context values.
@@ -88,7 +88,7 @@ The ``inherit_context=True`` flag on the three layout-scope callables stays from
 No manual import in ``page.py`` is needed.
 See :doc:`/content/topics/forms/overview` for scope rules and autodiscovery.
 
-Render the Create Form
+Render the create form
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Add the form to the index template.
@@ -130,7 +130,7 @@ The ``form`` variable inside the block is the unbound form on a GET and the boun
 
 Reload ``/``, submit the form with a title, and confirm that the index lists a new note.
 
-Edit a Note
+Edit a note
 ~~~~~~~~~~~
 
 Create a new page at ``notes/pages/notes/[id]/edit/``.
@@ -201,7 +201,7 @@ Add a link from the detail page.
      </p>
    </article>
 
-Delete a Note
+Delete a note
 ~~~~~~~~~~~~~
 
 Delete uses the same dispatch but does not need its own page because a single button can post directly to the action from the detail template.
@@ -227,7 +227,8 @@ The rendered form carries several hidden inputs from different sources.
 ``confirm`` is a real field on ``DeleteNoteForm``, so the template posts it explicitly.
 The ``{% form %}`` tag emits the framework fields itself.
 ``csrfmiddlewaretoken`` carries the CSRF token and ``_next_form_origin`` records the page URL, such as ``/notes/7/``.
-The dispatcher resolves that path against the URLconf, which recovers the captured ``id`` through the URL converter, so the action handler resolves ``DUrl["id", int]`` without any extra argument on the tag.
+The dispatcher resolves that path against the URLconf, which recovers the captured ``id`` through the URL converter.
+The action handler therefore resolves ``DUrl["id", int]`` without any extra argument on the tag.
 Add the delete handler to the detail page.
 ``DeleteNoteForm`` is declared in ``notes/forms.py`` and registers automatically at startup via autodiscovery.
 The detail ``page.py`` only needs to add its own context.
@@ -274,11 +275,11 @@ The complete file now looks like this.
 
 Submit the delete button on a note and the detail page redirects to the index, which no longer lists that note.
 
-How Re-render Works
+How re-render works
 ~~~~~~~~~~~~~~~~~~~
 
 A failing validation re-renders the origin page rather than producing an error page.
-The framework keeps a per-request cache that memoises ``Depends("name")`` callables across the initial render and any subsequent re-render in the same request, and the re-render reads from it instead of recomputing.
+The framework keeps a per-request cache that memoises dependency-injected values between the initial dispatch and the re-render, so the re-render reads from it instead of recomputing.
 See :doc:`/content/topics/dependency-injection` for the full cache model.
 It runs the same context functions, so the surrounding page content stays consistent.
 See :doc:`/content/topics/forms/validation-rerender` for the full re-render contract.
@@ -320,7 +321,7 @@ The Notes application is functionally complete.
 Users can create, view, edit, and delete notes.
 Every action goes through a typed action handler that receives the validated form and any DI markers it asks for.
 
-Common Pitfalls
+Common pitfalls
 ---------------
 
 Action fires but the page reloads with an empty form.
@@ -328,7 +329,7 @@ Action fires but the page reloads with an empty form.
    A handler that returns ``None`` renders the page again from scratch.
 
 CSRF token missing.
-   ``{% form "..." %}`` injects the token automatically, but only on POST forms.
+   ``{% form "..." %}`` injects the token automatically.
    Plain ``<form method="post">`` markup without the tag still needs ``{% csrf_token %}``.
 
 Edit form does not show the existing data.
@@ -337,7 +338,7 @@ Edit form does not show the existing data.
 
 See :doc:`/content/faq/troubleshooting` for the full catalog of errors and fixes.
 
-Next Steps
+Next steps
 ----------
 
 The application works end to end.

--- a/docs/content/intro/tutorial05.rst
+++ b/docs/content/intro/tutorial05.rst
@@ -1,6 +1,6 @@
 .. _intro-tutorial05:
 
-Testing and Autoreload
+Testing and autoreload
 ======================
 
 Goal
@@ -21,7 +21,7 @@ Keep that page open if you want the full helper catalog.
 Walkthrough
 -----------
 
-Install Test Dependencies
+Install test dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 next.dj ships the ``next.testing`` package, and its helpers work with Django ``TestCase``, stdlib ``unittest``, and pytest alike.
@@ -43,7 +43,7 @@ Add the pytest configuration.
    addopts = --tb=short
 
 Add a ``conftest.py`` at the project root.
-The conftest imports ``notes.forms`` and every ``page.py`` so actions register before the tests run.
+The conftest imports every ``page.py`` so the actions declared there register before the tests run.
 The ``PAGES_DIR`` path must match the actual app and page-root names, so a project that did not name its app ``notes`` adjusts the path accordingly.
 
 .. code-block:: python
@@ -51,23 +51,19 @@ The ``PAGES_DIR`` path must match the actual app and page-root names, so a proje
 
    from pathlib import Path
    import pytest
-   from notes import forms  # noqa: F401
-   from next.forms import autodiscover_forms
    from next.testing.loaders import eager_load_pages
 
    PAGES_DIR = Path(__file__).resolve().parent / "notes" / "pages"
 
    @pytest.fixture(autouse=True, scope="session")
    def _next_dj_registration():
-       autodiscover_forms()
        eager_load_pages(PAGES_DIR)
        yield
 
-Importing ``notes.forms`` at the top registers ``CreateNoteForm`` and ``DeleteNoteForm`` exactly as startup autodiscovery does.
-Form classes register through ``__init_subclass__`` when their module is first imported, so the registration survives for the whole session and re-importing a cached module does nothing.
-``autodiscover_forms`` covers any other app whose forms live in ``<app>/forms.py``.
+The forms in ``notes/forms.py`` need no conftest wiring.
+The ``next`` app runs form autodiscovery at startup, and pytest-django boots Django before any fixture runs, so ``CreateNoteForm`` and ``DeleteNoteForm`` are already registered.
 ``eager_load_pages`` walks ``notes/pages`` and imports every ``page.py``, which runs the page decorators.
-Both calls are idempotent, so the session-scoped fixture runs the registration once.
+The call is idempotent, so the session-scoped fixture runs the registration once.
 Database access uses the standard ``db`` fixture from pytest-django, no extra fixture is needed.
 
 .. note::
@@ -77,7 +73,7 @@ Database access uses the standard ``db`` fixture from pytest-django, no extra fi
    Re-importing ``notes/forms.py`` will not re-register them because Python caches the module, so the next ``post_action`` raises ``FormActionNotFoundError``.
    Reach for ``reset_registries()`` only in a test that deliberately swaps ``NEXT_FRAMEWORK`` backends, and re-register the affected forms inside that test.
 
-Write the First End-to-End Test
+Write the first end-to-end test
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Create ``tests/test_notes_e2e.py``.
@@ -118,7 +114,7 @@ Run the tests.
 
    uv run pytest
 
-Test the Create Action
+Test the create action
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The framework gives each action a stable URL.
@@ -134,13 +130,13 @@ The framework gives each action a stable URL.
        response = client.post_action("create_note_form", {"title": "From test", "body": "body"})
        assert response.status_code == 302
        assert Note.objects.filter(title="From test").exists()
-       assert response["Location"] == "/"  # redirect_to_origin falls back to "/"
+       assert response["Location"] == "/"
 
 ``post_action`` looks the action name up through ``resolve_action_url`` and posts the data to the dispatch endpoint.
 The action name ``create_note_form`` is derived automatically from the class name ``CreateNoteForm``.
 The redirect target is ``"/"`` because ``on_valid`` calls ``redirect_to_origin``, which sends the visitor back to the page that rendered the form and falls back to ``"/"``.
 
-Capture Action Signals
+Capture action signals
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Every successful dispatch fires the ``action_dispatched`` signal.
@@ -169,12 +165,13 @@ It accepts several signals at once and exposes ``first_for``, ``last_for``, and 
 Each captured event is a ``SignalEvent`` with ``signal``, ``sender``, and ``kwargs`` attributes.
 The ``action_dispatched`` payload carries ``action_name``, ``uid``, ``request``, ``form``, ``url_kwargs``, ``duration_ms``, ``response_status``, and ``dep_cache``.
 
-Test Validation Failure
+Test validation failure
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 A failed validation does not produce a redirect.
 The pipeline re-renders the origin page with the bound form and a non-zero error count.
 The test passes ``origin="/"``, which fills the hidden ``_next_form_origin`` field a browser submission carries, so the dispatcher knows which page to re-render.
+Append the failure test to ``tests/test_notes_actions.py``.
 
 .. code-block:: python
    :caption: tests/test_notes_actions.py
@@ -189,7 +186,7 @@ The response status is ``200`` because the index page rendered.
 This time the failing form replaces the unbound one in the template context.
 A failing POST without a resolvable ``origin`` returns HTTP 400 instead, because the dispatcher has no page to re-render.
 
-Use the Autoreloader
+Use the autoreloader
 ~~~~~~~~~~~~~~~~~~~~
 
 The development server already reloads on Python file changes.
@@ -228,7 +225,8 @@ Open ``http://127.0.0.1:8000/about/`` and confirm that the new page is served wi
 .. note::
 
    The framework emits ``action_dispatched`` after a successful handler run, recorded above through ``SignalRecorder``.
-   The autoreloader emits a companion ``router_reloaded`` signal each time the route set changes, so a test that wants to react to filesystem-driven route changes can subscribe to it the same way.
+   The router manager emits a companion ``router_reloaded`` signal each time it rebuilds its backends, for example on a settings reload.
+   A test that swaps ``NEXT_FRAMEWORK`` backends can subscribe to it the same way.
    See :doc:`/content/howto/observe-framework-signals` for the full subscriber pattern.
 
 Checkpoint
@@ -249,7 +247,7 @@ The project now has tests.
 The full test suite covers the index, the detail page, the create action, the create validation failure, and the ``action_dispatched`` signal.
 The development server reloads page and component changes without a manual restart.
 
-Common Pitfalls
+Common pitfalls
 ---------------
 
 ``post_action`` raises ``FormActionNotFoundError``.
@@ -265,7 +263,7 @@ Autoreloader does not pick up a change.
    Confirm that the changed file lives under one of the watched roots.
    The reloader watches ``page.py`` files under the page roots and ``component.py`` files under the component roots, so files elsewhere do not trigger a router reload.
 
-Next Steps
+Next steps
 ----------
 
 The Notes application works and is tested.

--- a/docs/content/intro/tutorial06.rst
+++ b/docs/content/intro/tutorial06.rst
@@ -1,6 +1,6 @@
 .. _intro-tutorial06:
 
-Live Updates with Partial Rendering
+Live updates with partial rendering
 ===================================
 
 Goal
@@ -19,12 +19,12 @@ The Notes application creates, edits, and deletes notes through registered actio
 The layout from :doc:`tutorial03` already pulls ``{% collect_scripts %}`` into the bottom of ``<body>``, and the static pipeline injects the client runtime through that tag.
 There is nothing new to install.
 
-Partial rendering layers on top of the ``POST`` then ``303`` then ``GET`` flow the framework already serves, covered in depth in :doc:`/content/topics/partial-rendering/index`.
+Partial rendering layers on top of the ``POST``, redirect, ``GET`` flow the framework already serves, covered in depth in :doc:`/content/topics/partial-rendering/index`.
 
 Walkthrough
 -----------
 
-Wrap the Note List in a Zone
+Wrap the note list in a zone
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A ``{% zone %}`` block marks a slice of a template the server can re-render on its own.
@@ -49,7 +49,7 @@ Each ``data-next-key`` keeps a row stable when the list re-renders, so the morph
 Reload ``/`` and confirm the list looks unchanged.
 The zone is invisible until something targets it.
 
-Filter the List as You Type
+Filter the list as you type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Add a search box above the list.
@@ -105,6 +105,8 @@ Update ``notes/pages/page.py`` so the ``notes`` context honours ``q``, and publi
 Both callables read ``request.GET`` the same way, so the zone fetch and the full page agree on the filter.
 The ``query`` context only feeds the input value, and the ``notes`` context drives the list.
 See :doc:`/content/topics/context` for how a page publishes named values.
+The hand-parsed ``request.GET`` keeps the example explicit.
+The ``DQuery`` marker from ``next.urls`` reads the same query parameter declaratively, see :doc:`/content/topics/dependency-injection`.
 
 There is no handler and no JavaScript.
 Typing ``gro`` debounces, then sends one zone ``GET``.
@@ -141,11 +143,12 @@ A new keystroke aborts an in-flight request, and a stale response that arrives a
 Without the runtime the same form is a plain ``GET`` that reloads the whole page with the filtered list.
 The provider reads ``request.GET`` either way, so the zone fetch reuses the exact query parsing the full page uses.
 
-Create a Note in Place
+Create a note in place
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 The create form from :doc:`tutorial04` already posts through a registered action.
 Teach its handler to answer a partial request with a patch instead of a redirect.
+Update the ``CreateNoteForm`` class in ``notes/forms.py`` and merge the new imports, keeping ``DeleteNoteForm`` and its imports in place.
 
 .. code-block:: python
    :caption: notes/forms.py, the create form
@@ -189,7 +192,7 @@ The morph keeps the caret in the title field, so a visitor can add several notes
 Submit a note with a title and watch it appear at the top of the list with no reload.
 Submit with an empty title and the form re-renders its error in place, the list untouched.
 
-How It Degrades
+How it degrades
 ~~~~~~~~~~~~~~~
 
 Turn JavaScript off and exercise the same page.
@@ -217,7 +220,7 @@ Filtering re-renders one zone as the visitor types, creating a note refreshes th
 No new models, no new URLs, and no client code.
 The behaviour rides the action dispatch and the file router the application already had.
 
-Common Pitfalls
+Common pitfalls
 ---------------
 
 The filter reloads the whole page instead of swapping the list.
@@ -233,7 +236,7 @@ The new note appears twice for a moment.
 
 See :doc:`/content/faq/troubleshooting` for the full catalog of errors and fixes.
 
-Next Steps
+Next steps
 ----------
 
 The Notes application is complete and live.

--- a/docs/content/intro/whatsnext.rst
+++ b/docs/content/intro/whatsnext.rst
@@ -1,12 +1,10 @@
 .. _intro-whatsnext:
 
-What to Read Next
+What to read next
 =================
 
 The tutorial covers the core flow.
 After :doc:`tutorial06`, read the topics, then the how-to guides, then the reference, then the internals when you need depth beyond the Notes walkthrough.
-
-The hubs below replace long subsystem-by-subsystem lists.
 
 - :doc:`/content/topics/index` explains each subsystem.
 - :doc:`/content/howto/index` answers task-shaped questions.
@@ -15,10 +13,10 @@ The hubs below replace long subsystem-by-subsystem lists.
 - :doc:`/content/deployment/index` and :doc:`/content/security/index` cover operations.
 - :doc:`/content/misc/examples` catalogues the repository ``examples/`` projects with links and doc cross-references.
 
-Learning Paths
+Learning paths
 --------------
 
-First Full-Stack App
+First full-stack app
 ~~~~~~~~~~~~~~~~~~~~
 
 1. :doc:`install`
@@ -30,7 +28,7 @@ First Full-Stack App
 7. :doc:`/content/topics/static-assets/index`
 8. :doc:`/content/deployment/checklist`
 
-Customize the Pipeline
+Customize the pipeline
 ~~~~~~~~~~~~~~~~~~~~~~
 
 1. :doc:`/content/topics/extending`
@@ -42,7 +40,7 @@ Customize the Pipeline
 7. :doc:`/content/howto/add-a-custom-template-loader`
 8. :doc:`/content/howto/observe-framework-signals`
 
-Multi-Tenant or Multi-Project Setup
+Multi-tenant or multi-project setup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. :doc:`/content/topics/multi-project`

--- a/docs/content/misc/design-philosophy.rst
+++ b/docs/content/misc/design-philosophy.rst
@@ -1,6 +1,6 @@
 .. _misc-design-philosophy:
 
-Design Philosophy
+Design philosophy
 =================
 
 Read this page when a framework decision surprises you and you want to understand the reasoning behind it.
@@ -10,35 +10,35 @@ For a practical description of what next.dj adds to Django, see :doc:`/content/i
    :local:
    :depth: 2
 
-Stay Inside Django
+Stay inside Django
 ------------------
 
 Ordinary Django concerns stay in place.
 See :ref:`intro-overview-django-unchanged` in :doc:`/content/intro/overview` for the split.
 This page explains why routing, layouts, components, assets, and form dispatch sit on that base and what trade-offs follow.
 
-Filesystem as a Single Source of Truth
+Filesystem as a single source of truth
 --------------------------------------
 
 A directory layout describes the URL tree, the layout tree, the component registry, and the asset tree.
 A reader does not switch between five settings files to learn the shape of a project.
 A change in the file system propagates without manual wiring.
 
-Convention With Explicit Names
+Convention with explicit names
 ------------------------------
 
 The framework defines a small set of conventions (``page.py``, ``layout.djx``, ``template.djx``, ``component.djx``, ``COMPONENTS_DIR``, ``PAGES_DIR``).
 Each convention has an explicit name that can be overridden through settings.
 Magic class names and module level decorators that depend on the filename are absent.
 
-Explicit Parameters
+Explicit parameters
 -------------------
 
 Page modules, render functions, action handlers, and context functions declare what they need through ordinary Python parameters.
 The resolver fills them.
 A function that does not ask for the request never receives it, which keeps the signatures honest and the tests easy.
 
-Composition Over Inheritance
+Composition over inheritance
 ----------------------------
 
 Layouts compose by string substitution, not by Django ``{% extends %}``.
@@ -51,7 +51,7 @@ Every page gets a stable URL name derived from its directory path.
 The name is predictable, so a reader can reverse it without consulting a URL configuration file.
 Moving a directory changes both the URL and its name, and ``{% url %}`` calls must be updated to match.
 
-Forms and Form Dispatch
+Forms and form dispatch
 -----------------------
 
 A form action is wired the same way a page is.
@@ -61,26 +61,26 @@ This follows the same filesystem-as-source-of-truth rule the rest of the framewo
 Every action posts to one endpoint, ``/_next/form/<uid>/``, where the ``uid`` is a stable short id derived from the action's scope and name, so moving a form between pages never changes the URL configuration.
 The dispatcher resolves the uid back to the registered action and runs the validation and re-render pipeline.
 
-Small Public Surfaces
+Small public surfaces
 ---------------------
 
 Each subsystem exposes a narrow public API through its ``__init__.py``.
 Importing deeper modules may work at runtime, yet anything not listed in :doc:`/content/ref/index` or :doc:`/content/faq/general` as stable is not part of the documented contract for application code.
 Keep application imports to the documented top-level ``next.*`` symbols.
 
-Signals for Side Channels
+Signals for side channels
 -------------------------
 
 Cross subsystem coordination uses signals.
 A change in the route set, in the registered components, in the form actions, or in the asset registry fires a signal that an audit tool or a websocket subscriber can listen to.
 
-No Lock In
+No lock in
 ----------
 
 The data lives in Django models and standard Django templates keep working.
 Page modules, layout composition, and framework template tags depend on next.dj, so removing it means rewriting the routed UI layer, not the data layer.
 
-Trade Offs
+Trade offs
 ----------
 
 Filesystem walks at startup.
@@ -88,8 +88,8 @@ Filesystem walks at startup.
    Large projects can opt into ``LAZY_COMPONENT_MODULES``.
 
 String composition of layouts.
-   No Django template caching of the composed result.
-   The framework recomputes the chain per render, which is acceptable for the average page.
+   The composed template is cached and compiled per page and invalidated by source mtime.
+   A body produced by a ``render`` function bypasses that cache and is recomposed per render.
 
 Convention based naming.
    Directories must respect the naming rules.
@@ -97,7 +97,7 @@ Convention based naming.
 
 These trade offs are the cost of keeping the developer model simple and the file router predictable.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/misc/examples.rst
+++ b/docs/content/misc/examples.rst
@@ -1,6 +1,6 @@
 .. _misc-examples:
 
-Repository Examples
+Repository examples
 ===================
 
 The ``examples/`` tree in the next.dj repository holds self-contained Django projects.
@@ -20,47 +20,47 @@ The **Primary docs** column points to the sections of this manual where the tech
    * - Folder
      - Focus
      - Primary docs
-   * - `shortener <https://github.com/next-dj/next-dj/tree/main/examples/shortener>`__
+   * - :repo:`shortener <tree/main/examples/shortener>`
      - File router, DI providers, LocMemCache, ``{% zone %}`` lists patched through ``Patches`` envelopes, management command
      - :doc:`/content/topics/file-router`, :doc:`/content/topics/dependency-injection`, :doc:`/content/topics/partial-rendering/index`
-   * - `markdown-blog <https://github.com/next-dj/next-dj/tree/main/examples/markdown-blog>`__
+   * - :repo:`markdown-blog <tree/main/examples/markdown-blog>`
      - Markdown posts, nested layouts, ``@context(serialize=True)``, context processor, co-located ``component.js``
      - :doc:`/content/topics/layouts`, :doc:`/content/topics/context`, :doc:`/content/topics/static-assets/js-context`
-   * - `feature-flags <https://github.com/next-dj/next-dj/tree/main/examples/feature-flags>`__
+   * - :repo:`feature-flags <tree/main/examples/feature-flags>`
      - Composite ``feature_guard``, signal receivers, cache invalidation
      - :doc:`/content/topics/components`, :doc:`/content/topics/signals`
-   * - `audit-forms <https://github.com/next-dj/next-dj/tree/main/examples/audit-forms>`__
+   * - :repo:`audit-forms <tree/main/examples/audit-forms>`
      - Custom ``FormActionBackend``, ``action_dispatched`` / ``form_validation_failed`` signals, dual audit channels, ``FormWizard`` in a modal layer, lazy audit-table zone
      - :doc:`/content/topics/forms/wizard`, :doc:`/content/topics/forms/backends`, :doc:`/content/topics/forms/signals`, :doc:`/content/topics/partial-rendering/index`
-   * - `search-catalog <https://github.com/next-dj/next-dj/tree/main/examples/search-catalog>`__
+   * - :repo:`search-catalog <tree/main/examples/search-catalog>`
      - Faceted site search. ``DQuery[T]``, faceted filters, nested layouts, ``inherit_context=True``, cached search
      - :doc:`/content/topics/dependency-injection`, :doc:`/content/topics/context`
-   * - `wiki <https://github.com/next-dj/next-dj/tree/main/examples/wiki>`__
+   * - :repo:`wiki <tree/main/examples/wiki>`
      - ``HybridRouterBackend``, ``router_manager.reload()`` on signal, DI, live search zone, forms with live Markdown preview
      - :doc:`/content/topics/file-router`, :doc:`/content/howto/write-a-router-backend`, :doc:`/content/topics/partial-rendering/index`
-   * - `multi-tenant <https://github.com/next-dj/next-dj/tree/main/examples/multi-tenant>`__
+   * - :repo:`multi-tenant <tree/main/examples/multi-tenant>`
      - Tenant middleware, request-scoped static URLs, shared blocks via ``COMPONENT_BACKENDS`` ``DIRS``
      - :doc:`/content/howto/scope-requests-per-tenant`, :doc:`/content/topics/static-assets/backends`
-   * - `kanban <https://github.com/next-dj/next-dj/tree/main/examples/kanban>`__
+   * - :repo:`kanban <tree/main/examples/kanban>`
      - Custom ``StaticBackend``, ``.jsx`` kind, ``DeepMergePolicy``, ``HashContentDedup``, composite components
      - :doc:`/content/topics/static-assets/asset-kinds`, :doc:`/content/topics/static-assets/deduplication`, :doc:`/content/topics/partial-rendering/framework-islands`
-   * - `live-polls <https://github.com/next-dj/next-dj/tree/main/examples/live-polls>`__
+   * - :repo:`live-polls <tree/main/examples/live-polls>`
      - Framework SSE bridge, ``refresh`` patches, request-id echo, ``action_dispatched`` fan-out, Vue SFC asset kind
      - :doc:`/content/topics/partial-rendering/sse`, :doc:`/content/howto/stream-live-updates-with-sse`, :doc:`/content/topics/extending`, :doc:`/content/topics/partial-rendering/framework-islands`
-   * - `observability <https://github.com/next-dj/next-dj/tree/main/examples/observability>`__
+   * - :repo:`observability <tree/main/examples/observability>`
      - Signal groups, custom ``ComponentsBackend``, ``DedupStrategy``, polling and lazy zones, custom patch verb, per-key ``JsContextSerializer``
      - :doc:`/content/topics/signals`, :doc:`/content/topics/extending`, :doc:`/content/topics/partial-rendering/index`
-   * - `admin <https://github.com/next-dj/next-dj/tree/main/examples/admin>`__
+   * - :repo:`admin <tree/main/examples/admin>`
      - Django admin UI rebuilt on next.dj, request-aware form factories, server-opened modal layers, two page roots, middleware guard
      - :doc:`/content/howto/integrate-django-admin`, :doc:`/content/topics/multi-project`, :doc:`/content/topics/partial-rendering/index`
 
 Shared assets
 -------------
 
-* `_shared <https://github.com/next-dj/next-dj/tree/main/examples/_shared>`__. A shared component palette consumed through ``COMPONENT_BACKENDS`` ``DIRS``.
-* `_template <https://github.com/next-dj/next-dj/tree/main/examples/_template>`__. An empty scaffold to copy when starting a new example-shaped project.
+* :repo:`_shared <tree/main/examples/_shared>`. A shared component palette consumed through ``COMPONENT_BACKENDS`` ``DIRS``.
+* :repo:`_template <tree/main/examples/_template>`. An empty scaffold to copy when starting a new example-shaped project.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/misc/glossary.rst
+++ b/docs/content/misc/glossary.rst
@@ -204,7 +204,7 @@ Terms used throughout the next.dj documentation.
       A named slice of a page template wrapped in ``{% zone %}``.
       The server re-renders the slice standalone, and patches address it by its name.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/misc/index.rst
+++ b/docs/content/misc/index.rst
@@ -1,6 +1,6 @@
 .. _misc:
 
-Meta and Miscellany
+Meta and miscellany
 ===================
 
 This section collects material that supports the rest of the documentation without belonging to a single subsystem.

--- a/docs/content/ref/apps.rst
+++ b/docs/content/ref/apps.rst
@@ -1,9 +1,9 @@
 .. _ref-apps:
 
-Apps Reference
+Apps reference
 ==============
 
-Module Summary
+Module summary
 --------------
 
 ``next.apps`` contains the Django ``AppConfig`` and the helpers that the framework runs at application startup.
@@ -29,13 +29,13 @@ Public API
 The installer submodules below are called exclusively from ``NextFrameworkConfig.ready`` and are not part of the project-level public API.
 They are documented here for framework contributors and for projects that instrument startup behaviour.
 
-Template Tag Registration
+Template tag registration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: next.apps.templates
    :members:
 
-Staticfiles Integration
+Staticfiles integration
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: next.apps.staticfiles
@@ -43,7 +43,7 @@ Staticfiles Integration
 
 ``staticfiles.install()`` calls ``next.static.register_defaults`` to register the built-in ``css``, ``js``, and ``module`` kinds and the ``styles`` and ``scripts`` slots.
 
-Autoreload Installer
+Autoreload installer
 ~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: next.apps.autoreload
@@ -51,9 +51,10 @@ Autoreload Installer
 
 ``install()`` swaps Django's ``StatReloader`` for ``NextStatReloader`` and connects the ``autoreload_started`` signal so the framework's watch specs are registered at dev-server startup.
 ``uninstall()`` restores the original ``StatReloader`` subclass.
-Test suites that call ``ready()`` multiple times use it to avoid double-patching.
+Test suites that patched the reloader through ``ready()`` call it to put the original class back.
+Repeated ``ready()`` calls need no such cleanup because ``install()`` itself is idempotent.
 
-Components Installer
+Components installer
 ~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: next.apps.components
@@ -63,7 +64,7 @@ Components Installer
 Unless ``LAZY_COMPONENT_MODULES`` is true it also imports every discovered ``component.py``.
 See :doc:`/content/internals/component-pipeline` for the discovery and load sequence.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/backends.rst
+++ b/docs/content/ref/backends.rst
@@ -1,0 +1,35 @@
+.. _ref-backends:
+
+Backends reference
+==================
+
+Module summary
+--------------
+
+``next.backends`` holds the shared loading and lazy management helpers behind every settings-driven backend family.
+``load_backends`` instantiates a configured backend list, ``resolve_backend_class`` resolves one dotted ``BACKEND`` path against a family root, and ``SingleBackendManager`` lazily builds the single backend named by one settings key.
+``BackendRoot`` is the type alias each family uses to pass its abstract root class to these helpers.
+
+The two loading paths differ in how they treat a misconfigured entry.
+``load_backends`` logs and skips it, so the family keeps serving with the remaining backends.
+``SingleBackendManager`` raises :class:`~django.core.exceptions.ImproperlyConfigured` instead, because a family with one backend has nothing to fall back to.
+
+Public API
+----------
+
+.. autofunction:: next.backends.load_backends
+
+.. autofunction:: next.backends.resolve_backend_class
+
+.. autoclass:: next.backends.SingleBackendManager
+   :members:
+
+.. autodata:: next.backends.BackendRoot
+
+See also
+--------
+
+.. seealso::
+
+   :doc:`settings` for the ``*_BACKENDS`` and ``*_BACKEND`` keys these helpers read.
+   :doc:`/content/topics/extending` for writing a custom backend.

--- a/docs/content/ref/components.rst
+++ b/docs/content/ref/components.rst
@@ -1,9 +1,9 @@
 .. _ref-components:
 
-Components Reference
+Components reference
 ====================
 
-Module Summary
+Module summary
 --------------
 
 ``next.components`` exposes the component discovery, registration, and rendering API.
@@ -11,9 +11,9 @@ The names in this reference are grouped by their intended audience.
 
 .. note::
 
-   The Application Imports, Framework Extension, and Internal Infrastructure tiers follow the public-surface rules in :ref:`faq-safe-symbols`.
+   The Application imports, Framework extension, and Internal infrastructure tiers follow the public-surface rules in :ref:`faq-safe-symbols`.
 
-Application Imports
+Application imports
 -------------------
 
 These are the names project code uses day-to-day.
@@ -27,7 +27,8 @@ These are the names project code uses day-to-day.
 .. autodata:: next.components.context
    :no-value:
 
-   The ``@component.context`` decorator, bound from ``ComponentContextManager.context``. Registers a context function inside a ``component.py``.
+   The ``@component.context`` decorator, bound from ``ComponentContextManager.context``.
+   It registers a context function inside a ``component.py``.
 
 .. autofunction:: next.components.get_component
 
@@ -43,7 +44,7 @@ Manager
 
 .. autodata:: next.components.components_manager
 
-Framework Extension
+Framework extension
 -------------------
 
 These names are used when writing a custom component backend or a custom renderer.
@@ -61,7 +62,7 @@ Backends
 
 The URL router calls this during the page-tree walk and application code does not invoke it directly.
 
-Context Pipeline
+Context pipeline
 ~~~~~~~~~~~~~~~~
 
 .. autoclass:: next.components.ComponentContextManager
@@ -91,12 +92,12 @@ Renderers
 ``ComponentsManager`` wires a single ``ComponentTemplateLoader`` into its render pipeline.
 The loader is fixed and not pluggable, so a custom backend reads component template bodies through this class rather than substituting its own.
 
-Internal Infrastructure
+Internal infrastructure
 -----------------------
 
 These classes are implementation details.
 They are exported for testing and advanced instrumentation.
-Prefer the Application Imports tier unless you are building framework tooling.
+Prefer the Application imports tier unless you are building framework tooling.
 
 .. autoclass:: next.components.ComponentInfo
    :members:
@@ -125,7 +126,7 @@ The duplicate-name check groups by ``(scope_root, name)`` and ignores ``scope_re
 
 .. autofunction:: next.components.get_component_paths_for_watch
 
-Test Doubles
+Test doubles
 ~~~~~~~~~~~~
 
 ``DummyBackend`` and ``BoomBackend`` are minimal ``ComponentsBackend`` implementations kept in this module so that dotted-path resolution in tests works through the standard loader.
@@ -169,7 +170,7 @@ The module ``next.components.signals`` exposes four ``django.dispatch.Signal`` i
      - ``ComponentsManager``
      - ``info`` (``ComponentInfo``), ``template_path`` (``Path`` or ``None``)
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/components.rst
+++ b/docs/content/ref/components.rst
@@ -57,9 +57,6 @@ Backends
 .. autoclass:: next.components.FileComponentsBackend
    :members:
 
-.. autoclass:: next.components.ComponentsFactory
-   :members:
-
 .. autofunction:: next.components.register_components_folder_from_router_walk
 
 The URL router calls this during the page-tree walk and application code does not invoke it directly.
@@ -131,16 +128,16 @@ The duplicate-name check groups by ``(scope_root, name)`` and ignores ``scope_re
 Test Doubles
 ~~~~~~~~~~~~
 
-``DummyBackend`` and ``BoomBackend`` are minimal ``ComponentsBackend`` implementations kept in this module so that dotted-path resolution in tests works through the standard factory.
+``DummyBackend`` and ``BoomBackend`` are minimal ``ComponentsBackend`` implementations kept in this module so that dotted-path resolution in tests works through the standard loader.
 They are **not** intended for production use.
 
 ``DummyBackend`` accepts a config dict, stores it on ``self``, and resolves no components.
-Use it to test factory wiring.
+Use it to test backend wiring.
 
 .. autoclass:: next.components.DummyBackend
    :members:
 
-``BoomBackend`` raises ``RuntimeError`` from ``__init__`` so you can assert that ``ComponentsManager`` catches and logs a failed backend instantiation.
+``BoomBackend`` raises ``RuntimeError`` from ``__init__`` so you can assert that a backend bug reaches the caller instead of being logged as a configuration error.
 
 .. autoclass:: next.components.BoomBackend
    :members:
@@ -166,8 +163,8 @@ The module ``next.components.signals`` exposes four ``django.dispatch.Signal`` i
      - ``ComponentRegistry``
      - ``infos`` (tuple of ``ComponentInfo``)
    * - ``component_backend_loaded``
-     - ``ComponentsManager``
-     - ``backend`` (``ComponentsBackend``), ``config`` (mapping)
+     - The component backend class
+     - ``instance`` (``ComponentsBackend``), ``config`` (mapping)
    * - ``component_rendered``
      - ``ComponentsManager``
      - ``info`` (``ComponentInfo``), ``template_path`` (``Path`` or ``None``)

--- a/docs/content/ref/conf.rst
+++ b/docs/content/ref/conf.rst
@@ -1,9 +1,9 @@
 .. _ref-conf:
 
-Configuration Reference
+Configuration reference
 =======================
 
-Module Summary
+Module summary
 --------------
 
 ``next.conf`` merges user ``NEXT_FRAMEWORK`` settings with framework defaults.
@@ -12,7 +12,7 @@ It exposes the merged-settings object, the import helpers, the ``extend_default_
 Public API
 ----------
 
-Settings Class
+Settings class
 ~~~~~~~~~~~~~~
 
 .. automodule:: next.conf.settings
@@ -30,7 +30,7 @@ Helpers
 .. automodule:: next.conf.helpers
    :members:
 
-Import Utilities
+Import utilities
 ~~~~~~~~~~~~~~~~
 
 .. autofunction:: next.conf.imports.import_class_cached
@@ -47,7 +47,7 @@ Signals
 
 See :doc:`signals` for the ``settings_reloaded`` signal.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/decorators.rst
+++ b/docs/content/ref/decorators.rst
@@ -1,9 +1,9 @@
 .. _ref-decorators:
 
-Decorators and Markers
+Decorators and markers
 ======================
 
-Module Summary
+Module summary
 --------------
 
 This page lists every public decorator and dependency marker that the framework exposes.
@@ -24,7 +24,7 @@ Called as ``@context("greeting")`` it receives a key string and binds the functi
 Pass ``inherit_context=True`` to publish the value to every descendant page.
 Pass ``serialize=True`` to expose the return value to the browser under ``window.Next.context``.
 The value must be JSON-encodable by the active serializer.
-See :ref:`Serialization for the Browser <topics-context-serialization>` for the contract.
+See :ref:`Serialization for the browser <topics-context-serialization>` for the contract.
 Pass ``serializer=`` to route that key through a custom ``JsContextSerializer``.
 
 @component.context
@@ -37,7 +37,7 @@ The first positional argument is ``func_or_key``.
 Called bare as ``@component.context`` it merges the function's returned dict into the component template scope.
 Called as ``@component.context("greeting")`` it binds the function's return value to that key.
 Pass ``serialize=True`` to include the return value in ``window.Next.context``.
-The value must be JSON-encodable by the active serializer, the same contract documented under :ref:`Serialization for the Browser <topics-context-serialization>`.
+The value must be JSON-encodable by the active serializer, the same contract documented under :ref:`Serialization for the browser <topics-context-serialization>`.
 Pass ``serializer=`` to route that key through a custom ``JsContextSerializer``.
 
 @action
@@ -61,7 +61,7 @@ Pass ``login_required=True`` or ``permission_required=`` to guard the dispatch e
 Applying ``@action`` to a class registers no action and returns the class unchanged.
 The misuse is recorded and reported as the ``next.E053`` system check by ``manage.py check``.
 
-Dependency Markers
+Dependency markers
 ------------------
 
 Depends
@@ -139,7 +139,7 @@ RegisteredParameterProvider
 Base class for custom parameter providers.
 Implement ``can_handle`` and ``resolve`` to plug a custom data source into the resolver.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/deps.rst
+++ b/docs/content/ref/deps.rst
@@ -1,9 +1,9 @@
 .. _ref-deps:
 
-Dependency Injection Reference
+Dependency injection reference
 ==============================
 
-Module Summary
+Module summary
 --------------
 
 ``next.deps`` exposes the resolver, the parameter providers, the dependency cache, and the public markers used in annotations.
@@ -67,7 +67,7 @@ Checks
 
 The dependency injection layer registers no Django system checks.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/forms.rst
+++ b/docs/content/ref/forms.rst
@@ -1,18 +1,18 @@
 .. _ref-forms:
 
-Forms Reference
+Forms reference
 ===============
 
-Module Summary
+Module summary
 --------------
 
 ``next.forms`` exposes form base classes, the ``@action`` decorator,
 formset helpers, frozen field and form specs,
 and a curated set of commonly used Django form fields and widgets.
 Any public ``django.forms`` name is also importable from ``next.forms``,
-see `Fields and Widgets`_ for the contract.
+see `Fields and widgets`_ for the contract.
 
-API Tiers
+API tiers
 ---------
 
 The forms surface splits into tiers that describe the intended audience for each name.
@@ -94,7 +94,7 @@ When ``registry_empty`` is true the message also explains that no actions are re
 .. autoexception:: next.forms.FormActionNotFoundError
    :members:
 
-Form Base Classes
+Form base classes
 ~~~~~~~~~~~~~~~~~
 
 ``check_permissions`` and ``has_object_permission`` are the opt-in dynamic permission hooks.
@@ -113,7 +113,7 @@ See :ref:`topics-forms-actions-dynamic-guards` for the authoring contract and th
 .. autoclass:: next.forms.BaseModelForm
    :members: get_initial, get_success_message, on_valid, check_permissions, has_object_permission
 
-Form Wizard
+Form wizard
 ~~~~~~~~~~~
 
 ``FormWizard`` routes a sequence of step forms across requests.
@@ -142,8 +142,11 @@ has nothing to fall back to.
 
 .. autoclass:: next.backends.SingleBackendManager
    :members:
+   :no-index:
 
-Fields and Widgets
+The canonical entry for the class lives in :doc:`backends`.
+
+Fields and widgets
 ~~~~~~~~~~~~~~~~~~
 
 The framework re-exports a curated set of commonly used Django form fields and widgets through
@@ -243,7 +246,7 @@ The rendered HTML flows through the static-assets pipeline, so co-located CSS an
 .. automodule:: next.forms.rendering
    :members: render_form_page_with_errors
 
-Registration Diagnostics
+Registration diagnostics
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``RegistrationDiagnostics`` buffers registration problems for the forms system checks, exposed as the module-level ``registration_diagnostics`` instance.
@@ -254,7 +257,7 @@ The test isolation helper :func:`next.testing.reset_form_registration_state` cle
 .. automodule:: next.forms.diagnostics
    :members:
 
-Action URL Helpers
+Action URL helpers
 ~~~~~~~~~~~~~~~~~~
 
 ``reverse_form_action`` resolves the dispatch URL for an action UID under either URL wiring,
@@ -262,12 +265,14 @@ the namespaced ``next:form_action`` route or the bare ``form_action`` route.
 It lives in ``next.forms.uid`` and is not re-exported at the package level.
 ``ORIGIN_FIELD_NAME`` is the wire name of the hidden origin field every rendered form carries, ``"_next_form_origin"``.
 ``validated_origin_path`` accepts a posted origin value only as a same-site path.
+``redirect_to_origin`` builds the success redirect back to the page named by the posted origin field, falling back to ``fallback`` when the field is absent or off-site.
+It is re-exported from ``next.forms``.
 ``FORM_ORIGIN_OVERRIDE_KEY`` names the render-context key whose value overrides the origin of a rendered form, which the partial shaping layer sets to the next step URL on a wizard advance.
 
 .. automodule:: next.forms.uid
    :members:
 
-Origin Resolution
+Origin resolution
 ~~~~~~~~~~~~~~~~~
 
 ``OriginMatch``, ``resolve_origin``, ``resolve_url_to_match``, and ``resolve_url_to_page`` are re-exported from ``next.forms``.
@@ -278,7 +283,7 @@ Origin Resolution
 .. automodule:: next.forms.origin
    :members: OriginMatch, resolve_origin, resolve_url_to_match, resolve_url_to_page
 
-Formset Helpers
+Formset helpers
 ~~~~~~~~~~~~~~~
 
 The Django factories ``formset_factory``, ``modelformset_factory``, and ``inlineformset_factory`` re-export through ``next.forms`` unchanged.
@@ -287,7 +292,7 @@ The Django factories ``formset_factory``, ``modelformset_factory``, and ``inline
 .. automodule:: next.forms.formsets
    :members:
 
-Frozen Specs
+Frozen specs
 ~~~~~~~~~~~~
 
 .. automodule:: next.forms.serializers
@@ -300,7 +305,7 @@ See :doc:`signals` and :doc:`/content/topics/forms/signals` for the form signals
 (``action_registered``, ``action_dispatched``, ``form_validation_failed``,
 ``wizard_step_submitted``, ``wizard_completed``, ``form_access_denied``).
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/forms.rst
+++ b/docs/content/ref/forms.rst
@@ -44,10 +44,9 @@ Framework machinery.
    ``FormActionDispatch`` lives in ``next.forms.dispatch``.
    ``FormActionManager``, the ``form_action_manager`` instance, and
    ``build_form_namespace_for_action`` live in ``next.forms.manager``.
-   ``ActionMeta``, ``FormActionFactory``, ``file_to_dotted_module``, ``scope_key_for``,
+   ``ActionMeta``, ``file_to_dotted_module``, ``scope_key_for``,
    ``build_action_guard``, and ``record_possible_collision`` live in ``next.forms.backends``.
-   ``WizardBackendManager`` and the ``wizard_backend_manager`` instance live in
-   ``next.forms.wizard``.
+   The ``wizard_backend_manager`` instance lives in ``next.forms.wizard``.
    ``FormProvider`` and ``CleanedDataProvider`` live in ``next.forms.markers``.
    ``bind_component_widgets`` lives in ``next.forms.widgets``.
    ``render_form_page_with_errors`` lives in ``next.forms.rendering``.
@@ -134,11 +133,14 @@ See :doc:`/content/topics/forms/wizard` and :doc:`/content/topics/forms/wizard-b
 .. autoclass:: next.forms.CacheFormWizardBackend
    :members:
 
-``WizardBackendManager`` is the lazy holder for the single configured wizard backend,
-exposed as the ``wizard_backend_manager`` instance in ``next.forms.wizard``.
-It reads ``FORM_WIZARD_BACKEND`` on first use and caches the result.
+``wizard_backend_manager`` in ``next.forms.wizard`` is the lazy holder for the single
+configured wizard backend, a ``SingleBackendManager`` bound to ``FORM_WIZARD_BACKEND``.
+It reads the setting on first use and caches the result.
+A malformed entry, an unimportable path, or a class outside the ``FormWizardBackend``
+family raises ``ImproperlyConfigured`` out of ``get``, since a family with one backend
+has nothing to fall back to.
 
-.. autoclass:: next.forms.wizard.WizardBackendManager
+.. autoclass:: next.backends.SingleBackendManager
    :members:
 
 Fields and Widgets
@@ -221,9 +223,8 @@ The target is one of ``handler``, ``form_class``, or ``wizard_class``, which let
 ``ActionGuard`` is the frozen access-requirement record built from ``Meta.login_required`` and ``Meta.permission_required`` or the matching ``@action`` keywords.
 It is stored under the ``guard`` key of ``ActionMeta`` and enforced by the dispatch pipeline before the form is built, so custom backends see the declared requirements without extra wiring.
 ``iter_actions`` yields every stored ``ActionMeta``, including its ``name`` key, which is how the forms system checks inspect any configured backend.
-``ActionMeta``, ``FormActionFactory``, and ``file_to_dotted_module`` import from ``next.forms.backends`` directly.
-``FormActionFactory`` instantiates one backend per ``FORM_ACTION_BACKENDS`` entry, passing the whole config dict to the backend constructor.
-``FormActionManager`` calls it, so application code rarely does.
+``ActionMeta`` and ``file_to_dotted_module`` import from ``next.forms.backends`` directly.
+``FormActionManager`` instantiates one backend per ``FORM_ACTION_BACKENDS`` entry, passing the whole config dict to the backend constructor.
 ``scope_key_for`` derives the registry scope key from a declaration file path and a scope, the same key that partitions actions and wizard storage.
 ``build_action_guard`` builds an ``ActionGuard`` from the declared ``login_required`` and ``permission_required`` values, or ``None`` when both are unset.
 ``record_possible_collision`` files a name collision into the registration diagnostics when a name is re-registered with a distinct handler, feeding the ``next.E041`` check.

--- a/docs/content/ref/index.rst
+++ b/docs/content/ref/index.rst
@@ -1,12 +1,12 @@
 .. _ref:
 
-API Reference
+API reference
 =============
 
 Module by module reference for the next.dj public API.
 Each page lists the public surface plus configuration and signal entries that belong to the subsystem.
 
-.. rubric:: Top-Level API
+.. rubric:: Top-level API
 
 The ``next`` package itself exports five curated names, the ones that page modules, component modules, and form handlers use most often.
 Import them from the package root with ``from next import Depends, action, component, context, page``.
@@ -88,6 +88,9 @@ Reading ``page``, ``context``, ``component``, or ``action`` loads a much larger 
 :doc:`utils`
    ``next.utils`` for small helpers that the framework uses internally.
 
+:doc:`backends`
+   ``next.backends`` for the shared loading of settings-driven backend families.
+
 .. rubric:: Configuration
 
 :doc:`settings`
@@ -96,7 +99,7 @@ Reading ``page``, ``context``, ``component``, or ``action`` loads a much larger 
 :doc:`system-checks`
    Django system checks that the framework contributes.
 
-.. rubric:: Templates and Decorators
+.. rubric:: Templates and decorators
 
 :doc:`template-tags`
    Every template tag registered by ``next.dj``.
@@ -121,6 +124,7 @@ Reading ``page``, ``context``, ``component``, or ``action`` loads a much larger 
    testing
    apps
    utils
+   backends
    settings
    system-checks
    template-tags

--- a/docs/content/ref/pages.rst
+++ b/docs/content/ref/pages.rst
@@ -1,9 +1,9 @@
 .. _ref-pages:
 
-Pages Reference
+Pages reference
 ===============
 
-Module Summary
+Module summary
 --------------
 
 ``next.pages`` exposes the page module API, the ``@context`` decorator, and the layout composition helpers.
@@ -82,20 +82,23 @@ Processors
 .. automodule:: next.pages.processors
    :members:
 
-System Checks
+System checks
 ~~~~~~~~~~~~~
 
 ``next.pages.checks`` registers the Django system checks for the pages subsystem.
 They run through ``uv run python manage.py check``.
 
-The module exports seven check callables.
+The module exports ten check callables.
 
 - ``check_context_functions``.
 - ``check_context_processor_signature``.
+- ``check_context_registration_files``.
 - ``check_layout_templates``.
 - ``check_page_functions``.
+- ``check_page_module_imports``.
 - ``check_pages_structure``.
 - ``check_request_in_context``.
+- ``check_single_keyless_context``.
 - ``check_template_loaders``.
 
 See :doc:`system-checks` for each check identifier, its condition, and the full autodoc of ``next.pages.checks``.
@@ -105,7 +108,7 @@ Signals
 
 See :doc:`signals` and :doc:`/content/topics/signals` for the pages signals (``template_loaded``, ``context_registered``, ``page_rendered``).
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/partial.rst
+++ b/docs/content/ref/partial.rst
@@ -1,16 +1,17 @@
 .. _ref-partial:
 
-Partial Rendering Reference
-===========================
+next.partial API reference
+==========================
 
-Module Summary
+Module summary
 --------------
 
 ``next.partial`` exposes the server side of partial rendering.
-The surface covers the ``Patches`` builder that authors a patch envelope, the response and stream classes that carry it, the zone-render and origin helpers, the custom-verb registration hook, and the protocol backend that serialises the wire format.
+The surface covers the ``Patches`` builder that authors a patch envelope, the response and stream classes that carry it, and the zone-render and origin helpers.
+It also covers the custom-verb registration hook and the protocol backend that serialises the wire format.
 The wire protocol, the ``data-next-*`` attributes, and the client runtime live in the topic section, see :doc:`/content/topics/partial-rendering/reference`.
 
-API Tiers
+API tiers
 ---------
 
 The surface splits into tiers that describe the intended audience for each name.
@@ -55,7 +56,7 @@ Internal hooks.
 Public API
 ----------
 
-Detecting a Partial Request
+Detecting a partial request
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``is_partial_request`` returns ``True`` when the request carries the ``X-Next-Request``
@@ -76,7 +77,7 @@ context provider reads to skip an expensive query on a full render.
 .. autoclass:: next.partial.headers.MergeMode
    :members:
 
-Building Patches
+Building patches
 ~~~~~~~~~~~~~~~~~
 
 ``Patches`` is the request-bound builder.
@@ -103,11 +104,12 @@ builder assembles, surfaced for a custom backend that serialises the wire format
 .. autoclass:: next.partial.FormMeta
    :members:
 
-Custom Verbs
+Custom verbs
 ~~~~~~~~~~~~
 
-``register_patch_op`` registers a custom verb name on the server, which clears the
-``next.E066`` check and earns the generic ``Patches.op`` channel.
+``register_patch_op`` registers a custom verb name on the server, validated by the
+``next.E066`` check, and earns the generic ``Patches.op`` channel.
+An unregistered name fails at runtime with ``UnknownPatchOpError``.
 The client supplies the handler through ``Next.partial.defineOp``.
 See :doc:`/content/topics/partial-rendering/extending` for the end-to-end recipe.
 
@@ -131,7 +133,7 @@ reached through ``next.partial.registry``.
 
 .. autofunction:: next.partial.registry.zones_of
 
-Origin and Authorisation
+Origin and authorisation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``resolve_partial_origin`` is a thin helper that reads the host page that owns a zone out
@@ -159,7 +161,7 @@ or the ``next.W068`` check warns that the runtime receives a full page instead.
 
 .. autofunction:: next.partial.shape_partial
 
-SSE Stream
+SSE stream
 ~~~~~~~~~~
 
 ``PatchEventStream`` is a :class:`~django.http.StreamingHttpResponse` that serialises each
@@ -171,7 +173,7 @@ See :doc:`/content/topics/partial-rendering/sse` for the WSGI and ASGI contract.
 .. autoclass:: next.partial.PatchEventStream
    :members:
 
-Protocol Backend
+Protocol backend
 ~~~~~~~~~~~~~~~~~
 
 ``PartialProtocolBackend`` owns the patch wire format and is the first entry of
@@ -241,15 +243,15 @@ See :doc:`signals` and :doc:`/content/topics/signals` for the partial signals
 (``zone_registered``, ``zone_rendered``, ``patch_op_registered``, ``field_validated``,
 ``sse_stream_opened``, ``sse_stream_closed``).
 
-System Checks
+System checks
 -------------
 
 See :doc:`system-checks` for the zone-placement, template-compile, custom-verb, and
 backend-configuration checks
-(``next.E060`` through ``next.E066``, ``next.E072``, ``next.E073``,
+(``next.E060`` through ``next.E067``, ``next.E072``, ``next.E073``,
 ``next.W067`` through ``next.W071``).
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/server.rst
+++ b/docs/content/ref/server.rst
@@ -1,9 +1,9 @@
 .. _ref-server:
 
-Server Reference
+Server reference
 ================
 
-Module Summary
+Module summary
 --------------
 
 ``next.server`` exposes the autoreload watcher, the watch-spec helpers, and the filesystem roots used by the development server.
@@ -61,7 +61,7 @@ The single payload argument is ``specs``, the deduplicated ``(path, glob)`` list
 
 See :doc:`signals` for the signal index.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/settings.rst
+++ b/docs/content/ref/settings.rst
@@ -3,7 +3,7 @@
 Settings
 ========
 
-Module Summary
+Module summary
 --------------
 
 This page lists every key inside ``NEXT_FRAMEWORK`` with its framework default and a short description.
@@ -11,7 +11,7 @@ Set ``NEXT_FRAMEWORK`` in ``settings.py`` to override any of these values.
 
 For production-specific recommendations (which values to change and why), see :doc:`/content/deployment/settings`.
 
-Key Naming
+Key naming
 ----------
 
 Keys inside ``NEXT_FRAMEWORK`` carry no ``DEFAULT_`` prefix.
@@ -20,7 +20,8 @@ A plural ``*_BACKENDS`` key holds an ordered list of sources the manager consult
 ``PARTIAL_BACKENDS`` is the exception.
 Partial rendering uses a single protocol backend, so only the first entry runs.
 A singular ``*_BACKEND`` key holds the one engine for a concern.
-A subsystem prefix (``PAGE_``, ``COMPONENT_``, ``STATIC_``, ``FORM_``, ``URL_``, ``TEMPLATE_``, ``JS_``) groups related keys.
+A subsystem prefix (``PAGE_``, ``COMPONENT_``, ``STATIC_``, ``FORM_``, ``URL_``, ``TEMPLATE_``, ``JS_``, ``PARTIAL_``) groups related keys.
+``NEXT_JS_OPTIONS`` stands outside the prefix scheme and configures the bundled client runtime.
 
 Backends
 --------
@@ -89,7 +90,7 @@ Default value.
 
 The first static backend's ``OPTIONS`` dict accepts ``JS_CONTEXT_POLICY``, a dotted path to a conflict-resolution class.
 The static manager applies the policy when two context functions publish the same key for serialisation.
-See :doc:`/content/topics/static-assets/js-context` under *Key Conflict Policy* for the available policies and an example.
+See :doc:`/content/topics/static-assets/js-context` under *Key conflict policy* for the available policies and an example.
 
 The same ``OPTIONS`` dict accepts ``DEDUP_STRATEGY``, a dotted path to a dedup strategy class the collector instantiates once per request to drop assets several components register more than once.
 See :doc:`/content/topics/static-assets/deduplication` for the bundled strategies and the custom-strategy protocol.
@@ -235,7 +236,7 @@ Default value.
 
 Loaders are consulted in order, first match wins.
 
-JavaScript Context
+JavaScript context
 ------------------
 
 NEXT_JS_OPTIONS
@@ -263,7 +264,7 @@ A value that does not resolve to a usable serializer triggers the ``next.W042`` 
 At render time such a value raises ``ImportError`` or ``TypeError`` on first use, so fix the dotted path rather than rely on a fallback.
 The built-in ``JsonJsContextSerializer`` steps in only when the setting is unset.
 
-See :doc:`static` under *JS Context Serializer* for the protocol and the bundled serializers.
+See :doc:`static` under *JS context serializer* for the protocol and the bundled serializers.
 
 Strictness
 ----------
@@ -290,7 +291,7 @@ Components discovered through ``_components`` directories beside page files are 
 Default value ``False``.
 See :doc:`/content/deployment/settings` for production defaults and :doc:`/content/topics/testing` for the ``eager_load_components`` helper.
 
-Patching Defaults
+Patching defaults
 -----------------
 
 Use ``next.conf.extend_default_backend`` to patch one key of a default backend entry without copying the whole default.
@@ -323,7 +324,7 @@ It raises ``IndexError`` when ``index`` is out of range for the default list.
 
 See :doc:`conf` for the helper API and :doc:`/content/howto/extend-a-default-backend` for the recipe.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/settings.rst
+++ b/docs/content/ref/settings.rst
@@ -160,6 +160,7 @@ PARTIAL_BACKENDS
 List of partial protocol backend configurations.
 The first entry is active and owns the patch wire format that partial rendering serialises over HTTP and Server-Sent Events.
 Entries after the first are ignored, and ``manage.py check`` reports them with ``next.W071``.
+The value has to be a list, since any other shape is dropped in favour of the default and ``manage.py check`` reports it with ``next.E067``.
 
 Default value.
 

--- a/docs/content/ref/signals.rst
+++ b/docs/content/ref/signals.rst
@@ -60,8 +60,8 @@ not be retained past the receiver call.
        A standalone zone render does not fire this signal.
        ``request`` may be ``None`` outside a request.
    * - ``component_backend_loaded``
-     - ``ComponentsManager``
-     - ``backend``, ``config``
+     - The component backend class
+     - ``config``, ``instance``
      - After a component backend is created from its configuration entry.
    * - ``component_registered``
      - ``ComponentRegistry``

--- a/docs/content/ref/signals.rst
+++ b/docs/content/ref/signals.rst
@@ -1,27 +1,24 @@
 .. _ref-signals:
 
-Signals Reference
+Signals reference
 =================
 
-Module Summary
+Module summary
 --------------
 
 ``next.signals`` is an aggregator that re-exports every framework signal.
 Importing a signal from ``next.signals`` is equivalent to importing it from its subpackage.
 
-Signal Catalog
+Signal catalog
 --------------
 
-Every signal below is a Django ``Signal``. The ``sender`` column lists the value
-passed to ``Signal.send``. Receivers connected with a matching ``sender`` only
-fire for that sender.
+Every signal below is a Django ``Signal``.
+The ``sender`` column lists the value passed to ``Signal.send``.
+Receivers connected with a matching ``sender`` only fire for that sender.
 
-The dispatch-time form signals (``action_dispatched``, ``form_validation_failed``,
-``wizard_step_submitted``, ``wizard_completed``, ``form_access_denied``) share two keyword arguments.
-``uid`` is the registry identity of the action, the value the dispatch URL and the
-``data-next-action`` markup attribute carry, or ``None`` when a custom backend stores
-no uid in its meta. ``request`` is the live ``HttpRequest`` being dispatched and must
-not be retained past the receiver call.
+The dispatch-time form signals (``action_dispatched``, ``form_validation_failed``, ``wizard_step_submitted``, ``wizard_completed``, ``form_access_denied``) share two keyword arguments.
+``uid`` is the registry identity of the action, the value the dispatch URL and the ``data-next-action`` markup attribute carry, or ``None`` when a custom backend stores no uid in its meta.
+``request`` is the live ``HttpRequest`` being dispatched and must not be retained past the receiver call.
 
 .. list-table::
    :header-rows: 1
@@ -158,7 +155,7 @@ not be retained past the receiver call.
      - ``zone_name``, ``page_path``, ``request``, ``duration_ms``
      - After a zone body renders for a partial request. ``duration_ms`` times the zone render.
 
-Subpackage Signals
+Subpackage signals
 ------------------
 
 The aggregator ``next.signals`` forwards from the modules below.
@@ -193,7 +190,7 @@ Static
 .. automodule:: next.static.signals
    :members:
 
-Partial Rendering
+Partial rendering
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: next.partial.signals
@@ -217,7 +214,7 @@ Configuration
 .. automodule:: next.conf.signals
    :members:
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/static.rst
+++ b/docs/content/ref/static.rst
@@ -1,9 +1,9 @@
 .. _ref-static:
 
-Static Reference
+Static reference
 ================
 
-Module Summary
+Module summary
 --------------
 
 ``next.static`` exposes the asset discovery, the request-scoped collector, and the backend chain.
@@ -58,7 +58,7 @@ See :doc:`/content/topics/static-assets/js-context` for the runtime script optio
 The init payload reserves the ``$csrf`` and ``$dev`` keys for the framework, so an automatically injected payload drops a project key of either name before it reaches ``window.Next.context``.
 See :doc:`/content/topics/static-assets/js-context` for the ownership rule and the ``next.W075`` check that reports a collision.
 
-JS Context Serializer
+JS context serializer
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: next.static.serializers
@@ -70,7 +70,7 @@ Defaults
 .. automodule:: next.static.defaults
    :members:
 
-Staticfiles Finder
+Staticfiles finder
 ~~~~~~~~~~~~~~~~~~
 
 .. automodule:: next.static.finders
@@ -92,7 +92,7 @@ Signals
 
 See :doc:`signals` and :doc:`/content/topics/static-assets/signals` for the static signals (``asset_registered``, ``collector_finalized``, ``html_injected``, ``backend_loaded``).
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -1,15 +1,15 @@
 .. _ref-system-checks:
 
-System Checks
+System checks
 =============
 
-Module Summary
+Module summary
 --------------
 
 next.dj contributes Django system checks for every subsystem.
 Run them through ``uv run python manage.py check`` and the framework reports configuration mistakes with a code and a hint.
 
-Check Registration
+Check registration
 ------------------
 
 ``next.checks.register_all`` runs during ``AppConfig.ready``.
@@ -24,7 +24,12 @@ Every next.dj check carries the ``next`` tag.
 Run ``uv run python manage.py check --tag next`` to execute only the framework checks and skip the built-in Django and third-party ones.
 Checks that also concern templates or URL patterns keep their :doc:`Django tags <django:ref/checks>` (``templates``, ``urls``) alongside ``next``, so filtering by those tags still reaches them.
 
-Shared Helpers
+``next.checks.reset_check_caches`` drops every per-run check cache so the next run rebuilds from the current sources.
+The cached state covers the router and components managers, the composed-pages memo, the collected URL patterns, the page module memo, and the context registry.
+Most of these caches also clear on ``settings_reloaded``, which a ``NEXT_FRAMEWORK`` change through ``override_settings`` triggers.
+Tests and scripts that invoke checks directly and mutate the page or component tree in place call ``reset_check_caches`` explicitly, since the caches otherwise freeze the scanned state for the lifetime of the process.
+
+Shared helpers
 ~~~~~~~~~~~~~~
 
 ``next.checks.common`` holds helpers reused across subsystem check modules.
@@ -33,7 +38,7 @@ It is imported indirectly by those modules rather than by ``register_all``.
 .. automodule:: next.checks.common
    :members:
 
-Subsystem Checks
+Subsystem checks
 ----------------
 
 Pages
@@ -66,7 +71,7 @@ Static
 .. automodule:: next.static.checks
    :members:
 
-Partial Rendering
+Partial rendering
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: next.partial.checks
@@ -84,7 +89,7 @@ Configuration
 .. automodule:: next.conf.checks
    :members:
 
-Dependency Injection
+Dependency injection
 ~~~~~~~~~~~~~~~~~~~~
 
 The dependency injection layer does not contribute Django system checks.
@@ -96,10 +101,10 @@ There is no ``next.ENNN`` code for a missing provider or a bad marker graph.
    Unresolved parameters become ``None``, and cycles raise ``DependencyCycleError``.
    Troubleshooting lives in :doc:`/content/topics/dependency-injection` and :doc:`/content/faq/troubleshooting`.
 
-Check Code Reference
+Check code reference
 --------------------
 
-The codes follow the :doc:`Django convention <django:ref/checks>` ``next.X<NN>`` where ``X`` is ``E`` for errors and ``W`` for warnings.
+The codes follow the :doc:`Django convention <django:ref/checks>` ``next.X<NNN>`` where ``X`` is ``E`` for errors and ``W`` for warnings.
 
 Errors
 ~~~~~~
@@ -410,10 +415,10 @@ Warnings
 
 .. note::
 
-   Codes are assigned per check and are not contiguous. Inspect the source of each
-   subsystem module above for the exact message text and trigger conditions.
+   Codes are assigned per check and are not contiguous.
+   Inspect the source of each subsystem module above for the exact message text and trigger conditions.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -296,6 +296,9 @@ Errors
    * - ``next.E066``
      - A custom patch op shadows a built-in verb or uses a name that is not a valid verb token.
      - ``next.partial.checks``
+   * - ``next.E067``
+     - ``NEXT_FRAMEWORK['PARTIAL_BACKENDS']`` is not a list, so the value is ignored and the default protocol backend loads in place of the configured one.
+     - ``next.partial.checks``
    * - ``next.E072``
      - A composed page template does not compile, so the syntax error would otherwise surface only as a 500 on the first request to the page.
      - ``next.partial.checks``

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -212,7 +212,7 @@ Errors
      - A component backend entry is missing a required key.
      - ``next.components.checks``
    * - ``next.E032``
-     - A component backend ``BACKEND`` or ``DIRS`` value has the wrong type.
+     - A component backend ``BACKEND`` or ``DIRS`` value has the wrong type, or ``BACKEND`` does not import as a ``ComponentsBackend`` subclass.
      - ``next.components.checks``
    * - ``next.E033``
      - ``COMPONENT_BACKENDS`` is empty.

--- a/docs/content/ref/system-checks.rst
+++ b/docs/content/ref/system-checks.rst
@@ -300,7 +300,7 @@ Errors
      - A composed page template does not compile, so the syntax error would otherwise surface only as a 500 on the first request to the page.
      - ``next.partial.checks``
    * - ``next.E073``
-     - A ``PARTIAL_BACKENDS`` entry has no ``BACKEND`` key, so the factory would refuse it with ``ImproperlyConfigured`` on the first partial request.
+     - A ``PARTIAL_BACKENDS`` entry has no ``BACKEND`` key, so the entry would fall back to the default protocol backend and the intended wire format would never load.
      - ``next.partial.checks``
    * - ``next.E074``
      - A ``@context`` registration binds to a file no page render collects.

--- a/docs/content/ref/template-tags.rst
+++ b/docs/content/ref/template-tags.rst
@@ -50,15 +50,16 @@ Forms
 
    The tag requires ``request`` in the template context for the CSRF token.
    It also uses ``current_page_module_path`` when present to scope the action lookup to the origin page, which is how the file router renders it.
-   That context value is not strictly required.
-   When it is absent the action lookup falls back to the name index.
+   Inside a component's own template body ``current_component_module_path`` takes precedence, so a component-anchored action resolves before the page anchor.
+   Neither context value is strictly required.
+   When both are absent the action lookup falls back to the name index.
 
 .. describe:: {% action_url "<name>" %}
 
    Returns the dispatch endpoint URL for a registered action.
    The first argument is the action name, a quoted string or a context variable that resolves to a string.
-   The lookup uses the same page scoping as ``{% form %}``.
-   A page-scoped match for the rendering page wins over a shared one, read from ``current_page_module_path`` when present.
+   The lookup uses the same anchor scoping as ``{% form %}``.
+   A match for the component anchor wins over the page anchor, and either wins over a shared one.
 
    As a ``simple_tag`` it supports assignment, ``{% action_url "delete_note" as delete_url %}``.
 

--- a/docs/content/ref/template-tags.rst
+++ b/docs/content/ref/template-tags.rst
@@ -1,9 +1,9 @@
 .. _ref-template-tags:
 
-Template Tags
+Template tags
 =============
 
-Module Summary
+Module summary
 --------------
 
 The framework registers its template tags as Django builtins through ``next.apps.templates.install``.
@@ -101,18 +101,18 @@ Components
    Block form.
    Marks a slot location inside a component template, with a fallback body used when the caller omits the slot.
 
-Multiline Tag Bodies
+Multiline tag bodies
 ~~~~~~~~~~~~~~~~~~~~
 
 The framework reinstalls Django's template tag pattern with the ``re.DOTALL`` flag so a single ``{% ... %}`` token may span several lines.
 That allows readable block components and slots when the inner markup is long.
 
-.. caution::
+.. warning::
 
    This changes template parsing for **every** template the process loads, not only DJX files.
    If you rely on Django's stock behaviour where a newline inside ``{% ... %}`` ends the tag, adjust those templates before adopting next.dj.
 
-Static Pipeline
+Static pipeline
 ---------------
 
 .. describe:: {% collect_styles %}
@@ -145,7 +145,7 @@ Static Pipeline
    Inline JS block.
    The body is rendered with the template context and deduplicated by content.
 
-Partial Rendering
+Partial rendering
 -----------------
 
 .. describe:: {% zone "<name>" tag="<element>" lazy="<trigger>" poll="<interval>" %}...{% placeholder %}...{% endzone %}
@@ -189,7 +189,7 @@ Layouts
    A ``layout.djx`` without this block raises ``next.W001`` during ``manage.py check``, since the page body would have nowhere to render.
    Nested layouts each carry their own ``{% block template %}`` and compose from innermost to outermost.
 
-Tag Loading
+Tag loading
 -----------
 
 .. autofunction:: next.apps.templates.install
@@ -198,7 +198,7 @@ Tag Loading
 The framework calls ``install`` during ``AppConfig.ready``.
 Project code does not need to load the tag libraries manually.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/testing.rst
+++ b/docs/content/ref/testing.rst
@@ -1,9 +1,9 @@
 .. _ref-testing:
 
-Testing Reference
+Testing reference
 =================
 
-Module Summary
+Module summary
 --------------
 
 ``next.testing`` exposes a test client, partial envelope decoding, signal recorder, registry isolation, action helpers, HTML utilities, rendering helpers, loaders, patching helpers, and dependency context builders.
@@ -14,7 +14,8 @@ Public API
 Client
 ~~~~~~
 
-``NextClient`` extends Django's test client with form-action shortcuts and the partial-request helpers ``get_zones``, ``envelope_of``, and ``PartialEnvelope`` for end to end HTTP tests.
+``NextClient`` extends Django's test client with form-action shortcuts and ``get_zones`` for end to end HTTP tests.
+The module also ships ``envelope_of`` and ``PartialEnvelope`` for decoding patch responses.
 
 .. automodule:: next.testing.client
    :members:
@@ -60,7 +61,7 @@ Loaders
 .. automodule:: next.testing.loaders
    :members:
 
-HTML Utilities
+HTML utilities
 ~~~~~~~~~~~~~~
 
 ``find_anchor``, ``assert_has_class``, and ``assert_missing_class`` inspect rendered HTML fragments.
@@ -84,7 +85,7 @@ Dependencies
 .. automodule:: next.testing.deps
    :members:
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/urls.rst
+++ b/docs/content/ref/urls.rst
@@ -1,9 +1,9 @@
 .. _ref-urls:
 
-URLs Reference
+URLs reference
 ==============
 
-Module Summary
+Module summary
 --------------
 
 ``next.urls`` exposes the router backends ``RouterBackend`` and ``FileRouterBackend``.
@@ -33,11 +33,13 @@ Manager
 Code that reads ``next.urls.urlpatterns`` directly observes that one-element list, not the individual page patterns.
 The wrapped sequence caches the concatenated pattern list against a pair of version counters, one owned by ``RouterManager`` and one by the form-action manager.
 ``router_manager.reload()`` bumps the router counter, and registering or clearing form actions through ``form_action_manager`` bumps the forms counter, so the next access rebuilds the list exactly when something changed.
+
 The counters are read after the pattern build, because expanding page modules can register form actions mid-build, so the cache stays valid for the post-registration state.
 A registration that bypasses the manager and writes into a backend directly is not tracked by the counters and does not appear in the cached list.
 The backends themselves are cached by ``router_manager`` and are only rebuilt when ``router_manager.reload()`` runs or when ``PAGE_BACKENDS`` changes.
 A page added on disk after that first collection needs ``router_manager.reload()``, which rebuilds the backends and clears the Django resolver cache.
 Within a backend both the per-application pattern lists and the patterns from the roots configured in ``DIRS`` are memoised after the first scan, and a settings reload recreates the backend with fresh caches.
+
 Reverse-name population iterates the wrapped sequence with ``reversed()``, which it answers through an explicit ``__reversed__`` that builds the pattern list once per pass.
 ``RouterManager`` owns the active backend list, and the ``router_manager`` singleton exposes ``reload()`` to rebuild it.
 ``reload()`` logs and skips a backend entry whose construction raises ``ValueError``, ``TypeError``, ``KeyError``, or ``ImportError``.
@@ -54,6 +56,7 @@ A route without parameters hits a dictionary keyed by the full route string, and
 The candidates are then tried with the standard ``pattern.resolve()`` in their original list order, so overlapping routes keep Django's first-match-wins semantics and converters behave as in plain Django.
 A miss falls back to the inherited linear scan, which raises the canonical ``Resolver404`` with a complete ``tried`` list and also covers patterns the trie cannot index, such as ones built with :func:`~django.urls.re_path`.
 On a successful match ``ResolverMatch.tried`` lists only the candidates that were actually tried, not every pattern preceding the winner.
+
 The internal route index is versioned by the same counters as the pattern concat, so a router reload or a late form-action registration rebuilds it before the next resolution.
 The ``URL_RESOLVER`` setting names the resolver class, so pointing it at ``django.urls.resolvers.URLResolver`` or a custom subclass replaces the trie dispatch.
 See :doc:`/content/internals/url-router` for the algorithm walk-through.
@@ -78,7 +81,7 @@ Dispatcher
 .. automodule:: next.urls.dispatcher
    :members:
 
-Reverse Helpers
+Reverse helpers
 ~~~~~~~~~~~~~~~
 
 .. autofunction:: next.urls.reverse.page_reverse
@@ -99,7 +102,7 @@ Markers
 .. automodule:: next.urls.markers
    :members:
 
-Parameter Providers
+Parameter providers
 ~~~~~~~~~~~~~~~~~~~
 
 The following provider classes are registered with the ``next.deps`` resolver at startup.
@@ -199,7 +202,7 @@ Checks
    :members:
    :no-index:
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/ref/utils.rst
+++ b/docs/content/ref/utils.rst
@@ -1,13 +1,15 @@
 .. _ref-utils:
 
-Utils Reference
+Utils reference
 ===============
 
-Module Summary
+Module summary
 --------------
 
 ``next.utils`` exposes two helpers that project code can import, ``resolve_base_dir`` and ``classify_dirs_entries``.
-The rest of the module serves decorator registration and is excluded from the table below, attributing a decorated object to the file where it was declared, naming it for diagnostics, and collecting the registrations that landed on another file.
+The rest of the module backs decorator registration.
+It attributes a decorated object to the file where it was declared, names it for diagnostics, and collects the registrations that landed on another file.
+Those helpers are excluded from the listing below.
 
 ``resolve_base_dir`` returns ``settings.BASE_DIR`` coerced to ``pathlib.Path``, or ``None`` when it is unset, for backends that resolve project-relative paths.
 ``classify_dirs_entries`` splits a backend ``DIRS`` list into existing directory roots and plain skip-name segments, the same split the file router applies.
@@ -19,7 +21,7 @@ Public API
    :members:
    :exclude-members: _classify_one_dir_entry, callable_name, defining_file, MisattributedContext, MisattributionLog
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/security/csp-and-nonce.rst
+++ b/docs/content/security/csp-and-nonce.rst
@@ -1,6 +1,6 @@
 .. _security-csp-and-nonce:
 
-CSP and Nonce
+CSP and nonce
 =============
 
 A Content Security Policy restricts which scripts a page may run.
@@ -10,7 +10,7 @@ The client runtime is designed to live under one, and this page covers how the r
    :local:
    :depth: 1
 
-The Nonce From currentScript
+The nonce from currentScript
 ----------------------------
 
 The runtime remembers the nonce of the script that bootstrapped it.
@@ -23,7 +23,7 @@ The asset elements inherit it.
 The nonce is the only attribute the runtime carries over from the page.
 An element it builds for a patch-inserted asset takes a fixed attribute set, so an ``integrity`` or ``crossorigin`` attribute a backend writes into its tag templates reaches the browser on a full render alone, see :doc:`/content/topics/partial-rendering/limitations`.
 
-Scripts in Patches Never Run
+Scripts in patches never run
 ----------------------------
 
 A ``<script>`` inside patch HTML is never executed by any insertion path.
@@ -38,7 +38,7 @@ A widget that relied on an inline initialiser in its markup has to move to a co-
 With the runtime's dev mode on, that is with Django ``DEBUG``, the runtime prints a ``console.warn`` for every script it neutralises.
 An inline initialiser that stopped working is therefore visible rather than silent.
 
-strict-dynamic as a Recommendation
+strict-dynamic as a recommendation
 -----------------------------------
 
 ``'strict-dynamic'`` lets a script already trusted by a nonce load further scripts without each one needing its own nonce in the policy.
@@ -50,7 +50,7 @@ The framework carries the nonce and refuses to run inline patch scripts, which r
 It does not author your policy, validate your directives, or promise that any particular policy is correct for your site.
 Treat ``'strict-dynamic'`` as a sensible default for a nonce-based policy and verify the resulting headers against your own threat model.
 
-A Worked Policy
+A worked policy
 ---------------
 
 A nonce-based policy with ``'strict-dynamic'`` looks like this, with ``{nonce}`` filled in per request by your CSP middleware.
@@ -63,7 +63,7 @@ A nonce-based policy with ``'strict-dynamic'`` looks like this, with ``{nonce}``
 The bootstrap script tag carries ``nonce="{nonce}"``, the runtime copies that nonce onto every asset element it injects, and ``'strict-dynamic'`` lets the bootstrap load the scripts among them.
 No patch can introduce an inline script, so no patch needs a nonce of its own.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/security/csrf-and-forms.rst
+++ b/docs/content/security/csrf-and-forms.rst
@@ -1,6 +1,6 @@
-.. _security-csrf-forms:
+.. _security-csrf-and-forms:
 
-CSRF and Forms
+CSRF and forms
 ==============
 
 This page covers how CSRF protection works through the next.dj dispatch path and what to do for forms that bypass the standard ``{% form %}`` tag.
@@ -9,7 +9,7 @@ This page covers how CSRF protection works through the next.dj dispatch path and
    :local:
    :depth: 2
 
-Standard Path
+Standard path
 -------------
 
 The ``{% form %}`` tag emits a CSRF token automatically.
@@ -22,7 +22,7 @@ The tag also depends on ``request`` existing in the template context so Django c
 If ``manage.py check`` reports a missing ``request`` context processor, add ``django.template.context_processors.request`` to the ``OPTIONS.context_processors`` list of your Django ``TEMPLATES`` entry.
 An equivalent processor that supplies ``request`` works as well, so layouts receive ``request``.
 
-Origin Validation
+Origin validation
 -----------------
 
 The framework adds a second hidden field named ``_next_form_origin``.
@@ -40,7 +40,7 @@ On the success path the same field feeds ``redirect_to_origin`` without URLconf 
 A missing or off-site value never blocks a successful dispatch, ``redirect_to_origin`` falls back to ``/``.
 Handlers can call ``redirect_to_origin`` from ``next.forms`` to redirect back to the page that rendered the form.
 
-Manual Forms
+Manual forms
 ------------
 
 The ``{% form %}`` tag is the supported way to render a form.
@@ -52,7 +52,7 @@ When a hand crafted form is unavoidable, render the tag once and copy the genera
 A fully manual form sets ``_next_form_origin`` to ``{{ request.path }}``, the same value the tag emits.
 A form rendered by a hand-written view outside the file router additionally needs the ``next_page_path`` attribute on that view before the error re-render works, see :ref:`topics-forms-templates-handwritten-views`.
 
-GET Forms
+GET forms
 ---------
 
 GET forms do not need CSRF protection.
@@ -75,7 +75,7 @@ Use ``DQuery[str]`` in the page context to read the value.
    The two status codes let the action surface be probed without a token.
    This is intended, the 405 reveals only that a uid is registered and no handler runs on a GET, so do not place secrets in action uids.
 
-AJAX Submissions
+AJAX submissions
 ----------------
 
 JavaScript that posts to the dispatch URL must supply the CSRF token, in the ``X-CSRFToken`` header or the ``csrfmiddlewaretoken`` body field, and the ``_next_form_origin`` value in the request body.
@@ -108,7 +108,7 @@ This works because every ``{% form %}`` block emits the ``_next_form_origin`` hi
 To post without a rendered form, use ``window.location.pathname``.
 The origin is the URL path of the current page, so no server-published value is needed.
 
-Wizard Steps
+Wizard steps
 ------------
 
 A wizard step POST is stricter than a plain form POST about the origin field.
@@ -118,7 +118,7 @@ For a wizard step the dispatcher requires a resolvable origin before any validat
 The ``{% form %}`` tag emits the field on every render, so a tag-rendered wizard needs nothing extra.
 A hand-crafted wizard POST or an AJAX wizard submission must include the ``_next_form_origin`` field with the current page path.
 
-Cross Origin Requests
+Cross origin requests
 ---------------------
 
 Add the public origin to ``CSRF_TRUSTED_ORIGINS`` for cross subdomain or cross origin submissions.
@@ -134,7 +134,7 @@ Add the public origin to ``CSRF_TRUSTED_ORIGINS`` for cross subdomain or cross o
 The framework does not relax CSRF policy.
 The trusted origins list comes directly from Django.
 
-Cookie Settings
+Cookie settings
 ---------------
 
 Use these cookie flags in production.
@@ -148,7 +148,7 @@ Use these cookie flags in production.
 
 Keep ``CSRF_COOKIE_HTTPONLY`` false so that AJAX requests can read the token.
 
-Common Pitfalls
+Common pitfalls
 ---------------
 
 Form post without ``_next_form_origin``.
@@ -174,7 +174,7 @@ Different origin without ``CSRF_TRUSTED_ORIGINS``.
    The middleware returns 403.
    Add every origin that posts to the project.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/security/di-and-untrusted-input.rst
+++ b/docs/content/security/di-and-untrusted-input.rst
@@ -1,6 +1,6 @@
-.. _security-di-untrusted:
+.. _security-di-and-untrusted-input:
 
-DI and Untrusted Input
+DI and untrusted input
 ======================
 
 The dependency resolver injects values from URL parameters, query strings, form bodies, and named providers.
@@ -10,7 +10,7 @@ This page covers the safety rules that apply to each source and the patterns tha
    :local:
    :depth: 2
 
-Untrusted by Default
+Untrusted by default
 --------------------
 
 Every value the resolver injects starts as untrusted input.
@@ -27,7 +27,7 @@ Never interpolate into queries.
    Use the :doc:`ORM <django:topics/db/queries>` and parameter substitution.
    :doc:`Raw SQL <django:topics/db/sql>` needs ``cursor.execute(sql, params)``.
 
-URL Parameters
+URL parameters
 --------------
 
 ``DUrl[T]`` coerces the captured value to ``T`` for ``int``, ``float``, ``bool``, ``UUID``, ``Decimal``, ``date``, and ``datetime``.
@@ -55,7 +55,7 @@ The same scoping rule applies to the ModelForm ``Meta.instance_from_url`` key.
 Its default ``get_initial`` runs an unscoped ``get_object_or_404(model, slug=<value>)``, so a form that edits a per-user row must override ``get_initial`` with a scoped query such as ``get_object_or_404(Note, slug=slug, owner=request.user)``.
 See :doc:`/content/topics/forms/modelforms` for the full pattern.
 
-URL Kwargs on a POST
+URL kwargs on a POST
 --------------------
 
 A form POST targets the dispatch endpoint, not the page URL, so the page's captured kwargs are not in the request path.
@@ -67,7 +67,7 @@ They are the mechanism behind the ``instance_from_url`` insecure direct object r
 
 Validate or scope every lookup that reads a URL kwarg, whether the value arrived in the live path or through the posted origin.
 
-Query Strings
+Query strings
 -------------
 
 ``DQuery[T]`` coerces the value to ``T`` for the same scalar set as ``DUrl``.
@@ -89,7 +89,7 @@ Validate the resulting values against business rules.
 
 The example clamps the page number to a reasonable range to prevent denial of service through huge offsets.
 
-Form Bodies
+Form bodies
 -----------
 
 Form actions validate through Django form ``clean`` methods.
@@ -107,7 +107,7 @@ Whitelist fields.
 The ``cleaned_data`` rule covers the form fields, not the extra parameters DI injects into ``on_valid``.
 A ``DUrl`` parameter or a URL kwarg argument on ``on_valid`` originates from the same untrusted path and posted origin described above, so validate or scope it the same way before using it in a lookup.
 
-Custom Validators
+Custom validators
 -----------------
 
 Add a custom validator when the type alone is not enough.
@@ -123,7 +123,7 @@ Add a custom validator when the type alone is not enough.
 
 Apply the validator on the form field or on a custom DI provider.
 
-Custom Providers
+Custom providers
 ----------------
 
 A custom provider that reads from external state (database, cache, HTTP) must validate inputs before the lookup.
@@ -190,7 +190,7 @@ Log every dispatched action through ``action_dispatched``.
 Log every failed validation through ``form_validation_failed``.
 Logs make it possible to spot mass scraping, credential stuffing, and other automated abuse.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/security/overview.rst
+++ b/docs/content/security/overview.rst
@@ -1,6 +1,6 @@
 .. _security-overview:
 
-Security Overview
+Security overview
 =================
 
 next.dj relies on Django's middleware stack and template engine for the bulk of its security guarantees.
@@ -10,7 +10,7 @@ This page lists the Django mechanisms that apply unchanged and the framework spe
    :local:
    :depth: 2
 
-Django Guarantees Used Unchanged
+Django guarantees used unchanged
 --------------------------------
 
 The framework does not bypass any standard :doc:`Django middleware <django:topics/http/middleware>`.
@@ -23,10 +23,10 @@ The framework does not bypass any standard :doc:`Django middleware <django:topic
 
 A standard ``MIDDLEWARE`` block in ``settings.py`` is therefore enough to inherit the full Django security baseline.
 
-Framework Specific Surfaces
+Framework specific surfaces
 ---------------------------
 
-The framework adds three surfaces that warrant attention.
+The framework adds four surfaces that warrant attention.
 
 File router input.
    Captured URL parameters and query values reach Python through the dependency resolver.
@@ -40,7 +40,11 @@ Co-located assets.
    Component and page level CSS and JS ship through the static collector.
    See :doc:`static-assets` for origins, hashes, and integrity.
 
-Common Threats
+Partial rendering endpoints.
+   Zone GET requests and the SSE stream answer partial clients.
+   See :doc:`/content/topics/partial-rendering/index` for the surface and `Access control`_ for the foreign-page rules.
+
+Common threats
 --------------
 
 CSRF.
@@ -66,19 +70,19 @@ Origin spoofing.
    The only page identity a form submission carries is the ``_next_form_origin`` URL path, which the dispatcher resolves through the URLconf with :func:`django.urls.resolve`.
    The client never supplies a filesystem path, so an error re-render can target only pages that are reachable through the routing table anyway.
    A value that does not resolve returns HTTP 400.
-   Substituting the origin of another routed page remains possible and is an authorization question, so guard mutating actions as described under `Access Control`_.
+   Substituting the origin of another routed page remains possible and is an authorization question, so guard mutating actions as described under `Access control`_.
 
 Open redirect.
    ``HttpResponseRedirect`` accepts any URL.
    Validate destinations before passing user input into a redirect target.
-   The partial ``redirect(href, external=True)`` patch is the same escape hatch on the client side, see `Server-Authored Redirects`_.
+   The partial ``redirect(href, external=True)`` patch is the same escape hatch on the client side, see `Server-authored redirects`_.
 
 Object-level authorization.
    A lookup keyed only on a URL value loads whatever row matches, regardless of who owns it.
    The ModelForm ``Meta.instance_from_url`` lookup is unscoped, so scope it to the user or tenant.
    See :doc:`/content/topics/forms/modelforms` for the ownership-scoped pattern and :doc:`di-and-untrusted-input` for the posted origin path that feeds the lookup.
 
-Server-Authored Redirects
+Server-authored redirects
 -------------------------
 
 A partial response can drive a full client navigation with the ``visit`` verb.
@@ -91,7 +95,7 @@ A user-supplied href behind ``external=True`` turns the page into an open redire
 The rule mirrors the plain ``HttpResponseRedirect`` case above.
 Validate or whitelist any destination that traces back to a request value before it reaches the patch.
 
-Access Control
+Access control
 --------------
 
 Form actions are unauthenticated by default.
@@ -111,7 +115,7 @@ The :ref:`howto-enforce-object-level-permissions` recipe shows the owner-only ed
 The out-of-band morph path enforces page-level access on its own.
 A ``morph(zone=..., page=...)`` onto a foreign page re-runs that page's authorization chain and raises ``ForeignPageNotAuthorizedError`` on a denial or ``DynamicForeignPageError`` for a dynamic body, see :doc:`/content/topics/partial-rendering/reference`.
 
-Production Hardening
+Production hardening
 --------------------
 
 A short list of production specific settings.
@@ -128,7 +132,7 @@ A short list of production specific settings.
 Run ``uv run python manage.py check --deploy`` and resolve every warning.
 See :doc:`/content/deployment/checklist` for the full pre-deploy review.
 
-System Checks
+System checks
 -------------
 
 The framework system checks cover configuration mistakes that affect security.
@@ -139,7 +143,7 @@ The framework system checks cover configuration mistakes that affect security.
 
 Run them with ``uv run python manage.py check``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/security/reporting.rst
+++ b/docs/content/security/reporting.rst
@@ -1,6 +1,6 @@
 .. _security-reporting:
 
-Reporting a Vulnerability
+Reporting a vulnerability
 =========================
 
 This page covers how to report a security vulnerability in next.dj.
@@ -10,7 +10,7 @@ The disclosure process is private and the maintainers acknowledge every report.
    :local:
    :depth: 2
 
-Where to Report
+Where to report
 ---------------
 
 Use the private GitHub Security Advisory form at the project repository.
@@ -19,7 +19,7 @@ The form accepts an encrypted description and lets the maintainers coordinate a 
 Public issues and pull requests are not the right channel.
 A public report exposes users before a fix is available.
 
-What to Include
+What to include
 ---------------
 
 A complete report contains the following.
@@ -32,19 +32,19 @@ A complete report contains the following.
 
 A reproducible test case shortens the triage time considerably.
 
-What Happens Next
+What happens next
 -----------------
 
 The maintainers respond within five business days with an acknowledgement and an initial assessment.
 A fix is prepared and released once the assessment confirms the issue.
 A coordinated public disclosure happens after the fix is available.
 
-Reporter Credit
+Reporter credit
 ---------------
 
 The fix announcement credits the reporter unless the reporter prefers to remain anonymous.
 
-Out of Scope
+Out of scope
 ------------
 
 The following items are out of scope for the security advisory program.
@@ -54,7 +54,7 @@ The following items are out of scope for the security advisory program.
 - Self denial of service through an extremely large form payload.
 - Discoveries that depend on a fork or modified copy of the framework.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/security/static-assets.rst
+++ b/docs/content/security/static-assets.rst
@@ -1,6 +1,6 @@
 .. _security-static-assets:
 
-Static Asset Security
+Static asset security
 =====================
 
 This page covers the security properties of the static pipeline including origin control, content hashing, integrity attributes, and CSP nonces.
@@ -9,7 +9,7 @@ This page covers the security properties of the static pipeline including origin
    :local:
    :depth: 2
 
-Origin Control
+Origin control
 --------------
 
 The static pipeline only serves files that the discovery scanner registered.
@@ -20,7 +20,7 @@ Add the directory whitelist to the backend and reject every path that falls outs
 
 An empty ``STATIC_BACKENDS`` falls back to the bundled ``StaticFilesBackend``, and ``manage.py check`` reports ``next.W030`` so the missing chain stays visible.
 
-Content Hash
+Content hash
 ------------
 
 The default ``StaticFilesBackend`` resolves asset URLs through Django staticfiles.
@@ -118,9 +118,9 @@ Co-located JS
 
 Component JS files run in the global browser context.
 Avoid using component scripts for sensitive operations such as form submission with secret tokens.
-Keep auth state in cookies and HTTP only attributes.
+Keep auth state in cookies flagged ``HttpOnly`` so component scripts cannot read it.
 
-Inline Init Payload
+Inline init payload
 -------------------
 
 The runtime injects serialised JS context through an inline ``<script>`` that calls ``Next._init``.
@@ -128,14 +128,14 @@ The framework escapes ``<``, ``>``, ``&``, U+2028, and U+2029 in that payload, s
 The remaining risk is visibility, since serialised values appear in the page source, not tag breakout.
 Never mark a secret ``serialize=True``.
 
-Cross Origin Resource Sharing
+Cross origin resource sharing
 -----------------------------
 
 CORS is a Django middleware concern.
 The framework does not add CORS headers on its own.
 Configure ``django-cors-headers`` or an equivalent middleware when the static origin serves cross site requests.
 
-Common Pitfalls
+Common pitfalls
 ---------------
 
 Inline script without nonce under strict CSP.
@@ -143,14 +143,14 @@ Inline script without nonce under strict CSP.
    Add the nonce attribute or move the script into a co-located file.
 
 Mixed content on a CDN host.
-   A ``http://`` page that loads a ``https://`` CDN asset triggers mixed content warnings.
-   Serve the HTML over HTTPS in production.
+   A ``https://`` page that loads a ``http://`` CDN asset triggers mixed content blocking.
+   Serve the CDN assets over HTTPS in production.
 
 Long lived service worker.
    A service worker that caches by path keeps stale assets when the hash changes.
    Key the cache on the full URL, which already carries the content hash in the filename.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/components.rst
+++ b/docs/content/topics/components.rst
@@ -17,7 +17,7 @@ Components compose freely.
 A page template can call a component, a component template can call another component, and a layout can call any component that is in scope.
 The :ref:`components-folder-discovery` section below covers how the default ``FileComponentsBackend`` finds them.
 
-Component Shapes
+Component shapes
 ----------------
 
 The backend recognises two shapes.
@@ -57,11 +57,12 @@ Composite components add Python logic when the template needs computed values th
 
 .. _components-folder-discovery:
 
-Component Folder Discovery
+Component folder discovery
 --------------------------
 
-Each entry in ``COMPONENT_BACKENDS`` carries its own ``COMPONENTS_DIR`` name, defaulting to ``_components``.
-The components backend treats every directory with that name as a component namespace.
+The URL router reads the component folder name from the ``COMPONENTS_DIR`` key of the first ``COMPONENT_BACKENDS`` entry and treats every directory with that name as a component namespace.
+``FileComponentsBackend`` itself never reads the key.
+The key is required in every entry, an entry that omits it is reported by the ``next.E031`` system check, and only the value of the first entry takes effect.
 
 When the URL router walks the page trees it skips directories that match a configured ``COMPONENTS_DIR``, so component folders never become URL segments.
 
@@ -103,7 +104,7 @@ Custom backends.
        ]
    }
 
-Component Scope
+Component scope
 ---------------
 
 Components are resolved through a scope tree.
@@ -118,11 +119,12 @@ Local scope.
 Global scope.
    Components in directories listed under ``DIRS`` are visible from every template, regardless of tree.
 
-Two components with the same name are valid when their scope roots differ, for example one in a page tree and one in a ``DIRS`` root, or one in each of two page trees.
+Two components with the same name are valid when their scope roots differ, for example one in a page tree and one in a ``DIRS`` root.
+One name in each of two page trees is valid only when at least one of them lives below the tree root, since one name at the root route scope of two trees is rejected by ``next.E034``.
 Within one tree the name must be unique regardless of nesting depth.
-The same-scope name clash is reported by a system check, covered in the `System Checks`_ section below.
+The same-scope name clash is reported by a system check, covered in the `System checks`_ section below.
 
-Calling a Component
+Calling a component
 -------------------
 
 Use the ``{% component %}`` tag.
@@ -134,7 +136,7 @@ Remaining arguments are ``key=value`` props.
 
    {% component "card" title="Hello" %}
 
-Void Form
+Void form
 ~~~~~~~~~
 
 The tag has no closing form when the component does not take slots.
@@ -146,7 +148,7 @@ Use the block form covered under :ref:`components-multiline-tags` when the compo
 
    {% component "button" text="Save" variant="default" %}
 
-Block Form
+Block form
 ~~~~~~~~~~
 
 Prepend a hash sign to open a block.
@@ -163,7 +165,7 @@ Pair it with the matching close tag.
 
 The block form lets the component template substitute child content through slots.
 
-Free Children
+Free children
 ~~~~~~~~~~~~~
 
 Child markup placed inside a ``{% #component %}`` block without a wrapping ``{% #slot %}`` reaches the component template under the ``children`` context variable.
@@ -180,13 +182,13 @@ The ``card`` template renders this content wherever it places ``{{ children }}``
 
 .. _components-multiline-tags:
 
-Multiline Tags
+Multiline tags
 ~~~~~~~~~~~~~~
 
 Both the void form and the block form accept line breaks inside the tag body, which is useful when a component takes many props.
 The framework enables ``re.DOTALL`` for Django's tag lexer at startup, so tag bodies wrap across lines in every template type.
 
-.. caution::
+.. warning::
 
    This changes template parsing for **every** template the process loads, not only DJX files.
    If you rely on Django's stock behaviour where a newline inside ``{% ... %}`` ends the tag, adjust those templates before adopting next.dj.
@@ -242,7 +244,7 @@ Template expression.
 A quoted string prop is always passed as an unescaped plain string.
 The component template autoescapes it through ``{{ prop }}``, so pass ``prop=value|safe`` or an already-safe variable when the component must receive raw HTML.
 
-Variable Forwarding
+Variable forwarding
 ~~~~~~~~~~~~~~~~~~~
 
 A component receives every variable that is in scope at the call site.
@@ -290,10 +292,10 @@ A caller-supplied slot replaces the component's ``{% #set_slot %}`` fallback bod
 When the caller omits the slot the fallback renders.
 
 Both the void ``{% slot "name" %}`` and the block ``{% #slot %}`` forms are supported on the caller side, mirroring the void and block split shown for ``{% component %}``.
-The void form suits a slot whose value comes from a prop or is left empty.
+The void caller slot marks the slot explicitly empty and suppresses the ``{% #set_slot %}`` fallback body.
 Caller slot content reaches the component scope under the ``slot_<name>`` key.
 
-Component Context
+Component context
 -----------------
 
 A ``component.py`` next to ``component.djx`` runs Python code for the component.
@@ -333,14 +335,14 @@ The framework resolves parameters from the surrounding template scope, from URL 
 
 Pass ``serialize=True`` and optionally ``serializer=`` to include the return value in ``window.Next.context``.
 The behaviour is identical to ``@context`` on a page module, so the value must be JSON-encodable by the active serializer.
-See :doc:`static-assets/js-context` for the serialization options and :ref:`Serialization for the Browser <topics-context-serialization>` for the encodability contract.
+See :doc:`static-assets/js-context` for the serialization options and :ref:`Serialization for the browser <topics-context-serialization>` for the encodability contract.
 
 An unkeyed ``@component.context`` returning a dict serializes each key of that dict separately.
 A ``serializer=`` on such an unkeyed callable applies to every key of the returned dict.
 A keyed ``@component.context`` serializes its return value under the given key.
 An unkeyed callable that returns anything other than a mapping is silently dropped from the template scope.
 
-Co-located Static Assets
+Co-located static assets
 ------------------------
 
 A component folder can ship its own CSS, JS, and ECMAScript modules.
@@ -363,7 +365,7 @@ The static collector picks up each asset by stem.
 The collector emits each asset exactly once per request, even when multiple components reference the same file.
 See :doc:`static-assets/deduplication` for the dedup rules.
 
-Module Loading
+Module loading
 --------------
 
 By default the framework imports every ``component.py`` from each ``DIRS`` root during component backend setup.
@@ -378,6 +380,7 @@ They are available regardless of ``LAZY_COMPONENT_MODULES``.
 
 The ``LAZY_COMPONENT_MODULES`` flag gates the ``DIRS`` bulk import only.
 When the flag is set the framework skips that step and imports a ``component.py`` on first resolve instead.
+A composite component whose template body lives in the module-level ``component`` string is still imported during discovery, because the scanner must read that attribute.
 See :ref:`ref-settings` for the exact behaviour.
 
 .. code-block:: python
@@ -387,7 +390,7 @@ See :ref:`ref-settings` for the exact behaviour.
        "LAZY_COMPONENT_MODULES": True,
    }
 
-The Render Function
+The render function
 -------------------
 
 A composite component can define a ``render`` function in ``component.py`` that returns the component body as a string in place of the template.
@@ -420,14 +423,14 @@ Invoke the guard from a page template and forward the flag from the surrounding 
 
 See ``examples/feature-flags`` for a feature guard built this way.
 
-Hot Reload
+Hot reload
 ----------
 
 The development server reloads when a ``component.py`` changes inside a watched component folder.
 The watched folders are the ``DIRS`` roots configured on a backend and the page-tree component folders the URL router walks.
 Template-only edits to ``.djx`` files are reflected on the next request without a process restart.
 
-Lifecycle Signals
+Lifecycle signals
 -----------------
 
 The framework emits four signals during the component lifecycle.
@@ -454,7 +457,7 @@ The framework emits four signals during the component lifecycle.
 
 See :doc:`/content/ref/signals` for the full signal catalog.
 
-System Checks
+System checks
 -------------
 
 The components subsystem contributes Django system checks.
@@ -465,11 +468,13 @@ The components subsystem contributes Django system checks.
   Use ``@component.context`` from ``next.components`` instead.
 - ``next.E034`` reports one component name used at the root route scope of more than one page tree.
   Rename one of the colliding components or move it to a different scope root.
+- ``next.E075`` reports a ``@component.context`` registration bound to a file no component render collects.
+  Decorate callables defined in the ``component.py`` itself.
 
 Run them with ``uv run python manage.py check``.
 The full catalog lives in :doc:`/content/ref/system-checks`.
 
-Common Patterns
+Common patterns
 ---------------
 
 Three patterns build on the sections above.
@@ -478,7 +483,7 @@ Three patterns build on the sections above.
 - Add a ``component.py`` when the template needs values computed from the surrounding context, see :doc:`/content/howto/build-a-composite-component`.
 - Ship a folder of reusable components under a ``DIRS`` root for a shared UI kit, see :doc:`multi-project` and :doc:`/content/misc/examples`.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/components.rst
+++ b/docs/content/topics/components.rst
@@ -446,8 +446,8 @@ The framework emits four signals during the component lifecycle.
      - ``ComponentRegistry``
      - ``infos``
    * - ``component_backend_loaded``
-     - ``ComponentsManager``
-     - ``backend``, ``config``
+     - The component backend class
+     - ``config``, ``instance``
    * - ``component_rendered``
      - ``ComponentsManager``
      - ``info``, ``template_path``

--- a/docs/content/topics/context.rst
+++ b/docs/content/topics/context.rst
@@ -33,7 +33,7 @@ Component context.
    ``@component.context("key")`` in a ``component.py``.
    Resolves once per component instance during render.
 
-Framework-Provided Keys
+Framework-provided keys
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Every rendered template starts with three keys populated.
@@ -53,14 +53,14 @@ A user ``@context`` callable reads ``request`` through an ``HttpRequest`` annota
 The ``current_template_path`` and ``current_page_module_path`` keys live in the template scope for the ``{% form %}`` and ``{% component %}`` tags to consume.
 They are not injected into a context callable by parameter name.
 
-The Decorator
+The decorator
 -------------
 
 The page-side ``@context`` decorator has two shapes.
 One is a keyed single value, the other is an unkeyed dict.
 The ``inherit_context`` flag and direct registration, covered after the two shapes, vary how a function is registered.
 
-Keyed Single Value
+Keyed single value
 ~~~~~~~~~~~~~~~~~~
 
 The most common shape.
@@ -78,7 +78,7 @@ The decorator takes a single key and the function returns the value.
 
 Templates reference the value as ``{{ notes }}``.
 
-Unkeyed Dict
+Unkeyed dict
 ~~~~~~~~~~~~
 
 Decorating a function with bare ``@context`` and returning a dict merges every key into the template scope.
@@ -98,7 +98,7 @@ Decorating a function with bare ``@context`` and returning a dict merges every k
 This shape runs the dependency once.
 Two separate ``@context("post")`` and ``@context("comments")`` would each hit the resolver and possibly the database twice.
 
-The inherit_context Flag
+The inherit_context flag
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``inherit_context=True`` makes a keyed value visible to every descendant route, not only to the page that declares it.
@@ -115,7 +115,7 @@ The inherit_context Flag
 Use this for header copy, brand colors, feature flags, and other shared values.
 Without the flag the value is only available when that exact ``page.py`` handles the request, and descendant routes cannot read it.
 
-Reusing a Shared Helper
+Reusing a shared helper
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 ``@context`` keys the registration on the file where the decorated function is declared, not on the file that runs the decorator.
@@ -141,7 +141,7 @@ The decorated object has to carry a declaring file of its own, which a function,
 A built-in such as ``datetime.now`` carries none, and decorating one raises ``TypeError`` at import time naming the object.
 Wrap it in a function declared in the page module instead.
 
-Reading Values Into a Context Function
+Reading values into a context function
 --------------------------------------
 
 A context function receives its parameters through the :doc:`dependency injector <dependency-injection>`.
@@ -184,7 +184,7 @@ The framework resolves ``load_note`` with its own ``note_id`` argument from the 
    Use it for values produced by shared dependency callables.
    See :doc:`dependency-injection`.
 
-Resolution Order
+Resolution order
 ----------------
 
 The framework computes the template scope in this order.
@@ -202,9 +202,9 @@ The framework computes the template scope in this order.
 
 A later step that uses the same key overrides earlier values.
 The full merged dict is shared across the entire ``layout.djx`` chain for that request, so all layout wrappers see the same final scope.
-The :doc:`layouts` page restates this from the layout side under *Context Processors*.
+The :doc:`layouts` page restates this from the layout side under *Context processors*.
 
-Inheritance Rules
+Inheritance rules
 -----------------
 
 Inherited context follows the filesystem route tree.
@@ -214,12 +214,12 @@ The framework walks up from the current ``page.py`` directory and runs every ``@
 - A ``page.py`` at ``notes/pages/admin/`` publishes inherited values only for pages under ``/admin/``.
 - A page at ``/admin/links/`` sees both layers because it sits below both directories.
 
-When two ancestor directories publish the same inherited key, the value from the outermost ancestor currently wins.
+When two ancestor directories publish the same inherited key, the value from the outermost ancestor wins.
 
 The current page can shadow an inherited value by declaring a context function with the same key.
 The page level value takes precedence, and every layout wrapper in the chain sees that value.
 
-Inherited Function That Names a URL Parameter
+Inherited function that names a URL parameter
 ---------------------------------------------
 
 When an inherited context function is keyed under the same name as a captured URL segment, the parameter it asks for changes type across runs.
@@ -239,11 +239,11 @@ Leave the parameter untyped and return early when it is already a model instance
            return category
        return Category.objects.get(slug=category)
 
-Declaring the parameter as ``str`` would break the descendant re-run.
+An annotation cannot be honest for both runs, because the second run on the declaring page receives the already resolved object, so leave the parameter untyped.
 
 .. _topics-context-serialization:
 
-Serialization for the Browser
+Serialization for the browser
 -----------------------------
 
 next.dj ships a ``window.Next`` object to the browser through the :doc:`static pipeline <static-assets/index>`.
@@ -265,7 +265,7 @@ The materialisation rule applies only to keys that travel to the client.
 See :doc:`static-assets/js-context` for serializers, duplicate-key policies, ``NEXT_JS_OPTIONS``, and reading values from co-located JS.
 See :doc:`/content/howto/override-the-js-context-serializer` for a guided recipe when the default JSON encoder is not enough.
 
-Component Context vs Page Context
+Component context vs page context
 ---------------------------------
 
 Component context and page context share the same decorator pattern but differ in scope.
@@ -283,7 +283,7 @@ Component context.
 A component context function can ask for any value that the template forwards, plus any value that the dependency injector knows how to produce.
 This includes the request, captured URL parameters, query strings, and custom providers.
 
-Signal When Context Registers
+Signal when context registers
 -----------------------------
 
 The framework fires ``context_registered`` after a ``@context`` callable in a ``page.py`` joins the registry.
@@ -293,10 +293,10 @@ Subscribe to it when an external system needs to track page context functions ac
 Folder discovery registers components through ``register_many``, which fires ``components_registered`` once per discovery batch with an ``infos`` tuple of ``ComponentInfo``.
 The singular ``component_registered`` fires only on a one-at-a-time ``register`` call.
 
-Common Patterns
+Common patterns
 ---------------
 
-Per Page Title
+Per page title
 ~~~~~~~~~~~~~~
 
 Publish the page title from each page.
@@ -319,13 +319,13 @@ Render it in the layout.
 
    <title>{{ page_title|default:"Notes" }}</title>
 
-Site Wide Configuration
+Site wide configuration
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Publish branding and navigation from the root ``page.py`` with ``inherit_context=True``.
 Every page under that directory reads the values without redeclaring them.
 
-Filter Values From Query String
+Filter values from query string
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Combine a context function with the ``DQuery[T]`` marker to read filters from the URL.
@@ -340,12 +340,12 @@ Combine a context function with the ``DQuery[T]`` marker to read filters from th
    def active_tag(tag: DQuery[str] = "") -> str:
        return tag
 
-Shared Dependency
+Shared dependency
 ~~~~~~~~~~~~~~~~~
 
 When two context functions need the same expensive value, factor the dependency into a custom DI provider or use the unkeyed dict shape.
 
-System Checks
+System checks
 -------------
 
 The framework validates context functions through ``check_context_functions``.
@@ -353,7 +353,11 @@ A keyless ``@context`` callable with a non-dict return annotation reports ``next
 A keyless callable with no return annotation is accepted by the check and raises ``TypeError`` at render time if the value is not a mapping.
 Functions decorated with a key may return any value.
 
-See Also
+A ``page.py`` holds one keyless slot.
+Registering a second bare ``@context`` replaces the first, and ``next.E018`` reports the shadowed callable.
+Give each function a key or merge them.
+
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/context.rst
+++ b/docs/content/topics/context.rst
@@ -49,8 +49,12 @@ The two path keys are seeded before any user-defined ``@context`` callable runs,
 ``current_page_module_path``.
    The absolute path of the ``page.py`` module being rendered.
 
+``current_component_module_path``.
+   The absolute path of the ``component.py`` beside the component template being rendered, or ``None`` for a component without one.
+   The ``{% component %}`` tag writes it for the component's own template body, so it never leaks into slot bodies rendered by the page.
+
 A user ``@context`` callable reads ``request`` through an ``HttpRequest`` annotation rather than by parameter name.
-The ``current_template_path`` and ``current_page_module_path`` keys live in the template scope for the ``{% form %}`` and ``{% component %}`` tags to consume.
+These path keys live in the template scope for the ``{% form %}`` and ``{% component %}`` tags to consume.
 They are not injected into a context callable by parameter name.
 
 The decorator

--- a/docs/content/topics/dependency-injection.rst
+++ b/docs/content/topics/dependency-injection.rst
@@ -1,6 +1,6 @@
 .. _topics-dependency-injection:
 
-Dependency Injection
+Dependency injection
 ====================
 
 The dependency resolver inspects the signature of every callable that the framework invokes and fills each parameter from a registered provider.
@@ -20,7 +20,7 @@ The form dispatch resolves the form-class factory, ``get_initial``, ``@action`` 
 Every call site shares one provider list and one set of markers.
 Custom providers and tests can import ``resolver`` from ``next.deps`` and call ``resolver.resolve_dependencies``.
 
-Built In Providers
+Built in providers
 ------------------
 
 The framework discovers a fixed list of providers and instantiates them on first use.
@@ -61,7 +61,7 @@ It runs before the ``DQuery`` provider, so a ``DQuery`` parameter that shares a 
    .. code-block:: python
       :caption: shadowing a same-named URL kwarg
 
-      # routes/shop/[category]/layout page.py
+      # routes/shop/[category]/page.py
       @context("category", inherit_context=True)
       def category() -> str:
           return "books"
@@ -98,7 +98,8 @@ A Django converter that pre-coerced the segment, such as ``[uuid:id]`` producing
 A failed parse falls back to the raw captured value rather than raising.
 ``bool`` treats ``"1"``, ``"true"``, and ``"yes"`` as ``True`` and everything else as ``False``.
 ``date`` and ``datetime`` parse the ISO 8601 forms accepted by :meth:`date.fromisoformat <datetime.date.fromisoformat>` and :meth:`datetime.fromisoformat <datetime.datetime.fromisoformat>`.
-For wildcard ``[[name]]`` segments the captured value is the matched path string. Annotate as ``DUrl[str]`` or leave it unannotated.
+For wildcard ``[[name]]`` segments the captured value is the matched path string.
+Annotate as ``DUrl[str]`` or leave it unannotated.
 
 The marker has three forms.
 
@@ -123,11 +124,11 @@ Hyphens in directory names are normalised to underscores in the kwarg, so a ``[m
 .. note::
 
    A ``DUrl[T]`` annotation is not the same thing as a Django URL converter label.
-   See :ref:`Converter Segments <topics-di-converter-segments>` below.
+   See :ref:`Converter segments <topics-di-converter-segments>` below.
 
 .. _topics-di-converter-segments:
 
-Converter Segments
+Converter segments
 ^^^^^^^^^^^^^^^^^^
 
 ``[slug:name]`` and ``[uuid:name]`` in directory names are Django URL converter labels that control routing and validation.
@@ -200,7 +201,7 @@ The provider returns the parameter default when the key is absent.
 ``DQuery`` accepts the same scalar set as ``DUrl``, namely ``str``, ``int``, ``bool``, ``float``, ``UUID``, ``Decimal``, ``date``, and ``datetime``, plus ``list[T]`` for any of those scalars.
 A value that fails to parse falls back to the raw query string rather than raising.
 
-Context Markers
+Context markers
 ---------------
 
 Two markers fill parameters from distinct data sources.
@@ -245,7 +246,7 @@ See :doc:`/content/internals/di-resolver` for the cycle and cache mechanics.
    ) -> str:
        return f"Hello {user_name}, theme is {theme}."
 
-Registering Named Dependencies
+Registering named dependencies
 ------------------------------
 
 Use ``resolver.dependency`` to register a callable that any handler can ask for through ``Depends("name")``.
@@ -262,7 +263,7 @@ Use ``resolver.dependency`` to register a callable that any handler can ask for 
 Import the module that defines the dependency from ``AppConfig.ready`` so the decorator runs before the first request.
 The registered callable can take any provider-resolved parameters because it is itself dispatched through the resolver.
 
-Diagnosing a Dependency Cycle
+Diagnosing a dependency cycle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A named dependency may itself ask for other named dependencies through ``Depends``.
@@ -313,7 +314,7 @@ Here ``settings`` does not need ``profile`` at all, so the fix is to drop that p
 
 When both dependencies genuinely need shared data, move that data into a third dependency and have both depend on it.
 
-Writing a Custom Provider
+Writing a custom provider
 -------------------------
 
 For data sources that do not fit the built ins, register a parameter provider.
@@ -379,7 +380,7 @@ The nine built-in providers occupy the range ``10`` (named dependency) through `
 ``FormProvider`` and ``CleanedDataProvider`` share priority ``40``.
 Set ``priority`` on the subclass when the new provider has to claim a parameter the built-ins would otherwise match, for example a value below ``60`` for an annotation that should outrank ``DUrl``.
 
-Resolution Cache
+Resolution cache
 ----------------
 
 Each resolution pass wraps a per-render dependency cache in a fresh ``DependencyCache``.
@@ -401,9 +402,10 @@ The function returns ``None`` outside a form dispatch, so callers handle the mis
 .. code-block:: python
    :caption: reading the cache
 
+   from django.http import HttpRequest
    from next.deps import get_request_dep_cache
 
-   def render(request) -> str:
+   def render(request: HttpRequest) -> str:
        cache = get_request_dep_cache(request)
        if cache is None:
            return "No form dispatch cache on this request."
@@ -413,7 +415,7 @@ The constant ``REQUEST_DEP_CACHE_ATTR`` names the request attribute that holds t
 
 More recipes for diagnosing missing markers and CSRF or dispatch errors live in :doc:`/content/faq/troubleshooting`.
 
-Avoid ``from __future__ import annotations`` in DI Modules
+Avoid ``from __future__ import annotations`` in DI modules
 ----------------------------------------------------------
 
 The resolver inspects real annotations, not strings.
@@ -427,16 +429,16 @@ Do not use future annotations in modules with DI parameters.
 
 Keep DI types runtime importable.
    Most providers compare annotations through ``typing.get_origin``, which returns ``None`` for string annotations and never imports the target type.
-   The ``HttpRequest`` provider does call ``typing.get_type_hints`` on the wrapped callable as a fallback, and that call evaluates string annotations.
+   The ``HttpRequest`` provider evaluates annotations through ``typing.get_type_hints`` first and falls back to the raw annotation, and the ``get_type_hints`` call evaluates string annotations.
    Types hidden behind ``if TYPE_CHECKING`` are not visible to either path, so keep DI-touching annotations on classes that import at module top level.
 
-Resolver Lifecycle
+Resolver lifecycle
 ------------------
 
 The resolver builds its provider registry on first use and reuses it, so register custom providers from ``AppConfig.ready``.
 See :doc:`/content/internals/di-resolver` for the full lifecycle.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/extending.rst
+++ b/docs/content/topics/extending.rst
@@ -10,7 +10,7 @@ Each section below states what its mechanism replaces and where to register it.
    :local:
    :depth: 2
 
-The Five Mechanisms
+The five mechanisms
 -------------------
 
 Backend.
@@ -132,7 +132,7 @@ Call ``default_stems.register(...)`` from ``AppConfig.ready`` so the new stem is
        def ready(self) -> None:
            default_stems.register("component", "theme")
 
-Autoreload Watch Specs
+Autoreload watch specs
 ~~~~~~~~~~~~~~~~~~~~~~
 
 The development reloader watches the page and component trees by default.
@@ -165,7 +165,7 @@ Duplicate ``(path, glob)`` pairs are dropped, so registering the same spec twice
 Subscribe to that signal to observe or audit the resolved spec set.
 See :doc:`/content/internals/autoreload` for the full watcher pipeline.
 
-Protocols and Abstract Base Classes
+Protocols and abstract base classes
 -----------------------------------
 
 A protocol is a structural contract.
@@ -223,7 +223,7 @@ Connect a receiver to react to a framework event.
 The signal catalog lives in :doc:`signals`.
 The patterns are uniform across the framework.
 
-Choosing Between Mechanisms
+Choosing between mechanisms
 ---------------------------
 
 Picking the right mechanism saves work.
@@ -238,15 +238,15 @@ Use the entries below as a quick map.
 - **Change how URLs land in HTML.** Customise a static backend.
 - **Vary URLs by request.** Use a request-aware static backend.
 - **Inspect every rendered page.** Subscribe to the ``page_rendered`` signal.
-- **Watch extra directories during development.** Call ``register_autoreload_watch_spec``. See *Autoreload Watch Specs* above.
+- **Watch extra directories during development.** Call ``register_autoreload_watch_spec``. See *Autoreload watch specs* above.
 
-Worked Examples
+Worked examples
 ---------------
 
 The repository ``examples/`` tree ships complete projects for every major extension mechanism.
 :doc:`/content/misc/examples` lists each folder, a one-line focus, links to GitHub, and the sections of this manual that explain the same techniques.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/file-router.rst
+++ b/docs/content/topics/file-router.rst
@@ -1,6 +1,6 @@
 .. _topics-file-router:
 
-File Router
+File router
 ===========
 
 The file router scans your project for ``page.py`` and ``template.djx`` files and generates Django URL patterns from the directory tree.
@@ -23,7 +23,7 @@ Adding a directory adds a URL.
 Renaming a directory renames the URL and its computed URL name.
 Removing a directory removes the URL.
 
-Route Shapes
+Route shapes
 ------------
 
 The router recognises four directory shapes.
@@ -62,7 +62,7 @@ The following layout shows the four shapes together.
        [[suffix]]/
          page.py                   /api/<path:suffix>/
 
-Captured Parameters
+Captured parameters
 -------------------
 
 The bracket syntax accepts every Django path converter.
@@ -118,7 +118,7 @@ Name your directories without hyphens when you want the parameter name and the d
 ``DUrl[int]`` reads the captured segment whose name matches the parameter, so ``post_id`` resolves the ``[int:post_id]`` segment and the marker coerces it to ``int``.
 See :doc:`dependency-injection` for the full set of ``DUrl`` forms and the coercion table.
 
-Virtual Routes
+Virtual routes
 --------------
 
 A directory that contains a ``template.djx`` without a ``page.py`` still becomes a URL.
@@ -140,7 +140,7 @@ A virtual route can still receive layout wrapping from any ancestor ``layout.djx
 Every view the router generates, virtual routes included, carries a ``next_page_path`` attribute naming the page source.
 The form dispatcher reads it when it resolves a posted origin back to the page that should re-render after a validation failure, see :doc:`/content/topics/forms/validation-rerender`.
 
-URL Names
+URL names
 ---------
 
 Every page receives a URL name in the ``next`` namespace.
@@ -187,10 +187,10 @@ The placeholder ``{name}`` must appear in the template so each page still gets a
 Reverse them through the standard ``{% url %}`` tag or with ``page_reverse``.
 See :doc:`url-reversing` for the Python side.
 
-Page Roots
+Page roots
 ----------
 
-The router resolves routes from two sources, in the same way ``staticfiles`` resolves static files.
+The router resolves routes from app directories and project directories, in the same way ``staticfiles`` resolves static files, with one fallback shape.
 
 App directories.
    When ``APP_DIRS`` is ``True`` the router scans each installed application for a directory named ``PAGES_DIR``.
@@ -253,7 +253,7 @@ The comparison is string equality after bracket conversion, so semantic overlap 
 The ``OPTIONS`` block accepts a list of Django context processor paths.
 Each processor contributes values to every template that the router renders.
 
-DIRS Entry Types
+DIRS entry types
 ~~~~~~~~~~~~~~~~
 
 Each entry in ``DIRS`` is classified by ``next.utils.classify_dirs_entries`` before the router uses it.
@@ -285,7 +285,7 @@ Segment entry.
 In the example above, any directory named ``_drafts`` under any application's page root is silently skipped.
 No URL is registered for it and the file walk does not descend into it.
 
-Components Folder Skipping
+Components folder skipping
 --------------------------
 
 The router shares its file walk with the components backend.
@@ -293,7 +293,7 @@ The name set in the first ``COMPONENT_BACKENDS`` entry under ``COMPONENTS_DIR`` 
 The default is ``_components``.
 Only that exact name is skipped, not every directory that starts with an underscore.
 
-Multiple Backends
+Multiple backends
 -----------------
 
 The settings list accepts more than one backend.
@@ -326,7 +326,7 @@ Resolution preserves the concatenated list order.
 The first match wins.
 Both backends emit the same signals and follow the same naming rules.
 
-Resolution Performance
+Resolution performance
 ----------------------
 
 URL resolution scales with the depth of the request path, not with the number of registered pages.
@@ -335,29 +335,29 @@ The final match runs through standard Django pattern resolution, so converters a
 Setting ``URL_RESOLVER`` in ``NEXT_FRAMEWORK`` to ``"django.urls.resolvers.URLResolver"`` restores the plain linear scan.
 See :doc:`/content/internals/url-router` for the algorithm and :doc:`/content/ref/settings` for the setting.
 
-Common Patterns
+Common patterns
 ---------------
 
-Single Page Application Root
+Single page application root
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A single ``routes/page.py`` registers the empty path ``/``.
 The router treats it as the default URL for the project.
 
-Static Content Section
+Static content section
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Use virtual routes for marketing pages and legal copy.
 The directory holds only a ``template.djx``, no Python required.
 
-Per Project Page Tree
+Per project page tree
 ~~~~~~~~~~~~~~~~~~~~~
 
 Place a layout and one ``page.py`` under ``chrome/`` and add ``chrome`` to ``DIRS``.
 The result is a project-level shell that wraps every application page.
 See :doc:`multi-project` for the full pattern.
 
-Hot Reload
+Hot reload
 ----------
 
 A backend that reads from a database or other dynamic source needs to rebuild its pattern list when the data changes.
@@ -368,7 +368,7 @@ A burst of model writes that each triggers a reload can dominate that request.
 Receivers should debounce or batch invocations when one logical change triggers many model signals at once.
 See :doc:`/content/howto/reload-routes-from-code` for the model-signal receiver that triggers the reload.
 
-System Checks
+System checks
 -------------
 
 The router contributes Django system checks that validate the configuration at startup.
@@ -385,7 +385,7 @@ The router contributes Django system checks that validate the configuration at s
 Run them through ``uv run python manage.py check``.
 A clean exit confirms that every page resolves and every name is unique.
 
-Extension Points
+Extension points
 ----------------
 
 Three surfaces let you replace or augment the router.
@@ -397,7 +397,7 @@ Three surfaces let you replace or augment the router.
 Subclass ``FileRouterBackend`` to add additional patterns or augment URL names without writing a backend from scratch.
 See :doc:`extending` for a worked example.
 
-Database Driven Routes
+Database driven routes
 ----------------------
 
 A hybrid backend combines file routes with routes built from database rows.
@@ -407,7 +407,7 @@ Register the backend in ``PAGE_BACKENDS`` and call ``router_manager.reload()`` f
 
 See :doc:`/content/howto/write-a-router-backend` for the full worked recipe.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/actions.rst
+++ b/docs/content/topics/forms/actions.rst
@@ -12,7 +12,7 @@ Plain functions register through the ``@action`` decorator.
    :local:
    :depth: 2
 
-Class-Bound Forms
+Class-bound forms
 -----------------
 
 Declaring a subclass of ``next.forms.Form`` or ``next.forms.ModelForm`` registers the class automatically.
@@ -20,6 +20,8 @@ No decorator is needed.
 
 .. code-block:: python
    :caption: notes/pages/note/page.py
+
+   from django.http import HttpRequest
 
    import next.forms
    from next.forms import redirect_to_origin
@@ -29,13 +31,13 @@ No decorator is needed.
            model = Note
            fields = ["title", "body"]
 
-       def on_valid(self, request):
+       def on_valid(self, request: HttpRequest):
            self.save()
            return redirect_to_origin(request)
 
 The framework derives the action name from the class name and infers the scope from the file where the class is declared.
 
-Name Derivation
+Name derivation
 ---------------
 
 The action name is the ``CamelCase`` class name converted to ``snake_case`` by inserting underscores before each uppercase letter that is preceded by a lowercase letter or a digit.
@@ -66,7 +68,7 @@ The conversion collapses consecutive uppercase runs, so an acronym stays a singl
    The exception message lists the closest registered names, so a rename typo is usually visible in the error itself.
    Update every template and reverse call when renaming a class.
 
-Anchor Files and Scope
+Anchor files and scope
 ----------------------
 
 The scope of a form class depends on the file it is declared in.
@@ -94,7 +96,7 @@ A class built by a factory such as ``next.forms.modelform_factory`` is attribute
 
 .. _topics-forms-actions-uid:
 
-UID Stability
+UID stability
 -------------
 
 Each action gets a stable URL at ``/_next/form/<uid>/``.
@@ -121,7 +123,7 @@ The UID is derived, never stored in a template by hand.
 A ``{% form "name" %}`` tag reverses the current UID at render time, so a freshly rendered page always posts to the right URL.
 Only out-of-band references to a stale UID break.
 
-The ``on_valid`` Method
+The ``on_valid`` method
 -----------------------
 
 ``on_valid`` runs after the framework validates the submitted form.
@@ -129,16 +131,16 @@ The method signature uses the same dependency-injection rules as any other DI-re
 
 .. code-block:: python
 
-   def on_valid(self, request):
+   def on_valid(self, request: HttpRequest):
        ...
 
 ``self`` is the bound, validated form instance.
-``request`` is the current ``HttpRequest``.
+``request`` receives the current ``HttpRequest`` only when the parameter is annotated ``HttpRequest``, an unannotated ``request`` parameter resolves to ``None``.
 Any additional parameter is resolved through the DI injector, through ``DUrl[...]`` markers, ``Depends`` providers, and similar mechanisms.
 
 The default implementation on ``BaseForm`` redirects to ``Meta.success_url`` when declared, otherwise it returns ``redirect_to_origin(request)``.
 The default implementation on ``BaseModelForm`` calls ``self.save()`` then follows the same redirect rule.
-See `Success Feedback`_ for the ``success_url`` contract.
+See `Success feedback`_ for the ``success_url`` contract.
 
 The return value follows the same contract as a handler function, checked in a fixed order.
 An ``HttpResponse`` instance passes through unchanged, and this check runs first, so every rich response type the framework ships subclasses ``HttpResponse``.
@@ -148,7 +150,7 @@ A model instance with a ``get_absolute_url`` method redirects to that URL, the `
 Any other object with a truthy ``url`` attribute redirects to that URL, a last-resort convenience for model-like objects.
 Any other return value emits a ``RuntimeWarning`` and is treated as ``None``.
 
-``get_initial`` Pre-Populates the Form
+``get_initial`` pre-populates the form
 --------------------------------------
 
 Override ``get_initial`` as a classmethod to provide initial data before the first render.
@@ -157,7 +159,7 @@ The classmethod is DI-resolved, so it can receive ``request``, URL parameters, o
 .. code-block:: python
 
    @classmethod
-   def get_initial(cls, request, note_id: int | None = None):
+   def get_initial(cls, request: HttpRequest, note_id: int | None = None):
        if note_id is None:
            return {}
        return Note.objects.get(pk=note_id)
@@ -168,14 +170,14 @@ The framework uses it as the ``instance`` kwarg when constructing the form.
 
 You never call ``get_initial`` yourself.
 The dispatcher calls it through the dependency injector before the initial render.
-``request`` is supplied by the framework.
+``request`` is supplied by the framework only to a parameter annotated ``HttpRequest``, an unannotated ``request`` parameter resolves to ``None``.
 A parameter whose name matches a captured URL segment is filled from the URL, so ``note_id`` above receives the ``note_id`` route kwarg.
 Any other parameter resolves through a registered provider, the same as on a handler.
 The base signatures carry no positional arguments of their own.
 ``BaseForm.get_initial(cls)`` takes none, and ``BaseModelForm.get_initial(cls, **url_kwargs)`` accepts the URL kwargs as keywords.
 Declare only the parameters an override actually reads.
 
-Form-Less Actions
+Form-less actions
 -----------------
 
 Use ``@action`` to register a plain callable when no form fields are needed.
@@ -203,13 +205,13 @@ The scope of a form-less action follows the same anchor-file rule.
 All other files produce shared actions.
 Pass ``scope="page"`` or ``scope="shared"`` to override the file-derived scope, the same override ``Meta.scope`` provides for a form class.
 Any other value triggers ``next.E047`` and the action is not registered.
-The ``login_required`` and ``permission_required`` keywords guard the endpoint, see `Access Guards`_.
+The ``login_required`` and ``permission_required`` keywords guard the endpoint, see `Access guards`_.
 
 Applying ``@action`` to a class registers no action.
 The decorator records the misuse, returns the class unchanged, and ``manage.py check`` reports it as ``next.E053``.
 Form classes register through ``__init_subclass__`` and must not use ``@action``.
 
-Stacking Decorators on ``@action``
+Stacking decorators on ``@action``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``@action`` keys the registration on the file where the decorated function is declared, not on the file that runs the decorator.
@@ -236,7 +238,7 @@ Keep ``@action`` outermost when other decorators apply to the same handler.
 ``transaction.atomic`` sets ``__wrapped__`` through :func:`functools.wraps`, so the action still registers under this ``page.py``.
 A hand-written decorator that omits ``functools.wraps`` hides the wrapped function, and the action registers under the decorator's own module instead.
 
-Injecting the Form Into a Handler
+Injecting the form into a handler
 ---------------------------------
 
 A handler registered with ``@action("name", form_class=...)`` receives the bound, validated form.
@@ -274,7 +276,7 @@ The marker only types the parameter.
 The framework still injects the same bound form a parameter named ``form`` would receive.
 See :doc:`/content/ref/decorators` for ``DForm`` and ``FormProvider``.
 
-Dynamic Form Classes
+Dynamic form classes
 --------------------
 
 A ``form_class=`` argument may be a factory callable instead of a form class.
@@ -310,7 +312,7 @@ See :doc:`formsets` for the same pattern applied to formset and inline-formset a
 
 .. _topics-forms-actions-abstract:
 
-Preventing Registration
+Preventing registration
 -----------------------
 
 A project base class that other forms subclass should not register as an action of its own.
@@ -319,11 +321,16 @@ Set ``Meta.abstract = True`` to skip auto-registration.
 .. code-block:: python
    :caption: app/forms.py — a shared base that does not register
 
+   from django.http import HttpRequest
+
+   import next.forms
+   from next.forms import redirect_to_origin
+
    class TenantForm(next.forms.Form):
        class Meta:
            abstract = True
 
-       def on_valid(self, request):
+       def on_valid(self, request: HttpRequest):
            return redirect_to_origin(request)
 
    class InviteForm(TenantForm):
@@ -335,7 +342,7 @@ The same ``Meta.abstract`` flag works on a ``FormWizard`` base class.
 
 .. _topics-forms-actions-guards:
 
-Access Guards
+Access guards
 -------------
 
 The dispatch endpoint of an action lives at ``/_next/form/<uid>/``, outside the page URL space, so page-level protection does not cover it.
@@ -384,7 +391,7 @@ The ``next.W060`` check warns when ``permission_required`` is declared while ``d
 
 .. _topics-forms-actions-dynamic-guards:
 
-Dynamic Permission Hooks
+Dynamic permission hooks
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The static guard answers a fixed question frozen at import time, whether the user is authenticated and holds a named permission.
@@ -481,10 +488,10 @@ The static guard runs first and pre-database.
 A request it denies never reaches a dynamic hook, so the static guard stays the cheap default for the authentication-and-named-permission case.
 ``check_permissions`` runs next, then the form binds, then ``has_object_permission`` runs on the bound form.
 
-The view hook resolves on the resolved form class, so a factory ``form_class`` is covered as well, see `Dynamic Form Classes`_.
+The view hook resolves on the resolved form class, so a factory ``form_class`` is covered as well, see `Dynamic form classes`_.
 A handler-only ``@action`` carries no class to host a method, so it has no dynamic hook.
 Such a handler runs its own check in the body and raises :exc:`~django.core.exceptions.PermissionDenied` or returns a redirect,
-the same pattern shown for ``messages.success`` under `Success Messages`_.
+the same pattern shown for ``messages.success`` under `Success messages`_.
 
 An object-level denial returns a bare HTTP 403.
 It does not re-render the origin page.
@@ -512,12 +519,12 @@ A wizard step binds from posted data and ``get_form_kwargs`` and never runs ``ge
 
 .. _topics-forms-actions-success:
 
-Success Feedback
+Success feedback
 ----------------
 
 Two ``Meta`` keys describe what a valid submission tells the user, a flash message and a redirect target.
 
-Success Messages
+Success messages
 ~~~~~~~~~~~~~~~~
 
 ``Meta.success_message`` flashes a message through :doc:`django.contrib.messages <django:ref/contrib/messages>` after a valid submission.
@@ -557,7 +564,7 @@ Call ``messages.success`` in the handler body instead.
        messages.success(request, "Note archived.")
        return redirect_to_origin(request)
 
-Success Redirects
+Success redirects
 ~~~~~~~~~~~~~~~~~
 
 ``Meta.success_url`` names where the default ``on_valid`` redirects after a valid submission.
@@ -584,7 +591,7 @@ Returning the instance redirects to its ``get_absolute_url()``, the ``CreateView
    def on_valid(self, request: HttpRequest):
        return self.save()
 
-System Checks
+System checks
 -------------
 
 The forms subsystem contributes Django system checks that run through ``python manage.py check``.
@@ -631,7 +638,7 @@ A UID hash collision between two distinct registrations is not reported as a sys
 It raises ``ImproperlyConfigured`` at import time when two different ``(scope_key, name)`` pairs hash to the same UID.
 This is distinct from the ``next.E041`` name collision above, which fires when one name is registered from two different handlers.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/actions.rst
+++ b/docs/content/topics/forms/actions.rst
@@ -91,6 +91,12 @@ Override with ``Meta.scope``.
 Customise the set of anchor file names through ``NEXT_FRAMEWORK["FORM_ANCHOR_FILES"]``.
 The default set is ``["page.py", "component.py"]``.
 
+Lookup order in templates.
+   ``{% form %}`` and ``{% action_url %}`` resolve a name against the nearest anchor first.
+   Inside a component's own template the chain is the component's ``component.py``, then the enclosing page's ``page.py``, then the shared registry.
+   In a page or layout template the chain is the page's ``page.py``, then the shared registry.
+   Slot bodies and free children passed to a component render in the page context, so they resolve against the page anchor.
+
 The file is the one the ``class`` statement is written in, not the file that imports the class.
 A class built by a factory such as ``next.forms.modelform_factory`` is attributed to the module that calls the factory, not to the module that runs the underlying ``type()`` call.
 

--- a/docs/content/topics/forms/backends.rst
+++ b/docs/content/topics/forms/backends.rst
@@ -35,14 +35,16 @@ A custom backend is the right tool when every dispatch needs an extra step such 
 How Backends Are Instantiated
 -----------------------------
 
-``FormActionManager`` builds one backend instance per entry in ``FORM_ACTION_BACKENDS`` through ``FormActionFactory``.
-The factory imports the ``BACKEND`` dotted path and calls the class with the whole config dict, including ``BACKEND`` and any ``OPTIONS``.
+``FormActionManager`` builds one backend instance per entry in ``FORM_ACTION_BACKENDS``, through the same loading helper every backend family shares.
+The helper imports the ``BACKEND`` dotted path, checks the class against ``FormActionBackend``, and calls it with the whole config dict, including ``BACKEND`` and any ``OPTIONS``.
 
 .. code-block:: python
-   :caption: what the factory does per entry
+   :caption: what the loader does per entry
 
    backend_class = import_class_cached(config["BACKEND"])
    backend = backend_class(config)
+
+An entry that names no importable ``FormActionBackend`` subclass is logged and skipped, so one broken entry costs its own backend and the rest of the list still loads.
 
 The constructor therefore receives the full entry, not only ``OPTIONS``.
 ``RegistryFormActionBackend.__init__`` accepts the config and ignores it, which is why a subclass that reads no options needs no constructor at all.
@@ -308,7 +310,8 @@ Testing
 
 Tests that register actions through ``@action`` must drop the global registry between cases so action names from one test do not leak into the next.
 Call :func:`next.testing.reset_form_actions` from a pytest fixture or a ``setUp`` method.
-The helper invokes ``form_action_manager._reload_config()``, which rebuilds the backend list from the current ``NEXT_FRAMEWORK["FORM_ACTION_BACKENDS"]`` setting and discards any actions registered against the previous backend instances.
+The helper invokes the manager's private ``_reload_config()``, which rebuilds the backend list from the current ``NEXT_FRAMEWORK["FORM_ACTION_BACKENDS"]`` setting and discards any actions registered against the previous backend instances.
+The rebuild also marks the manager as loaded, so a configuration that yields no backend is read once instead of on every later call.
 
 A test that registers extra actions on a live ``RegistryFormActionBackend`` takes a snapshot first and restores it afterwards.
 ``backend.snapshot()`` returns a ``RegistryBackendSnapshot``, an immutable copy of the three registry maps, and ``backend.restore(snapshot)`` puts the registry back exactly as it was, without reaching into the backend's private state.

--- a/docs/content/topics/forms/backends.rst
+++ b/docs/content/topics/forms/backends.rst
@@ -1,6 +1,6 @@
 .. _topics-forms-backends:
 
-Action Backends
+Action backends
 ===============
 
 A form action backend stores registered actions, generates their URL patterns, and dispatches submissions to handlers.
@@ -32,7 +32,7 @@ The default value registers one backend.
 Most projects never change this.
 A custom backend is the right tool when every dispatch needs an extra step such as audit logging or rate limiting.
 
-How Backends Are Instantiated
+How backends are instantiated
 -----------------------------
 
 ``FormActionManager`` builds one backend instance per entry in ``FORM_ACTION_BACKENDS``, through the same loading helper every backend family shares.
@@ -68,7 +68,7 @@ A backend that reads an option declares a constructor and pulls ``OPTIONS`` out 
 
 Always forward ``config`` to ``super().__init__`` so the registry is set up.
 
-The Backend Contract
+The backend contract
 --------------------
 
 A backend subclasses ``next.forms.FormActionBackend``, an abstract base class with four abstract methods.
@@ -95,7 +95,7 @@ The base class also offers four optional override points.
 - ``render_invalid_page``
 - ``shape_response``
 
-``get_meta`` and Multi-Backend Routing
+``get_meta`` and multi-backend routing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``get_meta(action_name, page_path=None)`` returns the stored ``ActionMeta`` for a name, or ``None`` when this backend does not own it.
@@ -115,7 +115,7 @@ That form renders without ``data-next-action`` and without a bound form instance
 Return a truthy meta for owned names to restore the attribute, the bound form, and the uid.
 A backend that defers entirely to ``RegistryFormActionBackend`` need not override ``get_meta``.
 
-``iter_actions`` and the System Checks
+``iter_actions`` and the system checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``iter_actions()`` yields the ``ActionMeta`` of every action the backend owns.
@@ -123,7 +123,7 @@ The base implementation yields nothing, and ``RegistryFormActionBackend`` yields
 The forms system checks that inspect registered actions, the wizard checks including ``next.E054``, the component-widget checks, the guard check, and the message check, walk every configured backend through this hook, so a backend that stores its own actions should implement it, or those actions stay invisible to ``manage.py check``.
 A subclass of ``RegistryFormActionBackend`` inherits a working implementation.
 
-Shaping the Response
+Shaping the response
 ~~~~~~~~~~~~~~~~~~~~
 
 Every outcome of the dispatch pipeline leaves through exactly one call to the backend's ``shape_response(request, outcome)``.
@@ -158,7 +158,7 @@ Override ``render_invalid_page`` when only the page HTML changes.
 The default envelope calls it on the invalid branch with the bound failing form, and again on the ``None``-result success re-render described above with ``form=None``.
 Override ``shape_response`` when the envelope itself changes, such as a different status code, extra headers, or a response other than a redirect on a wizard advance.
 
-Building a Backend From Scratch
+Building a backend from scratch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Most backends subclass ``RegistryFormActionBackend``.
@@ -224,7 +224,7 @@ The public method ``clear_registry()`` drops every registered action and resets 
 It exists for test isolation, so a test session that registers overlapping action names can start from an empty registry.
 Production code never calls it.
 
-Writing a Custom Backend
+Writing a custom backend
 ------------------------
 
 The most common customisation overrides ``dispatch`` to wrap the standard dispatch with extra work.
@@ -254,7 +254,7 @@ See :doc:`/content/howto/write-a-form-action-backend` for the guarded pattern th
 A ``dispatch`` override that needs to know which page initiated the submission reads the validated origin from the pipeline rather than parsing POST fields.
 On the invalid branch the ``ActionOutcome`` passed to ``shape_response`` carries the resolved ``page_path`` and ``origin``, and a custom redirect target keyed off the origin page is one such use.
 
-Registering a Custom Backend
+Registering a custom backend
 ----------------------------
 
 List the dotted path in ``FORM_ACTION_BACKENDS``.
@@ -284,12 +284,11 @@ A custom ``dispatch`` that drives the pipeline by hand reuses one static helper 
 ``ensure_http_response(response, request=None, action_name=None, backend=None)``.
    Coerces a handler return value into an ``HttpResponse``.
    A string becomes a body, an object with a ``url`` becomes a redirect, and ``None`` re-renders the origin page when ``request``, ``action_name``, and ``backend`` are passed, otherwise it returns a 204.
-   The ``None`` re-render follows the behaviour under `Shaping the Response`_, through ``backend.render_invalid_page`` and never re-entering ``shape_response``.
+   The ``None`` re-render follows the behaviour under `Shaping the response`_, through ``backend.render_invalid_page`` and never re-entering ``shape_response``.
 
-Every outcome of the standard pipeline funnels into exactly one call to the backend hook ``shape_response(request, outcome)`` described under `Shaping the Response`_.
-A layer that must reshape responses globally overrides that one hook instead of patching each dispatch branch.
+Every outcome funnels into the single ``shape_response`` call described under `Shaping the response`_, so a layer that must reshape responses globally overrides that one hook.
 
-Backend vs Signal
+Backend vs signal
 -----------------
 
 An override runs inside the dispatch and can change or block the response.
@@ -315,14 +314,15 @@ Testing
 Tests that register actions through ``@action`` must drop the global registry between cases so action names from one test do not leak into the next.
 Call :func:`next.testing.reset_form_actions` from a pytest fixture or a ``setUp`` method.
 The helper invokes the manager's private ``_reload_config()``, which rebuilds the backend list from the current ``NEXT_FRAMEWORK["FORM_ACTION_BACKENDS"]`` setting and discards any actions registered against the previous backend instances.
-The rebuild also marks the manager as loaded, so a configuration that yields no backend is read once instead of on every later call.
+The rebuild marks the manager as loaded when at least one backend loads or the entry list is empty.
+A configuration whose entries all fail stays unloaded and is reread on the next access, as described above.
 
 A test that registers extra actions on a live ``RegistryFormActionBackend`` takes a snapshot first and restores it afterwards.
 ``backend.snapshot()`` returns a ``RegistryBackendSnapshot``, an immutable copy of the three registry maps, and ``backend.restore(snapshot)`` puts the registry back exactly as it was, without reaching into the backend's private state.
 
 See :doc:`/content/topics/testing` for the surrounding helpers and fixtures.
 
-System Checks
+System checks
 -------------
 
 The framework validates the backend configuration at startup.
@@ -332,21 +332,21 @@ The framework validates the backend configuration at startup.
 
 Run ``uv run python manage.py check`` after editing the backend list.
 
-Common Patterns
+Common patterns
 ---------------
 
-Audit Log
+Audit log
 ~~~~~~~~~
 
 Subclass ``RegistryFormActionBackend`` and override ``dispatch`` to write an audit row.
 See ``examples/audit-forms``.
 
-Rate Limiting
+Rate limiting
 ~~~~~~~~~~~~~
 
 Override ``dispatch`` to check a rate limit before calling ``super().dispatch`` and return an ``HttpResponse`` with status 429 when the limit is exceeded.
 
-Custom Invalid-Page HTML
+Custom invalid-page HTML
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Override ``render_invalid_page`` to return custom HTML for the validation error path.
@@ -359,7 +359,7 @@ The bundled ``RegistryFormActionBackend`` re-renders the origin page through the
 When no action meta or template body is found, it falls back to rendering the form with its ``<p>`` layout template.
 Override ``render_invalid_page`` to replace this behaviour entirely.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/backends.rst
+++ b/docs/content/topics/forms/backends.rst
@@ -45,6 +45,10 @@ The helper imports the ``BACKEND`` dotted path, checks the class against ``FormA
    backend = backend_class(config)
 
 An entry that names no importable ``FormActionBackend`` subclass is logged and skipped, so one broken entry costs its own backend and the rest of the list still loads.
+A backend that answers ``ImproperlyConfigured`` from its own ``__init__`` is skipped the same way, while any other exception a constructor raises is a bug in that backend and reaches the caller.
+
+When every entry fails, the manager keeps rereading the setting instead of caching an empty list, so a corrected dotted path takes effect on the next access.
+Asking such a manager for a backend raises ``ImproperlyConfigured`` naming how many entries were tried, and the ``next.backends`` logger holds the reason each one was skipped.
 
 The constructor therefore receives the full entry, not only ``OPTIONS``.
 ``RegistryFormActionBackend.__init__`` accepts the config and ignores it, which is why a subclass that reads no options needs no constructor at all.

--- a/docs/content/topics/forms/backends.rst
+++ b/docs/content/topics/forms/backends.rst
@@ -49,6 +49,7 @@ A backend that answers ``ImproperlyConfigured`` from its own ``__init__`` is ski
 
 When every entry fails, the manager keeps rereading the setting instead of caching an empty list, so a corrected dotted path takes effect on the next access.
 Asking such a manager for a backend raises ``ImproperlyConfigured`` naming how many entries were tried, and the ``next.backends`` logger holds the reason each one was skipped.
+The action lookups ``get_action_url``, ``get_action_meta``, and ``require_action_meta`` raise the same error rather than reporting an unknown action, so a load failure never reads as a missing ``@action`` import.
 
 The constructor therefore receives the full entry, not only ``OPTIONS``.
 ``RegistryFormActionBackend.__init__`` accepts the config and ignores it, which is why a subclass that reads no options needs no constructor at all.

--- a/docs/content/topics/forms/field-components.rst
+++ b/docs/content/topics/forms/field-components.rst
@@ -1,6 +1,6 @@
 .. _topics-forms-field-components:
 
-Field Components
+Field components
 ================
 
 Changing an input's classes or accessibility markup across a project usually means editing every form, or overriding Django's project-wide ``FORM_RENDERER`` and its widget templates.
@@ -64,7 +64,7 @@ The constructor accepts a keyword-only ``attrs`` dict for persistent HTML attrib
 The ``attrs`` dict is merged Django-style through :meth:`~django.forms.Widget.build_attrs`, the same as on any Django widget, and render-time attributes win on a collision.
 Every other keyword argument is a component prop spread to the top level of the component context.
 
-The Context Contract
+The context contract
 --------------------
 
 When a field renders, the component template receives the values the bound field produced.
@@ -120,7 +120,7 @@ The widget writes them last, so they always win over a same-named entry from ``a
      class="flex h-10 w-full rounded-md border px-3 py-2 text-sm"
    />
 
-Scope and Registration
+Scope and registration
 ----------------------
 
 A ``ComponentWidget`` resolves its component the same way the ``{% component %}`` tag does, walking outward from the page's location.
@@ -149,7 +149,7 @@ The ``next.W054`` system check warns at startup when a ``ComponentWidget`` refer
 It is a warning rather than an error because the component may come from an app imported later in the boot sequence.
 A reference that still fails to resolve at render time raises ``RuntimeError``.
 
-Before and After
+Before and after
 ----------------
 
 Without ``ComponentWidget``, a form file carries a per-file ``INPUT_CLASS`` string and wraps it in Django widgets.
@@ -181,7 +181,7 @@ Every form that wants the same look copies the constant.
 The Tailwind classes now live once in the shared ``component.djx``.
 The ``INPUT_CLASS`` constant disappears from the form file, and a styling change happens in one place.
 
-When Not To Use It
+When not to use it
 ------------------
 
 Reach for a plain Django widget when it is simpler.
@@ -202,7 +202,7 @@ The ``next.W055`` system check warns at startup for the first two cases, where t
 The widget renders through next.dj's component runtime and bypasses Django's form renderer, so the project's ``FORM_RENDERER`` theming does not apply, and widget introspection through ``subwidgets`` or a ``BoundWidget`` does not reflect the rendered output.
 This is the intended contract, since the component is itself the rendering and theming layer.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/formsets.rst
+++ b/docs/content/topics/forms/formsets.rst
@@ -21,7 +21,7 @@ The ``form`` value in the handler is the bound formset, not an individual form.
 The ``next.forms.Form`` and ``next.forms.ModelForm`` base classes apply to each row form inside the formset.
 Use Django's standard :doc:`factory functions <django:topics/forms/formsets>` to build the formset class.
 
-Registering a Formset Action
+Registering a formset action
 ----------------------------
 
 Pass the formset class as ``form_class``.
@@ -43,7 +43,7 @@ Pass the formset class as ``form_class``.
 
 Mark the row form ``abstract``.
 Without the flag, ``__init_subclass__`` registers ``NoteRowForm`` as a standalone single-row save action next to the formset action.
-``formset_factory`` accepts the abstract class as usual, see :ref:`Preventing Registration <topics-forms-actions-abstract>`.
+``formset_factory`` accepts the abstract class as usual, see :ref:`Preventing registration <topics-forms-actions-abstract>`.
 
 .. code-block:: python
    :caption: notes/pages/notes/bulk/page.py
@@ -70,9 +70,9 @@ The ``init_kwargs`` reach the formset constructor, and a non-empty dict makes th
 An empty dict routes back into ``get_initial``, so keep ``init_kwargs`` non-empty, even when the only entry is a ``prefix`` or the neutral ``{"initial": {}}``.
 See :doc:`/content/howto/use-formsets` for the recipe built on this rule.
 
-The ``page_{path}`` URL name follows the file-router naming convention, see :doc:`/content/topics/file-router`.
+The ``page_{name}`` URL name follows the file-router naming convention, see :doc:`/content/topics/file-router`.
 
-Rendering the Formset
+Rendering the formset
 ---------------------
 
 Use the standard ``{% form %}`` tag.
@@ -131,7 +131,7 @@ Build the formset inside a ``@context`` callable named after the action and retu
 The helper is idempotent.
 Call it once after constructing the formset.
 
-Edit Existing Rows
+Edit existing rows
 ------------------
 
 Use ``modelformset_factory`` for editing several existing instances.
@@ -179,13 +179,13 @@ Use ``modelformset_factory`` for editing several existing instances.
 The ``@context("edit_all_notes")`` callable publishes a bound formset under the action-named key the ``{% form %}`` tag reads.
 The handler receives the same formset for save.
 
-Validation Failure
+Validation failure
 ------------------
 
 A failing validation re-renders the origin page with the bound formset in scope.
 Field errors render on each row through ``row.errors`` and non field errors render through ``form.non_form_errors``.
 
-Validating an Inline Formset
+Validating an inline formset
 ----------------------------
 
 A parent form that owns an inline formset attaches the formset on construction and validates it inside ``clean``.
@@ -247,21 +247,21 @@ The parent form is ``abstract`` because it dispatches only through the ``update_
 
 The parent page re-renders with both the parent and the row errors in scope on validation failure.
 
-Common Patterns
+Common patterns
 ---------------
 
-Add Form Button
+Add form button
 ~~~~~~~~~~~~~~~
 
 Pair the formset with client side JS that clones the empty extra row.
 The framework processes whatever the management form reports.
 
-Partial Save
+Partial save
 ~~~~~~~~~~~~
 
 Save only the valid rows by iterating the formset and skipping rows whose ``cleaned_data`` is empty or carries a truthy ``DELETE``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/modelforms.rst
+++ b/docs/content/topics/forms/modelforms.rst
@@ -6,7 +6,7 @@ ModelForms
 An edit page in plain Django reloads the instance by hand in both the initial render and the save handler, mapping each field twice.
 next.dj collapses that to one declarative line.
 A :doc:`ModelForm <django:topics/forms/modelforms>` adapts a Django model to a form, and ``Meta.instance_from_url`` loads the row the page already addresses in its URL, so a single class serves both create and edit.
-The `Before and After`_ section below shows the delta against the hand-written lookup.
+The `Before and after`_ section below shows the delta against the hand-written lookup.
 
 next.dj supports ModelForms anywhere a plain ``Form`` works.
 This page covers the ``next.forms.ModelForm`` base class, the declarative ``Meta.instance_from_url`` key that loads an instance for edit pages, and the create-and-edit-with-one-class pattern that follows from it.
@@ -15,7 +15,7 @@ This page covers the ``next.forms.ModelForm`` base class, the declarative ``Meta
    :local:
    :depth: 2
 
-Base Class Setup
+Base class setup
 ----------------
 
 Subclass the framework's ``ModelForm`` base class.
@@ -38,13 +38,13 @@ There is no ``@action`` decorator on the class and no ``form_class`` argument an
 Subclassing ``next.forms.ModelForm`` registers the form through the ``__init_subclass__`` hook the moment Python runs the ``class`` statement.
 See :doc:`actions` for the full registration rules and scope derivation.
 
-Loading an Instance From the URL
+Loading an instance from the URL
 --------------------------------
 
 ``Meta.instance_from_url`` tells the default ``get_initial`` how to find the model instance an edit page operates on.
 It is the primary CRUD path and replaces a hand-written instance lookup otherwise duplicated across ``get_initial`` and the handler.
 
-String Form
+String form
 ~~~~~~~~~~~
 
 A string names a URL kwarg that doubles as the model lookup field.
@@ -58,9 +58,9 @@ A string names a URL kwarg that doubles as the model lookup field.
            fields = ["slug", "title", "body"]
            instance_from_url = "slug"
 
-On a page whose route captures ``slug``, the default ``get_initial`` runs :func:`~django.shortcuts.get_object_or_404` with ``Note.objects.get(slug=<captured value>)`` and binds the result as the form instance.
+On a page whose route captures ``slug``, the default ``get_initial`` runs ``get_object_or_404(Note, slug=<captured value>)`` and binds the result as the form instance.
 
-Dict Form
+Dict form
 ~~~~~~~~~
 
 A dict maps a URL kwarg name to a different model lookup field for the case where the two names differ.
@@ -77,7 +77,7 @@ A dict maps a URL kwarg name to a different model lookup field for the case wher
 Here the route captures ``id`` and the form loads the instance with ``Note.objects.get(pk=<captured value>)``.
 The dict key is the URL kwarg name and the value is the model field used in the lookup.
 
-Lookup Behaviour
+Lookup behaviour
 ~~~~~~~~~~~~~~~~
 
 The declarative key has two boundary behaviours worth stating plainly.
@@ -91,7 +91,7 @@ When the kwarg is present but no row matches, :func:`~django.shortcuts.get_objec
 The field named by ``instance_from_url`` should be unique.
 :func:`~django.shortcuts.get_object_or_404` turns only the not-found case into a 404, so a lookup matching several rows surfaces as a server error instead.
 
-Ownership Is Not Scoped by Default
+Ownership is not scoped by default
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. warning::
@@ -117,13 +117,15 @@ Ownership Is Not Scoped by Default
    If the lookup cannot carry the scope, verify ownership in ``on_valid`` before ``self.save()``.
    See :doc:`/content/security/di-and-untrusted-input` for the untrusted-input rules and :doc:`/content/security/overview` for object-level authorization.
 
-Before and After
+Before and after
 ----------------
 
 Without ``Meta.instance_from_url``, an edit form loads the article twice and maps each field by hand.
 
 .. code-block:: python
    :caption: before — manual lookup duplicated across get_initial and on_valid
+
+   from django.http import HttpRequest
 
    class ArticleEditForm(next.forms.Form):
        article_id = next.forms.IntegerField(widget=next.forms.HiddenInput)
@@ -132,7 +134,7 @@ Without ``Meta.instance_from_url``, an edit form loads the article twice and map
        body_md = next.forms.CharField(required=False)
 
        @classmethod
-       def get_initial(cls, request, slug=None):
+       def get_initial(cls, request: HttpRequest, slug=None):
            if slug is None:
                return {}
            article = get_object_or_404(Article, slug=slug)
@@ -143,7 +145,7 @@ Without ``Meta.instance_from_url``, an edit form loads the article twice and map
                "body_md": article.body_md,
            }
 
-       def on_valid(self, request):
+       def on_valid(self, request: HttpRequest):
            article = get_object_or_404(Article, pk=self.cleaned_data["article_id"])
            article.slug = self.cleaned_data["slug"]
            article.title = self.cleaned_data["title"]
@@ -167,7 +169,7 @@ The instance-loading plumbing collapses to one line.
 The hidden ``article_id`` field, the second :func:`~django.shortcuts.get_object_or_404`, and the field-by-field copy all give way to ``instance_from_url = "slug"``.
 A real ModelForm still carries whatever genuine logic the page needs, such as a custom ``on_valid``, a ``clean_slug`` validator, or widget overrides under ``Meta.widgets``.
 
-Create and Edit With One Class
+Create and edit with one class
 ------------------------------
 
 The same ModelForm class can drive both a create page and an edit page.
@@ -203,7 +205,7 @@ The wiki example's create page declares a plain ``ArticleCreateForm`` while its 
 The multi-tenant example's create page likewise declares its own ``NoteCreateForm`` apart from the edit form.
 Split the two when the create and edit fields diverge, when validation differs, or when the rows must be scoped to something the URL does not carry.
 
-Handling Submissions
+Handling submissions
 --------------------
 
 The default ``on_valid`` on ``ModelForm`` calls ``self.save()`` and then redirects to the origin page.
@@ -236,7 +238,7 @@ To attach a request-derived value before writing the row, save with ``commit=Fal
 
 Call ``self.save_m2m()`` after ``note.save()`` when the model has many-to-many fields.
 
-Custom get_initial Escape Hatch
+Custom get_initial escape hatch
 -------------------------------
 
 Define ``get_initial`` only when the lookup the page needs cannot be expressed by ``instance_from_url``, for example a tenant-scoped query.
@@ -247,24 +249,26 @@ Define ``get_initial`` only when the lookup the page needs cannot be expressed b
    from django.shortcuts import get_object_or_404
    from notes.access import get_active_tenant
 
+   from next.urls import DUrl
+
    class NoteEditForm(next.forms.ModelForm):
        class Meta:
            model = Note
            fields = ["title", "body"]
 
        @classmethod
-       def get_initial(cls, request: HttpRequest, id: int | None = None):
+       def get_initial(cls, request: HttpRequest, note_id: DUrl["id", int]):
            tenant = get_active_tenant(request)
-           if tenant is None or id is None:
+           if tenant is None or note_id is None:
                return {}
-           return get_object_or_404(Note, pk=id, tenant=tenant)
+           return get_object_or_404(Note, pk=note_id, tenant=tenant)
 
 The ``get_active_tenant`` helper reads the tenant the middleware attached to the request, so the lookup stays scoped to the active tenant.
 Declare ``get_initial`` as a ``classmethod`` with a DI-friendly signature.
 The framework resolves ``request`` and captured URL parameters as keyword arguments.
 Return a model instance to bind an existing row for editing, or a dict to seed an unbound form.
 
-Validation Failure
+Validation failure
 ------------------
 
 A failing validation re-renders the origin page with the bound form in scope.
@@ -274,7 +278,7 @@ The framework does not call ``save()`` when validation fails.
 ``on_valid`` runs only after ``self.is_valid()`` returns ``True``.
 See :doc:`validation-rerender` for the re-render pipeline.
 
-System Checks
+System checks
 -------------
 
 Two checks guard ``Meta.instance_from_url``.
@@ -286,7 +290,7 @@ Correct the field name, or use the dict form to map the URL kwarg to the real mo
 ``next.E049`` fires when ``instance_from_url`` is set on a class that is not a ModelForm.
 The key only loads model instances, so move the declaration onto a ``next.forms.ModelForm`` subclass.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/overview.rst
+++ b/docs/content/topics/forms/overview.rst
@@ -1,6 +1,6 @@
 .. _topics-forms-overview:
 
-Forms Overview
+Forms overview
 ==============
 
 A Django form usually costs a URL entry, a view, manual CSRF handling, and a redirect-on-success per action before it accepts a single POST.
@@ -12,7 +12,7 @@ No decorator, no manual registry call, and no URL wiring is required.
    :local:
    :depth: 2
 
-Auto-Registration
+Auto-registration
 -----------------
 
 Every subclass of ``next.forms.BaseForm`` or ``next.forms.BaseModelForm`` registers itself through the ``__init_subclass__`` hook the moment Python executes the ``class`` statement.
@@ -40,7 +40,7 @@ The framework also records which file the class was declared in and uses that to
            self.save()
            return redirect_to_origin(request)
 
-Why a Stable URL
+Why a stable URL
 ----------------
 
 The framework hashes the action's scope key and name into a single POST endpoint at ``/_next/form/<uid>/``.
@@ -56,13 +56,15 @@ A form declared in any other file is shared, carries a project-wide name, and is
 .. code-block:: python
    :caption: app/forms.py — auto-registered as ``contact_form`` (shared)
 
+   from django.http import HttpRequest
+
    import next.forms
    from next.forms import redirect_to_origin
 
    class ContactForm(next.forms.Form):
        email = next.forms.EmailField()
 
-       def on_valid(self, request):
+       def on_valid(self, request: HttpRequest):
            send_email(self.cleaned_data["email"])
            return redirect_to_origin(request)
 
@@ -76,15 +78,18 @@ Autodiscover
 It imports the ``forms`` submodule of every installed app so shared forms declared in ``app/forms.py`` register before the first request arrives.
 Set ``NEXT_FRAMEWORK["FORM_AUTODISCOVER"] = False`` to disable the automatic import.
 
-Handling Submissions
+Handling submissions
 --------------------
 
 Override ``on_valid`` to run code after the form passes validation.
-The method receives at least ``request`` and may declare any parameter the dependency injector knows how to resolve.
+The framework injects the current request only into a parameter annotated ``HttpRequest``, an unannotated ``request`` parameter resolves to ``None``.
+The method may declare any other parameter the dependency injector knows how to resolve.
 
 .. code-block:: python
 
-   def on_valid(self, request):
+   from django.http import HttpRequest
+
+   def on_valid(self, request: HttpRequest):
        self.save()
        return redirect_to_origin(request)
 
@@ -99,24 +104,27 @@ Declare it as a ``classmethod`` with the same DI-friendly signature.
 
 .. code-block:: python
 
+   from django.http import HttpRequest
+
    @classmethod
-   def get_initial(cls, request, note_id: int | None = None):
+   def get_initial(cls, request: HttpRequest, note_id: int | None = None):
        if note_id is None:
            return {}
        return Note.objects.get(pk=note_id)
 
 The framework calls ``get_initial`` through the dependency injector, never application code.
-``request`` is supplied automatically, a parameter named after a URL segment is filled from the URL, and the rest resolve through providers.
+The framework supplies ``request`` to any parameter annotated ``HttpRequest``, an unannotated ``request`` parameter resolves to ``None``.
+A parameter named after a URL segment is filled from the URL, and the rest resolve through providers.
 See :doc:`actions` for the full signature rules.
 
-Shared Dependency Cache
+Shared dependency cache
 -----------------------
 
 ``get_initial``, the handler, and the re-render share one per-request dependency cache.
 An expensive provider such as a tenant lookup or a permission check runs once per request, even when validation fails and the page re-renders.
 See :doc:`validation-rerender` for the cache mechanics and the access path.
 
-Form-Less Actions
+Form-less actions
 -----------------
 
 Use ``@action`` to register a plain function when no form fields are needed.
@@ -139,7 +147,7 @@ A bare ``@action`` registers the function under its own name.
 
 The template tag works the same way, but ``form`` is ``None`` inside the block because there is no form class.
 
-Template Usage
+Template usage
 --------------
 
 The ``{% form "name" %}`` block tag renders the ``<form>`` element, injects the CSRF token, and publishes ``form`` inside the block body.
@@ -155,7 +163,7 @@ The ``{% form "name" %}`` block tag renders the ``<form>`` element, injects the 
 
 See :doc:`templates` for the full tag reference.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/plain-forms.rst
+++ b/docs/content/topics/forms/plain-forms.rst
@@ -1,6 +1,6 @@
 .. _topics-forms-plain-forms:
 
-Plain Forms
+Plain forms
 ===========
 
 A plain :doc:`Form <django:topics/forms/index>` collects and validates input without a Django model behind it.
@@ -11,7 +11,7 @@ The form validates ``cleaned_data`` and hands it to ``on_valid``, where the page
    :local:
    :depth: 2
 
-When To Reach For One
+When to reach for one
 ---------------------
 
 Use a plain ``Form`` when the submission does not map to a single model write.
@@ -47,7 +47,7 @@ See :doc:`actions` for the full scope rules.
      <button type="submit">Apply</button>
    {% endform %}
 
-Handling Submissions
+Handling submissions
 --------------------
 
 The default ``on_valid`` on a plain ``Form`` redirects to ``Meta.success_url`` when declared, otherwise back to the origin page through ``redirect_to_origin(request)``.
@@ -91,7 +91,7 @@ There is no model to save, so the page owns every write.
                    flag.save(update_fields=["enabled", "updated_at"])
            return HttpResponseRedirect("/admin/")
 
-Dynamic Choices
+Dynamic choices
 ---------------
 
 Populate choices in ``__init__`` when they depend on the database or the request.
@@ -132,7 +132,7 @@ The same pattern narrows a ``ModelChoiceField`` queryset to the submitted parent
            if poll_pk:
                self.fields["choice"].queryset = Choice.objects.filter(poll_id=poll_pk)
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/serializers.rst
+++ b/docs/content/topics/forms/serializers.rst
@@ -1,14 +1,14 @@
 .. _topics-forms-serializers:
 
-Frozen Form Specs
+Frozen form specs
 =================
 
-The forms subsystem ships frozen dataclass descriptors that describe a form, a formset, or a single field as immutable, comparable descriptors.
+The forms subsystem ships frozen dataclass specs that describe a form, a formset, or a single field as plain immutable data.
 This module (``next.forms.serializers``) is unrelated to JSON serializers for :doc:`the browser context object </content/topics/static-assets/js-context>`.
 Those live under ``next.static``.
 
-Each descriptor is a frozen dataclass, so it is immutable and supports value equality.
-This makes a descriptor safe to cache or compare across renders.
+Each descriptor is a frozen dataclass, so it is immutable once built.
+Its ``__eq__`` compares the Django-bound members ``FieldSpec.bound`` and ``FormsetSpec.management_form`` by identity, so compare specs on their plain-data attributes as `Snapshot diffing`_ shows.
 
 .. contents::
    :local:
@@ -43,7 +43,7 @@ FormSpec.
 
 Use these specs when you need to inspect a form structure from Python or to render in a custom template engine.
 
-Building a Spec
+Building a spec
 ----------------
 
 The module provides three constructor helpers.
@@ -62,6 +62,7 @@ The module provides three constructor helpers.
 
 The second argument of ``form_spec`` is a Django admin style ``fieldsets`` sequence of ``(label, options)`` pairs.
 Each ``options`` mapping carries a ``fields`` list and an optional ``description``.
+A field the fieldsets never name is omitted from the resulting ``FormSpec`` entirely, matching the Django admin contract, so list every field you want rendered.
 Each helper returns a frozen instance ready to pass into a template.
 
 ``field_spec`` accepts an ``is_extra`` keyword argument that defaults to ``False``.
@@ -70,7 +71,7 @@ The flag describes the row's origin, not whether the user filled it in.
 ``formset_spec`` computes ``is_extra`` per row and propagates it to every ``FieldSpec`` and ``FormsetRowSpec`` it builds, so a template can tell an extra row apart from an instance-backed one and style or hide it accordingly.
 A standalone ``field_spec`` call leaves ``is_extra`` at ``False`` unless the caller passes the argument.
 
-Using a Spec in Templates
+Using a spec in templates
 -------------------------
 
 Specs are designed to render in any template engine because they expose stable, immutable attributes.
@@ -98,7 +99,7 @@ Use them when the standard ``{% form %}`` tag does not match the layout you want
 A custom renderer can read the same fields from Python.
 The dataclass exposes a fixed set of attributes.
 
-Non-Django Engine Notes
+Non-Django engine notes
 -----------------------
 
 Two spec members are Django objects, not plain data.
@@ -115,7 +116,7 @@ A renderer running outside Django templates handles them explicitly.
 Treat both members as opaque HTML producers in a non-Django engine.
 The rest of every spec is plain immutable data safe to project to JSON or pass to any template language.
 
-Field Kinds
+Field kinds
 -----------
 
 Each field carries a ``FieldKind`` literal that classifies the widget.
@@ -142,7 +143,7 @@ Admin ``RelatedFieldWidgetWrapper`` widgets are unwrapped to their inner widget 
 The framework classifies the widget once when constructing the spec.
 Custom renderers can branch on ``kind`` without re instantiating the widget.
 
-Spec vs Bound Form
+Spec vs bound form
 ------------------
 
 Specs are descriptors, not replacements.
@@ -154,17 +155,17 @@ A template can choose either path.
 
 Pick the spec when the rendering engine cannot consume Django bound fields directly.
 
-Common Patterns
+Common patterns
 ---------------
 
-Render a Form in a Different Engine
+Render a form in a different engine
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use the spec to ship form structure to a Jinja2 macro or a JSON consumer.
 Each spec is a frozen dataclass, so a custom renderer can read its fields directly or build its own plain-dict projection.
 A bare Django ``Form`` is not JSON-encodable, so a form destined for ``@context(..., serialize=True)`` (see :doc:`/content/topics/static-assets/js-context`) must travel as a ``FormSpec`` (or a custom projection) rather than as the form instance itself.
 
-Snapshot Diffing
+Snapshot diffing
 ~~~~~~~~~~~~~~~~
 
 The dataclass ``__eq__`` does not detect structural drift on its own because ``FieldSpec.bound`` carries a Django ``BoundField`` without value equality.
@@ -179,12 +180,12 @@ Compare on stable attributes instead.
    added = set(field_names(new_spec)) - set(field_names(old_spec))
    removed = set(field_names(old_spec)) - set(field_names(new_spec))
 
-System Integration
+System integration
 ~~~~~~~~~~~~~~~~~~
 
 Use ``form_spec`` to render a form inside another rendering layer such as the Django admin while keeping dispatch on next.dj.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/signals.rst
+++ b/docs/content/topics/forms/signals.rst
@@ -1,6 +1,6 @@
 .. _topics-forms-signals:
 
-Form Signals
+Form signals
 ============
 
 The forms subsystem emits ``action_registered``, ``action_dispatched``, ``form_validation_failed``, ``wizard_step_submitted``, ``wizard_completed``, and ``form_access_denied`` from ``next.forms.signals``.
@@ -16,7 +16,7 @@ Read what you need from it inside the receiver and do not retain the object past
    :local:
    :depth: 2
 
-Connecting Receivers
+Connecting receivers
 --------------------
 
 Receivers live in a module that Django does not import on its own.
@@ -44,7 +44,7 @@ The sender is the backend class.
 
 The payload carries ``action_name``, ``uid``, ``form_class``, ``wizard_class``, ``file_path``, ``scope``, and ``handler``.
 Exactly one of ``handler``, ``form_class``, or ``wizard_class`` identifies the registered target, except the ``@action(form_class=...)`` path which supplies a handler and a form factory together.
-``form_class`` is the form class for a class-bound registration, a factory callable for a dynamic formset action, or ``None`` otherwise.
+``form_class`` is the form class for a class-bound registration, a factory callable for any dynamic ``form_class`` registration, or ``None`` otherwise.
 ``wizard_class`` is the ``FormWizard`` subclass for a wizard registration, ``None`` otherwise.
 ``file_path`` is the absolute path to the file where the class or function was declared.
 ``scope`` is ``"page"`` for anchor-file declarations (``page.py``, ``component.py``) and ``"shared"`` for all other files.
@@ -84,13 +84,7 @@ A step advance runs no handler and reports ``duration_ms`` as ``0.0``, and the f
 The sender is ``FormActionDispatch``.
 
 The payload carries ``action_name``, ``uid``, ``request``, ``form``, ``url_kwargs``, ``duration_ms``, ``response_status``, and ``dep_cache``.
-
-``uid``.
-   The registry identity of the action, matching the dispatch URL and the ``data-next-action`` attribute, or ``None`` for a backend without meta.
-
-``request``.
-   The live ``HttpRequest``.
-   Do not retain it past the receiver call.
+``uid`` and ``request`` follow the shared contract described at the top of this page.
 
 ``form``.
    The bound form after the handler returns normally and the response has been coerced, or ``None`` for a handler-only action registered without a ``form_class``.
@@ -259,9 +253,10 @@ The dispatcher builds the payload and sends the signal only when at least one re
            request.user,
        )
 
-A receiver runs inside the dispatch, so keep it cheap and do not retain the request past the call.
+A receiver runs inside the dispatch, so keep it cheap.
+``uid`` and ``request`` follow the shared contract described at the top of this page.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/templates.rst
+++ b/docs/content/topics/forms/templates.rst
@@ -1,6 +1,6 @@
 .. _topics-forms-templates:
 
-Form Templates
+Form templates
 ==============
 
 The ``{% form "name" %}`` block tag renders a ``<form>`` element, injects the CSRF token, and publishes the form instance inside the block body.
@@ -9,7 +9,7 @@ The ``{% form "name" %}`` block tag renders a ``<form>`` element, injects the CS
    :local:
    :depth: 2
 
-The Form Tag
+The form tag
 ------------
 
 .. code-block:: jinja
@@ -23,7 +23,7 @@ The Form Tag
 
 The first argument is the action name as a quoted string or a context variable that resolves to a string.
 An opening tag without the action name raises ``TemplateSyntaxError`` at parse time.
-Optional ``key="value"`` arguments after the name render as HTML attributes on the ``<form>`` element (see `HTML Attributes`_ below), except for the reserved partial param names (see `Partial Attributes`_ below).
+Optional ``key="value"`` arguments after the name render as HTML attributes on the ``<form>`` element (see `HTML attributes`_ below), except for the reserved partial param names (see `Partial attributes`_ below).
 
 The tag does the following.
 
@@ -46,7 +46,7 @@ The tag asks the form instance through ``is_multipart()``, so a ``FileField`` re
 
 A name that is not in the registry raises ``FormActionNotFoundError`` at render time.
 
-HTML Attributes
+HTML attributes
 ---------------
 
 Every other ``key="value"`` argument after the action name lands on the ``<form>`` element, after the framework attributes.
@@ -64,7 +64,7 @@ An explicit ``enctype="..."`` argument suppresses the automatic multipart value,
 The ``action`` and ``method`` attributes belong to the tag, as does every attribute starting with ``data-next-``, and passing any of them raises ``TemplateSyntaxError`` at parse time.
 ``data-next-*`` is the single framework namespace in rendered markup, so user attributes never collide with framework ones.
 
-Partial Attributes
+Partial attributes
 ------------------
 
 Five argument names are reserved for partial rendering and never land as raw HTML attributes.
@@ -104,14 +104,14 @@ Pass each as a ``key="value"`` argument like any other, and the value resolves a
      {{ form.query }}
    {% endform %}
 
-Scope Resolution
+Scope resolution
 ----------------
 
 When the template renders inside a page, the tag first looks for a page-scoped registration whose file matches the current ``page.py``.
 If no page-scoped match exists the tag falls back to the first registration of that name and accepts it only when its scope is shared.
 This means a page-local ``NoteForm`` takes precedence over a shared ``NoteForm`` with the same derived name.
 
-The ``form`` Variable
+The ``form`` variable
 ---------------------
 
 Inside the block body the variable ``form`` holds the form instance.
@@ -127,7 +127,7 @@ Form-less action.
    When the action is a plain function registered with ``@action`` (no form class), ``form`` resolves to ``None``.
    The block body should not attempt to render field widgets in this case.
 
-Captured URL Parameters
+Captured URL parameters
 -----------------------
 
 The tag does not need any extra argument to forward URL parameters.
@@ -145,7 +145,7 @@ The dispatcher resolves the posted ``_next_form_origin`` against the URLconf and
 A form rendered under ``/notes/42/`` posts ``_next_form_origin`` set to that path, and resolving it yields ``note_id=42`` as an ``int``.
 The handler receives the value through ``DUrl["note_id", int]``, typed identically on the canonical GET and on the re-render.
 
-Multiple Forms on One Page
+Multiple forms on one page
 --------------------------
 
 Each ``{% form %}`` call references a different action name.
@@ -167,7 +167,7 @@ The dispatcher routes submissions by URL alone, so the forms do not interfere.
 ``delete_note`` is a form-less action.
 The second block has no ``{{ form }}`` usage because ``form`` is ``None``.
 
-Rendering Field Errors
+Rendering field errors
 ----------------------
 
 Errors live on the bound form.
@@ -226,7 +226,7 @@ An unknown action name raises ``FormActionNotFoundError`` at render time, the sa
 
 .. _topics-forms-templates-handwritten-views:
 
-Forms in Hand-Written Views
+Forms in hand-written views
 ---------------------------
 
 A ``{% form %}`` tag also works inside a template rendered by an ordinary Django view, outside the file router.
@@ -250,22 +250,22 @@ The file may be a real page module or a synthesised location next to a ``templat
 
    feedback.next_page_path = Path(__file__).parent / "feedback" / "page.py"
 
-Common Patterns
+Common patterns
 ---------------
 
-Form in a Component
+Form in a component
 ~~~~~~~~~~~~~~~~~~~
 
 A component template hosts ``{% form %}`` exactly like a page template.
 The framework injects ``current_page_module_path`` from the surrounding page, so the action lookup scopes to the correct page.
 
-Form in a Layout
+Form in a layout
 ~~~~~~~~~~~~~~~~
 
 Layouts receive ``current_page_module_path`` from the page they wrap.
 A login form placed in the root layout posts the wrapped page's path as its origin, so a validation failure re-renders the original page.
 
-Render-Time Failures
+Render-time failures
 --------------------
 
 The tag raises ``ImproperlyConfigured`` when ``request`` is absent from the template context.
@@ -273,7 +273,7 @@ Add ``django.template.context_processors.request`` to ``TEMPLATES[*].OPTIONS.con
 
 The ``next.E019`` system check, described in :doc:`/content/security/csrf-and-forms`, catches the missing context processor before a request reaches the tag.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/validation-rerender.rst
+++ b/docs/content/topics/forms/validation-rerender.rst
@@ -1,6 +1,6 @@
 .. _topics-forms-validation-rerender:
 
-Validation and Re-render
+Validation and re-render
 ========================
 
 When a submission fails validation, users keep what they typed and you write no re-render code.
@@ -14,7 +14,7 @@ This page explains the validation and re-render flow end to end.
 
 .. _topics-forms-validation-rerender-origin:
 
-The Origin Page
+The origin page
 ---------------
 
 Every rendered ``{% form %}`` tag emits a hidden ``_next_form_origin`` field that carries the URL path of the page that rendered the form, such as ``/notes/42/``.
@@ -37,7 +37,7 @@ A directory that has only a ``template.djx`` and no ``page.py`` is a virtual rou
 The router stamps the synthesised ``page.py`` location on the virtual route's view as well, so its origin resolves like any other page.
 On validation failure the re-render composes the body from the template loader exactly as the initial render did, with no page module involved.
 
-The Render Pipeline
+The render pipeline
 -------------------
 
 A request to ``/_next/form/<uid>/`` follows a fixed pipeline.
@@ -51,7 +51,7 @@ A request to ``/_next/form/<uid>/`` follows a fixed pipeline.
 The pipeline stays inside the same request.
 A failing form does not redirect, the user stays on the same URL.
 
-One Response Funnel
+One response funnel
 -------------------
 
 Every outcome of the pipeline leaves through one funnel.
@@ -65,7 +65,7 @@ The status and the headers are behaviour of the default backend, not a guarantee
 A request carrying the partial-runtime headers receives the same outcome as a patch envelope instead of the full page, see :doc:`/content/topics/partial-rendering/how-it-works`.
 See :doc:`backends` for the override signature and the bundled implementation.
 
-What Survives Re-render
+What survives re-render
 -----------------------
 
 One thing carries over from the initial render.
@@ -84,7 +84,7 @@ Dependency cache.
 The frozen ``FormSpec`` descriptors in :doc:`serializers` are a separate user-facing tool.
 The dispatcher does not attach a ``FormSpec`` to the request on its own.
 
-What Restarts on Re-render
+What restarts on re-render
 --------------------------
 
 Other parts of the render restart from scratch.
@@ -100,7 +100,7 @@ Layout chain.
 Static collector.
    The collector restarts so the rendered HTML contains the right set of asset links.
 
-The Bound Form Variable
+The bound form variable
 -----------------------
 
 On the re-rendered page the variable ``form`` is the bound form with errors.
@@ -109,7 +109,7 @@ The template can render error messages inline with each field.
 On re-render the dispatcher always supplies the bound failing form under the action-named context key so the user sees the input that triggered the failure.
 ``get_initial`` still runs on the POST bind to seed the form's ``initial``, but the submitted values win in the rendered fields.
 
-Multiple Forms on the Same Page
+Multiple forms on the same page
 -------------------------------
 
 A page that hosts several actions only re-renders the failing form.
@@ -118,7 +118,7 @@ Other forms render as unbound, with their original ``@context("...")`` values in
 This works because every action has its own UID and only one URL fires the re-render.
 The dispatcher does not rerun the validation of any other form.
 
-Influencing the Re-render
+Influencing the re-render
 -------------------------
 
 One hook lets a page customise the form before it reaches the template.
@@ -129,7 +129,7 @@ The ``get_initial`` hook.
    On the re-render the submitted POST values win over the seeded initial, so the user sees what they typed.
    The one path that skips ``get_initial`` on POST is a ``form_class`` factory that returns a ``(FormClass, init_kwargs)`` tuple, see :doc:`actions`.
 
-Redirecting Back to the Origin
+Redirecting back to the origin
 ------------------------------
 
 A handler that succeeds usually returns an ``HttpResponseRedirect``.
@@ -154,7 +154,7 @@ It accepts the value only when it is a string that starts with a single ``/``.
 A protocol-relative input beginning with ``//`` is rejected, which blocks open-redirect input.
 When the field is absent or fails validation the helper redirects to ``fallback`` instead.
 
-One Field, Two Roles
+One field, two roles
 ~~~~~~~~~~~~~~~~~~~~
 
 The single hidden ``_next_form_origin`` field serves both directions of the round trip.
@@ -167,7 +167,7 @@ Success-redirect path.
 
 A failing form never redirects, the re-render stays on the dispatch URL.
 
-Server Side Effects Before Validation
+Server side effects before validation
 -------------------------------------
 
 Side effects belong inside the handler, after ``form.is_valid()`` returns true.
@@ -195,7 +195,7 @@ Two signals fire during the validation pipeline.
 
 See :doc:`signals` for the full list and payload shapes.
 
-Edge Cases
+Edge cases
 ----------
 
 - A missing or unresolvable ``_next_form_origin`` field returns HTTP 400 on the invalid branch.
@@ -217,28 +217,28 @@ Edge Cases
 - Text, select, checkbox, and textarea widgets keep their raw submitted values because the dispatcher binds the failing form to ``request.POST``.
   Password widgets clear unless ``render_value=True``.
 
-Common Patterns
+Common patterns
 ---------------
 
-Inline Errors
+Inline errors
 ~~~~~~~~~~~~~
 
 Render ``{{ form.field.errors }}`` next to each input.
 The re-render shows the previous value and the error in one place.
 
-Cross Field Validation
+Cross field validation
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Use Django ``clean`` and ``clean_<field>`` methods on the form class.
 The dispatcher treats these failures the same as field validation failures.
 
-Audit Trail
+Audit trail
 ~~~~~~~~~~~
 
 Subscribe to ``form_validation_failed`` to log every rejected attempt.
 The signal fires once per failed submission so log volume scales with failure rate, not request rate.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/wizard-backend.rst
+++ b/docs/content/topics/forms/wizard-backend.rst
@@ -1,6 +1,6 @@
 .. _topics-forms-wizard-backend:
 
-Wizard Backend
+Wizard backend
 ==============
 
 A wizard backend persists per-step draft data between requests.
@@ -12,7 +12,7 @@ This page covers the ``FormWizardBackend`` contract, the bundled ``SessionFormWi
    :local:
    :depth: 2
 
-The Backend Contract
+The backend contract
 --------------------
 
 ``next.forms.FormWizardBackend`` is an abstract base class with three methods.
@@ -32,7 +32,7 @@ Backends treat the id as an opaque string.
 A backend subclasses ``FormWizardBackend`` and implements all three methods.
 The wizard reads and writes through this contract alone, so the backend choice is invisible to the wizard class.
 
-The Session Backend
+The session backend
 -------------------
 
 ``next.forms.SessionFormWizardBackend`` is the default backend.
@@ -47,7 +47,7 @@ Drafts grow the session with each saved step.
 A database-backed or cache-backed session absorbs that growth, while the signed-cookie session engine carries the whole session in the cookie and runs into its size limit quickly.
 Prefer the cache backend for a wizard with large drafts when the project uses cookie-backed sessions.
 
-The Value Codec
+The value codec
 ~~~~~~~~~~~~~~~
 
 Sessions serialise to JSON, and a step's ``cleaned_data`` routinely holds values JSON cannot carry.
@@ -67,7 +67,7 @@ A value the codec does not recognise raises ``ImproperlyConfigured`` naming the 
 The error suggests the fix.
 Configure ``CacheFormWizardBackend`` or a custom ``FormWizardBackend`` for cleaned data that does not fit JSON.
 
-The Cache Backend
+The cache backend
 -----------------
 
 ``next.forms.CacheFormWizardBackend`` is the bundled alternative.
@@ -97,7 +97,7 @@ For an anonymous visitor the backend creates a session on the first saved step, 
 A draft started before login stays under the pre-login key unless the login flow rotates the session, in which case the visitor loses the draft.
 Start a wizard after login, or carry the draft across the rotation, when continuity matters for anonymous starts.
 
-Trust and Tamperability
+Trust and tamperability
 -----------------------
 
 .. warning::
@@ -108,7 +108,7 @@ Trust and Tamperability
 
    For a sensitive flow, use a signed or encrypted backend so a tampered draft is rejected, and re-check cross-step invariants inside ``done`` rather than trusting the merged dict.
 
-Sensitive Data in Drafts
+Sensitive data in drafts
 ------------------------
 
 .. warning::
@@ -121,7 +121,7 @@ Sensitive Data in Drafts
    The wizard calls ``clear`` after a successful ``done``, so a draft that never completes is what lingers.
    See :doc:`/content/deployment/checklist` for the production review.
 
-Draft Expiry Mid-Wizard
+Draft expiry mid-wizard
 -----------------------
 
 A draft can vanish between two steps when the session ends, when the cache backend's ``TIMEOUT`` is short, or when the cache evicts under pressure.
@@ -168,7 +168,7 @@ Switch to the cache backend to point drafts at a dedicated cache alias and short
 
 The ``next.E051`` system check fires when the dict is malformed, names a backend that cannot be imported, or names a class that is not a ``FormWizardBackend`` subclass.
 
-Writing a Custom Backend
+Writing a custom backend
 ------------------------
 
 A custom backend subclasses ``FormWizardBackend`` and implements the three methods.
@@ -219,16 +219,15 @@ Point ``FORM_WIZARD_BACKEND["BACKEND"]`` at the class to use it.
        },
    }
 
-The framework instantiates the backend lazily on first use and caches the instance, so the constructor runs once per process.
-A signed-cookie store or an external draft service follows the same shape, reading its own options from ``OPTIONS``.
-The framework reads ``FORM_WIZARD_BACKEND`` on first use, caches the result, and resets the cache when settings reload.
+The framework reads ``FORM_WIZARD_BACKEND`` on first use, caches the instance for the process, and resets the cache when settings reload, so the constructor runs once.
 The test isolation helper :func:`next.testing.reset_form_registration_state` resets it between cases.
+A signed-cookie store or an external draft service follows the same shape, reading its own options from ``OPTIONS``.
 
 .. note::
 
    The lazy instance is internal and application code never touches it directly.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/forms/wizard.rst
+++ b/docs/content/topics/forms/wizard.rst
@@ -1,6 +1,6 @@
 .. _topics-forms-wizard:
 
-Form Wizards
+Form wizards
 ============
 
 A multi-step form across several requests usually means hand-rolling step routing, stashing partial data in the session, and re-wiring all of it to support the browser back button or a branch that skips a step.
@@ -13,7 +13,7 @@ The wizard handles step routing and back-navigation, supports conditional branch
    :local:
    :depth: 2
 
-Mental Model
+Mental model
 ------------
 
 One wizard is one registered action.
@@ -35,7 +35,7 @@ It is enforced per step POST, before the step form binds, so a denied step write
 A wizard has no object-level hook.
 See :ref:`topics-forms-actions-dynamic-guards` for the hook contract.
 
-Declaring Steps
+Declaring steps
 ---------------
 
 Declare the ordered steps under ``Meta.steps`` as a list of ``(name, FormClass)`` tuples.
@@ -82,10 +82,10 @@ Under the default settings the same files live in ``access/pages/request/[step]/
 
 Every step form subclasses ``django.forms`` directly.
 A step is not a standalone action, so a plain Django form has nothing to register and nothing to suppress.
-The wizard never runs ``get_initial`` or ``on_valid`` on a step, so a plain Django form is the canonical base, see `How Step Forms Differ From Standalone Forms`_.
+The wizard never runs ``get_initial`` or ``on_valid`` on a step, so a plain Django form is the canonical base, see `How step forms differ from standalone forms`_.
 A ``next.forms`` base can still serve as a step, but then it must set ``Meta.abstract = True``.
 Without the flag ``__init_subclass__`` registers the step as its own form action whose default ``on_valid`` saves a partial row, and the ``next.W057`` system check warns about the double role.
-See :ref:`Preventing Registration <topics-forms-actions-abstract>` for the ``Meta.abstract`` semantics.
+See :ref:`Preventing registration <topics-forms-actions-abstract>` for the ``Meta.abstract`` semantics.
 
 ``Meta.steps`` is required.
 An empty or missing list triggers the ``next.E050`` system check and the wizard is not usable.
@@ -100,7 +100,7 @@ It defaults to ``"step"``, so a route segment of ``[step]`` works with no furthe
 Per-step drafts persist through the configured ``FORM_WIZARD_BACKEND``, which the project sets once for every wizard.
 See :doc:`wizard-backend` for the backend contract and its options.
 
-The ``done`` Method
+The ``done`` method
 -------------------
 
 ``done`` runs once after the last step validates.
@@ -135,7 +135,7 @@ Last write wins is the deliberate design for a single linear flow.
 An idempotent ``done`` keeps the final write correct under retries, which is the case that matters.
 A flow that must serialise concurrent tabs needs a custom backend that locks or compares and swaps the stored bucket.
 
-``done`` Is Dependency-Injected
+``done`` is dependency-injected
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The dispatcher resolves ``done`` through the same injector as an action handler or ``on_valid``.
@@ -157,7 +157,7 @@ Beyond the reserved names, ``done`` declares markers and named dependencies like
 A wizard module falls under the DI annotation rule.
 Do not add ``from __future__ import annotations`` to a module whose ``done`` the resolver inspects, see :doc:`/content/topics/dependency-injection`.
 
-The ``done`` Return Value
+The ``done`` return value
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The return value of ``done`` follows the same coercion as an action handler.
@@ -175,7 +175,7 @@ The return value of ``done`` follows the same coercion as an action handler.
    The dispatcher coerces ``None`` into a success re-render of the origin page with status 200, so the stored drafts are cleared and ``wizard_completed`` fires.
    The user is left on the last step with no confirmation, so return an explicit redirect away from the wizard.
 
-How Step Forms Differ From Standalone Forms
+How step forms differ from standalone forms
 -------------------------------------------
 
 The wizard drives a step through a different path than a standalone form action, which is why a plain Django form is the canonical step base.
@@ -216,7 +216,7 @@ Inside the block the tag publishes two variables.
 ``form`` is the current step's form, unbound on a GET and prefilled from the saved draft when the step was visited before.
 ``wizard`` is the ``FormWizard`` instance, which exposes the navigation helpers below.
 
-Wizard Template API
+Wizard template API
 ~~~~~~~~~~~~~~~~~~~~
 
 The ``wizard`` variable carries the methods used to build progress indicators and navigation.
@@ -295,7 +295,7 @@ A progress bar reads the step status in Python and iterates the precomputed list
      {% endfor %}
    </nav>
 
-Routing and Back-Navigation
+Routing and back-navigation
 ---------------------------
 
 The wizard lives on a route that captures the step segment, such as ``request/[step]/``.
@@ -313,7 +313,7 @@ Back-navigation works through the same URL.
 Visiting an earlier step prefills its form from the saved draft, so the user sees the values they entered before.
 The current step is always resolved from the URL kwarg, which keeps the browser back button and bookmarked step URLs working.
 
-The ``form`` Variable Has Two Sources
+The ``form`` variable has two sources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``form`` published inside the ``{% form %}`` block is built differently on a GET than on a validation failure.
@@ -324,7 +324,7 @@ The ``form`` published inside the ``{% form %}`` block is built differently on a
 The template variable is the same name in both cases.
 A template that renders ``{{ form.field.errors }}`` shows nothing on a clean GET and the validation errors on a re-render.
 
-Conditional Steps
+Conditional steps
 -----------------
 
 Override ``get_steps`` to choose the step list from the data gathered so far.
@@ -342,7 +342,7 @@ The hook reads the accumulated data through ``self.get_all_cleaned_data()`` and 
 When ``get_steps`` is not overridden it returns ``Meta.steps`` unchanged.
 The navigation helpers, the current-step resolution, and the final-step detection all read from ``get_steps``, so a conditional list flows through routing without extra wiring.
 
-Cross-Step Inputs
+Cross-step inputs
 -----------------
 
 Override ``get_form_kwargs`` to pass extra constructor arguments into a step form.
@@ -368,7 +368,7 @@ Both are sent with the wizard class as the sender, so a receiver connected with 
 An error response from ``done``, status 400 or above, skips ``wizard_completed`` and keeps the saved drafts for retry.
 See :doc:`signals` for the payloads and the receiver-wiring pattern.
 
-System Checks
+System checks
 -------------
 
 The ``next.E050`` and ``next.E051`` checks guard the steps declaration and the wizard backend configuration.
@@ -381,7 +381,7 @@ Add a ``[step]`` route segment or point ``Meta.url_param`` at the captured kwarg
 The static-step checks inspect ``Meta.steps`` only, a ``get_steps`` override is not visible to them.
 See :doc:`/content/ref/system-checks` for their conditions, and run ``uv run python manage.py check`` after editing a wizard or its backend.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/index.rst
+++ b/docs/content/topics/index.rst
@@ -1,6 +1,6 @@
 .. _topics:
 
-Topic Guides
+Topic guides
 ============
 
 Topic guides cover one subsystem at a time.
@@ -14,7 +14,7 @@ Read the topic that matches the part you are touching, then jump to the referenc
 :doc:`url-reversing`
    ``page_reverse`` and ``with_query`` helpers.
 
-.. rubric:: Pages, Layouts, and Components
+.. rubric:: Pages, layouts, and components
 
 :doc:`pages`
    Page modules, body sources, render functions, template loaders.
@@ -28,7 +28,7 @@ Read the topic that matches the part you are touching, then jump to the referenc
 :doc:`components`
    Simple and composite components, props, slots, co-located assets.
 
-.. rubric:: Forms and Static Assets
+.. rubric:: Forms and static assets
 
 :doc:`forms/index`
    Actions, templates, modelforms, field components, formsets, multi-step wizards, dispatch internals, signals.
@@ -39,7 +39,7 @@ Read the topic that matches the part you are touching, then jump to the referenc
 :doc:`partial-rendering/index`
    Zones, patches, forms, the modal wizard, lazy zones, co-located JavaScript, and the SSE bridge.
 
-.. rubric:: Cross-Cutting Concerns
+.. rubric:: Cross-cutting concerns
 
 :doc:`dependency-injection`
    Markers, providers, the resolver, request scoped cache.
@@ -53,7 +53,7 @@ Read the topic that matches the part you are touching, then jump to the referenc
 :doc:`extending`
    Five extension mechanisms across the framework.
 
-.. rubric:: Project Layout
+.. rubric:: Project layout
 
 :doc:`project-layout`
    Recommended single project tree and settings.

--- a/docs/content/topics/layouts.rst
+++ b/docs/content/topics/layouts.rst
@@ -23,7 +23,7 @@ Layouts compose through string substitution, not through Django template inherit
 There is no ``{% extends %}`` directive and no parent template identifier.
 The composition is purely structural, driven by directory placement.
 
-Layout Discovery
+Layout discovery
 ----------------
 
 The framework walks every ancestor directory upward from the page directory, bounded at 64 levels.
@@ -51,7 +51,7 @@ The innermost wraps the page body.
 The middle layout wraps the result.
 The outermost layout wraps the result again.
 
-Layout-Only Directories
+Layout-only directories
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 A page directory that contains a sibling ``layout.djx`` but no body source still renders.
@@ -59,7 +59,7 @@ The body slot is the empty string and the layout chain composes around it.
 Use this shape for landing routes whose whole markup belongs in the layout shell.
 :ref:`next.E012 <ref-system-checks>` does not fire in this case.
 
-Layout Template Contract
+Layout template contract
 ------------------------
 
 Every layout must contain a ``{% block template %}`` placeholder where the body of the wrapped content is substituted.
@@ -84,15 +84,15 @@ The closing tag can be written either way.
      </body>
    </html>
 
-Without the placeholder that layout emits its own markup and discards the wrapped content, so the page body and every inner layout below the broken layer vanish from the output without an error.
+Without the placeholder that layout is skipped during composition, so its own markup vanishes from the output while the page body and every inner layout still render, with no error raised.
 The ``check_layout_templates`` system check emits ``next.W001`` for a ``layout.djx`` sitting next to a discovered page when it lacks a ``{% block template %}`` block.
-The check scans one representative pages root per router, so in a project with several page-bearing applications ``next.W001`` surfaces only for layouts under the scanned root.
+The check scans one representative page root per router, so in a project with several page-bearing applications ``next.W001`` surfaces only for layouts under the scanned root.
 A layout in an intermediate segment directory without a sibling page is not covered, so ``uv run python manage.py check`` does not catch every broken layout.
 
 Layouts can declare layout-level CSS and JS through the static collector tags shown above.
 The tags also live in inner layouts when you want a section-scoped style sheet.
 
-Publishing Context From a Layout Segment
+Publishing context from a layout segment
 -----------------------------------------
 
 A segment directory that contains a ``layout.djx`` can also have a sibling ``page.py``.
@@ -117,10 +117,10 @@ The ``inherit_context=True`` flag publishes the value to every descendant page, 
 Context functions in a segment ``page.py`` take dependencies the same way any page does.
 The resolver shares its cache across the entire layout chain and the leaf page, so a value resolved at an ancestor segment is not recomputed further down.
 
-Nested Layout Patterns
+Nested layout patterns
 ----------------------
 
-Section Layout
+Section layout
 ~~~~~~~~~~~~~~
 
 Add a layout inside a section to share a sub navigation across every page under that section.
@@ -136,7 +136,7 @@ Add a layout inside a section to share a sub navigation across every page under 
      {% block template %}{% endblock template %}
    </section>
 
-Empty Pass Through
+Empty pass through
 ~~~~~~~~~~~~~~~~~~
 
 Sometimes a directory needs a visual-only layout boundary for context but no extra HTML.
@@ -149,13 +149,13 @@ Use an empty layout that contains only the placeholder.
 
 A sibling ``page.py`` in the same directory can publish inherited context for every page under ``/api/`` without that layout injecting any visible markup.
 
-Section Specific Static Assets
+Section specific static assets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Co-locate ``layout.css`` next to ``layout.djx`` to ship styles that apply only to pages under that directory.
 The static collector emits the file only when a request reaches a page below that layout.
 
-Multiple Backends and Layout Roots
+Multiple backends and layout roots
 ----------------------------------
 
 Two backends that scan different directories produce two separate layout chains.
@@ -190,48 +190,48 @@ A layout in a shared ancestor directory, such as the ``notes`` package directory
 Root layouts collected from ``DIRS`` are also global.
 The framework gathers them from every ``PAGE_BACKENDS`` entry and appends them to the chain of every page, regardless of which backend discovered the page.
 
-Project Level Root Layout
+Project level root layout
 -------------------------
 
 Place a root layout outside of any application by adding a project directory to ``DIRS`` so a single ``layout.djx`` wraps every page across every installed app.
 See :doc:`multi-project` for the full settings example and the layered-projects pattern.
 
-Cross Cutting Behaviour
+Cross cutting behaviour
 -----------------------
 
-Context Processors
+Context processors
 ~~~~~~~~~~~~~~~~~~
 
 Context processors are applied after every ``@context`` callable finishes but before any template (including the layout chain) renders.
 They contribute variables that every layout and every page template can use.
 Because they run last, a processor that returns the same key as a ``@context`` function overwrites that value.
 Processor-to-processor duplicates are resolved by dotted path, keeping the first occurrence.
-See :doc:`context` under *Resolution Order* for the full merge order and the **first** ``TEMPLATES`` entry rule.
+See :doc:`context` under *Resolution order* for the full merge order and the **first** ``TEMPLATES`` entry rule.
 A processor that raises ``TypeError``, ``ValueError``, ``AttributeError``, or ``KeyError`` is logged and swallowed by default.
 Set ``STRICT_CONTEXT = True`` to re-raise those exceptions instead.
 Any other exception type propagates regardless of the setting.
 Semantics live in :ref:`ref-settings`.
 
-Static Collector
+Static collector
 ~~~~~~~~~~~~~~~~
 
 The static collector runs once per request.
 Both layouts and the page contribute to the same collection slot.
 A ``{% collect_styles %}`` tag inside an inner layout still emits every collected stylesheet, not only the ones declared in that layout.
 
-Page Rendered Signal
+Page rendered signal
 ~~~~~~~~~~~~~~~~~~~~
 
 The ``page_rendered`` signal fires once per request after the layout chain produces the final HTML.
 Subscribe to observe rendering duration, the number of collected styles and scripts, and the keys present in the template scope.
 See :doc:`signals` for the full payload.
 
-Common Pitfalls
+Common pitfalls
 ---------------
 
-Layout renders but page body is missing.
+Layout markup is missing from the output.
    A ``{% block template %}`` placeholder is required, closed with either ``{% endblock %}`` or ``{% endblock template %}``.
-   Without it the framework still renders the layout but the page content is dropped.
+   Without it the framework drops that layout from the chain and renders the page body without its wrapper.
 
 Inherited context not visible to a sub-page.
    The ``inherit_context=True`` flag is required on the ancestor ``page.py`` that declares the value.
@@ -241,7 +241,7 @@ Two roots produce one composed page.
    A page composes its layout chain from its own ancestor directories.
    A page lives under exactly one backend, even when the file path is also reachable from another backend.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/multi-project.rst
+++ b/docs/content/topics/multi-project.rst
@@ -1,6 +1,6 @@
 .. _topics-multi-project:
 
-Multi-Project Setup
+Multi-project setup
 ===================
 
 A multi project setup hosts several Django projects from one repository.
@@ -11,7 +11,7 @@ This page covers the directory shape, the ``DIRS`` configuration, the shared com
    :local:
    :depth: 2
 
-When to Use Multi Project Layout
+When to use multi project layout
 --------------------------------
 
 Use this layout when more than one project needs to share components, layouts, and static assets without duplicating code.
@@ -21,7 +21,7 @@ For recipes focused on components only, see :doc:`/content/howto/share-component
 
 Reach for the single project layout in :doc:`project-layout` when only one Django project lives in the repository.
 
-Directory Shape
+Directory shape
 ---------------
 
 A typical multi project repository looks like this.
@@ -66,7 +66,7 @@ Two pieces stand out.
 - ``_shared/`` holds components and static files that are common to every project.
 - Each project under ``projects/`` has its own ``config/`` and its own ``chrome/`` directory.
 
-DIRS Configuration
+DIRS configuration
 ------------------
 
 Each project points at the shared directory through ``DIRS``.
@@ -105,7 +105,7 @@ The component backend reads from the shared components folder.
 Each project picks its own ``COMPONENTS_DIR`` and its own ``PAGES_DIR``.
 Different projects can use different names without affecting one another.
 
-Static Files
+Static files
 ------------
 
 The shared directory ships static files alongside components.
@@ -121,7 +121,7 @@ The shared directory ships static files alongside components.
 The Django static files finder picks up files from both directories.
 The static collector emits co-located CSS and JS sitting next to any component, page, or layout in either tree.
 
-Shared Components Convention
+Shared components convention
 ----------------------------
 
 Shared components live inside ``_shared/_components/``.
@@ -132,7 +132,7 @@ The framework does not consult ``COMPONENTS_DIR`` when it scans the ``DIRS`` roo
 The shared components folder ships UI primitives such as buttons, cards, dialogs, and form widgets.
 Each project consumes them through ``{% component "name" %}`` without redeclaring anything.
 
-Per Project Components
+Per project components
 ----------------------
 
 A project can ship project-specific components alongside the shared kit.
@@ -160,7 +160,7 @@ When two ``DIRS`` roots score equally the resolver breaks the tie first by compo
 Roots are scanned in ``DIRS`` order, so an entry placed earlier in the list shadows a same-named component from a later entry.
 Prefer distinct names for project-specific components over relying on this ordering.
 
-Hot Reload
+Hot reload
 ----------
 
 Every directory listed in a component backend ``DIRS`` contributes its own ``**/component.py`` watch spec to the :doc:`autoreloader </content/internals/autoreload>`.
@@ -170,29 +170,29 @@ A change to a ``component.py`` inside ``_shared/_components/`` restarts only the
 
 The ``components_registered`` signal includes the full set after each reload so long-lived processes can refresh their caches.
 
-Common Variations
+Common variations
 -----------------
 
-Repository Wide Layout
+Repository wide layout
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Put a single layout in ``_shared/chrome/`` and add the path to the ``PAGE_BACKENDS`` ``DIRS`` of every project.
 Every project then renders inside the same shell.
 
-Per Tenant Project
+Per tenant project
 ~~~~~~~~~~~~~~~~~~
 
 Run one project per tenant from the same repository.
 Each project ships its own settings, chrome, and applications.
 The shared components folder keeps the design consistent across tenants.
 
-Domain Specific Components
+Domain specific components
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Add a ``_internal/`` shared folder for components that should only be visible to a subset of projects.
 Reference it from the appropriate projects through ``DIRS``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/pages.rst
+++ b/docs/content/topics/pages.rst
@@ -16,7 +16,7 @@ Overview
 The smallest page is a folder that contains a ``page.py`` and a sibling ``template.djx``.
 A page module declares context functions, action handlers, and optional ``render`` or ``template`` attributes, and any number of ancestor ``layout.djx`` files wrap the resulting body.
 
-Body Sources
+Body sources
 ------------
 
 A page module can supply its body through these sources.
@@ -39,11 +39,11 @@ A page directory may instead host only a sibling ``layout.djx``.
 That directory has no body source, and the layout chain renders with an empty body slot.
 See *Layout-only directories* under :doc:`layouts` for the wrapping rules, and note that :ref:`next.E012 <ref-system-checks>` does not fire when a sibling ``layout.djx`` is present.
 
-See *Render Order* below for the per-request sequence and the ``render`` short-circuit.
+See *Render order* below for the per-request sequence and the ``render`` short-circuit.
 Processor ordering and ``STRICT_CONTEXT`` behaviour are documented in :doc:`context` and :ref:`ref-settings`.
-Multiple body sources trigger :ref:`next.W043 <ref-system-checks>`, see *Priority Resolution*.
+Multiple body sources trigger :ref:`next.W043 <ref-system-checks>`, see *Priority resolution*.
 
-Render Order
+Render order
 ------------
 
 The body source runs before the template context is built.
@@ -53,16 +53,16 @@ This is the authoritative ordering for the page render path.
    A ``render`` function is called first with its :doc:`DI-resolved <dependency-injection>` arguments.
    When ``render`` returns an :class:`~django.http.HttpResponseBase` the response is sent verbatim and the remaining steps are skipped, so layouts and the static pipeline do not run.
    A ``template`` attribute or a template file supplies the body string directly.
-2. The ``@context`` callables are collected and run to build the template variable namespace.
-3. The body is composed through the ancestor layouts and rendered with that namespace.
+2. The body is composed through the ancestor layouts.
+3. The ``@context`` callables are collected and run, and the composed template renders with that namespace.
 
 A ``render`` function therefore cannot read a value that a ``@context`` callable would publish, because the callables have not run yet.
 
 A partial-zone request takes a different path.
-When the request targets named zones, the view returns a zone response before step 3, so the full page render does not run.
+When the request targets named zones, the view returns a zone response before step 2, so the full page render does not run.
 See :doc:`/content/topics/partial-rendering/zones` for the zone-morph request.
 
-The ``render`` Function
+The ``render`` function
 -----------------------
 
 The ``render`` function takes any DI-resolved parameters the resolver can fill.
@@ -93,7 +93,7 @@ Anything else.
 
 Exceptions raised inside ``render`` propagate to the Django request stack unchanged.
 
-The ``template`` Attribute
+The ``template`` attribute
 --------------------------
 
 Assign a string to the module-level ``template`` attribute when the body is small enough to live next to the Python code.
@@ -109,7 +109,7 @@ Use it for trivial pages where a separate template file would be noise.
 
 The ``template`` attribute has a matching ``PythonTemplateLoader``, documented in :doc:`/content/ref/pages`.
 
-Template Files
+Template files
 --------------
 
 A ``template.djx`` sibling is the default source.
@@ -127,7 +127,7 @@ The file contains the body without any HTML envelope.
 The layout chain wraps this body with the ancestor ``layout.djx`` files.
 See :doc:`layouts` for the full composition rules.
 
-Context Functions
+Context functions
 -----------------
 
 A ``@context`` decorator publishes one or more values into the template scope.
@@ -155,16 +155,29 @@ Unkeyed dict.
    Useful when several values share a dependency you only want to resolve once.
    The unkeyed form must return a mapping, and a return annotation that is not a mapping type reports :ref:`next.E029 <ref-system-checks>`.
 
+   .. code-block:: python
+      :caption: unkeyed dict
+
+      from next import context
+      from notes.models import Post
+
+      @context
+      def post_context(post: Post) -> dict[str, object]:
+          return {
+              "post": post,
+              "comments": post.comment_set.all(),
+          }
+
 The ``inherit_context=True`` flag works on both the keyed and the unkeyed-dict shapes.
 It publishes the value to every descendant page rather than to the declaring page alone.
 See :doc:`context` for that flag and the other ways to vary the decorator.
 
-Including Values in the JS Context
+Including values in the JS context
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Pass ``serialize=True`` to include the return value in ``window.Next.context`` on the client side.
 The value must be JSON-encodable by the active serializer.
-See :ref:`Serialization for the Browser <topics-context-serialization>` for the accepted shapes and common pitfalls.
+See :ref:`Serialization for the browser <topics-context-serialization>` for the accepted shapes and common pitfalls.
 Pass ``serializer=`` with a ``JsContextSerializer`` instance to use a per-key serializer for that value instead of the global ``JS_CONTEXT_SERIALIZER`` setting.
 
 .. code-block:: python
@@ -176,19 +189,7 @@ Pass ``serializer=`` with a ``JsContextSerializer`` instance to use a per-key se
    def featured_payload() -> dict:
        return {"id": 1, "title": "Hello"}
 
-.. code-block:: python
-   :caption: unkeyed dict
-
-   from next import context
-
-   @context
-   def post_context(post: Post) -> dict[str, object]:
-       return {
-           "post": post,
-           "comments": post.comment_set.all(),
-       }
-
-Custom Template Loaders
+Custom template loaders
 -----------------------
 
 The sibling ``template.djx`` loader is one implementation of the ``next.pages.loaders.TemplateLoader`` contract.
@@ -233,12 +234,13 @@ Include ``DjxTemplateLoader`` explicitly when you still want sibling ``template.
 ``next.pages.page.register_template(file_path, template_str)`` seeds the composed-template cache that ``composed_template_for`` reads.
 That cache serves direct ``Page.render`` calls, including ``next.testing.render_page``, the form re-render after a validation failure, and standalone zone renders.
 A regular HTTP request for the page bypasses the cache and resolves the body from its disk source, so a registered string never serves the page at its URL.
+
 The method stores the supplied body verbatim, with no layout composition, so no ancestor ``layout.djx`` wraps it.
 Pre-compose the body through the layout chain before registering it when wrapping is required.
 See :doc:`/content/ref/pages` for the full ``Page`` surface.
 See :doc:`/content/howto/add-a-custom-template-loader` for the recipe-shaped walkthrough of a loader class.
 
-Loader Contract
+Loader contract
 ~~~~~~~~~~~~~~~~~
 
 A loader sets one class attribute, implements two required methods, and may override one optional method.
@@ -253,7 +255,8 @@ A loader sets one class attribute, implements two required methods, and may over
 
 ``load_template(file_path)``.
    Returns the body string or ``None`` for the same ``page.py`` path.
-   The framework treats ``None`` as "did not match" and tries the next loader.
+   Once ``can_load`` has claimed the page, a ``None`` result yields an empty body.
+   The next loader is consulted only when ``can_load`` itself returns ``False``.
 
 ``source_path(file_path)``.
    Optional.
@@ -261,7 +264,7 @@ A loader sets one class attribute, implements two required methods, and may over
    Edits to that file invalidate the composed template on the next request.
    The default returns ``None`` for non-file-based loaders.
 
-Priority Resolution
+Priority resolution
 -------------------
 
 When more than one body source applies the framework picks the highest priority one and emits a warning for the redundancy.
@@ -285,10 +288,10 @@ The template loaders have no fixed numbering between them.
 When a page directory declares more than one body source, :ref:`next.W043 <ref-system-checks>` reports it.
 The highest-priority source is used and the others are never consulted.
 
-Common Patterns
+Common patterns
 ---------------
 
-Pure Redirect Page
+Pure redirect page
 ~~~~~~~~~~~~~~~~~~
 
 A page that always redirects elsewhere uses a ``render`` function that returns ``HttpResponseRedirect``.
@@ -302,7 +305,7 @@ A page that always redirects elsewhere uses a ``render`` function that returns `
    def render(request) -> HttpResponseRedirect:
        return HttpResponseRedirect(page_reverse("auth/login"))
 
-JSON Endpoint
+JSON endpoint
 ~~~~~~~~~~~~~
 
 Return ``JsonResponse`` from ``render`` for a JSON endpoint that still benefits from URL naming.
@@ -315,7 +318,7 @@ Return ``JsonResponse`` from ``render`` for a JSON endpoint that still benefits 
    def render(request) -> JsonResponse:
        return JsonResponse({"status": "ok"})
 
-Streaming Response
+Streaming response
 ~~~~~~~~~~~~~~~~~~
 
 Reach for ``StreamingHttpResponse`` when the body is produced incrementally, such as Server Sent Events or a large export.
@@ -347,7 +350,7 @@ A synchronous generator works under WSGI and the development server.
 An ASGI deployment can yield from an async generator instead.
 See ``examples/live-polls`` for a worked SSE broker.
 
-Markdown Blog Post
+Markdown blog post
 ~~~~~~~~~~~~~~~~~~
 
 Register a ``MarkdownTemplateLoader`` in ``NEXT_FRAMEWORK["TEMPLATE_LOADERS"]`` and drop a ``template.md`` next to ``page.py`` instead of a ``template.djx``.
@@ -360,9 +363,9 @@ Wrap untrusted prose in ``{% verbatim %}`` blocks inside the loader, or escape t
 
 .. seealso::
 
-   The *Custom Template Loaders* section above for the ``template.md`` loader, and ``examples/markdown-blog`` for a working setup.
+   The *Custom template loaders* section above for the ``template.md`` loader, and ``examples/markdown-blog`` for a working setup.
 
-System Checks
+System checks
 -------------
 
 The pages subsystem contributes Django system checks. The ``check_page_functions`` check inspects every ``page.py`` and reports the following.
@@ -374,9 +377,9 @@ The pages subsystem contributes Django system checks. The ``check_page_functions
    The page module defines a ``render`` attribute that is not callable.
 
 ``next.W043``.
-   More than one body source is declared in the same directory, see *Priority Resolution*.
+   More than one body source is declared in the same directory, see *Priority resolution*.
 
-The ``check_context_functions`` check inspects ``page.py`` files under one representative pages root per router for keyless ``@context`` callables.
+The ``check_context_functions`` check inspects ``page.py`` files under one representative page root per router for keyless ``@context`` callables.
 In a project with several page-bearing applications the remaining roots are not scanned, so ``next.E029`` surfaces only for pages under the scanned root.
 
 ``next.E029``.
@@ -384,7 +387,7 @@ In a project with several page-bearing applications the remaining roots are not 
 
 Run them through ``uv run python manage.py check``.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/partial-rendering/co-located-js.rst
+++ b/docs/content/topics/partial-rendering/co-located-js.rst
@@ -1,6 +1,6 @@
 .. _topics-partial-rendering-co-located-js:
 
-Co-located JavaScript Under Partial Updates
+Co-located JavaScript under partial updates
 ===========================================
 
 A morph replaces DOM nodes.
@@ -8,7 +8,8 @@ A node that arrives in a patch was not in the document when the page loaded, and
 Co-located JavaScript has to survive that, and the rule is to attach behaviour to something that outlives the morph rather than to the markup itself.
 
 Each asset runs exactly once per page lifetime, a URL deduped by its address resolved against the document base, query included and fragment ignored, and an inline body by its content.
-The registry behind that promise is built from the document while it parses, so an asset a third party inserts after parsing ends stays outside it and a later manifest naming the same URL or the same inline body inserts it a second time.
+The registry behind that promise is built from the document while it parses.
+An asset a third party inserts after parsing ends stays outside it, so a later manifest naming the same URL or the same inline body inserts it a second time.
 A module loaded for the first zone that needs it is not re-run when a later patch brings more of the same markup.
 A module that wires itself up at load time finds the markup that exists at load time and nothing later.
 Use one of the three idioms below.
@@ -17,7 +18,7 @@ Use one of the three idioms below.
    :local:
    :depth: 1
 
-Delegate on the Document
+Delegate on the document
 ------------------------
 
 Bind one listener on ``document`` and match the target inside the handler.
@@ -52,13 +53,14 @@ The event bubbles, so a single document listener that checks ``event.target`` ca
 This is the idiom for behaviour that owns one element and needs to run when that element appears.
 
 ``next:mounted`` fires on the touched nodes of a patch, the roots an op replaces or morphs and the rows a merge brings, not on every descendant of a morphed zone.
-A deeply nested element that the morph reconciles in place is not a touched node, so ``event.target`` is the touched root above it and ``event.target.matches("[data-chart]")`` never matches the inner element.
+A deeply nested element that the morph reconciles in place is not a touched node.
+``event.target`` is the touched root above it, so ``event.target.matches("[data-chart]")`` never matches the inner element.
 For an element that lands deep inside a morphed subtree reach for ``Next.partial.onMount``, which scans the inserted subtree with ``querySelectorAll`` and runs for every match, descendants included.
 
 The ``next:mounted`` event lives only on ``document.addEventListener``.
 It never reaches the ``Next.on`` bus, so ``Next.on("next:mounted")`` is a silent no-op, as are ``Next.on("next:removed")``, ``Next.on("next:morph-element")``, and ``Next.on("next:morph-attribute")``.
 
-Register With Next.partial.onMount
+Register with Next.partial.onMount
 ----------------------------------
 
 ``Next.partial.onMount(selector, callback)`` is a re-executable registry.
@@ -78,7 +80,7 @@ The callback also re-runs for a matching element the morph reconciled in place, 
 Guard the setup with a data flag or a ``WeakSet`` so a second run over the same element does nothing.
 Reach for this when a module wired itself on ``DOMContentLoaded`` before and needs the same per-element setup to keep working under partial updates.
 
-The Anti-Pattern
+The anti-pattern
 ----------------
 
 Scanning the DOM at module load is the trap.
@@ -102,7 +104,7 @@ The search catalogue's minimum-length hint and the wiki's markdown preview both 
 With the runtime's dev mode on, that is with Django ``DEBUG``, the runtime prints a ``console.warn`` for every ``<script>`` it neutralises out of a patch.
 That surfaces a widget which died silently rather than letting it fail in quiet.
 
-Scripts in Patches Never Run
+Scripts in patches never run
 ----------------------------
 
 A ``<script>`` inside patch HTML is never executed by any insertion path.
@@ -113,13 +115,15 @@ See :doc:`/content/security/csp-and-nonce` for how this interacts with a Content
 
 What the applier neutralises is the script inside the patch markup itself.
 The zone's co-located assets travel separately, in the envelope's asset manifest, and those do load.
-A stylesheet, a classic script, or a module URL the page has not seen is inserted, and so is an inline body it has not seen whose kind wraps it in the element the verb builds, each once per page lifetime.
-The runtime inserts an asset by the verb the server derived from the kind's renderer, so a custom kind registered with ``render_link_tag``, ``render_script_tag``, or ``render_module_tag`` arrives the same way the built-in kinds do.
+A stylesheet, a classic script, or a module URL the page has not seen is inserted, each once per page lifetime.
+An inline body it has not seen is inserted the same way when its kind wraps it in the element the verb builds.
+The runtime inserts an asset by the verb the server derived from the kind's renderer.
+A custom kind registered with ``render_link_tag``, ``render_script_tag``, or ``render_module_tag`` therefore arrives the same way the built-in kinds do.
 A kind registered with a custom renderer carries no verb and is skipped, which the ``next.W074`` check reports at ``manage.py check``.
 Behaviour co-located with a zone therefore arrives on a standalone zone render.
 It must still use the three idioms above because of the once-per-page execution, not because a delivery channel is missing.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/partial-rendering/done-choreographies.rst
+++ b/docs/content/topics/partial-rendering/done-choreographies.rst
@@ -1,6 +1,6 @@
 .. _topics-partial-rendering-done-choreographies:
 
-Wizard Done Choreographies
+Wizard done choreographies
 ==========================
 
 A wizard inside a modal finishes on its last step.
@@ -15,7 +15,7 @@ The two choreographies differ only in what ``done`` returns and how the list get
    :local:
    :depth: 1
 
-Accept and Re-GET
+Accept and re-GET
 -----------------
 
 The default.
@@ -25,15 +25,18 @@ The wizard does not know the list exists.
 .. code-block:: python
    :caption: request/[step]/page.py
 
-   def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> HttpResponse:
-       """Create the access request and close the layer with a result."""
-       access_request = AccessRequest.objects.create(**cleaned_data)
-       return (
-           Patches(request)
-           .layer_close(result={"id": access_request.pk})
-           .toast("Request created", variant="success")
-           .response(fallback=f"/request/{access_request.pk}/audit/")
-       )
+   class AccessRequestWizard(FormWizard):
+       def done(
+           self, request: HttpRequest, cleaned_data: dict[str, Any]
+       ) -> HttpResponse:
+           """Create the access request and close the layer with a result."""
+           access_request = AccessRequest.objects.create(**cleaned_data)
+           return (
+               Patches(request)
+               .layer_close(result={"id": access_request.pk})
+               .toast("Request created", variant="success")
+               .response(fallback=f"/request/{access_request.pk}/audit/")
+           )
 
 The last step answers with a close and a toast.
 
@@ -65,7 +68,7 @@ It sits on any page without a change, and ``data-next-accepted`` moves with the 
 This is the cycle of a redirect with reloaded props.
 The cost is one extra GET after the modal closes.
 
-Server OOB Through Page Addressing
+Server OOB through page addressing
 ----------------------------------
 
 The canonical server-driven done choreography.
@@ -83,19 +86,26 @@ The builder takes ``page=`` and ``url_kwargs=`` alongside ``zone=``, and the req
    from next.partial import resolve_partial_origin
 
 
-   def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> HttpResponse:
-       """Create the access request and patch the host page list in one response."""
-       access_request = AccessRequest.objects.create(**cleaned_data)
-       origin = resolve_partial_origin(request)
-       if origin is None or origin.page_path is None:
-           raise Http404
-       return (
-           Patches(request)
-           .layer_close(result={"id": access_request.pk})
-           .morph(zone="request-list", page=origin.page_path, url_kwargs=origin.url_kwargs)
-           .toast("Request created", variant="success")
-           .response(fallback=f"/request/{access_request.pk}/audit/")
-       )
+   class AccessRequestWizard(FormWizard):
+       def done(
+           self, request: HttpRequest, cleaned_data: dict[str, Any]
+       ) -> HttpResponse:
+           """Create the access request and patch the host page list in one response."""
+           access_request = AccessRequest.objects.create(**cleaned_data)
+           origin = resolve_partial_origin(request)
+           if origin is None or origin.page_path is None:
+               raise Http404
+           return (
+               Patches(request)
+               .layer_close(result={"id": access_request.pk})
+               .morph(
+                   zone="request-list",
+                   page=origin.page_path,
+                   url_kwargs=origin.url_kwargs,
+               )
+               .toast("Request created", variant="success")
+               .response(fallback=f"/request/{access_request.pk}/audit/")
+           )
 
 The last step answers with all three operations in one envelope.
 
@@ -119,7 +129,7 @@ A denial surfaces as ``ForeignPageNotAuthorizedError`` rather than an empty morp
 This is the cycle of an out-of-band swap.
 One round trip closes everything at once.
 
-The Comparison
+The comparison
 --------------
 
 .. list-table::
@@ -156,7 +166,7 @@ The deciding argument is not the round trip but the authorization and the decoup
 The re-GET keeps the list's rights where they live, in the list's view, and leaves the wizard portable.
 Reach for server OOB when the one extra GET is genuinely visible and the wizard is dedicated to one host page.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/partial-rendering/extending.rst
+++ b/docs/content/topics/partial-rendering/extending.rst
@@ -1,6 +1,6 @@
 .. _topics-partial-rendering-extending:
 
-Extending the Protocol
+Extending the protocol
 ======================
 
 The protocol is closed by design.
@@ -12,30 +12,33 @@ A custom verb, a server-pushed context value, and a server-fired event each ride
    :local:
    :depth: 1
 
-A Custom Verb
+A custom verb
 -------------
 
 A verb beyond the built-in set is registered on both sides.
 The server registers the name and the client supplies the handler.
-A registered name clears the ``next.E066`` check and earns the generic ``op()`` channel on the builder, so the typed methods stay the only authors of the built-in verbs.
+A registered name earns the generic ``op()`` channel on the builder, so the typed methods stay the only authors of the built-in verbs.
+The ``next.E066`` check validates the registered names at ``manage.py check``, and an unregistered verb fails at runtime with ``UnknownPatchOpError``.
 
 Register the name once on the server.
 
 .. code-block:: python
    :caption: dashboard/page.py
 
-   from typing import Any
+   from dashboard.forms import GoalForm
+   from django.http import HttpRequest, HttpResponse
 
-   from django.http import HttpRequest
-
+   from next import action
+   from next.forms.markers import DForm
    from next.partial import Patches, register_patch_op
 
    register_patch_op("confetti")
 
 
-   def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> Any:
+   @action("save_goal", form_class=GoalForm)
+   def save_goal(request: HttpRequest, form: DForm[GoalForm]) -> HttpResponse:
        """Save the goal and rain confetti on every watching tab."""
-       Goal.objects.create(**cleaned_data)
+       form.save()
        return Patches(request).op("confetti", count=80).toast("Goal reached").response()
 
 ``register_patch_op`` runs at import, so a page module or an app ``ready`` hook is a natural home.
@@ -58,7 +61,7 @@ Supply the handler on the client through a co-located asset.
 The handler receives the patch and an apply context.
 The patch carries the payload fields the server authored, here ``patch.count``.
 The context exposes ``dispatch`` for an event on the ``Next.on`` bus, ``mergeContext`` for a context merge, and ``root`` for the document.
-It also exposes ``dev`` for the runtime's dev mode, which follows Django ``DEBUG`` and is described in the Client Runtime section of :doc:`reference`.
+It also exposes ``dev`` for the runtime's dev mode, which follows Django ``DEBUG`` and is described in the Client runtime section of :doc:`reference`.
 Registering the handler at load time is safe, because ``defineOp`` records a handler rather than scanning the DOM.
 
 The envelope carries the custom verb beside the built-ins.
@@ -76,7 +79,7 @@ The envelope carries the custom verb beside the built-ins.
 
 Without the runtime the mutation falls back to the full ``POST`` then ``303`` then ``GET`` cycle and the custom verb never ships, so a custom verb is an enhancement, never the only path to a result.
 
-Pushing Context
+Pushing context
 ---------------
 
 The ``context`` verb merges named values into ``window.Next.context`` and fires ``context-updated``.
@@ -85,11 +88,9 @@ A value is pushed by the name of a registered ``serialize=True`` provider on the
 .. code-block:: python
    :caption: cart/page.py
 
-   from typing import Any
+   from django.http import HttpRequest, HttpResponse
 
-   from django.http import HttpRequest
-
-   from next import context
+   from next import action, context
    from next.partial import Patches
 
 
@@ -99,14 +100,16 @@ A value is pushed by the name of a registered ``serialize=True`` provider on the
        return Cart.for_request(request).count
 
 
-   def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> Any:
+   @action("add_to_cart")
+   def add_to_cart(request: HttpRequest) -> HttpResponse:
        """Add the item and push the new cart count to the client."""
        cart = Cart.for_request(request)
-       cart.add(cleaned_data["sku"])
+       cart.add(request.POST["sku"])
        return Patches(request).context(cart_count=cart.count).response()
 
 A name that is not a ``serialize=True`` provider of the origin page raises ``UnknownContextNameError``, so the verb cannot smuggle an arbitrary value past the provider contract.
-The ``$csrf`` and ``$dev`` keys of the init payload raise ``ReservedContextKeyError`` whether or not the origin page registered them, symmetric to ``event()`` refusing a framework-owned event name, so the ``$`` namespace stays the framework's on a patch as it is on a full render.
+The ``$csrf`` and ``$dev`` keys of the init payload raise ``ReservedContextKeyError`` whether or not the origin page registered them, symmetric to ``event()`` refusing a framework-owned event name.
+The ``$`` namespace therefore stays the framework's on a patch as it is on a full render.
 A page that registers either name loses that value on the full render too, so no patch has anything to update, see :doc:`/content/topics/static-assets/js-context`.
 
 Read the merged value on the client through ``Next.context`` and react to the merge through ``context-updated``.
@@ -124,7 +127,7 @@ The event payload carries the whole merged store in ``context`` and the keys of 
 A stream source cannot build a ``context`` patch, because it has no page-render origin to read a provider value from.
 A stream that needs to push fresh context drives a ``refresh`` instead, and the re-fetched zone delivers the new context through its own render, see :doc:`sse`.
 
-Firing an Event
+Firing an event
 ---------------
 
 The ``event`` verb dispatches a ``CustomEvent`` on the document and the ``Next.on`` bus.
@@ -133,16 +136,18 @@ It is the seam for a server-authored signal that no morph expresses, a notificat
 .. code-block:: python
    :caption: orders/page.py
 
-   from typing import Any
+   from django.http import HttpRequest, HttpResponse
+   from orders.forms import OrderForm
 
-   from django.http import HttpRequest
-
+   from next import action
+   from next.forms.markers import DForm
    from next.partial import Patches
 
 
-   def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> Any:
+   @action("place_order", form_class=OrderForm)
+   def place_order(request: HttpRequest, form: DForm[OrderForm]) -> HttpResponse:
        """Place the order and signal the analytics island."""
-       order = Order.objects.create(**cleaned_data)
+       order = form.save()
        return (
            Patches(request)
            .event("order-placed", {"id": order.pk, "total": str(order.total)})
@@ -162,7 +167,7 @@ Consume it with a delegated document listener or the ``Next.on`` bus.
 The ``toast`` verb is sugar over ``event`` with a built-in container, so a project that wants its own notification surface listens for ``next:toast`` and renders the toast itself.
 The item still lands in the built-in ``[data-next-toasts]`` tray, so such a project also hides the tray with CSS.
 
-One Active Backend
+One active backend
 ------------------
 
 The three seams above extend the envelope from inside.
@@ -173,7 +178,7 @@ A configuration with more than one entry earns the ``next.W071`` warning at ``ma
 An application that needs a different envelope shape subclasses ``PartialProtocolBackend``, serialises its own wire format, and makes the subclass the single entry of ``PARTIAL_BACKENDS``.
 See :doc:`/content/ref/partial` for the ``PartialProtocolBackend`` API.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/partial-rendering/framework-islands.rst
+++ b/docs/content/topics/partial-rendering/framework-islands.rst
@@ -1,6 +1,6 @@
 .. _topics-partial-rendering-framework-islands:
 
-Framework Islands
+Framework islands
 =================
 
 A framework island is a Vue or React root mounted into one element of an otherwise server-rendered page.
@@ -15,7 +15,7 @@ The six lines below are the adapter.
    :local:
    :depth: 1
 
-The Mount and Unmount Pair
+The mount and unmount pair
 --------------------------
 
 ``next:mounted`` fires on every node a patch touches, after the operations apply.
@@ -26,7 +26,7 @@ Mount through :ref:`Next.partial.onMount <topics-partial-rendering-co-located-js
 The registry runs its callback over the matching elements present at load and over every matching element a later patch inserts, descendants included.
 Unmount through ``next:removed``, walking the detached subtree for islands, because the event fires on the detached root rather than on each descendant.
 
-A React Island
+A React island
 --------------
 
 .. code-block:: javascript
@@ -63,7 +63,7 @@ The ``roots.has(el)`` guard keeps the mount idempotent, because ``onMount`` re-r
 The ``next:removed`` handler walks the subtree because a morph that removes the zone containing the chart fires the event on the zone, not on the chart inside it.
 Matching the node itself and its descendants covers both the island-as-root and the island-inside-a-removed-zone cases.
 
-A Vue Island
+A Vue island
 ------------
 
 .. code-block:: javascript
@@ -96,7 +96,7 @@ A Vue Island
      }
    });
 
-Preserving the Island Through a Morph
+Preserving the island through a morph
 -------------------------------------
 
 A morph of the surrounding zone walks into the island and reconciles its DOM against the server markup, which fights the framework for ownership of that subtree.
@@ -111,7 +111,7 @@ With an id the child walk pairs it by hard match, without one it pairs by positi
 For a node the runtime should reconcile in some cases and not others, the per-node ``next:morph-element`` event carries a veto.
 A listener that calls ``preventDefault`` on it skips the morph of that node and its subtree, which lets a framework apply its own diff while the runtime stays out of the way.
 
-Two Kinds of Atomicity
+Two kinds of atomicity
 ----------------------
 
 The runtime treats two markers as morph boundaries, and they differ.
@@ -127,18 +127,20 @@ A server re-render that ships a stale attribute on a custom element overwrites t
 Use ``data-next-keep`` for an island whose attributes the framework drives after mount.
 Lean on the built-in custom-element atomicity only when the server attributes and the framework attributes never disagree, for example a web component the server seeds once and never re-authors.
 
-The Island Needs Stable Identity
+The island needs stable identity
 --------------------------------
 
 An island must carry a stable ``data-next-key`` or ``id``, or ``data-next-keep``, on its own root.
 Without one the morph pairs it by position, and a keyless re-sort of its siblings reuses a different node for it.
 
-The cost is a silent lost mount.
-A morph that drops the old island node fires ``next:removed`` on it, so the unmount runs, but the node the morph inserts in another position is not in the touched set, so ``next:mounted`` never fires for it and the mount never runs.
-The island unmounts and never comes back.
+The cost is churn and lost state.
+A morph that drops the old island node fires ``next:removed`` on it and the unmount runs.
+The replacement node is revived only by the ``onMount`` registry pass over the morphed zone, so the island remounts from scratch and its client state is gone.
+An adapter bound to the raw ``next:mounted`` event never sees the replacement at all.
+A keyless re-sort can also soft-match the island root to a different row, binding the mounted framework root to the wrong data.
 A stable key pins the island to its data so the morph reuses the same node, and ``data-next-keep`` pins it by leaving it untouched.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/partial-rendering/how-it-works.rst
+++ b/docs/content/topics/partial-rendering/how-it-works.rst
@@ -1,6 +1,6 @@
 .. _topics-partial-rendering-how-it-works:
 
-How a Partial Request Flows
+How a partial request flows
 ===========================
 
 A partial update is one request and one response laid over the ordinary page cycle.
@@ -11,7 +11,7 @@ This page follows one update end to end.
    :local:
    :depth: 1
 
-The Page and Its Zones
+The page and its zones
 ----------------------
 
 A directory maps to a URL and a ``page.py`` turns a segment into a page, rendered through a ``.djx`` template.
@@ -19,7 +19,7 @@ A ``{% zone %}`` block marks a slice of that template the server can re-render o
 A zone is an optimisation rather than required markup.
 The server can address a page region without one, and a zone names the region so the response carries only the slice instead of the whole document.
 
-The Request
+The request
 -----------
 
 An interaction issues a partial request instead of a full navigation.
@@ -27,7 +27,7 @@ A form submit, an auto-submitting filter, a paginating link, a lazy zone scrolli
 The request carries the ``X-Next-Request`` switch the server reads to choose a partial response over a full page.
 It also carries an ``Accept`` naming the patch media type at the content-negotiation level and further ``X-Next-*`` headers that name the zone, the origin page, and the asset version.
 
-The Envelope
+The envelope
 ------------
 
 The server shapes a patch envelope and serialises it through the configured ``PARTIAL_BACKENDS`` backend.
@@ -35,7 +35,7 @@ The envelope carries a version, an ordered list of operations, an asset manifest
 The server authors every operation and every address.
 A selector or a swap strategy never crosses the wire, so the client cannot be asked to do anything the server did not name.
 
-The Apply
+The apply
 ---------
 
 The client narrows the envelope and runs each operation against the addressed zone.
@@ -49,21 +49,21 @@ A reused node keeps its own state, scroll position included, because it never le
 The morph engine protects a focused input and a dirty field from the server value, leaves a ``data-next-keep`` node untouched, and treats a custom element or a shadow root as atomic.
 After the operations apply, ``next:mounted`` fires on every touched node, and before any node detaches ``next:removed`` fires on it, the pair a framework island binds to.
 
-The Surfaces Around the Apply
+The surfaces around the apply
 -----------------------------
 
 A modal opens through the layer stack, which pushes the honest URL of the modal body so the modal is shareable and a refresh resolves the URL as its own standalone page, and Back closes the top layer.
 A Server-Sent Events stream feeds the same apply pipeline, suppressing the echo of the client's own mutation and revalidating its zones on returning visibility.
 A lazy zone and a trigger pull their own follow-up request through the same wire.
 
-Degrading Without JavaScript
+Degrading without JavaScript
 ----------------------------
 
 Every interaction degrades to a full page cycle when the runtime is absent.
 The runtime is an enhancement over the ``POST`` then ``303`` then ``GET`` flow the framework already serves.
 A page that works without it keeps working with it and gains the partial behaviour for free.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/partial-rendering/index.rst
+++ b/docs/content/topics/partial-rendering/index.rst
@@ -1,6 +1,6 @@
 .. _topics-partial-rendering:
 
-Partial Rendering
+Partial rendering
 =================
 
 Partial rendering updates a slice of a page instead of reloading the whole document.
@@ -13,7 +13,7 @@ Every interaction in this section degrades to a full page cycle when JavaScript 
 Read :doc:`scenarios` first.
 It walks seven concrete tasks from markup to handler, and the rest of the section deepens one concern at a time.
 
-.. rubric:: The Tutorial
+.. rubric:: The tutorial
 
 :doc:`scenarios`
    Seven scenarios from task to markup to handler, from neighbouring forms and inline

--- a/docs/content/topics/partial-rendering/limitations.rst
+++ b/docs/content/topics/partial-rendering/limitations.rst
@@ -11,21 +11,21 @@ The boundaries below follow from that shape, and each one names where the model 
    :local:
    :depth: 1
 
-Zones Render Synchronously
+Zones render synchronously
 --------------------------
 
 A zone renders standalone over the full page context in one synchronous pass.
 There is no server-side suspense flush, so a slow zone holds the response rather than streaming a placeholder and a later patch.
 A ``lazy=`` zone defers its first render behind a placeholder, but the deferral is a separate client-driven round trip, not a server-held stream.
 
-Real Time Is Server-Sent Events Only
+Real time is server-sent events only
 ------------------------------------
 
 The streaming transport is Server-Sent Events, one direction from server to client, see :doc:`sse`.
 There is no WebSocket transport, so client-to-server push over a persistent socket is outside the current model.
 A client that needs to send state changes uses the same forms and actions every page already has.
 
-Polling Zones Are Client-Timed
+Polling zones are client-timed
 ------------------------------
 
 ``poll=`` is a client timer, not a server push.
@@ -33,14 +33,14 @@ The runtime re-GETs the zone on the interval while the tab is visible, a hidden 
 A change the server wants to announce the moment it happens is a stream's job, not a poll's.
 See the poll section of :doc:`zones`.
 
-One Active Backend
+One active backend
 ------------------
 
 ``PARTIAL_BACKENDS`` activates its first entry and ignores the rest.
 Multi-backend selection is not supported, and a list with more than one entry earns the ``next.W071`` warning at ``manage.py check``.
 A different wire format is a subclass of ``PartialProtocolBackend`` installed as the single entry, see :doc:`extending`.
 
-Scripts in Patch HTML Never Run
+Scripts in patch HTML never run
 -------------------------------
 
 A zone's co-located assets ship on a standalone render, inline bodies and URLs alike, through the envelope's asset manifest.
@@ -52,18 +52,19 @@ What never runs is a ``<script>`` inside the patch HTML itself, which the applie
 Every asset executes once per page lifetime, so behaviour binds through the mount idioms rather than a load-time scan.
 See :doc:`co-located-js` and :doc:`/content/topics/static-assets/asset-kinds`.
 
-Patch-Inserted Assets Carry a Fixed Attribute Set
+Patch-inserted assets carry a fixed attribute set
 -------------------------------------------------
 
 A full page render emits an asset through the backend tag templates, so ``css_tag``, ``js_tag``, and ``module_tag`` decide which attributes the element carries.
 A patch has no server-rendered tag, so the runtime builds the element itself from a fixed set of attributes.
-A stylesheet gets ``rel``, ``href``, and the page nonce, a script or a module gets ``type``, ``async``, and the page nonce.
+A stylesheet gets ``rel``, ``href``, and the page nonce.
+A script gets the page nonce, a module additionally ``type="module"``, and both are pinned non-async so insertion order is execution order.
 An attribute a project adds to its tag templates, such as ``media``, ``integrity``, ``crossorigin``, or ``defer``, therefore reaches the browser on a full render and not on a patch.
 Subresource Integrity in particular does not apply to a patch-inserted asset, so a deployment that relies on it treats the assets a patch brings as outside that guarantee.
 An asset the full render already emitted stays in the runtime's loaded registry and is never re-inserted, so the gap covers only assets that arrive for the first time through an envelope.
 See :doc:`/content/security/static-assets` for the backend-side SRI recipe and :doc:`/content/topics/static-assets/backends` for the tag templates.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/partial-rendering/reference.rst
+++ b/docs/content/topics/partial-rendering/reference.rst
@@ -1,6 +1,6 @@
 .. _topics-partial-rendering-reference:
 
-Partial Rendering Reference
+Partial rendering reference
 ===========================
 
 The patch verbs, the request and response headers, the ``data-next-*`` attributes, and the ``PARTIAL_BACKENDS`` settings, in tables.
@@ -10,7 +10,7 @@ For the narrative behind any of these, read the scenario that uses it in :doc:`s
    :local:
    :depth: 1
 
-Patch Verbs
+Patch verbs
 -----------
 
 A patch is one addressed DOM operation with a verb, an optional target, optional HTML, and verb-specific extras.
@@ -88,8 +88,14 @@ The envelope around the list always carries the ``assets`` and ``form`` keys, se
      - A full client navigation to a server-authored href. ``external=True`` skips same-host validation, see :ref:`security-overview`.
      - none
 
+A target carries exactly one address key, and the client resolves ``zone``, then ``form``, then ``field``, then ``css``.
+``zone`` names a ``data-next-zone`` wrapper and ``form`` names an action uid.
+``field`` is a ``[uid, name]`` pair addressing one named input of a form by its uid.
+``css`` is a raw selector, the escape hatch a bare layer shell relies on.
+
 A verb beyond this set is registered on both sides.
-``register_patch_op("confetti")`` on the server clears the ``next.E066`` check and earns the generic ``op()`` channel on the builder.
+``register_patch_op("confetti")`` on the server registers the name, which the ``next.E066`` check validates at ``manage.py check``, and earns the generic ``op()`` channel on the builder.
+An unregistered name fails at runtime with ``UnknownPatchOpError``.
 ``Next.partial.defineOp("confetti", handler)`` on the client supplies the handler.
 See :doc:`extending` for the end-to-end recipe, the ``context`` and ``event`` seams, and the custom-verb exceptions.
 
@@ -97,10 +103,11 @@ An event name that starts with ``partial:`` or ``next:``, or equals ``ready`` or
 ``Patches.event()`` rejects such a name with ``ReservedEventNameError``, symmetric to ``op()`` rejecting a built-in verb on the generic channel, so an application cannot forge a lifecycle event.
 
 The ``$csrf`` and ``$dev`` keys of the init payload are reserved the same way.
-``Patches.context()`` rejects either name with ``ReservedContextKeyError``, and the js-context delta of a zone render drops them before it becomes a ``context`` op, so the ``$`` namespace belongs to the framework on a patch exactly as it does on a full render.
+``Patches.context()`` rejects either name with ``ReservedContextKeyError``, and the js-context delta of a zone render drops them before it becomes a ``context`` op.
+The ``$`` namespace therefore belongs to the framework on a patch exactly as it does on a full render.
 A full render drops a page or component key of either name from the payload whether or not it has a framework value to write there, so no patch has a registered value to update.
 
-Asset Manifest
+Asset manifest
 --------------
 
 The ``assets`` key of an envelope lists the co-located assets the rendered targets registered.
@@ -124,20 +131,24 @@ Each entry carries ``kind`` and ``url`` always, plus ``inline`` and ``load`` whe
      - The body of an inline asset, absent on a URL-form asset.
    * - ``load``
      - ``link``, ``script``, or ``module``
-     - The insertion verb, derived from the renderer registered for the kind. Absent when that renderer is a custom backend method, and absent on an inline body whose kind does not wrap it in the element the verb builds.
+     - The insertion verb, derived from the renderer registered for the kind.
+       Absent when that renderer is a custom backend method, and absent on an
+       inline body whose kind does not wrap it in the element the verb builds.
 
 The runtime inserts an asset by its verb rather than by its kind, so a custom kind registered with one of the three built-in renderers loads like the built-in kind that shares it.
 The verb of an entry resolves in three steps.
 A ``load`` field the server wrote wins.
-A URL-form entry without that field falls back to the verb the name of a built-in kind implies, ``link`` for ``css``, ``script`` for ``js``, and ``module`` for ``module``, so an envelope authored before the field existed still loads.
-An entry carrying an inline body takes no such fallback, because the server spells the verb only when the kind wraps the body in the element the runtime builds, so a body with no explicit ``load`` is dropped at the boundary rather than executed in an element a full page render prints verbatim.
+A URL-form entry without that field falls back to the verb the name of a built-in kind implies, ``link`` for ``css``, ``script`` for ``js``, and ``module`` for ``module``.
+An envelope from a backend that spells no ``load`` field therefore still loads.
+An entry carrying an inline body takes no such fallback, because the server spells the verb only when the kind wraps the body in the element the runtime builds.
+A body with no explicit ``load`` is therefore dropped at the boundary rather than executed in an element a full page render prints verbatim.
 
 An entry that resolves to no verb is skipped.
 The ``next.W074`` check reports a registered kind whose renderer implies no verb, and ``next.W076`` a registered kind whose inline bodies lose the verb its URL form keeps.
 Both checks walk the kinds registered in the running process, so an entry naming a kind no registration backs is skipped with no check to announce it.
 See :doc:`/content/topics/static-assets/asset-kinds` for the renderer-to-verb mapping.
 
-Request Headers
+Request headers
 ---------------
 
 Client to server.
@@ -178,7 +189,7 @@ All values are ASCII, and zone names are ASCII slugs.
      - Every unsafe method
      - The name comes from ``CSRF_HEADER_NAME``, the token from the runtime payload, the cookie is never read.
 
-Response Headers
+Response headers
 ----------------
 
 Server to client.
@@ -206,7 +217,7 @@ Server to client.
      - An invalid form
      - The uid of the failed action.
 
-Status Codes
+Status codes
 ------------
 
 .. list-table::
@@ -234,7 +245,10 @@ Status Codes
    * - 404
      - An unknown form uid, the existing behaviour.
    * - 409
-     - A version mismatch on a safe method, with an empty body. The runtime fully visits the current URL. A mutation always runs, and a version mismatch surfaces in the envelope version, which the client reads to reload once into a full client visit.
+     - A version mismatch on a safe method, with an empty body. The runtime
+       fully visits the current URL. A mutation always runs, and a version
+       mismatch surfaces in the envelope version, which the client reads to
+       reload once into a full client visit.
    * - 5xx
      - No envelope. The runtime swaps nothing and fires ``partial:error``.
 
@@ -314,8 +328,10 @@ The form-behaviour attributes are written by the ``{% form %}`` tag from its par
      - A container
      - Subscribe to a patch stream at the URL.
    * - ``data-next-busy``
-     - Initiator and target
-     - The busy gate, written by the runtime alongside ``aria-busy="true"``.
+     - Layer opener, layer zone container
+     - Written during a layer open on the opener link and the layer's zone
+       container, alongside ``aria-busy="true"``. The submit double-click guard
+       is the per-uid mutation lock, not this attribute.
    * - ``data-next-dialog``
      - Runtime ``<dialog>``
      - Set by the runtime on every layer dialog, the styling hook for the modal shell.
@@ -326,13 +342,13 @@ The form-behaviour attributes are written by the ``{% form %}`` tag from its par
      - Runtime toast item
      - One toast, the value is the variant, the styling hook for a single notification.
 
-Lifecycle Events
+Lifecycle events
 ----------------
 
 The runtime fires events on three channels, the element, the document, and the ``Next.on`` bus.
 The ``next:*`` node events fire on the element as a bubbling ``CustomEvent`` caught with ``addEventListener``.
 The apply-stage ``partial:*`` events and ``next:toast`` fire on the document and the ``Next.on`` bus.
-A ``partial:error`` of kind ``asset``, raised when a co-located stylesheet fails to load or its version mismatches, reaches only the bus.
+A ``partial:error`` of kind ``asset``, raised when a co-located stylesheet fails to load or when the asset version still mismatches after the reload, reaches only the bus.
 ``ready``, ``context-updated``, ``partial:before-request``, and the fetch-stage ``partial:error`` reach only the bus.
 The ``next:mounted``, ``next:removed``, and ``next:morph-*`` node events live only on ``document.addEventListener`` and never reach the bus, so ``Next.on("next:mounted")`` is a silent no-op.
 
@@ -412,7 +428,7 @@ The ``next:mounted``, ``next:removed``, and ``next:morph-*`` node events live on
 The mount and morph events run during the patch apply, so a framework island can take over a node by vetoing its morph and managing its own subtree.
 The mounted and removed pair brackets the node's life inside the document, the symmetry an adapter relies on to mount and unmount a root.
 
-Client Runtime
+Client runtime
 --------------
 
 The runtime exposes ``window.Next`` once the bundle loads.
@@ -436,6 +452,10 @@ The surface is small, and every entry mirrors a seam the runtime already uses in
      - A re-executable mount registry. The callback runs over the matching elements at load and over every matching element a later patch inserts.
    * - ``Next.partial.parseHook(contentType, hook)``
      - Register a parser that turns a foreign content type into an envelope before the apply pipeline, so a third party can emulate another wire format.
+   * - ``Next.partial.apply(raw)``
+     - Parse and apply a wire envelope directly, the entry a parse hook or a test feeds.
+   * - ``Next.partial.fetch(request)``
+     - Send one partial request through the wire's queues and locks.
    * - ``Next.partial.layers``
      - The layer stack for driving modals from script: ``open(opener, href, zone)``, ``close(detail)``, and ``size()``.
    * - ``Next.partial.sse``
@@ -453,7 +473,7 @@ An ``ops`` or ``assets`` value that is not an array is dropped whole and earns i
 An asset whose insertion verb the envelope boundary cannot resolve is a ``console.debug`` skip naming its kind, because a kind with a custom renderer is a normal configuration rather than damage.
 A production page carries no ``$dev`` key, so it carries neither the measurements nor any of the console lines.
 
-Intercepting Modals
+Intercepting modals
 -------------------
 
 A ``data-next-layer`` link opens a modal over the current view and pushes the honest URL of the modal body.
@@ -470,7 +490,7 @@ The same gate protects every click-driven trigger, so a prompt fronts a layer op
 
 .. _partial-server-layers:
 
-Server-Initiated Layers
+Server-initiated layers
 -----------------------
 
 ``Patches.layer_open`` opens a layer from a handler, the server counterpart of the ``data-next-layer`` opener.
@@ -513,7 +533,7 @@ The href is validated same-site like every navigation sink, a cross-site value r
 
 The client ``data-next-layer="record"`` opener and the server ``layer_open(href, zone)`` do the same work, both load a page zone into a layer.
 
-Foreign-Zone Authorisation
+Foreign-zone authorisation
 --------------------------
 
 A modal body and a page-addressed zone ride ``X-Next-Origin`` so the server resolves the host page that owns the zone.
@@ -568,7 +588,7 @@ The rest are ignored, multi-backend selection is not supported, and a list with 
 
 See :doc:`/content/ref/settings` for every key inside ``NEXT_FRAMEWORK``.
 
-Styling Layers and Toasts
+Styling layers and toasts
 -------------------------
 
 The runtime creates a bare ``<dialog data-next-dialog>`` for every layer and a ``<div data-next-toasts>`` container for toasts.
@@ -619,7 +639,7 @@ With Tailwind Play CDN ``@apply`` is available inside a ``<style type="text/tail
 
 The ``next.dj`` examples use both patterns through the shared ``_shared/static/shared/css/base.css`` file.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/partial-rendering/scenarios.rst
+++ b/docs/content/topics/partial-rendering/scenarios.rst
@@ -1,17 +1,19 @@
 .. _topics-partial-rendering-scenarios:
 
-Partial Rendering by Scenario
+Partial rendering by scenario
 =============================
 
 This page is a tutorial, not a reference.
 Each scenario starts from a task, shows the markup and the handler that satisfy it, and ends with the wire traffic so the behaviour is observable.
 Every scenario degrades to a full page cycle without the runtime.
+The wire always carries the ``assets`` and ``form`` keys, serialised as ``[]`` and ``null`` when empty.
+The JSON examples on this page omit them when they are empty.
 
 .. contents::
    :local:
    :depth: 1
 
-Three Neighbouring Forms
+Three neighbouring forms
 ------------------------
 
 A board settings page carries three independent forms, one to rename the board, one to add a column, one to archive the board.
@@ -73,7 +75,7 @@ The response is a 200 carrying the existing invalid-form headers and a patch env
 
 Without the runtime the same submission returns the full page with errors, the current behaviour byte for byte.
 
-Inline Validation on Blur
+Inline validation on blur
 -------------------------
 
 A wizard step carries an email field.
@@ -132,7 +134,7 @@ A uniqueness validator never becomes an enumeration oracle for an unauthorised r
 
 Without the runtime nothing happens on blur and validation runs on submit, the current behaviour.
 
-An Auto-Submitting Filter
+An auto-submitting filter
 -------------------------
 
 A product catalogue is filtered by a panel form over search, brands, price, and sort.
@@ -200,7 +202,7 @@ Each ``data-next-key`` on a row keeps the morph stable as the list changes.
 
 Without the runtime nothing happens until the Apply button submits a plain GET that reloads the page.
 
-Pagination and Infinite Scroll
+Pagination and infinite scroll
 ------------------------------
 
 The same catalogue appends its next page of results to the list when the user scrolls to the end, with no reload and no duplicate rows.
@@ -272,7 +274,7 @@ Dropping the ``data-next-lazy="revealed"`` attribute leaves the same link click-
 
 Without the runtime the sentinel is a plain link and the click navigates to ``?page=2`` through the existing pagination component.
 
-A Live Stream
+A live stream
 -------------
 
 A poll page shows live results to every open tab.
@@ -281,7 +283,7 @@ The same patch envelope rides Server-Sent Events, the fan-out carries no foreign
 The stream page is a neighbour of the vote page and uses the page render escape hatch.
 
 .. code-block:: python
-   :caption: polls/[int:id]/stream/page.py
+   :caption: polls/screens/polls/[int:id]/stream/page.py
 
    from collections.abc import Iterator
 
@@ -353,7 +355,7 @@ See :doc:`sse` for the WSGI and ASGI contract behind the stream.
 
 Without the runtime the page is current at load time and a refresh is a manual reload.
 
-A Modal Wizard That Refreshes a List
+A modal wizard that refreshes a list
 ------------------------------------
 
 A home page carries a Start a new request button and a list of recent requests.
@@ -436,15 +438,18 @@ The default ``done`` closes the layer with a result and asks the opening link to
 .. code-block:: python
    :caption: request/[step]/page.py
 
-   def done(self, request: HttpRequest, cleaned_data: dict[str, Any]) -> HttpResponse:
-       """Create the access request and close the layer with a result."""
-       access_request = AccessRequest.objects.create(**cleaned_data)
-       return (
-           Patches(request)
-           .layer_close(result={"id": access_request.pk})
-           .toast("Request created", variant="success")
-           .response(fallback=f"/request/{access_request.pk}/audit/")
-       )
+   class AccessRequestWizard(FormWizard):
+       def done(
+           self, request: HttpRequest, cleaned_data: dict[str, Any]
+       ) -> HttpResponse:
+           """Create the access request and close the layer with a result."""
+           access_request = AccessRequest.objects.create(**cleaned_data)
+           return (
+               Patches(request)
+               .layer_close(result={"id": access_request.pk})
+               .toast("Request created", variant="success")
+               .response(fallback=f"/request/{access_request.pk}/audit/")
+           )
 
 The last step answers with a close and a toast.
 
@@ -472,7 +477,7 @@ The runtime closes the layer, fires accept, and by ``data-next-accepted="request
 The wizard never knows about the list, the list never knows about the wizard, and the opening link binds them.
 Without the runtime the button navigates to the full step page, steps advance with a 302 between step pages, and the last step redirects to the ``fallback`` audit page.
 
-Lazy Zones
+Lazy zones
 ----------
 
 A heavy audit table does not need to render on the first page paint.
@@ -500,6 +505,10 @@ Guard the expensive data with ``zone_requested`` so the query runs only when the
 .. code-block:: python
    :caption: admin/audit/page.py
 
+   from audit.models import AuditEntry
+   from django.http import HttpRequest
+
+   from next import context
    from next.partial import zone_requested
 
 
@@ -541,7 +550,7 @@ CSS loads before the morph, JS after, so the table cannot arrive without behavio
 
 Critical content must not be marked lazy, because the placeholder is all a no-JavaScript client ever sees.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/partial-rendering/sse.rst
+++ b/docs/content/topics/partial-rendering/sse.rst
@@ -1,6 +1,6 @@
 .. _topics-partial-rendering-sse:
 
-SSE Under WSGI and ASGI
+SSE under WSGI and ASGI
 =======================
 
 Server-Sent Events carry patch envelopes to every open tab.
@@ -11,7 +11,7 @@ This page covers the stream helper, the refresh fan-out, the echo suppression, a
    :local:
    :depth: 1
 
-The Stream Helper
+The stream helper
 -----------------
 
 ``PatchEventStream`` is a :class:`~django.http.StreamingHttpResponse` returned from a page's ``render`` escape hatch.
@@ -44,7 +44,7 @@ The page view authorises the subscriber, the same as any other page.
 Each ``Patches`` the source yields becomes one ``next-patches`` event, serialised by the active protocol backend, the same shape an HTTP response carries.
 A ``data-next-sse="/url/"`` element on the page opens the ``EventSource`` and routes each event into the same apply pipeline an HTTP response uses.
 
-The Refresh Fan-Out
+The refresh fan-out
 -------------------
 
 The recommended fan-out is the ``refresh`` verb.
@@ -67,7 +67,7 @@ A stream that needs to push fresh context drives a ``refresh``, and the re-fetch
 This is a documented limitation.
 The stream source addresses zones to refresh, not provider values to push directly.
 
-Echo Suppression
+Echo suppression
 ----------------
 
 The tab that triggered the change already has the fresh zone from its own response and must not apply the fan-out again.
@@ -123,7 +123,7 @@ The heartbeat period is ``SSE.HEARTBEAT_SECONDS`` in ``PARTIAL_BACKENDS``.
 To move a stream from sync to async, swap the broker's wake primitive for an async one and pass an async source to ``PatchEventStream``.
 The page module and the signal layer do not change.
 
-Stream Politeness
+Stream politeness
 -----------------
 
 ``PatchEventStream`` sets the politeness headers on construction so a proxy or ``GZipMiddleware`` does not eat the flush.
@@ -139,7 +139,7 @@ The set of tracked zones is bounded, so a long sleep cannot storm the server on 
 Events missed while paused are not lost, because ``refresh`` is idempotent.
 The re-fetch brings the current state regardless of how many fan-outs were missed.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/partial-rendering/zones.rst
+++ b/docs/content/topics/partial-rendering/zones.rst
@@ -1,17 +1,19 @@
 .. _topics-partial-rendering-zones:
 
-Zones Save Render and Traffic
+Zones save render and traffic
 =============================
 
 A zone is an optimisation, not required markup.
 Partial rendering works on pages with no zones at all.
 This page explains what a zone buys, what the default costs without one, and the rule for dynamic list rows.
+The wire always carries the ``assets`` and ``form`` keys, serialised as ``[]`` and ``null`` when empty.
+The JSON examples on this page omit them when they are empty.
 
 .. contents::
    :local:
    :depth: 1
 
-The Default Without a Zone
+The default without a zone
 --------------------------
 
 The default shape of an invalid form submission is an extract-morph.
@@ -38,7 +40,7 @@ The whole page renders even though one form is kept.
 The extract default costs no more than the no-runtime cycle, which re-renders the full page on every invalid submission.
 The runtime turns that same full render into a targeted DOM update for free.
 
-Adding a Zone
+Adding a zone
 -------------
 
 Wrapping the form in a ``{% zone %}`` and naming it on the tag trades the full render for a single-zone render.
@@ -70,18 +72,21 @@ The network payload shrinks from a page to a zone, and the server render shrinks
 Reach for a zone when a page is heavy, when a form sits among expensive siblings, or when the response size matters.
 Leave it off when the page is small and the extract default already does the job.
 
-Zone Assets on a Standalone Render
+Zone assets on a standalone render
 ----------------------------------
 
 A standalone zone render collects the co-located assets its body registers, component widgets included.
 The envelope carries them outward as an asset manifest, URL-form and inline alike.
-The client loads only what the page does not already have, inserting the link-verb assets before the operations apply and the script and module verbs after, and each asset executes once per page lifetime.
+The client loads only what the page does not already have, inserting the link-verb assets before the operations apply and the script and module verbs after.
+Each asset executes once per page lifetime.
 The verb comes from the renderer registered for the asset kind, so a kind registered with a custom renderer is skipped and reaches the browser only on a full render.
 An inline body keeps that verb only when the kind wraps it in the element the runtime builds, so a body of a kind that wraps it differently, or not at all, also stays with the full render.
-On a zone ``GET`` the envelope also ships the values of the page's ``serialize=True`` context providers, introduced in :doc:`/content/topics/context`, as a ``context`` patch, so ``Next.context`` stays in step with the re-rendered zone.
-See :doc:`co-located-js` for what once-per-page execution means for behaviour, :doc:`/content/topics/static-assets/asset-kinds` for the renderer that decides the verb, and :doc:`/content/topics/static-assets/index` for how the assets are discovered and bundled.
+On a zone ``GET`` the envelope also ships the values of the page's ``serialize=True`` context providers, introduced in :doc:`/content/topics/context`, as a ``context`` patch.
+``Next.context`` therefore stays in step with the re-rendered zone.
+See :doc:`co-located-js` for what once-per-page execution means for behaviour.
+See :doc:`/content/topics/static-assets/asset-kinds` for the renderer that decides the verb, and :doc:`/content/topics/static-assets/index` for how the assets are discovered and bundled.
 
-Poll a Zone on an Interval
+Poll a zone on an interval
 --------------------------
 
 A zone polls itself when the tag carries a ``poll=`` interval.
@@ -105,7 +110,7 @@ On its return to the foreground each zone refetches only when its own interval e
 A brief flicker between tabs therefore fetches nothing, and switching windows does not storm the server.
 A polling zone shows its body, so it cannot also be ``lazy=``, the two modes are exclusive and combining them is a compile error.
 
-The Wrapper Element
+The wrapper element
 -------------------
 
 A zone wraps its body in ``<div data-next-zone="name">`` by default.
@@ -132,7 +137,7 @@ Inside a ``<ul>``, a ``<select>``, or a ``<table>`` the parser would drop it, so
 
 The wrapper carries ``data-next-zone`` regardless of the tag, so the zone stays addressable.
 
-Key Your Dynamic List Rows
+Key your dynamic list rows
 --------------------------
 
 The morph engine matches old nodes to new ones to preserve identity, focus, and the caret.
@@ -177,7 +182,7 @@ It does not descend into a component template, so a form inside a ``{% component
 The remedy is the same either way.
 Thread a ``key=`` with a stable per-row value into the form, and the repeated morph lands on the submitted instance even when the form lives inside a looped component.
 
-Zone Rules the Checks Enforce
+Zone rules the checks enforce
 -----------------------------
 
 A few placements break a standalone zone render, and a system check catches each one before a request reaches it.
@@ -188,7 +193,7 @@ A ``lazy=`` zone needs a ``{% placeholder %}`` branch.
 A zone belongs to a page, not a component, so a ``{% zone %}`` in a component template is rejected.
 See :doc:`/content/ref/system-checks` for the full list and the check codes.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/project-layout.rst
+++ b/docs/content/topics/project-layout.rst
@@ -1,6 +1,6 @@
 .. _topics-project-layout:
 
-Project Layout
+Project layout
 ==============
 
 This page covers the directory layout that next.dj expects for a single Django project.
@@ -11,7 +11,7 @@ For projects with several applications or a shared UI kit, read :doc:`multi-proj
    :local:
    :depth: 2
 
-Recommended Tree
+Recommended tree
 ----------------
 
 The Notes project from the tutorial demonstrates the full layout.
@@ -70,7 +70,7 @@ Three things are special about this tree.
 - ``_components/`` lives at the application root. Every directory below it becomes a reusable component.
 - ``static/`` keeps project-wide assets that are not co-located with a page or a component.
 
-Configuration Touchpoints
+Configuration touchpoints
 -------------------------
 
 Three settings keys point at the directories above.
@@ -91,6 +91,7 @@ Three settings keys point at the directories above.
        "COMPONENT_BACKENDS": [
            {
                "BACKEND": "next.components.FileComponentsBackend",
+               "DIRS": [],
                "COMPONENTS_DIR": "_components",
            }
        ],
@@ -101,7 +102,7 @@ Three settings keys point at the directories above.
 The names are convention.
 You can choose anything that fits your domain.
 
-Settings Helpers
+Settings helpers
 ----------------
 
 When you need to override a single key inside ``PAGE_BACKENDS`` without rewriting the entire list, use ``extend_default_backend``.
@@ -140,7 +141,7 @@ A dict override illustrates the one-level-deep merge.
 The default backend ships ``OPTIONS`` carrying only the ``context_processors`` key.
 The override merges into that dict one level deep, so any key the override omits keeps its default value while the supplied ``context_processors`` list replaces the empty default.
 
-Per Project Page DIRS
+Per project page DIRS
 ---------------------
 
 A project that hosts a global layout or a project-wide page tree adds an entry to ``DIRS``.
@@ -177,7 +178,7 @@ The root ``conftest.py`` holds pytest collection settings, while ``tests/conftes
 A per application ``tests/`` directory works for projects with several applications.
 See :doc:`multi-project` for the layered layout.
 
-Static Files
+Static files
 ------------
 
 Project-wide assets that are not owned by a page or a component live under ``static/``.
@@ -189,35 +190,35 @@ Migrations
 next.dj does not touch migrations.
 Run ``uv run python manage.py makemigrations`` and ``uv run python manage.py migrate`` exactly as in a regular Django project.
 
-Custom Management Commands
+Custom management commands
 --------------------------
 
 Place commands inside ``notes/management/commands/``.
 The framework does not require any special wiring beyond what Django already documents.
 
-Common Variations
+Common variations
 -----------------
 
-Single Application Mode
+Single application mode
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 A small project lives entirely inside one application.
 The tree above is the typical shape.
 
-Project Layout With Chrome
+Project layout with chrome
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Add a ``chrome/`` directory at the project root and reference it through ``DIRS``.
 The chrome holds a project-wide layout and possibly a few project-level pages such as ``/login`` or ``/health``.
 
-Per Domain Trees
+Per domain trees
 ~~~~~~~~~~~~~~~~
 
 Define two backends in ``PAGE_BACKENDS``.
 Each backend walks a different directory.
 The first matching URL pattern wins, so the order matters.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/signals.rst
+++ b/docs/content/topics/signals.rst
@@ -11,7 +11,7 @@ This page lists every signal, its payload, and the typical patterns for receiver
    :local:
    :depth: 2
 
-Import Surface
+Import surface
 --------------
 
 Every signal lives in the subpackage that emits it.
@@ -33,10 +33,8 @@ Use the aggregator when a single module subscribes to events from several subsys
 Catalog
 -------
 
-Every signal the framework emits is listed below with the subsystem that
-emits it and the moment it fires. :doc:`/content/ref/signals` holds the
-canonical payload table, the ``sender`` value and the keyword arguments for
-each signal.
+Every signal the framework emits is listed below with the subsystem that emits it and the moment it fires.
+:doc:`/content/ref/signals` holds the canonical payload table, the ``sender`` value and the keyword arguments for each signal.
 
 .. list-table::
    :header-rows: 1
@@ -131,10 +129,9 @@ each signal.
      - After the settings layer drops its caches.
 
 The forms and static signals have dedicated topic pages with worked receiver examples, see :doc:`/content/topics/forms/signals` and :doc:`/content/topics/static-assets/signals`.
-The partial-rendering stream signals appear in context in
-:doc:`/content/topics/partial-rendering/sse`.
+The partial-rendering stream signals appear in context in :doc:`/content/topics/partial-rendering/sse`.
 
-Receiver Patterns
+Receiver patterns
 -----------------
 
 Connect once at startup.
@@ -168,7 +165,7 @@ Use ``django.dispatch.receiver`` to connect a callable to a signal.
    def log_dispatch(sender, **kwargs) -> None:
        logger.info("action dispatched: %s", kwargs["action_name"])
 
-Multiple Receivers
+Multiple receivers
 ~~~~~~~~~~~~~~~~~~
 
 Several receivers can connect to the same signal.
@@ -193,7 +190,7 @@ The same ``dispatch_uid`` passed to ``connect`` can be supplied to ``disconnect`
 
 The ``SignalRecorder`` from ``next.testing.signals`` disconnects its receivers on context-manager exit, or when ``stop()`` is called explicitly.
 
-Test Helpers
+Test helpers
 ------------
 
 The ``SignalRecorder`` from ``next.testing.signals`` captures events for assertions.
@@ -217,12 +214,12 @@ Each captured event is a ``SignalEvent`` with ``signal``, ``sender``, and ``kwar
 
 See :doc:`/content/topics/testing` for the full testing surface.
 
-Common Patterns
+Common patterns
 ---------------
 
 :doc:`/content/howto/observe-framework-signals` walks through the audit trail, cache invalidation, hot reload, and observability patterns with production-sized receiver code.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/static-assets/asset-kinds.rst
+++ b/docs/content/topics/static-assets/asset-kinds.rst
@@ -1,6 +1,6 @@
 .. _topics-static-asset-kinds:
 
-Asset Kinds
+Asset kinds
 ===========
 
 An asset kind binds a file extension to a placeholder slot and to a backend renderer method.
@@ -10,7 +10,7 @@ The framework ships three kinds and lets projects register more.
    :local:
    :depth: 2
 
-Built In Kinds
+Built in kinds
 --------------
 
 ``register_defaults`` registers three kinds at startup through ``next.static.default_kinds``.
@@ -39,7 +39,7 @@ Built In Kinds
 The static subsystem does not privilege CSS or JS in core code.
 The three built in kinds register through the same public API that a project uses for a new kind.
 
-The Registry
+The registry
 ------------
 
 The kind registry is ``next.static.default_kinds``, an instance of ``KindRegistry``.
@@ -64,7 +64,7 @@ A kind registration is keyed by the ``kind`` identifier and carries four pieces 
    The optional HTML wrapper element for an inline body, such as ``"style"`` or ``"script"``.
    It defaults to verbatim, which wraps nothing and emits the inline body as written.
 
-Registering a Kind
+Registering a kind
 ------------------
 
 Register kinds in ``AppConfig.ready`` so the kind exists before the first request.
@@ -91,7 +91,7 @@ The ``register`` call also accepts an optional ``inline_tag`` keyword, the HTML 
 A repeated call with identical parameters is idempotent.
 A repeated call with different parameters raises ``ValueError``.
 
-Renderer Methods
+Renderer methods
 ----------------
 
 The ``renderer`` value is a method name on the static backend.
@@ -125,7 +125,7 @@ A custom kind reuses one of these methods, or a custom backend can add a new met
 The backend is registered through ``STATIC_BACKENDS``, see :doc:`backends`.
 The renderer choice also decides whether the kind loads on a partial render, see the next section.
 
-Renderers and Partial Rendering
+Renderers and partial rendering
 -------------------------------
 
 A full page render inserts an asset through its backend renderer method, which returns the HTML tag.
@@ -160,11 +160,12 @@ A URL-form asset takes the verb of its renderer.
 An inline body keeps that verb only when the kind wraps it in the element the runtime builds, ``style`` for the ``link`` verb and ``script`` for the ``script`` verb.
 The ``module`` verb builds a typed ``<script type="module">`` that no ``inline_tag`` names, so an inline body under ``render_module_tag`` carries no verb, and neither does the inline body of a kind registered without an ``inline_tag``.
 Such a body reaches the browser on a full page render, which emits it verbatim, and is skipped on a partial render, so the two renders agree on the element that holds it.
-A kind whose ``inline_tag`` names a different element than its renderer's verb builds keeps its URL form on a patch and leaves its inline bodies to the full render, which the ``next.W076`` check reports.
+When a kind's ``inline_tag`` names an element different from the one its renderer's verb builds, its URL form still travels in a patch while its inline bodies stay on the full render.
+The ``next.W076`` check reports such a kind.
 
 The rule the two sides follow reads in three parts.
 The server derives the verb from the renderer registered for the kind and writes it into the entry.
-A URL-form entry that reaches the client with no ``load`` field falls back to the verb implied by the name of a built-in kind, ``link`` for ``css``, ``script`` for ``js``, and ``module`` for ``module``, so an envelope authored before the field existed still loads.
+A URL-form entry that reaches the client with no ``load`` field falls back to the verb implied by the name of a built-in kind, ``link`` for ``css``, ``script`` for ``js``, and ``module`` for ``module``.
 An entry carrying an inline body takes no such fallback, and without an explicit ``load`` field it is dropped rather than wrapped in an element the full render would not build.
 
 A kind registered with a custom renderer, such as the ``render_babel_tag`` example, carries no verb.
@@ -172,14 +173,14 @@ Its assets render on a full page render and are skipped on a partial render, bec
 The ``next.W074`` system check reports every such kind at ``manage.py check``.
 Register the kind with one of the three bundled renderers when its assets must also arrive through a patch envelope.
 
-Placeholder Slots
+Placeholder slots
 -----------------
 
 A slot is the location where the static manager injects rendered tags.
 The slot registry is ``next.static.default_placeholders``.
 The framework registers two slots, ``styles`` and ``scripts``, each with an HTML comment token.
 
-The Placeholder Registry
+The placeholder registry
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``default_placeholders`` is an instance of ``PlaceholderRegistry``, exported from ``next.static`` alongside the ``PlaceholderSlot`` record.
@@ -207,8 +208,9 @@ Register a new slot when a kind should inject somewhere other than the standard 
            )
 
 The layout must contain the slot token, or a template tag that emits it, for the manager to find a place to inject.
+A module-level list named after the slot, such as ``preload = [...]`` in ``page.py``, registers external URLs into it, see :ref:`topics-static-module-lists`.
 
-Module Kind
+Module kind
 -----------
 
 The ``module`` kind renders ``<script type="module" src="...">`` through ``render_module_tag``.
@@ -218,25 +220,25 @@ The ``module`` kind carries no ``inline_tag``, so it renders an inline body verb
 An inline body of such a kind carries no insertion verb, so it arrives on a full page render only, while the URL form of the same kind still loads through a patch envelope.
 The two renders agree on that split, because the client drops an inline entry that carries no verb instead of guessing one from the kind name.
 
-System Checks
+System checks
 -------------
 
 The static system checks ``next.W030``, ``next.W031``, and ``next.E036`` through ``next.E038`` validate the backend configuration.
 The ``next.W042`` check validates the ``JS_CONTEXT_SERIALIZER`` setting.
 The ``next.W074`` check walks the registered kinds and warns about each one whose renderer carries no client insertion verb.
 The ``next.W076`` check walks the same kinds and warns about each one whose ``inline_tag`` is not the element its renderer's verb builds, so its URL form travels in a patch envelope while its inline bodies do not.
-Both checks read the registry of the running process, so a kind no registration backs is outside their reach.
+Both checks read the registry of the running process, so a kind that was never registered is outside their reach.
 The ``next.W075`` check covers the init-payload keys the framework reserves rather than the kinds, see :doc:`js-context`.
 No check validates the shape of a registration, because a bad call to ``default_kinds.register`` raises ``ValueError`` during ``AppConfig.ready``.
 Because Django runs ``ready`` for every management command and during ASGI or WSGI worker boot, the exception aborts whatever process is starting up, not only ``manage.py check``.
 
-Common Patterns
+Common patterns
 ---------------
 
 Custom asset kinds drive worked projects, including the ``kanban`` example with a ``.jsx`` kind and the ``live-polls`` example with a Vue single file component kind.
 See :doc:`/content/misc/examples` for the runnable projects and their walkthroughs.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/static-assets/backends.rst
+++ b/docs/content/topics/static-assets/backends.rst
@@ -160,6 +160,7 @@ List the dotted path of the backend in ``STATIC_BACKENDS``.
 
 The manager builds the backend instance from the config dict through ``load_backends`` and emits the ``backend_loaded`` signal.
 An entry that names a class outside the ``StaticBackend`` family, or a path that cannot be imported, is logged and skipped, and the remaining entries still load.
+So is a backend that answers ``ImproperlyConfigured`` from its own ``__init__``, while any other exception a constructor raises is a bug in that backend and reaches the caller.
 When no entry survives, the manager seeds the built-in staticfiles backend so rendering always has one, and that seed announces itself through the same signal.
 
 Request Aware Output

--- a/docs/content/topics/static-assets/backends.rst
+++ b/docs/content/topics/static-assets/backends.rst
@@ -158,7 +158,9 @@ List the dotted path of the backend in ``STATIC_BACKENDS``.
        ]
    }
 
-The ``StaticsFactory`` builds the backend instance from the config dict and emits the ``backend_loaded`` signal.
+The manager builds the backend instance from the config dict through ``load_backends`` and emits the ``backend_loaded`` signal.
+An entry that names a class outside the ``StaticBackend`` family, or a path that cannot be imported, is logged and skipped, and the remaining entries still load.
+When no entry survives, the manager seeds the built-in staticfiles backend so rendering always has one, and that seed announces itself through the same signal.
 
 Request Aware Output
 --------------------
@@ -182,7 +184,7 @@ See the `multi-tenant example <https://github.com/next-dj/next-dj/tree/main/exam
 Signals
 -------
 
-The ``backend_loaded`` signal fires once per backend when the factory builds it.
+The ``backend_loaded`` signal fires once per configured backend when the manager builds it.
 The payload carries ``sender`` as the backend class, ``config`` as the config dict, and ``instance`` as the backend instance.
 
 System Checks

--- a/docs/content/topics/static-assets/backends.rst
+++ b/docs/content/topics/static-assets/backends.rst
@@ -1,6 +1,6 @@
 .. _topics-static-backends:
 
-Static Backends
+Static backends
 ===============
 
 A static backend resolves an asset file to a public URL and renders the link, script, and module tags.
@@ -11,7 +11,7 @@ A custom backend rewrites URLs, adds attributes, or points at a CDN.
    :local:
    :depth: 2
 
-Backend Contract
+Backend contract
 ----------------
 
 A backend subclasses ``next.static.StaticBackend``, an abstract base class.
@@ -20,7 +20,7 @@ The constructor receives the full backend entry from ``STATIC_BACKENDS``, a dict
 The only abstract method is ``register_file``.
 
 .. code-block:: python
-   :caption: register_file contract
+   :caption: next/static/backends.py
 
    def register_file(
        self,
@@ -42,7 +42,7 @@ A custom backend that wants a soft fail for an unresolvable asset should raise `
 Renderer methods are not abstract.
 A backend adds the renderer methods that its registered kinds reference, see :doc:`asset-kinds`.
 
-The Default Backend
+The default backend
 -------------------
 
 ``StaticFilesBackend`` resolves assets through Django staticfiles.
@@ -62,7 +62,7 @@ The backend ships three renderer methods.
 Each method takes the URL and an optional ``request`` keyword.
 The default backend ignores ``request``.
 
-Configuring the Default Backend
+Configuring the default backend
 --------------------------------
 
 ``StaticFilesBackend`` reads three option keys for the rendered tag markup.
@@ -96,7 +96,7 @@ Configuring the Default Backend
 Bake attributes such as ``crossorigin``, ``defer``, or ``integrity`` directly into the format string.
 This covers most customisation without a subclass.
 
-Dedup and JS Context Options
+Dedup and JS context options
 ----------------------------
 
 The first entry of ``STATIC_BACKENDS`` owns the pipeline-level options.
@@ -129,7 +129,7 @@ The same keys on a second or third backend are ignored, so place the configured 
        ]
    }
 
-Writing a Custom Backend
+Writing a custom backend
 ------------------------
 
 Subclass ``StaticFilesBackend`` to keep the staticfiles resolution and change only the rendered markup.
@@ -141,7 +141,7 @@ For a complete Subresource Integrity implementation that also computes the ``int
 
 Subclass the abstract ``StaticBackend`` directly only when the project resolves assets from a source other than Django staticfiles, such as a build manifest.
 
-Registering a Backend
+Registering a backend
 ---------------------
 
 List the dotted path of the backend in ``STATIC_BACKENDS``.
@@ -160,10 +160,11 @@ List the dotted path of the backend in ``STATIC_BACKENDS``.
 
 The manager builds the backend instance from the config dict through ``load_backends`` and emits the ``backend_loaded`` signal.
 An entry that names a class outside the ``StaticBackend`` family, or a path that cannot be imported, is logged and skipped, and the remaining entries still load.
-So is a backend that answers ``ImproperlyConfigured`` from its own ``__init__``, while any other exception a constructor raises is a bug in that backend and reaches the caller.
+A backend that raises ``ImproperlyConfigured`` from its own ``__init__`` is skipped the same way.
+Any other exception a constructor raises is a bug in that backend and reaches the caller.
 When no entry survives, the manager seeds the built-in staticfiles backend so rendering always has one, and that seed announces itself through the same signal.
 
-Request Aware Output
+Request aware output
 --------------------
 
 Every renderer method accepts a ``request`` keyword.
@@ -188,7 +189,7 @@ Signals
 The ``backend_loaded`` signal fires once per configured backend when the manager builds it.
 The payload carries ``sender`` as the backend class, ``config`` as the config dict, and ``instance`` as the backend instance.
 
-System Checks
+System checks
 -------------
 
 The static checks validate the backend configuration at startup.
@@ -198,10 +199,10 @@ The full list of static check codes lives in :doc:`/content/ref/system-checks`.
 The ``next.W031`` check validates the ``css_tag`` and ``js_tag`` templates.
 The ``module_tag`` template is not checked, so verify it contains ``{url}`` yourself.
 
-Common Patterns
+Common patterns
 ---------------
 
-Cache Busting
+Cache busting
 ~~~~~~~~~~~~~
 
 Use the default backend with ``ManifestStaticFilesStorage``.
@@ -212,12 +213,12 @@ Subresource Integrity
 
 Subclass ``StaticFilesBackend`` and override ``render_link_tag`` and ``render_script_tag`` to add an ``integrity`` attribute.
 
-Per-Tenant CDN
+Per-tenant CDN
 ~~~~~~~~~~~~~~
 
 Use a request aware backend that reads the tenant from the request and chooses a CDN host.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/static-assets/co-located-files.rst
+++ b/docs/content/topics/static-assets/co-located-files.rst
@@ -1,6 +1,6 @@
 .. _topics-static-co-located:
 
-Co-located Files
+Co-located files
 ================
 
 A co-located file is an asset that lives in the same directory as the page, layout, or component that owns it.
@@ -10,7 +10,7 @@ Discovery pairs each file with its owner through a stem convention so the collec
    :local:
    :depth: 2
 
-Stem Convention
+Stem convention
 ---------------
 
 A stem is the filename without the extension.
@@ -44,7 +44,7 @@ Discovery groups stems into three roles.
      template.css
      template.js
 
-Recognised Extensions
+Recognised extensions
 ---------------------
 
 Each stem accepts the extension of every registered asset kind.
@@ -71,7 +71,7 @@ A file named ``component.mjs`` is therefore picked up as a ``module`` asset.
 Custom kinds extend the set through :doc:`asset-kinds`.
 Custom stems extend the recognised filenames through :doc:`custom-stems`.
 
-How Discovery Pairs a File
+How discovery pairs a file
 --------------------------
 
 The full disk-to-HTML trace lives in :doc:`overview`.
@@ -81,7 +81,7 @@ A file is recognised only when its stem matches a registered stem for the owner'
 A file that does not match a registered stem and kind pair is ignored.
 Discovery does not warn on unknown files because the folder may hold documentation or fixtures.
 
-Asset Ownership
+Asset ownership
 ---------------
 
 Every asset belongs to one owner.
@@ -103,7 +103,7 @@ The owner determines when the collector adds the asset to the request.
 A component referenced twice on the same page contributes the asset once.
 The collector deduplicates entries through its dedup strategy, see :doc:`deduplication`.
 
-Loading Order
+Loading order
 -------------
 
 The collector preserves insertion order.
@@ -111,14 +111,16 @@ Layout assets enter first as the layout chain unfolds from the root.
 Page assets follow.
 Component assets enter in the order the components appear in the template.
 
-Common Patterns
+Common patterns
 ---------------
 
 A ``layout.css`` at the root applies to every page under that layout because layout assets enter the collector first.
 A ``layout.css`` at an inner layout scopes the styles to pages below that layout only.
 Use ``component.js`` for plain behaviour and ``component.mjs`` when the script depends on ECMAScript module imports.
 
-External URLs via Module Lists
+.. _topics-static-module-lists:
+
+External URLs via module lists
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Declare ``styles`` and ``scripts`` at module level in ``page.py`` or ``component.py`` to register external URLs alongside co-located files.
@@ -131,11 +133,13 @@ Declare ``styles`` and ``scripts`` at module level in ``page.py`` or ``component
 
 Each variable is a list of strings.
 The slot is picked from the registered placeholder name, ``styles`` or ``scripts``.
+Every registered placeholder slot works the same way, because discovery reads a module-level variable named after each slot.
+A project that registers a ``preload`` slot may declare a module-level ``preload`` list next to it.
 The kind is inferred from the URL extension through the kind registry.
 URLs with an unknown extension are dropped with a debug log.
 A URL whose kind belongs to a different slot than the list name is also dropped with a debug log, so a stylesheet URL in ``scripts`` never renders.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/static-assets/custom-stems.rst
+++ b/docs/content/topics/static-assets/custom-stems.rst
@@ -1,6 +1,6 @@
 .. _topics-static-custom-stems:
 
-Custom Stems
+Custom stems
 ============
 
 A stem is the filename without the extension.
@@ -11,7 +11,7 @@ This page covers how to register new stems so discovery picks up additional file
    :local:
    :depth: 2
 
-The Stem Registry
+The stem registry
 -----------------
 
 The stem registry is ``next.static.discovery.default_stems``, an instance of ``StemRegistry``.
@@ -37,7 +37,7 @@ It maps a role to a list of stems.
 A role can hold several stems.
 Discovery combines every stem of a role with every registered kind extension.
 
-When to Add a Stem
+When to add a stem
 ------------------
 
 Add a stem when a project ships an asset under a filename that the default stems do not cover.
@@ -45,7 +45,7 @@ Add a stem when a project ships an asset under a filename that the default stems
 - A ``page`` stem so that ``page.css`` is picked up alongside ``template.css``.
 - A ``vendor`` stem for third party assets inside a component folder.
 
-Registering a Stem
+Registering a stem
 ------------------
 
 Register stems in ``AppConfig.ready``.
@@ -74,13 +74,13 @@ A repeated registration of the same stem is a no op.
    Discovery probes only the three built-in roles, ``template``, ``layout``, and ``component``.
    Registering a stem under a new role name has no effect on asset collection.
 
-Stem and Kind Interaction
+Stem and kind interaction
 -------------------------
 
 A new stem participates in every registered kind, so a registration combines with every kind extension automatically.
 See :doc:`/content/howto/add-a-custom-stem` for a worked example, and :doc:`asset-kinds` for pairing a stem with a custom kind.
 
-Owner Resolution
+Owner resolution
 ----------------
 
 A stem does not change ownership.
@@ -89,20 +89,20 @@ A ``page.css`` next to ``template.djx`` is still owned by the page.
 
 The owner determines when the collector adds the asset.
 
-Common Patterns
+Common patterns
 ---------------
 
-Alternative Page Filename
+Alternative page filename
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Register a ``page`` stem under the ``template`` role so the page asset can be named ``page.css`` to match the ``page.py`` module.
 
-Vendor Assets per Component
+Vendor assets per component
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Register a ``vendor`` stem under the ``component`` role for third party files that ship next to the component that depends on them.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/static-assets/deduplication.rst
+++ b/docs/content/topics/static-assets/deduplication.rst
@@ -3,7 +3,8 @@
 Deduplication
 =============
 
-The collector emits each asset once per request even when several components reference the same file.
+The pipeline emits each asset once per request even when several components reference the same file.
+The collector's dedup strategy decides which registrations survive to injection.
 This page covers the bundled dedup strategies, how the collector applies them, and how to plug a custom strategy.
 
 .. contents::
@@ -34,7 +35,7 @@ The framework ships three strategies in ``next.static.collector``.
    Disables deduplication.
    Every registration yields a unique key, so every asset is emitted.
 
-Choosing a Strategy
+Choosing a strategy
 -------------------
 
 The collector takes the strategy through its constructor.
@@ -58,7 +59,7 @@ The ``DEDUP_STRATEGY`` value is the dotted path to a dedup strategy class.
 The manager instantiates it once per request when it builds the collector.
 When the key is absent the collector uses ``UrlDedup``.
 
-Inline Assets
+Inline assets
 -------------
 
 Inline ``{% #use_style %}`` and ``{% #use_script %}`` blocks participate in deduplication.
@@ -66,7 +67,7 @@ The strategy keys them by the rendered body, so two identical inline blocks coll
 Inline blocks always append.
 They never prepend.
 
-Writing a Custom Strategy
+Writing a custom strategy
 -------------------------
 
 A strategy implements the ``DedupStrategy`` protocol.
@@ -109,26 +110,26 @@ Point the backend ``OPTIONS`` at the new strategy.
 
 The strategy lives for one request, so it can hold per request state.
 
-Common Patterns
+Common patterns
 ---------------
 
-Shared Vendor File
+Shared vendor file
 ~~~~~~~~~~~~~~~~~~
 
 The default ``UrlDedup`` already collapses two references to the same vendor URL.
 No configuration is needed for the common case.
 
-Content Aware Dedup
+Content aware dedup
 ~~~~~~~~~~~~~~~~~~~
 
 Switch to ``HashContentDedup`` when the same content ships from two different paths and should emit once.
 
-Disable Dedup
+Disable dedup
 ~~~~~~~~~~~~~
 
 Switch to ``IdentityDedup`` for debugging, to confirm exactly which owners registered which assets.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/static-assets/index.rst
+++ b/docs/content/topics/static-assets/index.rst
@@ -1,9 +1,9 @@
 .. _topics-static-assets:
 
-Static Assets
+Static assets
 =============
 
-The static pipeline discovers co-located CSS, JS, and module files, deduplicates them across requests, and injects them into HTML.
+The static pipeline discovers co-located CSS, JS, and module files, deduplicates them within a request, and injects them into HTML.
 
 .. rubric:: Concepts
 

--- a/docs/content/topics/static-assets/js-context.rst
+++ b/docs/content/topics/static-assets/js-context.rst
@@ -1,6 +1,6 @@
 .. _topics-static-js-context:
 
-JavaScript Context
+JavaScript context
 ==================
 
 next.dj ships a ``Next`` object to the browser that holds context values marked for serialisation.
@@ -10,13 +10,13 @@ This page covers how to opt a context value in, how to choose a serializer, and 
    :local:
    :depth: 2
 
-The Next Object
+The next object
 ---------------
 
 The static manager injects a runtime script that defines ``window.Next`` before the collected scripts run.
 Context values opted into serialisation land under ``window.Next.context``.
 
-Opting In
+Opting in
 ---------
 
 Pass ``serialize=True`` on the ``@context`` decorator, or on ``@component.context`` in a component.
@@ -26,7 +26,7 @@ Keys without the flag stay server-side only.
 
 A value the active serializer cannot encode raises ``TypeError`` during rendering, when the collector registers it.
 The error names the offending key.
-See :ref:`Serialization for the Browser <topics-context-serialization>` for the accepted shapes and the common materialisation patterns.
+See :ref:`Serialization for the browser <topics-context-serialization>` for the accepted shapes and the common materialisation patterns.
 
 .. note::
 
@@ -51,7 +51,7 @@ The framework ships two implementations.
    Requires the ``pydantic`` package.
    The class raises ``ImportError`` at construction when ``pydantic`` is not installed.
 
-Project-Wide Serializer
+Project-wide serializer
 -----------------------
 
 Set ``NEXT_FRAMEWORK["JS_CONTEXT_SERIALIZER"]`` to the dotted path of a serializer class.
@@ -66,7 +66,7 @@ Set ``NEXT_FRAMEWORK["JS_CONTEXT_SERIALIZER"]`` to the dotted path of a serializ
 ``resolve_serializer`` reads the setting on every call.
 When the key is absent or set to an empty string the framework uses ``JsonJsContextSerializer``.
 
-System Check
+System check
 ~~~~~~~~~~~~
 
 The ``next.W042`` system check validates ``JS_CONTEXT_SERIALIZER`` at startup.
@@ -80,14 +80,14 @@ It warns under any of five conditions.
 
 The check is skipped when the key is absent or set to an empty string.
 
-Per-Key Serializer
+Per-key serializer
 ------------------
 
 Pass ``serializer=`` on a single ``@context`` decorator to route one key through a custom serializer.
 The override applies only to that key.
 
 .. code-block:: python
-   :caption: per key serializer
+   :caption: notes/pages/page.py
 
    from next import context
    from next.static import PydanticJsContextSerializer
@@ -107,7 +107,7 @@ The ``serializer=`` parameter takes an already-instantiated object.
    Creating an instance at module level raises ``ImportError`` on startup when pydantic is not installed.
    Use the ``JS_CONTEXT_SERIALIZER`` setting for a process-wide override that keeps the import lazy.
 
-Writing a Serializer
+Writing a serializer
 --------------------
 
 A serializer is any class with a ``dumps`` method.
@@ -132,7 +132,7 @@ A serializer is any class with a ``dumps`` method.
 Point ``JS_CONTEXT_SERIALIZER`` at the dotted path of the class.
 The framework instantiates it through ``resolve_serializer``.
 
-Key Conflict Policy
+Key conflict policy
 -------------------
 
 Two context functions can mark the same key for serialisation.
@@ -170,7 +170,7 @@ Configure the policy through the first static backend ``OPTIONS``.
    }
 
 The configured policy fires anywhere the same key reaches the collector twice, including page-to-component, component-to-component, page-to-layout, and any contributor that calls ``StaticCollector.add_js_context`` directly.
-Two ``@context`` decorators on the same page that register the same key always resolve first-wins, regardless of ``JS_CONTEXT_POLICY``.
+Two ``@context`` decorators on the same page that register the same key resolve last-wins, because the second registration replaces the first in the page registry before ``JS_CONTEXT_POLICY`` ever sees the key.
 Pick distinct keys when both registrations live in the same module.
 The framework owns the ``$``-prefixed keys of the init payload, ``$csrf`` and ``$dev``, and claims them once the policy has already run.
 A project key of either name is dropped from the collected context on every automatically injected payload, whichever way the project registered it, together with the pre-encoded fragment and the per-key serializer that key recorded.
@@ -183,7 +183,7 @@ A keyless ``serialize=True`` provider spreads the keys of the dict it returns at
 A partial render honours the same ownership.
 ``Patches.context()`` refuses ``$csrf`` and ``$dev`` with ``ReservedContextKeyError``, and the js-context delta of a zone render drops them before it becomes a ``context`` patch, so no patch updates either key.
 
-Writing a Policy
+Writing a policy
 ----------------
 
 A custom policy implements the ``JsContextPolicy`` protocol from ``next.static.collector``.
@@ -209,7 +209,7 @@ The protocol has one method, ``merge(existing, key, value)``, which returns the 
 
 Point ``JS_CONTEXT_POLICY`` in the first static backend ``OPTIONS`` at the dotted path of the class.
 
-Reading on the Client
+Reading on the client
 ---------------------
 
 Register the key server-side with ``serialize=True``.
@@ -237,7 +237,7 @@ Co-located JS and inline scripts then read the value under ``window.Next.context
 The runtime script defines ``window.Next`` before the collected scripts run.
 The runtime script is always the first tag in the ``scripts`` slot, ahead of every co-located, module-list, and ``{% use_script %}`` asset, so any of those may safely read ``window.Next``.
 
-Client Event API
+Client event API
 ~~~~~~~~~~~~~~~~~
 
 The ``Next`` object exposes an event API alongside ``window.Next.context``.
@@ -281,7 +281,7 @@ A plugin is any function that takes the ``Next`` object, so it can subscribe to 
      value: () => next.context.note_count ?? 0,
    }));
 
-Runtime Script Options
+Runtime script options
 ----------------------
 
 The setting ``NEXT_FRAMEWORK["NEXT_JS_OPTIONS"]`` is a dict that configures the runtime script builder.
@@ -331,7 +331,7 @@ Accepted string values for ``policy`` are ``"auto"``, ``"disabled"``, and ``"man
    Any co-located JavaScript or inline script that reads ``window.Next.context`` will fail at runtime.
    Review every ``component.js`` and inline script before switching away from ``AUTO``.
 
-Runtime Script Templates
+Runtime script templates
 ------------------------
 
 The ``NEXT_JS_OPTIONS`` dict also accepts ``preload_template``, ``script_tag_template``, and ``init_template`` keys.
@@ -354,7 +354,7 @@ The templates are formatted with Python ``str.format``, not Django templates.
 A literal ``{`` or ``}`` inside the template body collides with the formatter and must be doubled to ``{{`` or ``}}`` to survive ``str.format``.
 For per-request values such as CSP nonces, use a custom static backend instead.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/static-assets/overview.rst
+++ b/docs/content/topics/static-assets/overview.rst
@@ -1,6 +1,6 @@
 .. _topics-static-overview:
 
-Static Assets Overview
+Static assets overview
 ======================
 
 The static pipeline finds CSS, JS, and module files that live next to pages and components.
@@ -11,7 +11,7 @@ This page covers the four moving pieces of the pipeline and traces a single asse
    :local:
    :depth: 2
 
-The Pipeline
+The pipeline
 ------------
 
 Four parts make up the pipeline.
@@ -52,7 +52,7 @@ StaticAsset
 A URL asset carries a non-empty ``url`` and a ``None`` ``inline``.
 An inline asset carries an empty ``url`` and a non-empty ``inline`` body.
 
-Asset Kinds
+Asset kinds
 -----------
 
 A kind binds a file extension to a placeholder slot and a backend renderer method.
@@ -83,20 +83,20 @@ The kind registry is ``next.static.default_kinds``.
 Projects register additional kinds through ``default_kinds.register``.
 See :doc:`asset-kinds` for the registration recipe.
 
-A Single Asset From Disk to HTML
+A single asset from disk to HTML
 --------------------------------
 
 A file named ``component.css`` next to ``component.djx`` reaches the browser in one pass.
 Discovery records it as a ``css`` ``StaticAsset`` because ``component`` is a registered stem and ``.css`` is the ``css`` kind extension.
 A render that uses the component adds the asset to the collector, which deduplicates it.
 After the page renders, the static manager replaces the ``styles`` slot token emitted by ``{% collect_styles %}`` with the link tags produced by ``render_link_tag`` on the active backend.
-``render_link_tag`` resolves the on-disk path to a public URL through Django staticfiles, so manifest hashing and CDN settings apply to the emitted tag.
+``register_file`` resolves the on-disk path to a public URL through Django staticfiles during discovery, so manifest hashing and CDN settings apply to the URL that ``render_link_tag`` formats into the tag.
 
 The same flow applies to ``component.js`` (kind ``js``, classic script) and ``component.mjs`` (kind ``module``, ECMAScript module), which both land in the ``scripts`` slot emitted by ``{% collect_scripts %}``.
 The extension picks the kind, so a file named ``component.js`` never renders through ``render_module_tag``.
 :doc:`/content/internals/static-pipeline` traces the pipeline step by step.
 
-Stems and Owners
+Stems and owners
 ----------------
 
 Discovery recognises files by stem.
@@ -123,19 +123,19 @@ The stem registry is ``default_stems``, which lives at ``next.static.discovery``
 Projects register extra stems through ``default_stems.register``.
 See :doc:`custom-stems`.
 
-Where Assets Live
+Where assets live
 -----------------
 
 :doc:`co-located-files` shows the directory layout where co-located assets sit next to pages, layouts, and components.
 
-Hot Reload
+Hot reload
 ----------
 
-The collector re-probes co-located files on every request, so a saved or added ``component.css`` or ``component.js`` is picked up on the next page load without a process restart.
+Discovery re-probes co-located files on every request, so a saved or added ``component.css`` or ``component.js`` is picked up on the next page load without a process restart.
 Module-level ``styles`` and ``scripts`` lists are read when the module imports, so an edit to one takes effect after a ``page.py`` change restarts the dev server.
-See the Hot Reload section of :doc:`/content/topics/components` for the full reload contract across ``page.py``, ``component.py``, and ``.djx`` changes.
+See the Hot reload section of :doc:`/content/topics/components` for the full reload contract across ``page.py``, ``component.py``, and ``.djx`` changes.
 
-Production Build
+Production build
 ----------------
 
 In production, ``collectstatic`` copies every registered asset into ``STATIC_ROOT`` under the ``next/`` namespace.
@@ -143,12 +143,12 @@ The framework hooks into the staticfiles finders through ``NextStaticFilesFinder
 
 See :doc:`/content/deployment/static-files` for production guidance.
 
-Public API Touchpoints
+Public API touchpoints
 ----------------------
 
 :doc:`/content/ref/static` is the full reference for the pipeline's public names.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/static-assets/signals.rst
+++ b/docs/content/topics/static-assets/signals.rst
@@ -86,7 +86,7 @@ The sender is the static manager.
 backend_loaded
 ~~~~~~~~~~~~~~
 
-Fires after the static factory instantiates a backend.
+Fires after the static manager instantiates a configured backend.
 The sender is the backend class.
 The payload carries ``config`` and ``instance``.
 

--- a/docs/content/topics/static-assets/signals.rst
+++ b/docs/content/topics/static-assets/signals.rst
@@ -1,6 +1,6 @@
 .. _topics-static-signals:
 
-Static Signals
+Static signals
 ==============
 
 The static pipeline emits ``asset_registered``, ``collector_finalized``, ``html_injected``, and ``backend_loaded`` from ``next.static.signals``.
@@ -8,7 +8,11 @@ The static pipeline emits ``asset_registered``, ``collector_finalized``, ``html_
 Import either from ``next.static.signals`` or from the aggregator ``next.signals``.
 Import receiver modules from ``AppConfig.ready`` so receivers exist before the first request.
 
-Signals and Payloads
+.. contents::
+   :local:
+   :depth: 2
+
+Signals and payloads
 --------------------
 
 asset_registered
@@ -101,7 +105,7 @@ Pipeline placement
 
 See :doc:`/content/internals/static-pipeline` for where each signal fires relative to discovery and HTML injection.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/static-assets/template-tags.rst
+++ b/docs/content/topics/static-assets/template-tags.rst
@@ -1,6 +1,6 @@
 .. _topics-static-template-tags:
 
-Static Template Tags
+Static template tags
 ====================
 
 The static pipeline registers four Django template tags plus two inline block forms.
@@ -18,7 +18,7 @@ collect_styles
 ``{% collect_styles %}`` marks the slot where the static manager injects every collected CSS link tag.
 
 .. code-block:: jinja
-   :caption: layout
+   :caption: notes/pages/layout.djx
 
    <!doctype html>
    <html>
@@ -32,7 +32,7 @@ collect_styles
    </html>
 
 The tag takes no arguments.
-It emits a placeholder token at parse time.
+It emits a placeholder token when the template renders.
 After the page renders, the static manager replaces the token with the rendered link tags for every asset in the ``styles`` slot.
 
 Place the tag inside ``<head>`` so the browser fetches stylesheets before rendering the body.
@@ -43,7 +43,7 @@ collect_scripts
 ``{% collect_scripts %}`` marks the slot for collected JS and module tags.
 
 .. code-block:: jinja
-   :caption: layout
+   :caption: notes/pages/layout.djx
 
    <body>
      {% block template %}{% endblock template %}
@@ -60,7 +60,7 @@ use_style
 ``{% use_style %}`` registers an external CSS URL on the active collector.
 
 .. code-block:: jinja
-   :caption: external stylesheet
+   :caption: notes/pages/template.djx
 
    {% use_style "https://cdn.example.com/reset.css" %}
 
@@ -73,7 +73,7 @@ use_script
 ``{% use_script %}`` registers an external JS URL on the active collector.
 
 .. code-block:: jinja
-   :caption: external script
+   :caption: notes/pages/template.djx
 
    {% use_script "https://cdn.example.com/vendor.js" %}
 
@@ -81,21 +81,21 @@ The asset is prepended to the collector the same way as ``use_style``.
 The tag always registers the URL under kind ``js``, so it cannot publish an ECMAScript module.
 For a ``.mjs`` dependency, list the URL in the page or component ``scripts`` module-level variable instead, see :doc:`co-located-files`.
 
-Inline Blocks
+Inline blocks
 -------------
 
 ``{% use_style %}`` and ``{% use_script %}`` also have a block form for inline content.
 Prepend a hash sign to open the block and pair it with the matching close tag.
 
 .. code-block:: jinja
-   :caption: inline css
+   :caption: notes/pages/template.djx
 
    {% #use_style %}
      .note-list { padding: 0; }
    {% /use_style %}
 
 .. code-block:: jinja
-   :caption: inline script
+   :caption: notes/pages/template.djx
 
    {% #use_script %}
      console.log("hello");
@@ -108,7 +108,7 @@ The block body is rendered with the current template context, so inline blocks c
 Blank only blocks are dropped.
 The collector deduplicates inline entries by the rendered body, so two identical blocks collapse to one.
 
-Placement Rules
+Placement rules
 ---------------
 
 Place each ``{% collect_styles %}`` and ``{% collect_scripts %}`` tag exactly once in the layout chain.
@@ -118,39 +118,39 @@ The recommended placement is the outermost layout.
 - ``{% collect_styles %}`` inside ``<head>``.
 - ``{% collect_scripts %}`` at the bottom of ``<body>``.
 
-Customising the Tag Output
+Customising the tag output
 --------------------------
 
 The ``collect`` tags accept no HTML attributes, and the rendered ``<link>``, ``<script>``, and ``<script type="module">`` markup comes from the active backend.
 See :doc:`backends` for the ``css_tag``, ``js_tag``, and ``module_tag`` ``OPTIONS`` keys.
 
-Tag Loading
+Tag loading
 -----------
 
 The framework loads the static template tags as Django builtins through ``next.apps.templates.install``.
 Templates do not need a ``{% load %}`` statement.
 The same applies to ``{% form %}`` and ``{% component %}``.
 
-Common Patterns
+Common patterns
 ---------------
 
-Vendor CSS Before Component Styles
+Vendor CSS before component styles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use ``{% use_style %}`` for a vendor stylesheet.
 The prepend behaviour guarantees the vendor file loads before any co-located ``component.css``.
 
-Critical Inline CSS
+Critical inline CSS
 ~~~~~~~~~~~~~~~~~~~
 
 Use the inline block form of ``{% #use_style %}`` for a small critical stylesheet that should ship in the document.
 
-Per-Page Script
+Per-page script
 ~~~~~~~~~~~~~~~
 
 Use the inline block form of ``{% #use_script %}`` for a one off script that interpolates page context.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/testing.rst
+++ b/docs/content/topics/testing.rst
@@ -10,7 +10,7 @@ This page covers the public surface of the module and the patterns for testing p
    :local:
    :depth: 2
 
-Choose the Right Helper
+Choose the right helper
 -----------------------
 
 ``next.testing`` groups its helpers into focused submodules.
@@ -83,7 +83,7 @@ You can import everything above from the ``next.testing`` package.
 Submodule imports stay valid when you prefer explicit paths.
 See :doc:`/content/ref/testing` for generated signatures.
 
-Boot the Suite
+Boot the suite
 --------------
 
 The ``next.testing`` helpers assume the app registry is populated before any helper is imported.
@@ -102,7 +102,7 @@ Pytest.
 Stdlib ``unittest``.
    Call ``django.setup()`` once before importing any ``next.testing`` helper, then run the suite with the standard runner.
 
-Registry State Between Tests
+Registry state between tests
 ----------------------------
 
 Action and component registrations are side effects of importing ``page.py`` and ``component.py`` modules.
@@ -143,7 +143,7 @@ Every project under ``examples/`` uses this scaffold.
    With the default ``LAZY_COMPONENT_MODULES = False``, all registrations are in place after ``AppConfig.ready``, so the extra call is unnecessary.
    See :ref:`ref-settings` for the full description of ``LAZY_COMPONENT_MODULES``.
 
-Resetting Registries
+Resetting registries
 ~~~~~~~~~~~~~~~~~~~~
 
 ``reset_registries()`` is an opt-in helper for tests that mutate ``NEXT_FRAMEWORK`` or the registries themselves.
@@ -180,7 +180,7 @@ Tests that write ``template.djx`` or ``page.py`` files to ``tmp_path`` register 
        reset_registries()
        reset_page_cache()
 
-Eager Page Loading
+Eager page loading
 ~~~~~~~~~~~~~~~~~~
 
 ``eager_load_pages(base_dir)`` imports every ``page.py`` under a given directory.
@@ -208,7 +208,7 @@ The client mirrors Django's ``Client`` API.
 ``get``, ``post``, ``put``, ``delete``, and ``patch`` all work.
 Pass ``follow=True`` to a request to follow redirects, exactly as with Django's ``Client``.
 
-Posting to Actions
+Posting to actions
 ~~~~~~~~~~~~~~~~~~
 
 ``NextClient.post_action`` resolves an action name to its URL and posts the data in one call.
@@ -237,7 +237,7 @@ A value already present in ``data`` under ``_next_form_origin`` wins over the ke
 Both methods resolve the name through ``resolve_action_url`` from ``next.testing.actions``.
 An unknown name raises ``FormActionNotFoundError`` from ``next.forms``.
 
-Partial Requests
+Partial requests
 ~~~~~~~~~~~~~~~~
 
 The client drives partial rendering without hand-built headers.
@@ -278,7 +278,7 @@ It raises when the response is not a patch envelope, so a navigation fallback ne
 ``PartialEnvelope`` exposes ``version``, ``ops``, and ``assets``, plus ``op_verbs``, ``targets``, ``zone_targets``, ``form_targets``, ``form_meta``, ``toasts``, and ``html_for_zone`` for asserting on the server contract without parsing HTML.
 See :doc:`/content/topics/partial-rendering/index` for the zone and patch model these helpers exercise.
 
-Render a Page
+Render a page
 -------------
 
 Use ``next.testing.rendering`` to render a page without an HTTP round trip.
@@ -312,7 +312,7 @@ Extra keyword arguments are forwarded to the underlying ``page.render`` call as 
        html = render_page("notes/pages/page.py", request)
        assert "Notes" in html
 
-Capture Signals
+Capture signals
 ---------------
 
 ``SignalRecorder`` subscribes to one or more signals on enter and unsubscribes on exit.
@@ -379,7 +379,7 @@ Two convenience wrappers cover the common multi-signal cases.
 
 ``capture_framework_signals()`` attaches to every name in ``next.signals.__all__``, which helps integration tests assert ordering without listing signals by hand.
 
-Action Helpers
+Action helpers
 --------------
 
 ``next.testing.actions`` exposes ``resolve_action_url`` and ``build_form_for``.
@@ -398,7 +398,7 @@ Both raise ``FormActionNotFoundError`` from ``next.forms`` for an unknown action
        form = build_form_for("create_note", {"title": "Direct", "body": ""})
        assert form.is_valid()
 
-HTML Utilities
+HTML utilities
 --------------
 
 ``next.testing.html`` provides assertions for inspecting rendered HTML fragments.
@@ -523,7 +523,7 @@ Implement the ``ParameterProvider`` protocol on a plain class for the stub, beca
            kwargs = resolve_call(count_notes)
        assert kwargs == {"limit": 7}
 
-Resolution Context Doubles
+Resolution context doubles
 --------------------------
 
 ``next.testing.deps.make_resolution_context`` builds a ``ResolutionContext`` for unit tests on providers.
@@ -542,7 +542,7 @@ Both accept the same loose keyword arguments, ``request``, ``form``, ``url_kwarg
 Pass ``resolve_call`` a callable whose annotated parameters a provider can fill, then assert on the returned mapping.
 Use these helpers for testing custom providers without booting the router.
 
-System Checks
+System checks
 -------------
 
 Pytest can run ``manage.py check`` as part of the suite.
@@ -555,7 +555,7 @@ Pytest can run ``manage.py check`` as part of the suite.
    def test_no_check_warnings() -> None:
        call_command("check", verbosity=0)
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/content/topics/url-reversing.rst
+++ b/docs/content/topics/url-reversing.rst
@@ -1,6 +1,6 @@
 .. _topics-url-reversing:
 
-URL Reversing
+URL reversing
 =============
 
 next.dj generates a URL name for every file-routed page.
@@ -53,7 +53,7 @@ The default ``page_{name}`` yields ``next:page_posts_slug``.
 Changing ``URL_NAME_TEMPLATE`` changes the name ``page_reverse`` resolves against without any call-site edits.
 See :doc:`file-router` for the setting and the segment-naming rules.
 
-Namespace Override
+Namespace override
 ~~~~~~~~~~~~~~~~~~
 
 The default namespace is ``next``, configured through ``next.urls.manager.app_name``.
@@ -82,13 +82,13 @@ The ``/admin/`` prefix comes from the ``path("admin/", ...)`` mount, not from th
 
 Passing a ``namespace`` that no Django mount registers raises ``NoReverseMatch``.
 
-When to Use page_reverse Instead of reverse
+When to use page_reverse instead of reverse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``django.urls.reverse("next:page_posts_slug", kwargs={"slug": "hello"})`` and ``page_reverse("posts/[slug]", slug="hello")`` are equivalent.
 Use ``page_reverse`` when the call site references the directory tree, ``reverse`` when the call site already has the URL name in a variable.
 
-The Lazy Variant
+The lazy variant
 ~~~~~~~~~~~~~~~~
 
 ``page_reverse_lazy`` takes the same arguments and defers the resolution until the value is first coerced to ``str``.
@@ -137,7 +137,7 @@ The helper takes a URL string and adds, replaces, or removes query parameters.
 ``with_query`` preserves blank-valued keys such as ``flag=`` because it parses the existing query with blank values kept.
 Pass the key explicitly to change or drop it.
 
-Multi Value Keys
+Multi value keys
 ~~~~~~~~~~~~~~~~
 
 Passing a list or tuple repeats the key in the output.
@@ -175,10 +175,10 @@ Compose both helpers when the base URL needs both reversal and query parameters.
 The ``None`` value drops the key entirely.
 This is convenient for building pagination links where the current filter may or may not be set.
 
-Common Patterns
+Common patterns
 ---------------
 
-Redirect After Action
+Redirect after action
 ~~~~~~~~~~~~~~~~~~~~~
 
 An action handler can return an ``HttpResponseRedirect`` to a reversed page URL.
@@ -200,7 +200,7 @@ An action handler can return an ``HttpResponseRedirect`` to a reversed page URL.
            self.save()
            return HttpResponseRedirect(page_reverse())
 
-Building Links in Components
+Building links in components
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A component can compute a URL through ``@component.context``.
@@ -254,7 +254,7 @@ Use ``pytest-django`` or call ``django.setup()`` once, then assert against the p
    def test_page_reverse_empty() -> None:
        assert page_reverse() == "/"
 
-Reading the Query String Back
+Reading the query string back
 -----------------------------
 
 The helpers on this page write query strings.
@@ -268,7 +268,7 @@ They flow through ``DUrl`` or plain URL kwargs as described in :doc:`dependency-
 
 See :doc:`/content/howto/read-query-parameters` for the full typed-query walkthrough.
 
-See Also
+See also
 --------
 
 .. seealso::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ next.dj
    toctrees below. Its body is intentionally not displayed.
 
 .. toctree::
-   :caption: Getting Started
+   :caption: Getting started
    :hidden:
    :maxdepth: 1
 
@@ -31,7 +31,7 @@ next.dj
    content/ref/index
 
 .. toctree::
-   :caption: Going Further
+   :caption: Going further
    :hidden:
    :maxdepth: 1
 
@@ -40,7 +40,7 @@ next.dj
    content/security/index
 
 .. toctree::
-   :caption: Help and Project
+   :caption: Help and project
    :hidden:
    :maxdepth: 1
 

--- a/examples/audit-forms/README.md
+++ b/examples/audit-forms/README.md
@@ -61,7 +61,7 @@ NEXT_FRAMEWORK = {
 }
 ```
 
-The framework loads each entry lazily on first access via `next.forms.backends.FormActionFactory`. `AuditedFormActionBackend` subclasses `RegistryFormActionBackend`, so all `@action` registrations are still honoured — the override only wraps `dispatch` to add the audit rows.
+The framework loads each entry lazily on first access: `FormActionManager` hands the list to the shared `load_backends` helper, which imports every `BACKEND` dotted path, checks it against `FormActionBackend`, and calls it with the whole entry. `AuditedFormActionBackend` subclasses `RegistryFormActionBackend`, so all `@action` registrations are still honoured — the override only wraps `dispatch` to add the audit rows.
 
 ```python
 # access/backends.py
@@ -244,7 +244,7 @@ def done(self, request, cleaned_data):
     )
 ```
 
-The session key still threads the new request id to the backend audit row, exactly as before — the builder change does not break the correlation column.
+The session key threads the request id to the backend audit row, so the correlation column stays populated.
 
 **With the runtime.** The link opens a native `<dialog>` and creates an empty `access-wizard` container before the request, then GETs the step page for that zone alone. Each step submits inside the modal: an invalid step morphs only the `access-wizard` zone and the modal stays open, a valid non-final step morphs the zone to the next step with no redirect, and the final step's `done` returns `layer.close` plus a toast. The runtime closes the modal and, because the opening link named `data-next-accepted`, re-GETs the `request-list` zone of the landing page with its own cookies, so the list authorizes and renders in its own view before morphing under the now-closed modal.
 

--- a/next/backends.py
+++ b/next/backends.py
@@ -13,14 +13,6 @@ from next.conf import import_class_cached, next_framework_settings
 
 logger = logging.getLogger(__name__)
 
-# What importing the dotted path and calling the class can raise.
-_CONFIG_ERRORS: tuple[type[Exception], ...] = (
-    ImproperlyConfigured,
-    ImportError,
-    TypeError,
-    ValueError,
-)
-
 # A family root is a class, but an abstract one cannot pass as `type[T]`, so
 # it travels under its constructor signature and `_root_class` narrows it back.
 type BackendRoot[T] = Callable[..., T]
@@ -68,18 +60,25 @@ def load_backends[T](
     default: str | None = None,
     signal: Signal | None = None,
 ) -> list[T]:
-    """Instantiate every configured backend, skipping the entries that fail.
+    """Instantiate every configured backend, skipping the misconfigured entries.
 
-    One broken entry costs its own backend and nothing else, so a site
-    keeps serving with the backends that did load.
+    An entry is misconfigured when its dotted path does not resolve into
+    the family, or when the backend itself answers `ImproperlyConfigured`.
+    Such an entry costs its own backend and nothing else, so a site keeps
+    serving with the rest. Anything else a constructor raises is a bug in
+    that backend and reaches the caller.
     """
     name = _root_class(base).__name__
     backends: list[T] = []
     for config in configs:
         try:
             klass = resolve_backend_class(config, base=base, default=default)
+        except (ImproperlyConfigured, ImportError):
+            logger.exception("error resolving %s from config %s", name, config)
+            continue
+        try:
             instance = _instantiate_backend(klass, config)
-        except _CONFIG_ERRORS:
+        except ImproperlyConfigured:
             logger.exception("error creating %s from config %s", name, config)
             continue
         if signal is not None:

--- a/next/backends.py
+++ b/next/backends.py
@@ -53,6 +53,14 @@ def _instantiate_backend[T](klass: type[T], config: Mapping[str, Any]) -> T:
     return factory(config)
 
 
+def backend_entries(setting: str) -> list[dict[str, Any]]:
+    """Return the dict entries under one list-valued framework settings key."""
+    raw = getattr(next_framework_settings, setting, [])
+    if not isinstance(raw, list):
+        return []
+    return [entry for entry in raw if isinstance(entry, dict)]
+
+
 def load_backends[T](
     configs: Iterable[Mapping[str, Any]],
     *,
@@ -114,7 +122,16 @@ class SingleBackendManager[T]:
     @cached_property
     def _backend(self) -> T:
         config = self._select_config()
-        klass = resolve_backend_class(config, base=self._base, default=self._default)
+        try:
+            klass = resolve_backend_class(
+                config, base=self._base, default=self._default
+            )
+        except ImportError as exc:
+            msg = (
+                f"NEXT_FRAMEWORK[{self._setting!r}] names a backend that "
+                f"cannot be imported: {exc}"
+            )
+            raise ImproperlyConfigured(msg) from exc
         return _instantiate_backend(klass, config)
 
     def get(self) -> T:
@@ -134,6 +151,7 @@ class SingleBackendManager[T]:
 __all__ = [
     "BackendRoot",
     "SingleBackendManager",
+    "backend_entries",
     "load_backends",
     "resolve_backend_class",
 ]

--- a/next/backends.py
+++ b/next/backends.py
@@ -1,0 +1,140 @@
+"""Shared loading and lazy management of the settings-driven backend families."""
+
+import logging
+from collections.abc import Callable, Iterable, Mapping
+from functools import cached_property
+from typing import Any, cast
+
+from django.core.exceptions import ImproperlyConfigured
+from django.dispatch import Signal
+
+from next.conf import import_class_cached, next_framework_settings
+
+
+logger = logging.getLogger(__name__)
+
+# What importing the dotted path and calling the class can raise.
+_CONFIG_ERRORS: tuple[type[Exception], ...] = (
+    ImproperlyConfigured,
+    ImportError,
+    TypeError,
+    ValueError,
+)
+
+# A family root is a class, but an abstract one cannot pass as `type[T]`, so
+# it travels under its constructor signature and `_root_class` narrows it back.
+type BackendRoot[T] = Callable[..., T]
+
+
+def _root_class[T](base: BackendRoot[T]) -> type[T]:
+    """Return the family root as the class every family declares it to be."""
+    return cast("type[T]", base)
+
+
+def resolve_backend_class[T](
+    config: Mapping[str, Any], *, base: BackendRoot[T], default: str | None = None
+) -> type[T]:
+    """Return the class named by `config['BACKEND']`, checked against `base`."""
+    root = _root_class(base)
+    dotted = config.get("BACKEND", default)
+    if not isinstance(dotted, str) or not dotted:
+        msg = (
+            f"A {root.__name__} entry names its backend by a dotted path "
+            f"under BACKEND, got {config!r}."
+        )
+        raise ImproperlyConfigured(msg)
+    klass: type[Any] = import_class_cached(dotted)
+    if not (isinstance(klass, type) and issubclass(klass, root)):
+        msg = f"Backend {dotted!r} is not a {root.__name__} subclass."
+        raise ImproperlyConfigured(msg)
+    return klass
+
+
+def _instantiate_backend[T](klass: type[T], config: Mapping[str, Any]) -> T:
+    """Build one backend from its config entry.
+
+    Every backend family takes the whole entry as its single argument, a
+    contract `type[T]` cannot express, so the class is called through a
+    factory signature.
+    """
+    factory = cast("Callable[[Mapping[str, Any]], T]", klass)
+    return factory(config)
+
+
+def load_backends[T](
+    configs: Iterable[Mapping[str, Any]],
+    *,
+    base: BackendRoot[T],
+    default: str | None = None,
+    signal: Signal | None = None,
+) -> list[T]:
+    """Instantiate every configured backend, skipping the entries that fail.
+
+    One broken entry costs its own backend and nothing else, so a site
+    keeps serving with the backends that did load.
+    """
+    name = _root_class(base).__name__
+    backends: list[T] = []
+    for config in configs:
+        try:
+            klass = resolve_backend_class(config, base=base, default=default)
+            instance = _instantiate_backend(klass, config)
+        except _CONFIG_ERRORS:
+            logger.exception("error creating %s from config %s", name, config)
+            continue
+        if signal is not None:
+            signal.send(sender=klass, config=dict(config), instance=instance)
+        backends.append(instance)
+    return backends
+
+
+class SingleBackendManager[T]:
+    """Instantiates the single backend named by one framework settings key.
+
+    A misconfigured entry raises out of `get()` rather than being logged
+    and skipped, because a family with one backend has nothing to fall
+    back to.
+    """
+
+    def __init__(
+        self, setting: str, *, base: BackendRoot[T], default: str | None = None
+    ) -> None:
+        """Bind the manager to a settings key without reading it."""
+        self._setting = setting
+        self._base = base
+        self._default = default
+
+    def _select_config(self) -> Mapping[str, Any]:
+        raw = getattr(next_framework_settings, self._setting, None)
+        if isinstance(raw, Mapping):
+            return raw
+        if isinstance(raw, list):
+            return next((entry for entry in raw if isinstance(entry, Mapping)), {})
+        return {}
+
+    @cached_property
+    def _backend(self) -> T:
+        config = self._select_config()
+        klass = resolve_backend_class(config, base=self._base, default=self._default)
+        return _instantiate_backend(klass, config)
+
+    def get(self) -> T:
+        """Return the configured backend, building it on first use."""
+        return self._backend
+
+    def reset(self) -> None:
+        """Drop the cached backend so the next `get()` rereads settings.
+
+        Invalidation only. The rebuild waits for a caller that asks for
+        the backend, so a settings reload nobody follows up on costs
+        nothing.
+        """
+        self.__dict__.pop("_backend", None)
+
+
+__all__ = [
+    "BackendRoot",
+    "SingleBackendManager",
+    "load_backends",
+    "resolve_backend_class",
+]

--- a/next/checks/common.py
+++ b/next/checks/common.py
@@ -11,6 +11,7 @@ from django.apps import apps
 from django.conf import settings
 from django.core.checks import CheckMessage, Error
 
+from next.conf.imports import import_class_cached
 from next.conf.signals import settings_reloaded
 
 
@@ -47,6 +48,19 @@ def registration_file_errors(
     errors = _cross_file_errors(subject, records)
     errors.extend(_dead_file_errors(subject, registrations, _names_by_file(records)))
     return errors
+
+
+def import_backend_class(dotted_path: str) -> type[Any]:
+    """Import a dotted backend path, folding any import-time failure into ImportError.
+
+    A backend module runs arbitrary code at import, and a check that lets it
+    raise takes the whole run down instead of reporting one error.
+    """
+    try:
+        return import_class_cached(dotted_path)
+    except Exception as exc:
+        msg = f"{dotted_path} raised {type(exc).__name__}: {exc}"
+        raise ImportError(msg) from exc
 
 
 def _names_by_file(records: list[tuple[Path, Path, str]]) -> dict[Path, set[str]]:
@@ -264,6 +278,7 @@ __all__ = [
     "get_first_root_pages_path",
     "get_pages_directory",
     "get_router_manager",
+    "import_backend_class",
     "iter_scanned_page_pairs",
     "reset_components_manager_cache",
     "reset_router_manager_cache",

--- a/next/components/__init__.py
+++ b/next/components/__init__.py
@@ -4,7 +4,7 @@ Each subsystem lives in a small submodule. `info` holds the value
 object, `loading` the module cache, `scanner` the filesystem walk,
 `registry` the ordered store and visibility resolver, `context` the
 `@component.context` decorator, `renderers` the render strategies,
-`backends` the backend contract and factory, `manager` the orchestrator,
+`backends` the backend contract, `manager` the orchestrator,
 `watch` the read-only autoreload scan, and `facade` the short helpers
 used from templates. Internal classes are reachable with deep imports
 of the form `from next.components.registry import ComponentRegistry`.
@@ -16,7 +16,6 @@ from . import checks, signals
 from .backends import (
     BoomBackend,
     ComponentsBackend,
-    ComponentsFactory,
     DummyBackend,
     FileComponentsBackend,
     register_components_folder_from_router_walk,
@@ -56,7 +55,6 @@ __all__ = [
     "ComponentTemplateLoader",
     "ComponentVisibilityResolver",
     "ComponentsBackend",
-    "ComponentsFactory",
     "ComponentsManager",
     "CompositeComponentRenderer",
     "ContextFunction",

--- a/next/components/backends.py
+++ b/next/components/backends.py
@@ -1,19 +1,17 @@
-"""Components backend contract, factory, and file-based implementation.
+"""Components backend contract and file-based implementation.
 
 `ComponentsBackend` is the ABC for alternative component sources.
 `FileComponentsBackend` is the default filesystem-based backend.
-`ComponentsFactory` creates backend instances from merged
-`COMPONENT_BACKENDS` entries. `DummyBackend` and `BoomBackend`
-are tiny doubles kept here so dotted-path resolution in tests works
-through `import_class_cached`.
+`DummyBackend` and `BoomBackend` are tiny doubles kept here so
+dotted-path resolution in tests works through `import_class_cached`.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, cast, override
+from typing import TYPE_CHECKING, Any, override
 
-from next.conf import import_class_cached, next_framework_settings
+from next.conf import next_framework_settings
 
 from .loading import ModuleLoader
 from .registry import ComponentRegistry, ComponentVisibilityResolver
@@ -25,6 +23,10 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from .info import ComponentInfo
+
+
+# An entry that names no BACKEND means the filesystem source.
+_DEFAULT_BACKEND_PATH = "next.components.FileComponentsBackend"
 
 
 class ComponentsBackend(ABC):
@@ -145,10 +147,10 @@ class DummyBackend(ComponentsBackend):
 
 
 class BoomBackend(ComponentsBackend):
-    """Test double that raises from `__init__` for factory error handling tests."""
+    """Test double that raises from `__init__` for load error-path tests."""
 
     def __init__(self, config: dict[str, Any]) -> None:
-        """Raise immediately so `ComponentsManager` logs and skips this entry."""
+        """Raise the kind of error the loader never swallows."""
         _ = config
         msg = "boom"
         raise RuntimeError(msg)
@@ -164,17 +166,6 @@ class BoomBackend(ComponentsBackend):
     ) -> Mapping[str, ComponentInfo]:
         """Unreachable because construction always raises."""
         raise NotImplementedError
-
-
-class ComponentsFactory:
-    """Instantiates backends from merged `COMPONENT_BACKENDS` entries."""
-
-    @classmethod
-    def create_backend(cls, config: dict[str, Any]) -> ComponentsBackend:
-        """Return a single backend from one config dict (`BACKEND` class path)."""
-        backend_path = config.get("BACKEND", "next.components.FileComponentsBackend")
-        backend_class = import_class_cached(backend_path)
-        return cast("ComponentsBackend", backend_class(config))
 
 
 def register_components_folder_from_router_walk(
@@ -201,7 +192,6 @@ def register_components_folder_from_router_walk(
 __all__ = [
     "BoomBackend",
     "ComponentsBackend",
-    "ComponentsFactory",
     "DummyBackend",
     "FileComponentsBackend",
     "register_components_folder_from_router_walk",

--- a/next/components/backends.py
+++ b/next/components/backends.py
@@ -127,7 +127,7 @@ class FileComponentsBackend(ComponentsBackend):
 
 
 class DummyBackend(ComponentsBackend):
-    """Test double that stores the factory `config` dict on `self`."""
+    """Test double that keeps its settings `config` entry on `self`."""
 
     def __init__(self, config: dict[str, Any]) -> None:
         """Keep `config` on `self` for assertions about wiring."""

--- a/next/components/checks.py
+++ b/next/components/checks.py
@@ -13,11 +13,12 @@ from next.checks.common import (
     RegistrationSubject,
     errors_for_unknown_keys,
     get_components_manager,
+    import_backend_class,
     registration_file_errors,
 )
 from next.conf import next_framework_settings
 
-from .backends import FileComponentsBackend
+from .backends import ComponentsBackend, FileComponentsBackend
 from .context import component
 
 
@@ -44,6 +45,29 @@ _PAGE_CONTEXT_MODULES = frozenset({"next", "next.pages"})
 _PAGE_CONTEXT_OWNERS = frozenset({"next", "page", "next.page", "next.pages"})
 
 
+def _backend_class_errors(dotted: str, prefix: str) -> list[CheckMessage]:
+    """Import the dotted backend path and verify the family subclass."""
+    try:
+        klass = import_backend_class(dotted)
+    except ImportError as exc:
+        return [
+            Error(
+                f"{prefix}.BACKEND cannot be imported: {exc}.",
+                obj=settings,
+                id="next.E032",
+            )
+        ]
+    if not (isinstance(klass, type) and issubclass(klass, ComponentsBackend)):
+        return [
+            Error(
+                f"{prefix}.BACKEND is not a ComponentsBackend subclass.",
+                obj=settings,
+                id="next.E032",
+            )
+        ]
+    return []
+
+
 def _validate_single_component_backend(
     config: dict[str, object], index: int
 ) -> list[CheckMessage]:
@@ -56,10 +80,13 @@ def _validate_single_component_backend(
     ]
     if errors:
         return errors
-    if not isinstance(config["BACKEND"], str):
+    backend_path = config["BACKEND"]
+    if not isinstance(backend_path, str):
         errors.append(
             Error(f"{prefix}.BACKEND must be a string.", obj=settings, id="next.E032")
         )
+    else:
+        errors.extend(_backend_class_errors(backend_path, prefix))
     if not isinstance(config["DIRS"], list):
         errors.append(
             Error(f"{prefix}.DIRS must be a list.", obj=settings, id="next.E032")

--- a/next/components/manager.py
+++ b/next/components/manager.py
@@ -2,18 +2,18 @@
 
 The manager loads configured backends lazily, shares a render pipeline
 between them, and subscribes to `settings_reloaded` so a fresh config
-rebuilds its state without reimporting this module.
+drops the cached state without reimporting this module.
 """
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, cast
 
+from next.backends import load_backends
 from next.conf import next_framework_settings
 from next.conf.signals import settings_reloaded
 
-from .backends import ComponentsBackend, ComponentsFactory
+from .backends import _DEFAULT_BACKEND_PATH, ComponentsBackend
 from .loading import ModuleLoader
 from .renderers import (
     ComponentRenderer,
@@ -31,15 +31,14 @@ if TYPE_CHECKING:
     from .info import ComponentInfo
 
 
-logger = logging.getLogger(__name__)
-
-
 class ComponentsManager:
     """Loads backends from settings and merges name resolution across them."""
 
     def __init__(self) -> None:
         """Prepare an empty backend list and load settings on first access."""
         self._backends: list[ComponentsBackend] = []
+        # An empty list is a legitimate load result, so only a flag knows.
+        self._loaded: bool = False
         self._walk_registered_folders: set[Path] = set()
         self._template_loader: ComponentTemplateLoader | None = None
         self._component_renderer: ComponentRenderer | None = None
@@ -72,30 +71,32 @@ class ComponentsManager:
         self._ensure_render_pipeline()
         return cast("ComponentRenderer", self._component_renderer)
 
-    def _reload_config(self) -> None:
+    def _invalidate(self) -> None:
+        """Drop cached backends and the render pipeline without rebuilding.
+
+        Settings reload far more often than a component renders, so the
+        rebuild waits for the next access instead of running in the
+        signal receiver.
+        """
         self._reset_render_pipeline()
-        self._backends.clear()
+        self._backends = []
         self._walk_registered_folders.clear()
+        self._loaded = False
+
+    def _reload_config(self) -> None:
+        self._invalidate()
         configs = next_framework_settings.COMPONENT_BACKENDS
-        if not isinstance(configs, list):
-            return
-        for config in configs:
-            if not isinstance(config, dict):
-                continue
-            try:
-                backend = ComponentsFactory.create_backend(config)
-            except Exception:
-                logger.exception(
-                    "Error creating component backend from config %s", config
-                )
-                continue
-            component_backend_loaded.send(
-                sender=ComponentsManager, backend=backend, config=config
-            )
-            self._backends.append(backend)
+        entries = configs if isinstance(configs, list) else []
+        self._backends = load_backends(
+            [config for config in entries if isinstance(config, dict)],
+            base=ComponentsBackend,
+            default=_DEFAULT_BACKEND_PATH,
+            signal=component_backend_loaded,
+        )
+        self._loaded = True
 
     def _ensure_backends(self) -> None:
-        if not self._backends:
+        if not self._loaded:
             self._reload_config()
 
     def _claim_router_walk_folder(self, folder: Path) -> bool:
@@ -136,8 +137,8 @@ components_manager = ComponentsManager()
 
 
 def _on_settings_reloaded(**kwargs) -> None:
-    """Rebuild component backends when framework settings reload."""
-    components_manager._reload_config()
+    """Drop cached component backends when framework settings reload."""
+    components_manager._invalidate()
 
 
 settings_reloaded.connect(_on_settings_reloaded)

--- a/next/components/manager.py
+++ b/next/components/manager.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from next.backends import load_backends
-from next.conf import next_framework_settings
+from next.backends import backend_entries, load_backends
 from next.conf.signals import settings_reloaded
 
 from .backends import _DEFAULT_BACKEND_PATH, ComponentsBackend
@@ -85,10 +84,8 @@ class ComponentsManager:
 
     def _reload_config(self) -> None:
         self._invalidate()
-        configs = next_framework_settings.COMPONENT_BACKENDS
-        entries = configs if isinstance(configs, list) else []
         self._backends = load_backends(
-            [config for config in entries if isinstance(config, dict)],
+            backend_entries("COMPONENT_BACKENDS"),
             base=ComponentsBackend,
             default=_DEFAULT_BACKEND_PATH,
             signal=component_backend_loaded,

--- a/next/components/renderers.py
+++ b/next/components/renderers.py
@@ -58,6 +58,17 @@ def _render_template_string(template_str: str, context_dict: dict[str, Any]) -> 
     return Template(template_str).render(DjangoTemplateContext(context_dict))
 
 
+def _stamp_component_anchor(info: ComponentInfo, context_dict: dict[str, Any]) -> None:
+    """Overwrite the form-action anchor with this component's own module path.
+
+    Always written, so a component without a component.py never inherits
+    the anchor of an enclosing component or a caller-supplied value.
+    """
+    context_dict["current_component_module_path"] = (
+        str(info.module_path) if info.module_path is not None else None
+    )
+
+
 def _merge_csrf_context(
     context_dict: dict[str, Any], request: HttpRequest | None
 ) -> None:
@@ -148,6 +159,7 @@ class SimpleComponentRenderer:
         if template_str is None:
             return ""
         context_dict = dict(context_data)
+        _stamp_component_anchor(info, context_dict)
         if request is not None:
             context_dict.setdefault("request", request)
             _merge_csrf_context(context_dict, request)
@@ -222,6 +234,7 @@ class CompositeComponentRenderer:
             return ""
 
         context_dict = dict(context_data)
+        _stamp_component_anchor(info, context_dict)
         if request is not None:
             context_dict["request"] = request
             _merge_csrf_context(context_dict, request)
@@ -236,7 +249,9 @@ class CompositeComponentRenderer:
         template_str = self._template_loader.load(info)
         if template_str is None:
             return ""
-        return _render_template_string(template_str, dict(context_data))
+        context_dict = dict(context_data)
+        _stamp_component_anchor(info, context_dict)
+        return _render_template_string(template_str, context_dict)
 
 
 class ComponentRenderer:

--- a/next/components/watch.py
+++ b/next/components/watch.py
@@ -13,8 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from django.core.exceptions import ImproperlyConfigured
 
-from next.backends import resolve_backend_class
-from next.conf import next_framework_settings
+from next.backends import backend_entries, resolve_backend_class
 
 from .backends import _DEFAULT_BACKEND_PATH, ComponentsBackend, FileComponentsBackend
 from .info import _paths_from_component_info
@@ -57,12 +56,7 @@ def _collect_component_paths_under_page_trees() -> set[Path]:
     from next.urls import RouterFactory  # noqa: PLC0415
 
     result: set[Path] = set()
-    page_configs = next_framework_settings.PAGE_BACKENDS
-    if not isinstance(page_configs, list):
-        return result
-    for config in page_configs:
-        if not isinstance(config, dict):
-            continue
+    for config in backend_entries("PAGE_BACKENDS"):
         try:
             backend = RouterFactory.create_backend(config)
         except Exception:
@@ -90,12 +84,7 @@ def _collect_component_paths_under_page_trees() -> set[Path]:
 def _collect_component_paths_from_backend_dirs() -> set[Path]:
     """Collect paths from component backend `DIRS` entries only."""
     result: set[Path] = set()
-    comp_configs = next_framework_settings.COMPONENT_BACKENDS
-    if not isinstance(comp_configs, list):
-        return result
-    for config in comp_configs:
-        if not isinstance(config, dict):
-            continue
+    for config in backend_entries("COMPONENT_BACKENDS"):
         try:
             klass = resolve_backend_class(
                 config, base=ComponentsBackend, default=_DEFAULT_BACKEND_PATH

--- a/next/components/watch.py
+++ b/next/components/watch.py
@@ -11,9 +11,12 @@ import itertools
 import logging
 from typing import TYPE_CHECKING, Any
 
+from django.core.exceptions import ImproperlyConfigured
+
+from next.backends import resolve_backend_class
 from next.conf import next_framework_settings
 
-from .backends import ComponentsFactory, FileComponentsBackend
+from .backends import _DEFAULT_BACKEND_PATH, ComponentsBackend, FileComponentsBackend
 from .info import _paths_from_component_info
 from .loading import ModuleLoader
 from .scanner import ComponentScanner, component_extra_roots_from_config
@@ -94,13 +97,16 @@ def _collect_component_paths_from_backend_dirs() -> set[Path]:
         if not isinstance(config, dict):
             continue
         try:
-            backend = ComponentsFactory.create_backend(config)
-        except Exception:
+            klass = resolve_backend_class(
+                config, base=ComponentsBackend, default=_DEFAULT_BACKEND_PATH
+            )
+        except (ImproperlyConfigured, ImportError):
             logger.exception(
-                "error creating component backend for autoreload scan %s", config
+                "error resolving component backend for autoreload scan %s", config
             )
             continue
-        if not isinstance(backend, FileComponentsBackend):
+        # A read-only scan reads roots off the config, so it skips the instance.
+        if not issubclass(klass, FileComponentsBackend):
             continue
         scanner = ComponentScanner(module_loader=ModuleLoader())
         for root in component_extra_roots_from_config(config):

--- a/next/forms/backends.py
+++ b/next/forms/backends.py
@@ -5,7 +5,7 @@ import hashlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypedDict, cast, override
+from typing import TYPE_CHECKING, Any, TypedDict, override
 from weakref import WeakSet
 
 from django.core.exceptions import ImproperlyConfigured
@@ -13,8 +13,6 @@ from django.core.signals import setting_changed
 from django.http import Http404
 from django.urls import get_script_prefix, path
 from django.views.decorators.http import require_http_methods
-
-from next.conf import import_class_cached
 
 from .diagnostics import registration_diagnostics
 from .dispatch import ActionOutcome, FormActionDispatch
@@ -554,23 +552,11 @@ class RegistryFormActionBackend(FormActionBackend):
         return render_form_page_with_errors(self, request, params, page_file_path)
 
 
-class FormActionFactory:
-    """Instantiates backends from merged `FORM_ACTION_BACKENDS` entries."""
-
-    @classmethod
-    def create_backend(cls, config: dict[str, Any]) -> FormActionBackend:
-        """Return a single backend instance for one settings entry."""
-        backend_path = config["BACKEND"]
-        backend_class = import_class_cached(backend_path)
-        return cast("FormActionBackend", backend_class(config))
-
-
 __all__ = [
     "ActionGuard",
     "ActionMeta",
     "ActionRegistration",
     "FormActionBackend",
-    "FormActionFactory",
     "FormActionNotFoundError",
     "RegistryBackendSnapshot",
     "RegistryFormActionBackend",

--- a/next/forms/backends.py
+++ b/next/forms/backends.py
@@ -275,7 +275,13 @@ class FormActionBackend(ABC):
     def get_meta(
         self, action_name: str, page_path: str | None = None
     ) -> "ActionMeta | None":
-        """Return optional per-action metadata for subclasses."""
+        """Return optional per-action metadata for subclasses.
+
+        A lookup with `page_path` returns the exact page-scoped meta for that
+        path or a shared-scoped fallback, never a page-scoped meta registered
+        under a different path. The template tags rely on this to tell an
+        exact anchor hit apart from the fallback.
+        """
         del action_name, page_path
         return None
 

--- a/next/forms/manager.py
+++ b/next/forms/manager.py
@@ -35,6 +35,8 @@ class FormActionManager:
         self._backends: list[FormActionBackend] = list(backends) if backends else []
         # An empty list is a legitimate load result, so only a flag knows.
         self._loaded: bool = bool(self._backends)
+        # Entries the last load tried, so an empty result can name its reason.
+        self._attempted: int = 0
 
     @override
     def __repr__(self) -> str:
@@ -55,7 +57,11 @@ class FormActionManager:
         self._version += 1
         # No default: an entry without BACKEND is a next.E044 misconfiguration.
         self._backends = load_backends(configs, base=FormActionBackend)
-        self._loaded = True
+        self._attempted = len(configs)
+        # Losing every entry is a broken config rather than a load result, so
+        # the next access rereads settings. A settings_reloaded receiver cannot
+        # do it instead, because dropping the backends drops their actions.
+        self._loaded = bool(self._backends) or not configs
 
     def _ensure_backends(self) -> None:
         if not self._loaded:
@@ -65,12 +71,21 @@ class FormActionManager:
         """Return the first backend or raise when none are configured."""
         self._ensure_backends()
         if not self._backends:
-            msg = (
-                "No form action backends configured. Add at least one entry to "
-                "NEXT_FRAMEWORK['FORM_ACTION_BACKENDS']."
-            )
-            raise ImproperlyConfigured(msg)
+            raise ImproperlyConfigured(self._no_backends_message())
         return self._backends[0]
+
+    def _no_backends_message(self) -> str:
+        """Tell an unconfigured family apart from one whose entries all failed."""
+        if self._attempted:
+            return (
+                f"None of the {self._attempted} entries in "
+                "NEXT_FRAMEWORK['FORM_ACTION_BACKENDS'] could be loaded. The "
+                "next.backends logger names why each one was skipped."
+            )
+        return (
+            "No form action backends configured. Add at least one entry to "
+            "NEXT_FRAMEWORK['FORM_ACTION_BACKENDS']."
+        )
 
     def register_action(self, registration: "ActionRegistration") -> None:
         """Forward registration to the first backend."""

--- a/next/forms/manager.py
+++ b/next/forms/manager.py
@@ -1,14 +1,14 @@
 """Manager for form action backends and routing."""
 
-import logging
 import types
 from typing import TYPE_CHECKING, Any, cast, override
 
 from django.core.exceptions import ImproperlyConfigured
 
+from next.backends import load_backends
 from next.conf import next_framework_settings
 
-from .backends import FormActionFactory, FormActionNotFoundError
+from .backends import FormActionBackend, FormActionNotFoundError
 from .dispatch import _form_action_context_callable
 from .origin import _url_kwargs_for_request
 
@@ -19,10 +19,7 @@ if TYPE_CHECKING:
     from django.http import HttpRequest
     from django.urls import URLPattern
 
-    from .backends import ActionMeta, ActionRegistration, FormActionBackend
-
-
-logger = logging.getLogger(__name__)
+    from .backends import ActionMeta, ActionRegistration
 
 
 class FormActionManager:
@@ -36,6 +33,8 @@ class FormActionManager:
     def __init__(self, backends: "list[FormActionBackend] | None" = None) -> None:
         """Initialise with explicit backends or defer loading to settings."""
         self._backends: list[FormActionBackend] = list(backends) if backends else []
+        # An empty list is a legitimate load result, so only a flag knows.
+        self._loaded: bool = bool(self._backends)
 
     @override
     def __repr__(self) -> str:
@@ -49,23 +48,17 @@ class FormActionManager:
             yield from backend.generate_urls()
 
     def _reload_config(self) -> None:
-        self._version += 1
-        self._backends = []
-        configs = cast(
+        entries = cast(
             "list[Any]", getattr(next_framework_settings, "FORM_ACTION_BACKENDS", [])
         )
-        for config in configs:
-            if not isinstance(config, dict):
-                continue
-            try:
-                self._backends.append(FormActionFactory.create_backend(config))
-            except ImproperlyConfigured:
-                logger.exception(
-                    "Error creating form-action backend from config %s", config
-                )
+        configs = [entry for entry in entries if isinstance(entry, dict)]
+        self._version += 1
+        # No default: an entry without BACKEND is a next.E044 misconfiguration.
+        self._backends = load_backends(configs, base=FormActionBackend)
+        self._loaded = True
 
     def _ensure_backends(self) -> None:
-        if not self._backends:
+        if not self._loaded:
             self._reload_config()
 
     def _first_backend(self) -> "FormActionBackend":

--- a/next/forms/manager.py
+++ b/next/forms/manager.py
@@ -1,12 +1,11 @@
 """Manager for form action backends and routing."""
 
 import types
-from typing import TYPE_CHECKING, Any, cast, override
+from typing import TYPE_CHECKING, override
 
 from django.core.exceptions import ImproperlyConfigured
 
-from next.backends import load_backends
-from next.conf import next_framework_settings
+from next.backends import backend_entries, load_backends
 
 from .backends import FormActionBackend, FormActionNotFoundError
 from .dispatch import _form_action_context_callable
@@ -35,8 +34,6 @@ class FormActionManager:
         self._backends: list[FormActionBackend] = list(backends) if backends else []
         # An empty list is a legitimate load result, so only a flag knows.
         self._loaded: bool = bool(self._backends)
-        # Entries the last load tried, so an empty result can name its reason.
-        self._attempted: int = 0
 
     @override
     def __repr__(self) -> str:
@@ -50,14 +47,10 @@ class FormActionManager:
             yield from backend.generate_urls()
 
     def _reload_config(self) -> None:
-        entries = cast(
-            "list[Any]", getattr(next_framework_settings, "FORM_ACTION_BACKENDS", [])
-        )
-        configs = [entry for entry in entries if isinstance(entry, dict)]
+        configs = backend_entries("FORM_ACTION_BACKENDS")
         self._version += 1
         # No default: an entry without BACKEND is a next.E044 misconfiguration.
         self._backends = load_backends(configs, base=FormActionBackend)
-        self._attempted = len(configs)
         # Losing every entry is a broken config rather than a load result, so
         # the next access rereads settings. A settings_reloaded receiver cannot
         # do it instead, because dropping the backends drops their actions.
@@ -67,18 +60,23 @@ class FormActionManager:
         if not self._loaded:
             self._reload_config()
 
-    def _first_backend(self) -> "FormActionBackend":
-        """Return the first backend or raise when none are configured."""
+    def _require_backends(self) -> None:
+        """Load the backends and refuse a lookup that has none to consult."""
         self._ensure_backends()
         if not self._backends:
             raise ImproperlyConfigured(self._no_backends_message())
+
+    def _first_backend(self) -> "FormActionBackend":
+        """Return the first backend or raise when none are configured."""
+        self._require_backends()
         return self._backends[0]
 
     def _no_backends_message(self) -> str:
         """Tell an unconfigured family apart from one whose entries all failed."""
-        if self._attempted:
+        attempted = len(backend_entries("FORM_ACTION_BACKENDS"))
+        if attempted:
             return (
-                f"None of the {self._attempted} entries in "
+                f"None of the {attempted} entries in "
                 "NEXT_FRAMEWORK['FORM_ACTION_BACKENDS'] could be loaded. The "
                 "next.backends logger names why each one was skipped."
             )
@@ -102,7 +100,7 @@ class FormActionManager:
 
     def get_action_url(self, action_name: str, *, page_path: str | None = None) -> str:
         """Return the reverse URL from the first backend that knows `action_name`."""
-        self._ensure_backends()
+        self._require_backends()
         if len(self._backends) == 1:
             return self._backends[0].get_action_url(action_name, page_path=page_path)
         caught: list[FormActionNotFoundError] = []
@@ -122,7 +120,7 @@ class FormActionManager:
         self, action_name: str, *, page_path: str | None = None
     ) -> "ActionMeta | None":
         """Return the action meta from the first backend that knows the name."""
-        self._ensure_backends()
+        self._require_backends()
         for backend in self._backends:
             meta = backend.get_meta(action_name, page_path)
             if meta is not None:
@@ -164,6 +162,20 @@ class FormActionManager:
 form_action_manager = FormActionManager()
 
 
+def resolve_component_anchor(
+    action_name: str, component_path: str
+) -> "ActionMeta | None":
+    """Return the action meta registered exactly under the component anchor.
+
+    An exact anchor hit carries page scope, which tells it apart from the
+    path-independent shared fallback a scoped lookup may return.
+    """
+    meta = form_action_manager.get_action_meta(action_name, page_path=component_path)
+    if meta is not None and meta.get("scope") == "page":
+        return meta
+    return None
+
+
 def build_form_namespace_for_action(
     action_name: str, request: "HttpRequest", page_path: str | None = None
 ) -> types.SimpleNamespace | None:
@@ -193,4 +205,5 @@ __all__ = [
     "FormActionManager",
     "build_form_namespace_for_action",
     "form_action_manager",
+    "resolve_component_anchor",
 ]

--- a/next/forms/wizard.py
+++ b/next/forms/wizard.py
@@ -16,7 +16,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model
 from django.http import HttpRequest, HttpResponse
 
-from next.conf import import_class_cached, next_framework_settings
+from next.backends import SingleBackendManager
 from next.conf.signals import settings_reloaded
 
 from .backends import ActionRegistration, scope_key_for
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 
 
 _WIZARD_LOAD_CACHE_ATTR: Final[str] = "_next_wizard_load_cache"
+_FORM_WIZARD_BACKEND_KEY: Final[str] = "FORM_WIZARD_BACKEND"
 
 type _JSONValue = (
     None | bool | int | float | str | list[_JSONValue] | dict[str, _JSONValue]
@@ -268,27 +269,10 @@ class SessionFormWizardBackend(FormWizardBackend):
             session.pop(self._key(storage_id), None)
 
 
-class WizardBackendManager:
-    """Lazily instantiates the single configured wizard backend."""
-
-    def __init__(self) -> None:
-        """Initialise an empty backend cache."""
-        self._backend: FormWizardBackend | None = None
-
-    def reset(self) -> None:
-        """Drop the cached backend so a fresh config takes effect."""
-        self._backend = None
-
-    def get(self) -> FormWizardBackend:
-        """Return the backend configured by `FORM_WIZARD_BACKEND`."""
-        if self._backend is None:
-            config = next_framework_settings.FORM_WIZARD_BACKEND
-            backend_class = import_class_cached(config["BACKEND"])
-            self._backend = cast("FormWizardBackend", backend_class(config))
-        return self._backend
-
-
-wizard_backend_manager = WizardBackendManager()
+# The settings key carries its own default path, so no fallback here.
+wizard_backend_manager = SingleBackendManager(
+    _FORM_WIZARD_BACKEND_KEY, base=FormWizardBackend
+)
 
 
 def _on_settings_reloaded(**kwargs) -> None:
@@ -577,6 +561,5 @@ __all__ = [
     "FormWizard",
     "FormWizardBackend",
     "SessionFormWizardBackend",
-    "WizardBackendManager",
     "wizard_backend_manager",
 ]

--- a/next/partial/checks.py
+++ b/next/partial/checks.py
@@ -58,6 +58,7 @@ E_ZONE_IN_IF: Final = "next.E063"
 E_LAZY_WITHOUT_PLACEHOLDER: Final = "next.E064"
 E_ZONE_IN_COMPONENT: Final = "next.E065"
 E_UNREGISTERED_OP: Final = "next.E066"
+E_BACKENDS_NOT_A_LIST: Final = "next.E067"
 E_COMPOSED_TEMPLATE_SYNTAX: Final = "next.E072"
 E_BACKEND_WITHOUT_PATH: Final = "next.E073"
 
@@ -67,6 +68,7 @@ W_MANIFEST_VERSION_NO_STORAGE: Final = "next.W069"
 W_FORM_IN_FOR_NO_KEY: Final = "next.W070"
 W_TOO_MANY_BACKENDS: Final = "next.W071"
 
+_PARTIAL_BACKENDS_KEY: Final = "PARTIAL_BACKENDS"
 _MIN_DUPLICATE_COUNT: Final = 2
 _FORM_TARGET_ATTR: Final = "data-next-target"
 _FORM_KEY_ATTR: Final = "data-next-key"
@@ -513,9 +515,35 @@ def check_form_backend_partial_aware(*args, **kwargs) -> list[CheckMessage]:
     return messages
 
 
+@register(NEXT)
+def check_partial_backends_is_a_list(*args, **kwargs) -> list[CheckMessage]:
+    """Error when `PARTIAL_BACKENDS` is not a list (`next.E067`).
+
+    The settings layer merges the key only when it holds a list, so a tuple
+    or a bare dict is dropped and the default protocol backend loads in its
+    place. Every other partial diagnostic reads the merged value, so nothing
+    else would report the drop.
+    """
+    raw = getattr(settings, "NEXT_FRAMEWORK", None)
+    if not isinstance(raw, dict):
+        return []
+    configs = raw.get(_PARTIAL_BACKENDS_KEY)
+    if configs is None or isinstance(configs, list):
+        return []
+    return [
+        Error(
+            f"NEXT_FRAMEWORK[{_PARTIAL_BACKENDS_KEY!r}] must be a list. The "
+            "value is ignored, so the default protocol backend loads instead "
+            "of the configured one.",
+            obj=settings,
+            id=E_BACKENDS_NOT_A_LIST,
+        )
+    ]
+
+
 def _partial_backend_configs() -> list[object]:
     """Return PARTIAL_BACKENDS as a list, tolerating any malformed shape."""
-    configs = getattr(next_framework_settings, "PARTIAL_BACKENDS", ())
+    configs = getattr(next_framework_settings, _PARTIAL_BACKENDS_KEY, ())
     if isinstance(configs, list | tuple):
         return list(configs)
     return []

--- a/next/partial/checks.py
+++ b/next/partial/checks.py
@@ -558,9 +558,9 @@ _STATICFILES_ALIAS: Final = "staticfiles"
 def check_partial_backend_names_a_path(*args, **kwargs) -> list[CheckMessage]:
     """Error when a PARTIAL_BACKENDS entry omits its BACKEND key (`next.E073`).
 
-    The factory refuses such an entry with `ImproperlyConfigured` on the
-    first partial request. The check surfaces the same misconfiguration at
-    startup, naming the entry that lacks a dotted path.
+    Such an entry falls back to the default protocol backend, so the
+    intended wire format would silently never load. The check names the
+    entry that lacks a dotted path at startup instead.
     """
     messages: list[CheckMessage] = []
     for index, config in enumerate(_partial_backend_configs()):

--- a/next/partial/manager.py
+++ b/next/partial/manager.py
@@ -1,13 +1,13 @@
-"""Facade owning the protocol-backend factory, manager, and version resolution."""
+"""Facade owning the protocol-backend manager and version resolution."""
 
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 from django.contrib.staticfiles.storage import ManifestFilesMixin, staticfiles_storage
 from django.core.exceptions import ImproperlyConfigured
 
-from next.conf import import_class_cached, next_framework_settings
+from next.backends import SingleBackendManager
 from next.conf.signals import settings_reloaded
 
 from .backends import PartialProtocolBackend
@@ -27,69 +27,27 @@ _DEFAULT_BACKEND_PATH = (
 )
 
 
-class PartialProtocolFactory:
-    """Instantiates protocol backends from `PARTIAL_BACKENDS` entries."""
-
-    @classmethod
-    def create_backend(cls, config: "Mapping[str, Any]") -> PartialProtocolBackend:
-        """Return a single backend instance for one settings entry."""
-        backend_path = config.get("BACKEND")
-        if not isinstance(backend_path, str):
-            msg = (
-                "A PARTIAL_BACKENDS entry names its protocol backend by a "
-                f"dotted path under BACKEND, got {config!r}."
-            )
-            raise ImproperlyConfigured(msg)
-        backend_class = import_class_cached(backend_path)
-        return cast("PartialProtocolBackend", backend_class(config))
+# PARTIAL_BACKENDS is a list, but one protocol is active (next.W071).
+partial_backend_manager = SingleBackendManager(
+    _PARTIAL_BACKENDS_KEY, base=PartialProtocolBackend, default=_DEFAULT_BACKEND_PATH
+)
 
 
-class PartialBackendManager:
-    """Lazily instantiates the single configured protocol backend.
+def asset_version() -> str:
+    """Return the asset version string stamped on a partial response.
 
-    Only the first valid PARTIAL_BACKENDS entry is used, a second entry is
-    reported by next.W071.
+    An explicit `VERSION` option wins so a deployment may pin the version
+    to a release tag. The `"manifest"` sentinel resolves to a stable hash
+    of the staticfiles manifest when the active staticfiles storage hashes
+    its files, so the deploy-mismatch guard works out of the box. Without
+    a manifest storage the sentinel falls back to a stable default and the
+    guard never fires.
     """
-
-    def __init__(self) -> None:
-        """Initialise an empty backend cache."""
-        self._backend: PartialProtocolBackend | None = None
-
-    def reset(self) -> None:
-        """Drop the cached backend so a reloaded config takes effect."""
-        self._backend = None
-
-    def _ensure_backend(self) -> PartialProtocolBackend:
-        if self._backend is None:
-            configs = getattr(next_framework_settings, _PARTIAL_BACKENDS_KEY, [])
-            config = next(
-                (c for c in configs if isinstance(c, dict)),
-                {"BACKEND": _DEFAULT_BACKEND_PATH},
-            )
-            self._backend = PartialProtocolFactory.create_backend(config)
-        return self._backend
-
-    def get(self) -> PartialProtocolBackend:
-        """Return the active protocol backend."""
-        return self._ensure_backend()
-
-    def version(self) -> str:
-        """Return the asset version string stamped on a partial response.
-
-        An explicit `VERSION` option wins so a deployment may pin the
-        version to a release tag. The `"manifest"` sentinel resolves to a
-        stable hash of the staticfiles manifest when the active
-        staticfiles storage hashes its files, so the deploy-mismatch guard
-        works out of the box. Without a manifest storage the sentinel
-        falls back to a stable default and the guard never fires.
-        """
-        configured = self.get().options.get(_VERSION_OPTION, _MANIFEST_VERSION)
-        if isinstance(configured, str) and configured != _MANIFEST_VERSION:
-            return configured
-        return _manifest_version()
-
-
-partial_backend_manager = PartialBackendManager()
+    options = partial_backend_manager.get().options
+    configured = options.get(_VERSION_OPTION, _MANIFEST_VERSION)
+    if isinstance(configured, str) and configured != _MANIFEST_VERSION:
+        return configured
+    return _manifest_version()
 
 
 def _manifest_version() -> str:
@@ -131,4 +89,4 @@ def _on_settings_reloaded(**kwargs) -> None:
 settings_reloaded.connect(_on_settings_reloaded)
 
 
-__all__ = ["PartialBackendManager", "PartialProtocolFactory", "partial_backend_manager"]
+__all__ = ["asset_version", "partial_backend_manager"]

--- a/next/partial/patches.py
+++ b/next/partial/patches.py
@@ -21,7 +21,7 @@ from .headers import (
     is_partial_request,
     set_partial_vary,
 )
-from .manager import partial_backend_manager
+from .manager import asset_version, partial_backend_manager
 from .registry import BUILTIN_OPS, patch_op_registry
 from .render import render_zone
 
@@ -381,7 +381,7 @@ class Patches:
         response path leaves it unset since the answer already reaches the
         initiator.
         """
-        self._init_state(request, partial_backend_manager.version(), echo_of)
+        self._init_state(request, asset_version(), echo_of)
 
     @classmethod
     def versioned(cls, version: str, *, echo_of: str | None = None) -> "Patches":

--- a/next/partial/view.py
+++ b/next/partial/view.py
@@ -6,7 +6,7 @@ from django.http import HttpResponse
 
 from . import keys
 from .headers import MergeMode, set_partial_vary
-from .manager import partial_backend_manager
+from .manager import asset_version, partial_backend_manager
 from .patches import Envelope, Patches, PatchResponse
 from .render import UnknownZoneError, render_zone
 
@@ -42,7 +42,7 @@ def zone_response(
     travel back as one patch envelope.
     """
     backend = partial_backend_manager.get()
-    version = partial_backend_manager.version()
+    version = asset_version()
     if dynamic_body:
         return _bad_request("zone in dynamic body")
     if request.method in _SAFE_METHODS and _version_conflict(intent, version):

--- a/next/static/__init__.py
+++ b/next/static/__init__.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from . import signals
 from .assets import KindRegistry, StaticAsset, default_kinds
-from .backends import StaticBackend, StaticFilesBackend, StaticsFactory
+from .backends import StaticBackend, StaticFilesBackend
 from .collector import (
     PlaceholderRegistry,
     PlaceholderSlot,
@@ -68,7 +68,6 @@ __all__ = [
     "StaticCollector",
     "StaticFilesBackend",
     "StaticManager",
-    "StaticsFactory",
     "collect_component_assets",
     "default_kinds",
     "default_manager",

--- a/next/static/backends.py
+++ b/next/static/backends.py
@@ -12,10 +12,9 @@ methods are concrete on the default backend and selected per asset by
 adding more named methods such as `render_babel_script_tag` and
 registering kinds that point to them.
 
-A small factory builds backend instances from
-`NEXT_FRAMEWORK['STATIC_BACKENDS']` entries. The factory also
-emits the `backend_loaded` signal so user code may react to backend
-construction.
+Instances are built from `NEXT_FRAMEWORK['STATIC_BACKENDS']` entries by
+the static manager, which emits the `backend_loaded` signal for each one
+so user code may react to backend construction.
 """
 
 from __future__ import annotations
@@ -25,10 +24,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, override
 
 from django.contrib.staticfiles.storage import staticfiles_storage
 
-from next.conf import import_class_cached
-
 from .assets import StaticNamespace
-from .signals import backend_loaded
 
 
 if TYPE_CHECKING:
@@ -165,29 +161,3 @@ class StaticFilesBackend(StaticBackend):
         """
         del request
         return self._module_tag.format(url=url)
-
-
-class StaticsFactory:
-    """Build static backend instances from configuration dicts."""
-
-    DEFAULT_BACKEND: ClassVar[str] = "next.static.StaticFilesBackend"
-
-    @classmethod
-    def create_backend(cls, config: Mapping[str, Any]) -> StaticBackend:
-        """Instantiate the backend class named by `config['BACKEND']`.
-
-        Raises `TypeError` when the configured class is not a subclass
-        of `StaticBackend`.
-        """
-        backend_path = config.get("BACKEND", cls.DEFAULT_BACKEND)
-        backend_class = import_class_cached(backend_path)
-        if not isinstance(backend_class, type) or not issubclass(
-            backend_class, StaticBackend
-        ):
-            msg = f"Backend {backend_path!r} is not a StaticBackend subclass"
-            raise TypeError(msg)
-        instance: StaticBackend = backend_class(config)
-        backend_loaded.send(
-            sender=backend_class, config=dict(config), instance=instance
-        )
-        return instance

--- a/next/static/manager.py
+++ b/next/static/manager.py
@@ -22,13 +22,13 @@ from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils.functional import LazyObject, empty
 
-from next.backends import load_backends
+from next.backends import backend_entries, load_backends
 from next.conf import import_class_cached, next_framework_settings
 from next.conf.signals import settings_reloaded
 from next.pages.watch import get_pages_directories_for_watch
 
 from .assets import default_kinds
-from .backends import StaticBackend, StaticFilesBackend
+from .backends import StaticBackend
 from .collector import HEAD_CLOSE, StaticCollector, default_placeholders
 from .discovery import AssetDiscovery, PathResolver
 from .scripts import (
@@ -73,7 +73,8 @@ class StaticManager:
     def __init__(self) -> None:
         """Initialise empty backend and discovery caches, loaded lazily."""
         self._backends: list[StaticBackend] = []
-        # An empty list is a legitimate load result, so only a flag knows.
+        # The reload always seeds at least one backend, so the flag only
+        # gates the lazy first load and the settings-reload invalidation.
         self._loaded: bool = False
         self._discovery: AssetDiscovery | None = None
         self._cached_page_roots: tuple[Path, ...] | None = None
@@ -270,21 +271,17 @@ class StaticManager:
         self._script_builder = None
         self._dedup_factory = None
         self._js_policy_factory = None
-        configs = next_framework_settings.STATIC_BACKENDS
-        if not isinstance(configs, list):  # pragma: no cover
-            configs = []
         self._backends = load_backends(
-            [config for config in configs if isinstance(config, dict)],
+            backend_entries("STATIC_BACKENDS"),
+            base=StaticBackend,
+            default=_DEFAULT_BACKEND_PATH,
+            signal=backend_loaded,
+        ) or load_backends(
+            [{}],
             base=StaticBackend,
             default=_DEFAULT_BACKEND_PATH,
             signal=backend_loaded,
         )
-        if not self._backends:
-            seed = StaticFilesBackend()
-            self._backends.append(seed)
-            backend_loaded.send(
-                sender=StaticFilesBackend, config=dict(seed.config), instance=seed
-            )
         self._loaded = True
         self._resolve_collector_strategies()
 

--- a/next/static/manager.py
+++ b/next/static/manager.py
@@ -16,19 +16,19 @@ wrapper when `NEXT_FRAMEWORK` changes.
 from __future__ import annotations
 
 import contextlib
-import logging
 from typing import TYPE_CHECKING, Any, cast
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils.functional import LazyObject, empty
 
+from next.backends import load_backends
 from next.conf import import_class_cached, next_framework_settings
 from next.conf.signals import settings_reloaded
 from next.pages.watch import get_pages_directories_for_watch
 
 from .assets import default_kinds
-from .backends import StaticBackend, StaticFilesBackend, StaticsFactory
+from .backends import StaticBackend, StaticFilesBackend
 from .collector import HEAD_CLOSE, StaticCollector, default_placeholders
 from .discovery import AssetDiscovery, PathResolver
 from .scripts import (
@@ -40,7 +40,7 @@ from .scripts import (
     ScriptInjectionPolicy,
     csrf_payload_for,
 )
-from .signals import collector_finalized, html_injected
+from .signals import backend_loaded, collector_finalized, html_injected
 
 
 if TYPE_CHECKING:
@@ -56,10 +56,9 @@ if TYPE_CHECKING:
     from .scripts import NextScriptBuilder as NextScriptBuilderType
 
 
-logger = logging.getLogger(__name__)
-
-
 _RUNTIME_SLOT_NAME = "scripts"
+
+_DEFAULT_BACKEND_PATH = "next.static.StaticFilesBackend"
 
 
 class StaticManager:
@@ -74,6 +73,8 @@ class StaticManager:
     def __init__(self) -> None:
         """Initialise empty backend and discovery caches, loaded lazily."""
         self._backends: list[StaticBackend] = []
+        # An empty list is a legitimate load result, so only a flag knows.
+        self._loaded: bool = False
         self._discovery: AssetDiscovery | None = None
         self._cached_page_roots: tuple[Path, ...] | None = None
         self._script_builder: NextScriptBuilderType | None = None
@@ -254,17 +255,16 @@ class StaticManager:
         return cast("str", renderer(asset.url, request=request))
 
     def _ensure_backends(self) -> None:
-        if not self._backends:
+        if not self._loaded:
             self._reload_config()
 
     def _reload_config(self) -> None:
         """Rebuild the backend list from merged framework settings.
 
-        Only `ImportError`, `TypeError`, and `ValueError` from a single
-        backend entry are swallowed. Other exceptions propagate so bugs
-        in user backends surface loudly.
+        An entry that fails to load costs only itself, the remaining
+        entries still build. A list that ends up empty is seeded with the
+        staticfiles backend so rendering always has one.
         """
-        self._backends.clear()
         self._discovery = None
         self._cached_page_roots = None
         self._script_builder = None
@@ -273,22 +273,24 @@ class StaticManager:
         configs = next_framework_settings.STATIC_BACKENDS
         if not isinstance(configs, list):  # pragma: no cover
             configs = []
-        for config in configs:
-            if not isinstance(config, dict):  # pragma: no cover
-                continue
-            try:
-                backend = StaticsFactory.create_backend(config)
-            except (ImportError, TypeError, ValueError):
-                logger.exception("Error creating static backend from config %s", config)
-                continue
-            self._backends.append(backend)
+        self._backends = load_backends(
+            [config for config in configs if isinstance(config, dict)],
+            base=StaticBackend,
+            default=_DEFAULT_BACKEND_PATH,
+            signal=backend_loaded,
+        )
         if not self._backends:
-            self._backends.append(StaticFilesBackend())
+            seed = StaticFilesBackend()
+            self._backends.append(seed)
+            backend_loaded.send(
+                sender=StaticFilesBackend, config=dict(seed.config), instance=seed
+            )
+        self._loaded = True
         self._resolve_collector_strategies()
 
     def _resolve_collector_strategies(self) -> None:
         """Read dedup and js-context policy dotted paths from the first backend."""
-        options = dict(self.default_backend.config.get("OPTIONS") or {})
+        options = dict(self._backends[0].config.get("OPTIONS") or {})
         dedup_path = options.get("DEDUP_STRATEGY")
         policy_path = options.get("JS_CONTEXT_POLICY")
         self._dedup_factory = (

--- a/next/static/signals.py
+++ b/next/static/signals.py
@@ -23,9 +23,9 @@ are `html_before`, `html_after`, `collector`, `placeholders_replaced`,
 `injected_bytes`, and `request`. The `request` argument carries the
 active `HttpRequest` or None.
 
-The `backend_loaded` signal fires after the static factory
-instantiates a backend. The sender is the backend class. The keyword
-arguments are `config` and `instance`.
+The `backend_loaded` signal fires after the shared backend loader
+instantiates a static backend. The sender is the backend class. The
+keyword arguments are `config` and `instance`.
 """
 
 from django.dispatch import Signal

--- a/next/templatetags/forms.py
+++ b/next/templatetags/forms.py
@@ -8,7 +8,11 @@ from django.middleware.csrf import get_token
 from django.utils.html import format_html
 
 from next.forms.backends import FormActionNotFoundError
-from next.forms.manager import _build_form_namespace_from_meta, form_action_manager
+from next.forms.manager import (
+    _build_form_namespace_from_meta,
+    form_action_manager,
+    resolve_component_anchor,
+)
 from next.forms.uid import (
     FORM_ORIGIN_OVERRIDE_KEY,
     ORIGIN_FIELD_NAME,
@@ -37,6 +41,8 @@ if TYPE_CHECKING:
     from django import forms as django_forms
     from django.http import HttpRequest
     from django.template.base import FilterExpression
+
+    from next.forms.backends import ActionMeta
 
 
 register = template.Library()
@@ -81,6 +87,24 @@ def _page_path_from_context(context: template.Context) -> str | None:
     return str(raw_page) if raw_page else None
 
 
+def _component_path_from_context(context: template.Context) -> str | None:
+    """Return the current component module path stored in the render context."""
+    raw_component = context.get("current_component_module_path")
+    return str(raw_component) if raw_component else None
+
+
+def _anchor_lookup_from_context(
+    context: template.Context, action_name: str
+) -> "tuple[str | None, ActionMeta | None]":
+    """Return the lookup anchor, with the meta when the component anchor wins."""
+    component_path = _component_path_from_context(context)
+    if component_path is not None:
+        meta = resolve_component_anchor(action_name, component_path)
+        if meta is not None:
+            return component_path, meta
+    return _page_path_from_context(context), None
+
+
 @register.simple_tag(takes_context=True)
 def action_url(context: template.Context, action_name: str) -> str:
     """Return the endpoint URL for an action, page-scoped like `{% form %}`."""
@@ -92,9 +116,8 @@ def action_url(context: template.Context, action_name: str) -> str:
             "action name to pass it as a literal."
         )
         raise FormActionNotFoundError(msg)
-    return form_action_manager.get_action_url(
-        name, page_path=_page_path_from_context(context)
-    )
+    anchor, _meta = _anchor_lookup_from_context(context, name)
+    return form_action_manager.get_action_url(name, page_path=anchor)
 
 
 def _parse_form_attr(
@@ -229,12 +252,13 @@ class FormNode(template.Node):
             )
             raise FormActionNotFoundError(msg, name=token)
 
-        page_path = _page_path_from_context(context)
+        page_path, meta = _anchor_lookup_from_context(context, action_name)
 
         resolved_action_url = form_action_manager.get_action_url(
             action_name, page_path=page_path
         )
-        meta = form_action_manager.get_action_meta(action_name, page_path=page_path)
+        if meta is None:
+            meta = form_action_manager.get_action_meta(action_name, page_path=page_path)
 
         form_obj = context.get(action_name)
         if form_obj and hasattr(form_obj, "form"):

--- a/tests/benchmarks/forms/test_bench_factory.py
+++ b/tests/benchmarks/forms/test_bench_factory.py
@@ -2,22 +2,29 @@ from __future__ import annotations
 
 import pytest
 
+from next.backends import resolve_backend_class
 from next.conf.imports import clear_import_cache
-from next.forms.backends import FormActionFactory
+from next.forms.backends import FormActionBackend
 
 
 _REGISTRY_CONFIG = {"BACKEND": "next.forms.RegistryFormActionBackend"}
 
 
-class TestBenchFormActionFactory:
-    @pytest.mark.benchmark(group="forms.factory")
-    def test_create_backend_cached(self, benchmark) -> None:
-        """The dotted path is served from the framework import cache."""
-        FormActionFactory.create_backend(_REGISTRY_CONFIG)
-        benchmark(FormActionFactory.create_backend, _REGISTRY_CONFIG)
+def _build_backend() -> FormActionBackend:
+    """Resolve and instantiate one entry, what `_reload_config` does per config."""
+    klass = resolve_backend_class(_REGISTRY_CONFIG, base=FormActionBackend)
+    return klass(_REGISTRY_CONFIG)
 
-    @pytest.mark.benchmark(group="forms.factory")
-    def test_create_backend_cold(self, benchmark) -> None:
+
+class TestBenchFormActionBackendLoad:
+    @pytest.mark.benchmark(group="forms.backend_load")
+    def test_build_backend_cached(self, benchmark) -> None:
+        """The dotted path is served from the framework import cache."""
+        _build_backend()
+        benchmark(_build_backend)
+
+    @pytest.mark.benchmark(group="forms.backend_load")
+    def test_build_backend_cold(self, benchmark) -> None:
         """The framework import cache is cleared on every round.
 
         `clear_import_cache()` only invalidates the per-framework dict
@@ -27,13 +34,10 @@ class TestBenchFormActionFactory:
         benches in the same session are not penalised.
         """
 
-        def setup() -> tuple[tuple[object, ...], dict[str, object]]:
+        def setup() -> None:
             clear_import_cache()
-            return (_REGISTRY_CONFIG,), {}
 
         try:
-            benchmark.pedantic(
-                FormActionFactory.create_backend, setup=setup, rounds=200, iterations=1
-            )
+            benchmark.pedantic(_build_backend, setup=setup, rounds=200, iterations=1)
         finally:
-            FormActionFactory.create_backend(_REGISTRY_CONFIG)
+            _build_backend()

--- a/tests/benchmarks/forms/test_bench_manager.py
+++ b/tests/benchmarks/forms/test_bench_manager.py
@@ -39,14 +39,9 @@ class TestBenchEnsureBackends:
 
     @pytest.mark.benchmark(group="forms.manager")
     def test_reload_config_cold(self, benchmark) -> None:
-        """Dropping the backends forces a full reload from settings."""
+        """A reload rereads settings and rebuilds every configured backend."""
         manager = FormActionManager()
-
-        def run() -> None:
-            manager._backends = []
-            manager._reload_config()
-
-        benchmark(run)
+        benchmark(manager._reload_config)
 
 
 class TestBenchRegisterThroughManager:

--- a/tests/benchmarks/static/test_bench_manager.py
+++ b/tests/benchmarks/static/test_bench_manager.py
@@ -60,6 +60,23 @@ def _warmed_manager(
     return manager
 
 
+class TestBenchEnsureBackends:
+    """`_ensure_backends` guards every discovery and injection entry point."""
+
+    @pytest.mark.benchmark(group="static.manager.load")
+    def test_ensure_backends_warm(self, benchmark) -> None:
+        """Backends are already loaded, so the call touches no settings."""
+        manager = StaticManager()
+        manager._ensure_backends()
+        benchmark(manager._ensure_backends)
+
+    @pytest.mark.benchmark(group="static.manager.load")
+    def test_reload_config_cold(self, benchmark) -> None:
+        """A reload rereads settings and rebuilds every configured backend."""
+        manager = StaticManager()
+        benchmark(manager._reload_config)
+
+
 class TestBenchStaticManagerInject:
     @pytest.mark.benchmark(group="static.manager")
     def test_inject_typical_page(self, benchmark) -> None:

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from next.components import ComponentInfo
+from next.components import ComponentInfo, FileComponentsBackend, components_manager
 from next.components.signals import (
     component_backend_loaded,
     component_registered,
@@ -17,6 +17,30 @@ from next.components.signals import (
 def min_component_config() -> dict[str, object]:
     """Minimal FileComponentsBackend configuration."""
     return {"DIRS": [], "COMPONENTS_DIR": "_components"}
+
+
+@pytest.fixture()
+def installed_file_backend(
+    min_component_config: dict[str, object],
+) -> Generator[FileComponentsBackend, None, None]:
+    """Run the shared manager over one file backend and restore it afterwards.
+
+    The manager is told the settings were read, otherwise the first access
+    reloads from settings and drops the installed backend.
+    """
+    backend = FileComponentsBackend(dict(min_component_config))
+    saved_backends = components_manager._backends
+    saved_loaded = components_manager._loaded
+    saved_folders = components_manager._walk_registered_folders
+    components_manager._backends = [backend]
+    components_manager._loaded = True
+    components_manager._walk_registered_folders = set()
+    try:
+        yield backend
+    finally:
+        components_manager._backends = saved_backends
+        components_manager._loaded = saved_loaded
+        components_manager._walk_registered_folders = saved_folders
 
 
 @pytest.fixture()
@@ -83,11 +107,18 @@ def capture_components_registered() -> Generator[list[dict[str, Any]], None, Non
 
 @pytest.fixture()
 def capture_component_backend_loaded() -> Generator[list[dict[str, Any]], None, None]:
-    """Capture ``component_backend_loaded`` signal events."""
+    """Capture ``component_backend_loaded`` events with their class sender."""
     events: list[dict[str, Any]] = []
 
-    def _listener(sender: object, **kwargs) -> None:
-        events.append({"sender": sender, **kwargs})
+    def _listener(
+        sender: object,
+        config: dict[str, Any] | None = None,
+        instance: object = None,
+        **kwargs,
+    ) -> None:
+        events.append(
+            {"sender": sender, "config": config, "instance": instance, **kwargs}
+        )
 
     component_backend_loaded.connect(_listener)
     try:

--- a/tests/components/test_backends.py
+++ b/tests/components/test_backends.py
@@ -2,13 +2,11 @@ import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 from django.test import override_settings
 
 import next.components as next_components_mod
 from next.components import (
     ComponentInfo,
-    ComponentsFactory,
     ComponentsManager,
     DummyBackend,
     FileComponentsBackend,
@@ -19,6 +17,12 @@ from next.components import (
 from tests.support import (
     next_framework_settings_component_backends_list as _next_framework_settings_component_backends_list,
 )
+
+
+def _install(manager: ComponentsManager, *backends: object) -> None:
+    """Put ready-made backends on a manager as a finished load."""
+    manager._backends = list(backends)
+    manager._loaded = True
 
 
 class TestComponentsModuleExports:
@@ -270,49 +274,66 @@ class TestFileComponentsBackend:
         assert backend.loaded_module_paths() == ()
 
 
-class TestComponentsFactory:
-    """Tests for ComponentsFactory."""
+class TestFileBackendFromConfig:
+    """A merged `COMPONENT_BACKENDS` entry configures the file backend."""
 
-    def test_create_backend_file_default(self) -> None:
-        """Create FileComponentsBackend with merged-style keys."""
-        config = {
-            "BACKEND": "next.components.FileComponentsBackend",
-            "DIRS": [],
-            "COMPONENTS_DIR": "_components",
-        }
-        backend = ComponentsFactory.create_backend(config)
-        assert isinstance(backend, FileComponentsBackend)
+    def test_empty_dirs_yield_no_extra_roots(self) -> None:
+        """Nothing to scan beyond the page trees when ``DIRS`` is empty."""
+        backend = FileComponentsBackend(
+            {
+                "BACKEND": "next.components.FileComponentsBackend",
+                "DIRS": [],
+                "COMPONENTS_DIR": "_components",
+            }
+        )
         assert backend._extra_component_roots == []
 
-    def test_create_backend_file_ignores_the_components_dir_name(self) -> None:
+    def test_the_components_dir_name_is_not_a_root(self) -> None:
         """``COMPONENTS_DIR`` names a router skip folder and never reaches the backend."""
-        config = {
-            "BACKEND": "next.components.FileComponentsBackend",
-            "DIRS": [str(Path(__file__).parent)],
-            "COMPONENTS_DIR": "components",
-        }
-        backend = ComponentsFactory.create_backend(config)
-        assert isinstance(backend, FileComponentsBackend)
+        backend = FileComponentsBackend(
+            {
+                "BACKEND": "next.components.FileComponentsBackend",
+                "DIRS": [str(Path(__file__).parent)],
+                "COMPONENTS_DIR": "components",
+            }
+        )
         assert backend._extra_component_roots == [Path(__file__).parent]
 
-    def test_create_backend_unknown_raises(self) -> None:
-        """Unknown backend class path raises ImportError."""
-        with pytest.raises(ImportError):
-            ComponentsFactory.create_backend(
-                {"BACKEND": "next.components.UnknownBackend"}
-            )
 
+class TestComponentsManagerLoading:
+    """`ComponentsManager` branches around the shared backend loader."""
 
-class TestComponentsFactoryManager:
-    """ComponentsFactory import path and ComponentsManager branches."""
-
-    def test_create_backend_imports_class_and_passes_config(self) -> None:
-        """Backend is loaded by dotted path and receives the full config dict."""
-        b = ComponentsFactory.create_backend(
-            {"BACKEND": "next.components.DummyBackend", "OPTIONS": {"marker": 7}}
+    def test_entry_without_backend_falls_back_to_the_file_backend(self) -> None:
+        """An entry naming no ``BACKEND`` still gets the filesystem source."""
+        mgr = ComponentsManager()
+        mock_ns = _next_framework_settings_component_backends_list(
+            [{"DIRS": [], "COMPONENTS_DIR": "_components"}]
         )
-        assert isinstance(b, DummyBackend)
-        assert b.config["OPTIONS"]["marker"] == 7
+        with patch("next.components.manager.next_framework_settings", mock_ns):
+            mgr._reload_config()
+        assert [type(backend) for backend in mgr._backends] == [FileComponentsBackend]
+
+    def test_backend_receives_its_own_config_entry(self) -> None:
+        """The whole entry is handed to the backend constructor."""
+        mgr = ComponentsManager()
+        mock_ns = _next_framework_settings_component_backends_list(
+            [{"BACKEND": "next.components.DummyBackend", "OPTIONS": {"marker": 7}}]
+        )
+        with patch("next.components.manager.next_framework_settings", mock_ns):
+            mgr._reload_config()
+        backend = mgr._backends[0]
+        assert isinstance(backend, DummyBackend)
+        assert backend.config["OPTIONS"]["marker"] == 7
+
+    def test_entry_outside_the_family_is_skipped(self) -> None:
+        """A class that is no ``ComponentsBackend`` never joins the list."""
+        mgr = ComponentsManager()
+        mock_ns = _next_framework_settings_component_backends_list(
+            [{"BACKEND": "builtins.dict"}]
+        )
+        with patch("next.components.manager.next_framework_settings", mock_ns):
+            mgr._reload_config()
+        assert mgr._backends == []
 
     def test_dummy_backend_lookups_are_empty(self) -> None:
         """DummyBackend does not resolve names and reports no visible components."""
@@ -343,22 +364,6 @@ class TestComponentsFactoryManager:
             mgr2._reload_config()
             assert len(mgr2._backends) >= 1
 
-    def test_manager_swallows_backend_init_exception(self) -> None:
-        """An exception from ``create_backend`` is logged. The backend is not appended."""
-        mgr = ComponentsManager()
-        mock_ns = _next_framework_settings_component_backends_list(
-            [
-                {
-                    "BACKEND": "next.components.BoomBackend",
-                    "DIRS": [],
-                    "COMPONENTS_DIR": "_components",
-                }
-            ]
-        )
-        with patch("next.components.manager.next_framework_settings", mock_ns):
-            mgr._reload_config()
-        assert mgr._backends == []
-
     def test_manager_collect_visible_first_backend_wins(self) -> None:
         """Same component name from two backends: first backend wins."""
         mgr = ComponentsManager()
@@ -368,7 +373,7 @@ class TestComponentsFactoryManager:
         b1.collect_visible_components.return_value = {"a": info1}
         b2 = MagicMock()
         b2.collect_visible_components.return_value = {"a": info2}
-        mgr._backends = [b1, b2]
+        _install(mgr, b1, b2)
         merged = mgr.collect_visible_components(Path("/t.djx"))
         assert merged["a"] is info1
 
@@ -377,7 +382,7 @@ class TestComponentsFactoryManager:
         mgr = ComponentsManager()
         b = MagicMock()
         b.get_component.return_value = None
-        mgr._backends = [b]
+        _install(mgr, b)
         assert mgr.get_component("x", Path("/p")) is None
 
     def test_manager_get_component_returns_first_hit(self) -> None:
@@ -388,7 +393,7 @@ class TestComponentsFactoryManager:
         b1.get_component.return_value = None
         b2 = MagicMock()
         b2.get_component.return_value = hit
-        mgr._backends = [b1, b2]
+        _install(mgr, b1, b2)
         assert mgr.get_component("n", Path("/t")) is hit
 
 

--- a/tests/components/test_backends.py
+++ b/tests/components/test_backends.py
@@ -309,7 +309,7 @@ class TestComponentsManagerLoading:
         mock_ns = _next_framework_settings_component_backends_list(
             [{"DIRS": [], "COMPONENTS_DIR": "_components"}]
         )
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             mgr._reload_config()
         assert [type(backend) for backend in mgr._backends] == [FileComponentsBackend]
 
@@ -319,7 +319,7 @@ class TestComponentsManagerLoading:
         mock_ns = _next_framework_settings_component_backends_list(
             [{"BACKEND": "next.components.DummyBackend", "OPTIONS": {"marker": 7}}]
         )
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             mgr._reload_config()
         backend = mgr._backends[0]
         assert isinstance(backend, DummyBackend)
@@ -331,7 +331,7 @@ class TestComponentsManagerLoading:
         mock_ns = _next_framework_settings_component_backends_list(
             [{"BACKEND": "builtins.dict"}]
         )
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             mgr._reload_config()
         assert mgr._backends == []
 
@@ -345,7 +345,7 @@ class TestComponentsManagerLoading:
         """If ``COMPONENT_BACKENDS`` is not a list, return early. Non-dict entries are skipped."""
         mgr = ComponentsManager()
         mock_ns = _next_framework_settings_component_backends_list("bad")
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             mgr._reload_config()
             assert mgr._backends == []
 
@@ -360,7 +360,7 @@ class TestComponentsManagerLoading:
                 },
             ]
         )
-        with patch("next.components.manager.next_framework_settings", mock_ns2):
+        with patch("next.backends.next_framework_settings", mock_ns2):
             mgr2._reload_config()
             assert len(mgr2._backends) >= 1
 

--- a/tests/components/test_checks.py
+++ b/tests/components/test_checks.py
@@ -2,18 +2,21 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ImproperlyConfigured
 
 from next.checks import (
     check_component_context_registration_files,
     check_component_py_no_pages_context,
     check_cross_root_component_name_conflicts,
     check_duplicate_component_names,
+    check_next_components_configuration,
     reset_check_caches,
 )
 from next.components import ComponentInfo, FileComponentsBackend
 from next.components.context import ComponentContextRegistry, component
 from tests.support import (
     importable_dir,
+    next_framework_settings_component_backends_list as _next_framework_settings_component_backends_list,
     next_framework_settings_for_checks_backends_value as _next_framework_settings_for_checks_backends_value,
     patch_checks_components_manager,
 )
@@ -36,6 +39,28 @@ class TestChecks:
         mock_ns = _next_framework_settings_for_checks_backends_value(None)
         with patch("next.components.checks.next_framework_settings", mock_ns):
             assert check_duplicate_component_names() == []
+
+    def test_backend_failing_at_import_is_reported(self) -> None:
+        """A backend module raising at import becomes next.E032, not a traceback."""
+        mock_ns = _next_framework_settings_component_backends_list(
+            [
+                {
+                    "BACKEND": "myapp.backends.Broken",
+                    "DIRS": [],
+                    "COMPONENTS_DIR": "_components",
+                }
+            ]
+        )
+        with (
+            patch("next.components.checks.next_framework_settings", mock_ns),
+            patch(
+                "next.checks.common.import_class_cached",
+                side_effect=ImproperlyConfigured("MYAPP_KEY is unset"),
+            ),
+        ):
+            errors = check_next_components_configuration()
+        assert [e.id for e in errors] == ["next.E032"]
+        assert "MYAPP_KEY is unset" in errors[0].msg
 
     def test_check_component_py_no_pages_context_empty_when_no_config(self) -> None:
         """check_component_py_no_pages_context returns [] when backends is not a list."""

--- a/tests/components/test_manager.py
+++ b/tests/components/test_manager.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from django.test import RequestFactory, override_settings
 
 from next.components import (
@@ -11,6 +12,7 @@ from next.components import (
     ComponentsManager,
     ComponentTemplateLoader,
     CompositeComponentRenderer,
+    DummyBackend,
     FileComponentsBackend,
     ModuleLoader,
     SimpleComponentRenderer,
@@ -21,6 +23,7 @@ from next.components import (
     register_components_folder_from_router_walk,
     render_component,
 )
+from next.components.manager import _on_settings_reloaded
 from next.components.renderers import _inject_component_context, _merge_csrf_context
 from next.conf import next_framework_settings
 from tests.support import (
@@ -48,7 +51,7 @@ class TestComponentsManager:
             assert manager.collect_visible_components(Path("/x")) == {}
 
     def test_reload_config_swallows_backend_creation_error(self) -> None:
-        """When create_backend raises, _reload_config logs and continues."""
+        """An unimportable ``BACKEND`` is logged and costs only its own entry."""
         mock_ns = _next_framework_settings_component_backends_list(
             [{"BACKEND": "next.components.NonexistentBackend", "OPTIONS": {}}]
         )
@@ -67,17 +70,163 @@ class TestComponentsManager:
         assert isinstance(mgr.component_renderer, ComponentRenderer)
 
 
+class TestBackendsLoadedOnce:
+    """Settings are read once, whatever the load leaves behind."""
+
+    def test_empty_settings_do_not_reload_on_every_access(self) -> None:
+        """An empty list is a load result, not a reason to reread settings."""
+        manager = ComponentsManager()
+        mock_ns = _next_framework_settings_component_backends_list([])
+        with (
+            patch("next.components.manager.next_framework_settings", mock_ns),
+            patch(
+                "next.components.manager.load_backends", return_value=[]
+            ) as load_backends_mock,
+        ):
+            manager._ensure_backends()
+            manager.get_component("card", Path("/t.djx"))
+            manager.collect_visible_components(Path("/t.djx"))
+        assert load_backends_mock.call_count == 1
+
+    def test_unusable_settings_do_not_reload_on_every_access(self) -> None:
+        """A list nobody can load stays loaded rather than retrying per call."""
+        manager = ComponentsManager()
+        mock_ns = _next_framework_settings_component_backends_list(
+            [{"BACKEND": "next.components.NoSuchBackend"}]
+        )
+        with (
+            patch("next.components.manager.next_framework_settings", mock_ns),
+            patch(
+                "next.components.manager.load_backends", return_value=[]
+            ) as load_backends_mock,
+        ):
+            manager._ensure_backends()
+            manager._ensure_backends()
+        assert load_backends_mock.call_count == 1
+
+    def test_a_caller_emptying_the_list_does_not_trigger_a_reload(self) -> None:
+        """The flag, not the list, answers whether settings were read."""
+        manager = ComponentsManager()
+        mock_ns = _next_framework_settings_component_backends_list(
+            [{"BACKEND": "next.components.DummyBackend"}]
+        )
+        with patch("next.components.manager.next_framework_settings", mock_ns):
+            manager._ensure_backends()
+            manager._backends.clear()
+            manager._ensure_backends()
+        assert manager._backends == []
+
+    def test_reload_config_reads_settings_again(self) -> None:
+        """The explicit reload is still eager, which test helpers rely on."""
+        manager = ComponentsManager()
+        mock_ns = _next_framework_settings_component_backends_list(
+            [{"BACKEND": "next.components.DummyBackend"}]
+        )
+        with patch("next.components.manager.next_framework_settings", mock_ns):
+            manager._ensure_backends()
+            first = manager._backends[0]
+            manager._reload_config()
+        assert manager._backends[0] is not first
+
+
+class TestEntryWithoutBackendKey:
+    """The manager and the watch scan resolve a ``BACKEND``-less entry alike."""
+
+    def test_manager_falls_back_to_the_file_backend(self) -> None:
+        """An entry naming no ``BACKEND`` loads the filesystem source."""
+        manager = ComponentsManager()
+        mock_ns = _next_framework_settings_component_backends_list(
+            [{"DIRS": [], "COMPONENTS_DIR": "_components"}]
+        )
+        with patch("next.components.manager.next_framework_settings", mock_ns):
+            manager._ensure_backends()
+        assert isinstance(manager._backends[0], FileComponentsBackend)
+
+    def test_watch_scan_falls_back_to_the_file_backend(self, tmp_path: Path) -> None:
+        """The read-only scan applies the same default, so it still sees the roots."""
+        root = tmp_path / "extra"
+        root.mkdir()
+        (root / "solo.djx").write_text("x")
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "PAGE_BACKENDS": [],
+                "COMPONENT_BACKENDS": [
+                    {"DIRS": [str(root)], "COMPONENTS_DIR": "_components"}
+                ],
+            }
+        ):
+            next_framework_settings.reload()
+            paths = get_component_paths_for_watch()
+        next_framework_settings.reload()
+        assert (root / "solo.djx").resolve() in paths
+
+
+class TestBackendConstructionErrorsEscape:
+    """Only configuration errors are swallowed, backend bugs are not."""
+
+    def test_runtime_error_from_backend_init_propagates(self) -> None:
+        """A user backend raising from ``__init__`` reaches the caller."""
+        manager = ComponentsManager()
+        mock_ns = _next_framework_settings_component_backends_list(
+            [{"BACKEND": "next.components.BoomBackend"}]
+        )
+        with (
+            patch("next.components.manager.next_framework_settings", mock_ns),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            manager._ensure_backends()
+
+
+class TestSettingsReloadedIsLazy:
+    """The settings receiver invalidates and leaves the rebuild to the next access."""
+
+    def test_receiver_does_not_build_backends(self) -> None:
+        """A reload costs no backend construction on its own."""
+        manager = ComponentsManager()
+        mock_ns = _next_framework_settings_component_backends_list(
+            [{"BACKEND": "next.components.DummyBackend"}]
+        )
+        with patch("next.components.manager.next_framework_settings", mock_ns):
+            manager._ensure_backends()
+            assert len(manager._backends) == 1
+            with patch("next.components.manager.load_backends") as load_backends_mock:
+                manager._invalidate()
+            load_backends_mock.assert_not_called()
+            assert manager._backends == []
+            assert manager._loaded is False
+
+            manager._ensure_backends()
+        assert isinstance(manager._backends[0], DummyBackend)
+
+    def test_receiver_drops_the_render_pipeline_and_walk_folders(self) -> None:
+        """Cached pipeline and router-walk bookkeeping go with the backends."""
+        manager = ComponentsManager()
+        mock_ns = _next_framework_settings_component_backends_list([])
+        with patch("next.components.manager.next_framework_settings", mock_ns):
+            manager._ensure_backends()
+            assert manager.template_loader is not None
+            assert manager._claim_router_walk_folder(Path("/tmp")) is True
+            manager._invalidate()
+        assert manager._component_renderer is None
+        assert manager._walk_registered_folders == set()
+
+    def test_receiver_invalidates_the_module_level_manager(self) -> None:
+        """The wired receiver drops the shared manager state without a rebuild."""
+        components_manager._ensure_backends()
+        with patch("next.components.manager.load_backends") as load_backends_mock:
+            _on_settings_reloaded()
+        load_backends_mock.assert_not_called()
+        assert components_manager._loaded is False
+
+
 class TestRegisterComponentsFolderFromRouterWalk:
     """``register_components_folder_from_router_walk`` wiring."""
 
     def test_registers_scanned_components_on_backend(
-        self, tmp_path: Path, min_component_config: dict
+        self, tmp_path: Path, installed_file_backend: FileComponentsBackend
     ) -> None:
         """Each folder is scanned into the first file components backend registry."""
-        components_manager._walk_registered_folders.clear()
-        components_manager._backends.clear()
-        backend = FileComponentsBackend(dict(min_component_config))
-        components_manager._backends.append(backend)
+        backend = installed_file_backend
         folder = tmp_path / "_components"
         folder.mkdir()
         (folder / "z.djx").write_text("z")
@@ -86,13 +235,10 @@ class TestRegisterComponentsFolderFromRouterWalk:
         assert "z" in names
 
     def test_second_call_skips_same_resolved_folder(
-        self, tmp_path: Path, min_component_config: dict
+        self, tmp_path: Path, installed_file_backend: FileComponentsBackend
     ) -> None:
         """Repeated registration for the same path is ignored."""
-        components_manager._walk_registered_folders.clear()
-        components_manager._backends.clear()
-        backend = FileComponentsBackend(dict(min_component_config))
-        components_manager._backends.append(backend)
+        backend = installed_file_backend
         folder = tmp_path / "_components"
         folder.mkdir()
         (folder / "a.djx").write_text("a")
@@ -101,13 +247,10 @@ class TestRegisterComponentsFolderFromRouterWalk:
         assert len(list(backend._registry.get_all())) == 1
 
     def test_loads_component_py_when_composite_has_module(
-        self, tmp_path: Path, min_component_config: dict
+        self, tmp_path: Path, installed_file_backend: FileComponentsBackend
     ) -> None:
         """Router walk loads ``component.py`` for composite components (coverage)."""
-        components_manager._walk_registered_folders.clear()
-        components_manager._backends.clear()
-        backend = FileComponentsBackend(dict(min_component_config))
-        components_manager._backends.append(backend)
+        backend = installed_file_backend
         comp_dir = tmp_path / "_components" / "news"
         comp_dir.mkdir(parents=True)
         (comp_dir / "component.djx").write_text("<span>news</span>")
@@ -636,14 +779,14 @@ class TestGetComponentPathsForWatch:
                 assert get_component_paths_for_watch() == set()
         next_framework_settings.reload()
 
-    def test_swallows_component_backend_create_error(self) -> None:
-        """Failure to build a component backend is skipped."""
+    def test_swallows_component_backend_resolution_error(self) -> None:
+        """An entry whose ``BACKEND`` does not import is logged and skipped."""
         with override_settings(
             NEXT_FRAMEWORK={
                 "PAGE_BACKENDS": [],
                 "COMPONENT_BACKENDS": [
                     {
-                        "BACKEND": "next.components.FileComponentsBackend",
+                        "BACKEND": "next.components.NoSuchBackend",
                         "DIRS": [],
                         "COMPONENTS_DIR": "_components",
                     }
@@ -651,11 +794,7 @@ class TestGetComponentPathsForWatch:
             }
         ):
             next_framework_settings.reload()
-            with patch(
-                "next.components.manager.ComponentsFactory.create_backend",
-                side_effect=RuntimeError("boom"),
-            ):
-                assert get_component_paths_for_watch() == set()
+            assert get_component_paths_for_watch() == set()
         next_framework_settings.reload()
 
     def test_skips_non_file_component_backend(self) -> None:

--- a/tests/components/test_manager.py
+++ b/tests/components/test_manager.py
@@ -37,7 +37,7 @@ class TestComponentsManager:
     def test_get_component_empty_when_no_config(self) -> None:
         """When ``BACKENDS`` is empty, get_component returns None."""
         mock_ns = _next_framework_settings_component_backends_list([])
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             manager = ComponentsManager()
             manager._reload_config()
             assert manager.get_component("card", Path("/tmp/t.djx")) is None
@@ -45,7 +45,7 @@ class TestComponentsManager:
     def test_collect_visible_components_merges_backends(self) -> None:
         """collect_visible_components merges from all backends, first wins."""
         mock_ns = _next_framework_settings_component_backends_list([])
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             manager = ComponentsManager()
             manager._reload_config()
             assert manager.collect_visible_components(Path("/x")) == {}
@@ -55,7 +55,7 @@ class TestComponentsManager:
         mock_ns = _next_framework_settings_component_backends_list(
             [{"BACKEND": "next.components.NonexistentBackend", "OPTIONS": {}}]
         )
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             manager = ComponentsManager()
             manager._reload_config()
             assert len(manager._backends) == 0
@@ -64,7 +64,7 @@ class TestComponentsManager:
         """Render pipeline uses ``ComponentTemplateLoader`` wrapping ``ModuleLoader``."""
         mgr = ComponentsManager()
         mock_ns = _next_framework_settings_component_backends_list([])
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             mgr._reload_config()
         assert isinstance(mgr.template_loader, ComponentTemplateLoader)
         assert isinstance(mgr.component_renderer, ComponentRenderer)
@@ -78,7 +78,7 @@ class TestBackendsLoadedOnce:
         manager = ComponentsManager()
         mock_ns = _next_framework_settings_component_backends_list([])
         with (
-            patch("next.components.manager.next_framework_settings", mock_ns),
+            patch("next.backends.next_framework_settings", mock_ns),
             patch(
                 "next.components.manager.load_backends", return_value=[]
             ) as load_backends_mock,
@@ -95,7 +95,7 @@ class TestBackendsLoadedOnce:
             [{"BACKEND": "next.components.NoSuchBackend"}]
         )
         with (
-            patch("next.components.manager.next_framework_settings", mock_ns),
+            patch("next.backends.next_framework_settings", mock_ns),
             patch(
                 "next.components.manager.load_backends", return_value=[]
             ) as load_backends_mock,
@@ -110,7 +110,7 @@ class TestBackendsLoadedOnce:
         mock_ns = _next_framework_settings_component_backends_list(
             [{"BACKEND": "next.components.DummyBackend"}]
         )
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             manager._ensure_backends()
             manager._backends.clear()
             manager._ensure_backends()
@@ -122,7 +122,7 @@ class TestBackendsLoadedOnce:
         mock_ns = _next_framework_settings_component_backends_list(
             [{"BACKEND": "next.components.DummyBackend"}]
         )
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             manager._ensure_backends()
             first = manager._backends[0]
             manager._reload_config()
@@ -138,7 +138,7 @@ class TestEntryWithoutBackendKey:
         mock_ns = _next_framework_settings_component_backends_list(
             [{"DIRS": [], "COMPONENTS_DIR": "_components"}]
         )
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             manager._ensure_backends()
         assert isinstance(manager._backends[0], FileComponentsBackend)
 
@@ -171,7 +171,7 @@ class TestBackendConstructionErrorsEscape:
             [{"BACKEND": "next.components.BoomBackend"}]
         )
         with (
-            patch("next.components.manager.next_framework_settings", mock_ns),
+            patch("next.backends.next_framework_settings", mock_ns),
             pytest.raises(RuntimeError, match="boom"),
         ):
             manager._ensure_backends()
@@ -186,7 +186,7 @@ class TestSettingsReloadedIsLazy:
         mock_ns = _next_framework_settings_component_backends_list(
             [{"BACKEND": "next.components.DummyBackend"}]
         )
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             manager._ensure_backends()
             assert len(manager._backends) == 1
             with patch("next.components.manager.load_backends") as load_backends_mock:
@@ -202,7 +202,7 @@ class TestSettingsReloadedIsLazy:
         """Cached pipeline and router-walk bookkeeping go with the backends."""
         manager = ComponentsManager()
         mock_ns = _next_framework_settings_component_backends_list([])
-        with patch("next.components.manager.next_framework_settings", mock_ns):
+        with patch("next.backends.next_framework_settings", mock_ns):
             manager._ensure_backends()
             assert manager.template_loader is not None
             assert manager._claim_router_walk_folder(Path("/tmp")) is True
@@ -588,7 +588,7 @@ class TestGetComponentPathsForWatch:
         mock_nf = SimpleNamespace(
             PAGE_BACKENDS="not-a-list", COMPONENT_BACKENDS="not-a-list"
         )
-        with patch("next.components.watch.next_framework_settings", mock_nf):
+        with patch("next.backends.next_framework_settings", mock_nf):
             assert get_component_paths_for_watch() == set()
 
     def test_collects_composite_under_pages_tree(self, tmp_path: Path) -> None:

--- a/tests/components/test_signals.py
+++ b/tests/components/test_signals.py
@@ -184,7 +184,7 @@ class TestComponentBackendLoadedSignal:
             {"BACKEND": "next.components.DummyBackend", "COMPONENTS_DIR": "b"},
         ]
 
-        with patch("next.components.manager.next_framework_settings") as fake_settings:
+        with patch("next.backends.next_framework_settings") as fake_settings:
             fake_settings.COMPONENT_BACKENDS = configs
             manager._reload_config()
 
@@ -197,7 +197,7 @@ class TestComponentBackendLoadedSignal:
     ) -> None:
         """The class is the sender, so receivers can filter on it."""
         manager = ComponentsManager()
-        with patch("next.components.manager.next_framework_settings") as fake_settings:
+        with patch("next.backends.next_framework_settings") as fake_settings:
             fake_settings.COMPONENT_BACKENDS = [
                 {"BACKEND": "next.components.DummyBackend"}
             ]
@@ -211,7 +211,7 @@ class TestComponentBackendLoadedSignal:
     ) -> None:
         """``instance`` is the backend the manager kept, under its new name."""
         manager = ComponentsManager()
-        with patch("next.components.manager.next_framework_settings") as fake_settings:
+        with patch("next.backends.next_framework_settings") as fake_settings:
             fake_settings.COMPONENT_BACKENDS = [
                 {"BACKEND": "next.components.DummyBackend"}
             ]
@@ -227,7 +227,7 @@ class TestComponentBackendLoadedSignal:
         """A receiver mutating ``config`` cannot corrupt the settings entry."""
         entry = {"BACKEND": "next.components.DummyBackend"}
         manager = ComponentsManager()
-        with patch("next.components.manager.next_framework_settings") as fake_settings:
+        with patch("next.backends.next_framework_settings") as fake_settings:
             fake_settings.COMPONENT_BACKENDS = [entry]
             manager._reload_config()
 
@@ -240,7 +240,7 @@ class TestComponentBackendLoadedSignal:
     ) -> None:
         """An entry that never loads emits no event."""
         manager = ComponentsManager()
-        with patch("next.components.manager.next_framework_settings") as fake_settings:
+        with patch("next.backends.next_framework_settings") as fake_settings:
             fake_settings.COMPONENT_BACKENDS = [
                 {"BACKEND": "next.components.NoSuchBackend"}
             ]

--- a/tests/components/test_signals.py
+++ b/tests/components/test_signals.py
@@ -7,7 +7,7 @@ import pytest
 from django.dispatch import Signal
 
 from next.components import ComponentInfo, render_component
-from next.components.backends import ComponentsBackend, ComponentsFactory
+from next.components.backends import DummyBackend
 from next.components.manager import ComponentsManager
 from next.components.registry import ComponentRegistry
 from next.components.signals import (
@@ -159,7 +159,9 @@ class TestComponentBackendLoadedSignal:
             sender=object, config={"BACKEND": "next.components.FileComponentsBackend"}
         )
         assert len(capture_component_backend_loaded) == 1
-        assert "config" in capture_component_backend_loaded[0]
+        assert capture_component_backend_loaded[0]["config"] == {
+            "BACKEND": "next.components.FileComponentsBackend"
+        }
 
     def test_sender_is_preserved(
         self, capture_component_backend_loaded: list[dict[str, Any]]
@@ -176,39 +178,76 @@ class TestComponentBackendLoadedSignal:
         self, capture_component_backend_loaded: list[dict[str, Any]]
     ) -> None:
         """`ComponentsManager._reload_config` fires once per built backend."""
-        sentinel: ComponentsBackend = ComponentsFactory.create_backend(
-            {"BACKEND": "next.components.DummyBackend", "COMPONENTS_DIR": "_widgets"}
-        )
-
-        class _StubFactory:
-            calls = 0
-
-            @classmethod
-            def create_backend(cls, _config: dict[str, Any]) -> ComponentsBackend:
-                cls.calls += 1
-                return sentinel
-
         manager = ComponentsManager()
         configs = [
             {"BACKEND": "next.components.DummyBackend", "COMPONENTS_DIR": "a"},
             {"BACKEND": "next.components.DummyBackend", "COMPONENTS_DIR": "b"},
         ]
 
-        with (
-            patch("next.components.manager.next_framework_settings") as fake_settings,
-            patch.object(
-                ComponentsFactory, "create_backend", _StubFactory.create_backend
-            ),
-        ):
+        with patch("next.components.manager.next_framework_settings") as fake_settings:
             fake_settings.COMPONENT_BACKENDS = configs
             manager._reload_config()
 
         assert len(capture_component_backend_loaded) == 2
-        senders = {ev["sender"] for ev in capture_component_backend_loaded}
-        assert senders == {ComponentsManager}
         captured_configs = [ev["config"] for ev in capture_component_backend_loaded]
         assert captured_configs == configs
-        assert all(ev["backend"] is sentinel for ev in capture_component_backend_loaded)
+
+    def test_sender_is_the_backend_class(
+        self, capture_component_backend_loaded: list[dict[str, Any]]
+    ) -> None:
+        """The class is the sender, so receivers can filter on it."""
+        manager = ComponentsManager()
+        with patch("next.components.manager.next_framework_settings") as fake_settings:
+            fake_settings.COMPONENT_BACKENDS = [
+                {"BACKEND": "next.components.DummyBackend"}
+            ]
+            manager._reload_config()
+
+        senders = {ev["sender"] for ev in capture_component_backend_loaded}
+        assert senders == {DummyBackend}
+
+    def test_instance_carries_the_loaded_backend(
+        self, capture_component_backend_loaded: list[dict[str, Any]]
+    ) -> None:
+        """``instance`` is the backend the manager kept, under its new name."""
+        manager = ComponentsManager()
+        with patch("next.components.manager.next_framework_settings") as fake_settings:
+            fake_settings.COMPONENT_BACKENDS = [
+                {"BACKEND": "next.components.DummyBackend"}
+            ]
+            manager._reload_config()
+
+        event = capture_component_backend_loaded[0]
+        assert event["instance"] is manager._backends[0]
+        assert "backend" not in event
+
+    def test_config_is_a_copy_of_the_entry(
+        self, capture_component_backend_loaded: list[dict[str, Any]]
+    ) -> None:
+        """A receiver mutating ``config`` cannot corrupt the settings entry."""
+        entry = {"BACKEND": "next.components.DummyBackend"}
+        manager = ComponentsManager()
+        with patch("next.components.manager.next_framework_settings") as fake_settings:
+            fake_settings.COMPONENT_BACKENDS = [entry]
+            manager._reload_config()
+
+        captured = capture_component_backend_loaded[0]["config"]
+        assert captured == entry
+        assert captured is not entry
+
+    def test_skipped_entry_sends_nothing(
+        self, capture_component_backend_loaded: list[dict[str, Any]]
+    ) -> None:
+        """An entry that never loads emits no event."""
+        manager = ComponentsManager()
+        with patch("next.components.manager.next_framework_settings") as fake_settings:
+            fake_settings.COMPONENT_BACKENDS = [
+                {"BACKEND": "next.components.NoSuchBackend"}
+            ]
+            manager._reload_config()
+
+        assert capture_component_backend_loaded == []
+        assert manager._backends == []
 
 
 class TestComponentRenderedSignal:

--- a/tests/components/test_tags.py
+++ b/tests/components/test_tags.py
@@ -541,6 +541,92 @@ class TestComponentTag:
             Template("{% load components %}{% /component %}")
 
 
+class TestComponentAnchorContext:
+    """The component tag pins current_component_module_path for its own body."""
+
+    def test_component_with_module_exposes_its_module_path(
+        self, tmp_path: Path
+    ) -> None:
+        """A component backed by component.py sees its own module path."""
+        (tmp_path / "widget.djx").write_text(
+            "<b>{{ current_component_module_path }}</b>"
+        )
+        module_path = tmp_path / "widget" / "component.py"
+        info = ComponentInfo(
+            name="widget",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=tmp_path / "widget.djx",
+            module_path=module_path,
+            is_simple=True,
+        )
+        with patch.object(components_manager, "get_component", return_value=info):
+            t = Template('{% load components %}{% component "widget" %}')
+            result = t.render(
+                Context({"current_template_path": str(tmp_path / "t.djx")})
+            )
+        assert str(module_path) in result
+
+    def test_nested_component_without_module_sees_none(self, tmp_path: Path) -> None:
+        """An inner component never inherits the outer component's anchor."""
+        outer_module = tmp_path / "outer" / "component.py"
+        (tmp_path / "outer.djx").write_text(
+            'outer:{{ current_component_module_path }}|{% component "inner" %}'
+        )
+        (tmp_path / "inner.djx").write_text(
+            "inner:[{{ current_component_module_path }}]"
+        )
+
+        def fake_get(name: str, _: Path) -> ComponentInfo | None:
+            module_paths = {"outer": outer_module, "inner": None}
+            return ComponentInfo(
+                name=name,
+                scope_root=tmp_path,
+                scope_relative="",
+                template_path=tmp_path / f"{name}.djx",
+                module_path=module_paths[name],
+                is_simple=True,
+            )
+
+        with patch.object(components_manager, "get_component", side_effect=fake_get):
+            t = Template('{% load components %}{% component "outer" %}')
+            result = t.render(
+                Context({"current_template_path": str(tmp_path / "page.djx")})
+            )
+        assert f"outer:{outer_module}" in result
+        assert "inner:[None]" in result
+
+    def test_slot_body_and_children_keep_caller_anchor(self, tmp_path: Path) -> None:
+        """Slot bodies and free children render in the caller's context."""
+        module_path = tmp_path / "box" / "component.py"
+        (tmp_path / "box.djx").write_text(
+            '<div data-anchor="{{ current_component_module_path }}">'
+            "{{ slot_head }}|{{ children }}</div>"
+        )
+        info = ComponentInfo(
+            name="box",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=tmp_path / "box.djx",
+            module_path=module_path,
+            is_simple=True,
+        )
+        with patch.object(components_manager, "get_component", return_value=info):
+            t = Template(
+                "{% load components %}"
+                '{% #component "box" %}'
+                '{% #slot "head" %}S[{{ current_component_module_path }}]{% /slot %}'
+                "C[{{ current_component_module_path }}]"
+                "{% /component %}"
+            )
+            result = t.render(
+                Context({"current_template_path": str(tmp_path / "page.djx")})
+            )
+        assert f'data-anchor="{module_path}"' in result
+        assert "S[]" in result
+        assert "C[]" in result
+
+
 class TestSlotTag:
     """Tests for ``{% #slot %}``, ``{% /slot %}``, and short ``{% slot %}``."""
 

--- a/tests/forms/test_backends.py
+++ b/tests/forms/test_backends.py
@@ -871,14 +871,14 @@ class TestFormActionManagerReloadConfig:
         assert [type(backend) for backend in manager._backends] == [
             RegistryFormActionBackend
         ]
-        assert "error creating FormActionBackend from config" in caplog.text
+        assert "error resolving FormActionBackend from config" in caplog.text
 
 
 class TestFormActionManagerLoadedFlag:
-    """Settings are read once even when they yield no usable backend."""
+    """An empty settings list is cached, a list whose entries all failed is not."""
 
-    def test_unusable_configuration_loads_once(self, settings) -> None:
-        """A list nobody can load stays loaded, rather than retrying per call."""
+    def test_unusable_configuration_is_reread(self, settings) -> None:
+        """Entries that all fail keep the manager rereading settings."""
         settings.NEXT_FRAMEWORK = {
             "FORM_ACTION_BACKENDS": [{"BACKEND": "next.forms.NoSuchBackend"}]
         }
@@ -888,16 +888,43 @@ class TestFormActionManagerLoadedFlag:
         ) as load_backends_mock:
             assert manager.backends == ()
             assert manager.get_action_meta("missing") is None
-            with pytest.raises(ImproperlyConfigured):
-                manager.register_action(
-                    ActionRegistration(
-                        name="never_registered",
-                        file_path=_FAKE_FILE,
-                        scope="shared",
-                        handler=lambda: None,
-                    )
+        assert load_backends_mock.call_count == 2
+
+    def test_a_corrected_configuration_takes_effect(self, settings) -> None:
+        """A fixed dotted path loads on the next access, without a restart."""
+        settings.NEXT_FRAMEWORK = {
+            "FORM_ACTION_BACKENDS": [{"BACKEND": "next.forms.NoSuchBackend"}]
+        }
+        manager = FormActionManager()
+        assert manager.backends == ()
+
+        settings.NEXT_FRAMEWORK = {
+            "FORM_ACTION_BACKENDS": [
+                {"BACKEND": "next.forms.RegistryFormActionBackend"}
+            ]
+        }
+        assert [type(backend) for backend in manager.backends] == [
+            RegistryFormActionBackend
+        ]
+
+    def test_failed_entries_are_named_as_such(self, settings) -> None:
+        """The raised message counts the entries instead of claiming none exist."""
+        settings.NEXT_FRAMEWORK = {
+            "FORM_ACTION_BACKENDS": [
+                {"BACKEND": "next.forms.NoSuchBackend"},
+                {"BACKEND": "next.forms.AlsoMissing"},
+            ]
+        }
+        manager = FormActionManager()
+        with pytest.raises(ImproperlyConfigured, match="None of the 2 entries"):
+            manager.register_action(
+                ActionRegistration(
+                    name="never_registered",
+                    file_path=_FAKE_FILE,
+                    scope="shared",
+                    handler=lambda: None,
                 )
-        assert load_backends_mock.call_count == 1
+            )
 
     def test_empty_configuration_keeps_the_version_stable(self, settings) -> None:
         """No reload per call means the urlpatterns cache token stops churning."""

--- a/tests/forms/test_backends.py
+++ b/tests/forms/test_backends.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,7 +23,6 @@ from next.forms import (
     RegistryFormActionBackend,
 )
 from next.forms.backends import (
-    FormActionFactory,
     RegistryBackendSnapshot,
     file_to_dotted_module,
     scope_key_for,
@@ -847,42 +847,80 @@ class TestFormActionManagerReloadConfig:
         assert len(manager._backends) == 1
         assert isinstance(manager._backends[0], RegistryFormActionBackend)
 
-    def test_factory_failure_is_logged_and_skipped(self, settings, caplog) -> None:
-        """If a backend constructor raises ImproperlyConfigured, the entry is skipped and logged."""
+    @pytest.mark.parametrize(
+        "broken",
+        [
+            pytest.param({"OPTIONS": {}}, id="missing-backend"),
+            pytest.param({"BACKEND": "next.forms.NoSuchBackend"}, id="unimportable"),
+            pytest.param({"BACKEND": "next.forms.ActionOutcome"}, id="outside-family"),
+        ],
+    )
+    def test_broken_entry_is_logged_and_the_rest_of_the_list_loads(
+        self, settings, caplog, broken
+    ) -> None:
+        """A broken entry costs its own backend and nothing else."""
+        settings.NEXT_FRAMEWORK = {
+            "FORM_ACTION_BACKENDS": [
+                broken,
+                {"BACKEND": "next.forms.RegistryFormActionBackend"},
+            ]
+        }
+        manager = FormActionManager()
+        with caplog.at_level(logging.ERROR, logger="next.backends"):
+            manager._reload_config()
+        assert [type(backend) for backend in manager._backends] == [
+            RegistryFormActionBackend
+        ]
+        assert "error creating FormActionBackend from config" in caplog.text
+
+
+class TestFormActionManagerLoadedFlag:
+    """Settings are read once even when they yield no usable backend."""
+
+    def test_unusable_configuration_loads_once(self, settings) -> None:
+        """A list nobody can load stays loaded, rather than retrying per call."""
+        settings.NEXT_FRAMEWORK = {
+            "FORM_ACTION_BACKENDS": [{"BACKEND": "next.forms.NoSuchBackend"}]
+        }
+        manager = FormActionManager()
+        with patch(
+            "next.forms.manager.load_backends", return_value=[]
+        ) as load_backends_mock:
+            assert manager.backends == ()
+            assert manager.get_action_meta("missing") is None
+            with pytest.raises(ImproperlyConfigured):
+                manager.register_action(
+                    ActionRegistration(
+                        name="never_registered",
+                        file_path=_FAKE_FILE,
+                        scope="shared",
+                        handler=lambda: None,
+                    )
+                )
+        assert load_backends_mock.call_count == 1
+
+    def test_empty_configuration_keeps_the_version_stable(self, settings) -> None:
+        """No reload per call means the urlpatterns cache token stops churning."""
+        settings.NEXT_FRAMEWORK = {"FORM_ACTION_BACKENDS": []}
+        manager = FormActionManager()
+        assert manager.backends == ()
+        version = manager._version
+        assert manager.backends == ()
+        assert manager.get_action_meta("missing") is None
+        assert manager._version == version
+
+    def test_explicit_backends_are_not_replaced_by_settings(self, settings) -> None:
+        """A manager built with backends never reads the settings list."""
         settings.NEXT_FRAMEWORK = {
             "FORM_ACTION_BACKENDS": [
                 {"BACKEND": "next.forms.RegistryFormActionBackend"}
             ]
         }
-
-        def boom(_config: dict) -> None:
-            msg = "boom"
-            raise ImproperlyConfigured(msg)
-
-        with patch.object(FormActionFactory, "create_backend", side_effect=boom):
-            manager = FormActionManager()
-            with caplog.at_level("ERROR"):
-                manager._reload_config()
-        assert manager._backends == []
-        assert any(
-            "Error creating form-action backend" in r.message for r in caplog.records
-        )
-
-
-class TestFormActionFactory:
-    """`FormActionFactory.create_backend` resolves dotted paths to backends."""
-
-    def test_explicit_backend_path(self) -> None:
-        """Explicit `BACKEND` path is honoured."""
-        backend = FormActionFactory.create_backend(
-            {"BACKEND": "next.forms.RegistryFormActionBackend"}
-        )
-        assert isinstance(backend, RegistryFormActionBackend)
-
-    def test_missing_backend_key_raises_keyerror(self) -> None:
-        """Configuration without `BACKEND` is the system-check's responsibility."""
-        with pytest.raises(KeyError):
-            FormActionFactory.create_backend({})
+        explicit = _MinimalBackend()
+        manager = FormActionManager(backends=[explicit])
+        with patch("next.forms.manager.load_backends") as load_backends_mock:
+            assert manager.backends == (explicit,)
+        load_backends_mock.assert_not_called()
 
 
 class TestGetActionUrlNoReverseMatchFallback:

--- a/tests/forms/test_backends.py
+++ b/tests/forms/test_backends.py
@@ -27,11 +27,28 @@ from next.forms.backends import (
     file_to_dotted_module,
     scope_key_for,
 )
-from next.forms.manager import FormActionManager, form_action_manager
+from next.forms.manager import (
+    FormActionManager,
+    form_action_manager,
+    resolve_component_anchor,
+)
 
 
 _FAKE_FILE = "/fake/myapp/forms.py"
 _FAKE_FILE_PAGE = "/fake/myapp/page.py"
+
+
+def _register_action(
+    backend: RegistryFormActionBackend,
+    name: str,
+    file_path: str = _FAKE_FILE,
+    scope: str = "shared",
+) -> None:
+    backend.register_action(
+        ActionRegistration(
+            name=name, file_path=file_path, scope=scope, handler=lambda: None
+        )
+    )
 
 
 class TestFormActionNotFoundError:
@@ -503,22 +520,12 @@ class TestRegistryFormActionBackend:
 class TestNameIndexScopeFilter:
     """The name-index fallback honours registration scope for page lookups."""
 
-    @staticmethod
-    def _register(
-        backend: RegistryFormActionBackend, name: str, file_path: str, scope: str
-    ) -> None:
-        backend.register_action(
-            ActionRegistration(
-                name=name, file_path=file_path, scope=scope, handler=lambda: None
-            )
-        )
-
     def test_page_scoped_action_invisible_from_another_page(self, tmp_path) -> None:
         """A page-scoped name never resolves through another page's lookup."""
         backend = RegistryFormActionBackend()
         page_a = str(tmp_path / "a" / "page.py")
         page_b = str(tmp_path / "b" / "page.py")
-        self._register(backend, "note_form", page_a, "page")
+        _register_action(backend, "note_form", page_a, "page")
         assert backend.get_meta("note_form", page_b) is None
         with pytest.raises(
             FormActionNotFoundError, match="Unknown form action"
@@ -531,7 +538,7 @@ class TestNameIndexScopeFilter:
         """A shared-scope name resolves through any page's lookup."""
         backend = RegistryFormActionBackend()
         page_b = str(tmp_path / "b" / "page.py")
-        self._register(backend, "shared_form", _FAKE_FILE, "shared")
+        _register_action(backend, "shared_form")
         meta = backend.get_meta("shared_form", page_b)
         assert meta is not None
         assert meta["scope"] == "shared"
@@ -542,7 +549,7 @@ class TestNameIndexScopeFilter:
         """A lookup without page_path keeps the unfiltered name-index fallback."""
         backend = RegistryFormActionBackend()
         page_a = str(tmp_path / "a" / "page.py")
-        self._register(backend, "note_form", page_a, "page")
+        _register_action(backend, "note_form", page_a, "page")
         meta = backend.get_meta("note_form")
         assert meta is not None
         assert meta["scope"] == "page"
@@ -552,7 +559,7 @@ class TestNameIndexScopeFilter:
         """The declaring page hits the exact registry key, no fallback needed."""
         backend = RegistryFormActionBackend()
         page_a = str(tmp_path / "a" / "page.py")
-        self._register(backend, "note_form", page_a, "page")
+        _register_action(backend, "note_form", page_a, "page")
         meta = backend.get_meta("note_form", page_a)
         assert meta is not None
         assert meta["scope"] == "page"
@@ -560,16 +567,40 @@ class TestNameIndexScopeFilter:
         assert "_next/form/" in url
 
 
+class TestResolveComponentAnchor:
+    """resolve_component_anchor accepts only an exact page-scoped anchor hit."""
+
+    def test_exact_component_hit_returns_the_meta(self, tmp_path) -> None:
+        """A page-scoped registration under component.py is an anchor hit."""
+        comp = str(tmp_path / "widget" / "component.py")
+        _register_action(
+            form_action_manager.default_backend, "anchor_component_action", comp, "page"
+        )
+        meta = resolve_component_anchor("anchor_component_action", comp)
+        assert meta is not None
+        assert meta["scope"] == "page"
+        assert meta is form_action_manager.get_action_meta(
+            "anchor_component_action", page_path=comp
+        )
+
+    def test_shared_fallback_is_not_an_anchor_hit(self, tmp_path) -> None:
+        """A shared registration reachable by fallback still returns None."""
+        comp = str(tmp_path / "widget" / "component.py")
+        _register_action(form_action_manager.default_backend, "anchor_shared_action")
+        assert (
+            form_action_manager.get_action_meta("anchor_shared_action", page_path=comp)
+            is not None
+        )
+        assert resolve_component_anchor("anchor_shared_action", comp) is None
+
+    def test_unknown_name_returns_none(self, tmp_path) -> None:
+        """A name without any registration yields no anchor meta."""
+        comp = str(tmp_path / "widget" / "component.py")
+        assert resolve_component_anchor("anchor_missing_action", comp) is None
+
+
 class TestUnknownActionSuggestions:
     """Lookup failures carry close-match suggestions from the registry."""
-
-    @staticmethod
-    def _register(backend: RegistryFormActionBackend, name: str) -> None:
-        backend.register_action(
-            ActionRegistration(
-                name=name, file_path=_FAKE_FILE, scope="shared", handler=lambda: None
-            )
-        )
 
     @pytest.mark.parametrize(
         ("lookup_name", "expected_suggestions", "message_tail"),
@@ -593,7 +624,7 @@ class TestUnknownActionSuggestions:
     ) -> None:
         """The lookup error carries close matches and renders them last."""
         backend = RegistryFormActionBackend()
-        self._register(backend, "delete_note")
+        _register_action(backend, "delete_note")
         with pytest.raises(FormActionNotFoundError) as excinfo:
             backend.get_action_url(lookup_name)
         assert excinfo.value.suggestions == expected_suggestions
@@ -603,9 +634,9 @@ class TestUnknownActionSuggestions:
         """The manager merges backend suggestions without duplicates."""
         first = RegistryFormActionBackend()
         second = RegistryFormActionBackend()
-        self._register(first, "delete_note")
-        self._register(second, "delete_note")
-        self._register(second, "delete_card")
+        _register_action(first, "delete_note")
+        _register_action(second, "delete_note")
+        _register_action(second, "delete_card")
         manager = FormActionManager(backends=[first, second])
         with pytest.raises(FormActionNotFoundError) as excinfo:
             manager.get_action_url("delete_not")
@@ -615,14 +646,6 @@ class TestUnknownActionSuggestions:
 
 class TestEmptyRegistryDiagnosis:
     """Lookup failures on an empty registry explain the autodiscover miss."""
-
-    @staticmethod
-    def _register(backend: RegistryFormActionBackend, name: str) -> None:
-        backend.register_action(
-            ActionRegistration(
-                name=name, file_path=_FAKE_FILE, scope="shared", handler=lambda: None
-            )
-        )
 
     def test_backend_empty_registry_mentions_autodiscover(self) -> None:
         """An empty backend names the import miss instead of a bare typo message."""
@@ -636,7 +659,7 @@ class TestEmptyRegistryDiagnosis:
     def test_backend_with_actions_skips_the_diagnosis(self) -> None:
         """A populated backend reports a plain unknown-action failure."""
         backend = RegistryFormActionBackend()
-        self._register(backend, "delete_note")
+        _register_action(backend, "delete_note")
         with pytest.raises(FormActionNotFoundError) as excinfo:
             backend.get_action_url("zzzzzz")
         assert excinfo.value.registry_empty is False
@@ -654,7 +677,7 @@ class TestEmptyRegistryDiagnosis:
         """One populated backend is enough to drop the empty-registry hint."""
         first = RegistryFormActionBackend()
         second = RegistryFormActionBackend()
-        self._register(second, "delete_note")
+        _register_action(second, "delete_note")
         manager = FormActionManager(backends=[first, second])
         with pytest.raises(FormActionNotFoundError) as excinfo:
             manager.get_action_url("zzzzzz")
@@ -887,7 +910,8 @@ class TestFormActionManagerLoadedFlag:
             "next.forms.manager.load_backends", return_value=[]
         ) as load_backends_mock:
             assert manager.backends == ()
-            assert manager.get_action_meta("missing") is None
+            with pytest.raises(ImproperlyConfigured, match="None of the 1 entries"):
+                manager.get_action_meta("missing")
         assert load_backends_mock.call_count == 2
 
     def test_a_corrected_configuration_takes_effect(self, settings) -> None:
@@ -933,8 +957,20 @@ class TestFormActionManagerLoadedFlag:
         assert manager.backends == ()
         version = manager._version
         assert manager.backends == ()
-        assert manager.get_action_meta("missing") is None
+        with pytest.raises(ImproperlyConfigured, match="No form action backends"):
+            manager.get_action_meta("missing")
         assert manager._version == version
+
+    def test_lookups_name_the_failed_entries(self, settings) -> None:
+        """A lookup blames the unloadable config, not the caller's imports."""
+        settings.NEXT_FRAMEWORK = {
+            "FORM_ACTION_BACKENDS": [{"BACKEND": "next.forms.NoSuchBackend"}]
+        }
+        manager = FormActionManager()
+        with pytest.raises(ImproperlyConfigured, match="None of the 1 entries"):
+            manager.get_action_url("vote")
+        with pytest.raises(ImproperlyConfigured, match="None of the 1 entries"):
+            manager.require_action_meta("vote")
 
     def test_explicit_backends_are_not_replaced_by_settings(self, settings) -> None:
         """A manager built with backends never reads the settings list."""

--- a/tests/forms/test_rendering.py
+++ b/tests/forms/test_rendering.py
@@ -644,21 +644,21 @@ class TestFormTagFormsetRender:
         assert "</form>" in html
 
 
+def _register_page_action(name: str, file_path: str) -> None:
+    form_action_manager.default_backend.register_action(
+        ActionRegistration(
+            name=name, file_path=file_path, scope="page", handler=lambda: None
+        )
+    )
+
+
 class TestActionUrlTag:
     """{% action_url %} resolves page and shared scopes and rejects unknown names."""
-
-    @staticmethod
-    def _register_page_action(name: str, page_path: str) -> None:
-        form_action_manager.default_backend.register_action(
-            ActionRegistration(
-                name=name, file_path=page_path, scope="page", handler=lambda: None
-            )
-        )
 
     def test_resolves_page_scoped_action(self, form_engine, tmp_path) -> None:
         """The tag resolves a page-scoped action through the context page path."""
         page_path = str(tmp_path / "page.py")
-        self._register_page_action("tag_page_action", page_path)
+        _register_page_action("tag_page_action", page_path)
         out = form_engine.from_string('{% action_url "tag_page_action" %}').render(
             Context({"current_page_module_path": page_path})
         )
@@ -673,7 +673,7 @@ class TestActionUrlTag:
         """The tag honours the same scope filter as {% form %}."""
         page_a = str(tmp_path / "a" / "page.py")
         page_b = str(tmp_path / "b" / "page.py")
-        self._register_page_action("tag_scoped_action", page_a)
+        _register_page_action("tag_scoped_action", page_a)
         t = form_engine.from_string('{% action_url "tag_scoped_action" %}')
         with pytest.raises(FormActionNotFoundError, match="Unknown form action"):
             t.render(Context({"current_page_module_path": page_b}))
@@ -705,6 +705,131 @@ class TestActionUrlTag:
         t = form_engine.from_string("{% action_url save_note %}")
         with pytest.raises(FormActionNotFoundError, match="empty action name"):
             t.render(Context({}))
+
+
+class TestComponentAnchoredActions:
+    """Actions declared in component.py resolve inside the component's template."""
+
+    @staticmethod
+    def _paths(tmp_path) -> tuple[str, str]:
+        page = str(tmp_path / "page.py")
+        comp = str(tmp_path / "widget" / "component.py")
+        return page, comp
+
+    def test_action_url_resolves_component_anchored_action(
+        self, form_engine, tmp_path
+    ) -> None:
+        """The tag reaches a page-scoped action registered under component.py."""
+        page, comp = self._paths(tmp_path)
+        _register_page_action("widget_save", comp)
+        out = form_engine.from_string('{% action_url "widget_save" %}').render(
+            Context(
+                {
+                    "current_page_module_path": page,
+                    "current_component_module_path": comp,
+                }
+            )
+        )
+        assert out == form_action_manager.get_action_url("widget_save", page_path=comp)
+        assert "/_next/form/" in out
+
+    def test_form_tag_resolves_component_anchored_action(
+        self, form_engine, csrf_request, tmp_path
+    ) -> None:
+        """{% form %} renders with the uid of the component registration."""
+        page, comp = self._paths(tmp_path)
+        _register_page_action("widget_save", comp)
+        t = form_engine.from_string('{% form "widget_save" %}x{% endform %}')
+        html = t.render(
+            Context(
+                {
+                    "request": csrf_request,
+                    "current_page_module_path": page,
+                    "current_component_module_path": comp,
+                }
+            )
+        )
+        meta = form_action_manager.get_action_meta("widget_save", page_path=comp)
+        assert meta is not None
+        assert f'data-next-action="{meta["uid"]}"' in html
+        assert "</form>" in html
+
+    def test_page_anchored_action_resolves_inside_component_context(
+        self, form_engine, tmp_path
+    ) -> None:
+        """A component-tier miss falls back to the enclosing page anchor."""
+        page, comp = self._paths(tmp_path)
+        _register_page_action("widget_save", page)
+        out = form_engine.from_string('{% action_url "widget_save" %}').render(
+            Context(
+                {
+                    "current_page_module_path": page,
+                    "current_component_module_path": comp,
+                }
+            )
+        )
+        assert out == form_action_manager.get_action_url("widget_save", page_path=page)
+
+    def test_component_anchored_action_invisible_without_component_context(
+        self, form_engine, tmp_path
+    ) -> None:
+        """Without a component anchor the shared-only fallback still rejects it."""
+        page, comp = self._paths(tmp_path)
+        _register_page_action("widget_save", comp)
+        t = form_engine.from_string('{% action_url "widget_save" %}')
+        with pytest.raises(FormActionNotFoundError, match="Unknown form action"):
+            t.render(Context({"current_page_module_path": page}))
+
+    def test_form_tag_still_raises_without_component_context(
+        self, form_engine, csrf_request, tmp_path
+    ) -> None:
+        """{% form %} keeps the pre-fix failure for component-only registrations."""
+        page, comp = self._paths(tmp_path)
+        _register_page_action("widget_save", comp)
+        t = form_engine.from_string('{% form "widget_save" %}x{% endform %}')
+        with pytest.raises(FormActionNotFoundError, match="Unknown form action"):
+            t.render(
+                Context({"request": csrf_request, "current_page_module_path": page})
+            )
+
+    def test_component_registration_wins_inside_component_context(
+        self, form_engine, tmp_path
+    ) -> None:
+        """The same name under both anchors resolves to the component one."""
+        page, comp = self._paths(tmp_path)
+        _register_page_action("shadowed_save", comp)
+        _register_page_action("shadowed_save", page)
+        component_url = form_action_manager.get_action_url(
+            "shadowed_save", page_path=comp
+        )
+        page_url = form_action_manager.get_action_url("shadowed_save", page_path=page)
+        assert component_url != page_url
+        out = form_engine.from_string('{% action_url "shadowed_save" %}').render(
+            Context(
+                {
+                    "current_page_module_path": page,
+                    "current_component_module_path": comp,
+                }
+            )
+        )
+        assert out == component_url
+
+    def test_page_registration_wins_without_component_context(
+        self, form_engine, tmp_path
+    ) -> None:
+        """Without a component anchor the page registration keeps priority."""
+        page, comp = self._paths(tmp_path)
+        _register_page_action("shadowed_save", comp)
+        _register_page_action("shadowed_save", page)
+        out = form_engine.from_string('{% action_url "shadowed_save" %}').render(
+            Context({"current_page_module_path": page})
+        )
+        assert out == form_action_manager.get_action_url(
+            "shadowed_save", page_path=page
+        )
+        assert out != form_action_manager.get_action_url(
+            "shadowed_save", page_path=comp
+        )
 
 
 class TestFormTagMarkupIdentity:

--- a/tests/forms/test_wizard.py
+++ b/tests/forms/test_wizard.py
@@ -15,16 +15,13 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.test import RequestFactory, override_settings
 
-from next.conf import next_framework_settings
 from next.forms import Form, ModelForm, PermissionOutcome
 from next.forms.diagnostics import registration_diagnostics
 from next.forms.manager import form_action_manager
 from next.forms.wizard import (
     CacheFormWizardBackend,
     FormWizard,
-    FormWizardBackend,
     SessionFormWizardBackend,
-    WizardBackendManager,
     _ensure_session_key,
     _replace_step_segment,
     wizard_backend_manager,
@@ -1005,69 +1002,45 @@ class TestSessionFormWizardBackend:
         backend.clear(request, "wiz")
 
 
-class _StubWizardBackend(FormWizardBackend):
-    """Minimal backend recording the config it was constructed with."""
+class TestWizardBackendSelection:
+    """The shared manager serves the backend named by `FORM_WIZARD_BACKEND`."""
 
-    instances: ClassVar[list] = []
+    def test_default_setting_yields_the_session_backend(self) -> None:
+        """The bundled default resolves to session-backed draft storage."""
+        assert isinstance(wizard_backend_manager.get(), SessionFormWizardBackend)
 
-    def __init__(self, config=None) -> None:
-        type(self).instances.append(config)
-
-    def load(self, request, storage_id):
-        return {}
-
-    def save_step(self, request, storage_id, step, data) -> None:
-        return None
-
-    def clear(self, request, storage_id) -> None:
-        return None
-
-
-class TestWizardBackendManager:
-    """`WizardBackendManager` caches, resets, and reloads the configured backend."""
-
-    def test_get_returns_default_backend_and_caches(self) -> None:
-        """`get` instantiates the configured backend once and caches it."""
-        manager = WizardBackendManager()
-        first = manager.get()
-        second = manager.get()
-        assert isinstance(first, SessionFormWizardBackend)
-        assert first is second
-
-    def test_reset_forces_reinstantiation(self) -> None:
-        """`reset` drops the cached backend so the next `get` rebuilds it."""
-        manager = WizardBackendManager()
-        first = manager.get()
-        manager.reset()
-        assert manager.get() is not first
-
-    def test_custom_backend_from_settings_is_used(self) -> None:
-        """A configured custom backend path is imported and constructed with config."""
-        _StubWizardBackend.instances.clear()
+    def test_configured_backend_replaces_the_default(self) -> None:
+        """A reloaded config swaps the backend the manager hands out."""
         config = {
-            "BACKEND": f"{__name__}._StubWizardBackend",
-            "OPTIONS": {"flag": True},
+            "BACKEND": "next.forms.wizard.CacheFormWizardBackend",
+            "OPTIONS": {"CACHE_ALIAS": "alt"},
         }
         with override_settings(NEXT_FRAMEWORK={"FORM_WIZARD_BACKEND": config}):
-            next_framework_settings.reload()
-            manager = WizardBackendManager()
-            backend = manager.get()
-        assert isinstance(backend, _StubWizardBackend)
-        assert _StubWizardBackend.instances[-1]["OPTIONS"] == {"flag": True}
+            backend = wizard_backend_manager.get()
 
-    def test_settings_reloaded_signal_resets_global_manager(self) -> None:
-        """The settings_reloaded signal drops the shared manager's backend."""
-        first = wizard_backend_manager.get()
-        with override_settings(
-            NEXT_FRAMEWORK={
-                "FORM_WIZARD_BACKEND": {
-                    "BACKEND": "next.forms.wizard.CacheFormWizardBackend",
-                    "OPTIONS": {},
-                }
-            }
+        assert isinstance(backend, CacheFormWizardBackend)
+        assert backend.cache_alias == "alt"
+
+    def test_backend_without_a_dotted_path_is_refused(self) -> None:
+        """A BACKEND that is not a dotted path raises instead of a bare KeyError."""
+        with (
+            override_settings(
+                NEXT_FRAMEWORK={"FORM_WIZARD_BACKEND": {"BACKEND": None}}
+            ),
+            pytest.raises(ImproperlyConfigured, match="under BACKEND"),
         ):
-            next_framework_settings.reload()
-            assert wizard_backend_manager.get() is not first
+            wizard_backend_manager.get()
+
+    def test_backend_outside_the_family_is_refused(self) -> None:
+        """A class that is no `FormWizardBackend` never reaches wizard storage."""
+        config = {"BACKEND": "next.forms.RegistryFormActionBackend"}
+        with (
+            override_settings(NEXT_FRAMEWORK={"FORM_WIZARD_BACKEND": config}),
+            pytest.raises(
+                ImproperlyConfigured, match="not a FormWizardBackend subclass"
+            ),
+        ):
+            wizard_backend_manager.get()
 
 
 class PermStep(Form):

--- a/tests/partial/test_checks.py
+++ b/tests/partial/test_checks.py
@@ -523,6 +523,29 @@ class TestBackendNamesPathCheck:
             assert checks.check_partial_backend_names_a_path() == []
 
 
+class TestBackendsShapeCheck:
+    """`next.E067` fires when PARTIAL_BACKENDS holds anything but a list."""
+
+    @pytest.mark.parametrize(
+        "configs",
+        [(_BACKEND_DICT,), _BACKEND_DICT, "next.partial.PartialProtocolBackend"],
+        ids=["tuple", "bare_dict", "dotted_path"],
+    )
+    def test_non_list_value_errors(self, configs: object) -> None:
+        with override_settings(NEXT_FRAMEWORK={"PARTIAL_BACKENDS": configs}):
+            ids = [m.id for m in checks.check_partial_backends_is_a_list()]
+        assert ids == [checks.E_BACKENDS_NOT_A_LIST]
+
+    @pytest.mark.parametrize(
+        "framework",
+        [{"PARTIAL_BACKENDS": [_BACKEND_DICT]}, {"PARTIAL_BACKENDS": []}, {}, "broken"],
+        ids=["list_entry", "empty_list", "key_absent", "settings_not_a_dict"],
+    )
+    def test_list_or_absent_value_is_silent(self, framework: object) -> None:
+        with override_settings(NEXT_FRAMEWORK=framework):
+            assert checks.check_partial_backends_is_a_list() == []
+
+
 class TestChecksSilentOnValidComposite:
     """A page with well-formed zones triggers none of the zone checks."""
 

--- a/tests/partial/test_manager.py
+++ b/tests/partial/test_manager.py
@@ -1,8 +1,9 @@
 import hashlib
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from unittest.mock import patch
 
-import pytest
 from django.contrib.staticfiles.storage import ManifestFilesMixin
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
@@ -10,22 +11,23 @@ from django.utils.functional import SimpleLazyObject
 
 from next.conf.signals import settings_reloaded
 from next.partial import PartialProtocolBackend
-from next.partial.manager import (
-    PartialBackendManager,
-    PartialProtocolFactory,
-    partial_backend_manager,
-)
+from next.partial.manager import asset_version, partial_backend_manager
 
 
 _DEFAULT_BACKEND = "next.partial.PartialProtocolBackend"
 
 
-def _manager_with_options(options: dict[str, object]) -> PartialBackendManager:
-    manager = PartialBackendManager()
+@contextmanager
+def _backend_options(options: dict[str, object]) -> Iterator[None]:
+    """Run the body against a protocol backend configured with `options`.
+
+    Entering and leaving `override_settings` reloads the framework
+    settings, which resets the shared manager on both edges, so the body
+    sees exactly the entry declared here.
+    """
     config = {"BACKEND": _DEFAULT_BACKEND, "OPTIONS": options}
     with override_settings(NEXT_FRAMEWORK={"PARTIAL_BACKENDS": [config]}):
-        manager.get()
-    return manager
+        yield
 
 
 class _RecordedHashStorage(ManifestFilesMixin):
@@ -53,48 +55,59 @@ def _expected_mapping_hash(hashed_files: dict[str, str]) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
 
 
-class TestManagerVersion:
-    """The manager resolves the asset version stamped on a partial response."""
+class TestAssetVersion:
+    """`asset_version` resolves the version stamped on a partial response."""
 
     def test_explicit_version_wins(self) -> None:
         # an explicit VERSION string wins over the manifest sentinel even when a
         # manifest storage is active, so a release tag pins the version
         storage = _RecordedHashStorage("deadbeef")
-        with patch("next.partial.manager.staticfiles_storage", storage):
-            manager = _manager_with_options({"VERSION": "abc123"})
-            assert manager.version() == "abc123"
+        with (
+            patch("next.partial.manager.staticfiles_storage", storage),
+            _backend_options({"VERSION": "abc123"}),
+        ):
+            assert asset_version() == "abc123"
 
     def test_manifest_sentinel_uses_recorded_hash(self) -> None:
         storage = _RecordedHashStorage("9f3c2e1bcafe")
-        with patch("next.partial.manager.staticfiles_storage", storage):
-            manager = _manager_with_options({"VERSION": "manifest"})
-            assert manager.version() == "9f3c2e1bcafe"
+        with (
+            patch("next.partial.manager.staticfiles_storage", storage),
+            _backend_options({"VERSION": "manifest"}),
+        ):
+            assert asset_version() == "9f3c2e1bcafe"
 
     def test_manifest_sentinel_hashes_mapping_without_recorded_hash(self) -> None:
         files = {"app/a.css": "app/a.abc.css", "app/b.js": "app/b.def.js"}
         storage = _MappingOnlyStorage(files)
-        with patch("next.partial.manager.staticfiles_storage", storage):
-            manager = _manager_with_options({"VERSION": "manifest"})
-            assert manager.version() == _expected_mapping_hash(files)
+        with (
+            patch("next.partial.manager.staticfiles_storage", storage),
+            _backend_options({"VERSION": "manifest"}),
+        ):
+            assert asset_version() == _expected_mapping_hash(files)
 
     def test_mapping_hash_is_stable_across_calls(self) -> None:
-        files = {"x.css": "x.1.css"}
-        storage = _MappingOnlyStorage(files)
-        with patch("next.partial.manager.staticfiles_storage", storage):
-            manager = _manager_with_options({"VERSION": "manifest"})
-            assert manager.version() == manager.version()
+        storage = _MappingOnlyStorage({"x.css": "x.1.css"})
+        with (
+            patch("next.partial.manager.staticfiles_storage", storage),
+            _backend_options({"VERSION": "manifest"}),
+        ):
+            assert asset_version() == asset_version()
 
     def test_manifest_sentinel_falls_back_without_manifest_storage(self) -> None:
-        with patch("next.partial.manager.staticfiles_storage", _PlainStorage()):
-            manager = _manager_with_options({"VERSION": "manifest"})
-            assert manager.version() == "0"
+        with (
+            patch("next.partial.manager.staticfiles_storage", _PlainStorage()),
+            _backend_options({"VERSION": "manifest"}),
+        ):
+            assert asset_version() == "0"
 
     def test_missing_version_resolves_to_default(self) -> None:
         # an absent VERSION option defaults to the manifest sentinel, which
         # falls back to the stable default under the plain test storage
-        with patch("next.partial.manager.staticfiles_storage", _PlainStorage()):
-            manager = _manager_with_options({})
-            assert manager.version() == "0"
+        with (
+            patch("next.partial.manager.staticfiles_storage", _PlainStorage()),
+            _backend_options({}),
+        ):
+            assert asset_version() == "0"
 
     def test_unconfigured_storage_falls_back_to_default(self) -> None:
         # the lazy storage proxy raises ImproperlyConfigured when STATIC_ROOT is
@@ -104,48 +117,47 @@ class TestManagerVersion:
             raise ImproperlyConfigured
 
         proxy = SimpleLazyObject(_unconfigured)
-        with patch("next.partial.manager.staticfiles_storage", proxy):
-            manager = _manager_with_options({"VERSION": "manifest"})
-            assert manager.version() == "0"
+        with (
+            patch("next.partial.manager.staticfiles_storage", proxy),
+            _backend_options({"VERSION": "manifest"}),
+        ):
+            assert asset_version() == "0"
 
 
-class TestFactory:
-    """The factory instantiates the backend named in a settings entry."""
+class TestPartialBackendSelection:
+    """The shared manager serves the backend named by `PARTIAL_BACKENDS`."""
 
-    def test_create_backend(self) -> None:
-        config = {"BACKEND": _DEFAULT_BACKEND, "OPTIONS": {}}
-        backend = PartialProtocolFactory.create_backend(config)
-        assert isinstance(backend, PartialProtocolBackend)
+    def test_get_returns_the_configured_backend(self) -> None:
+        with _backend_options({"VERSION": "pinned"}):
+            backend = partial_backend_manager.get()
 
-    def test_entry_without_backend_path_is_refused(self) -> None:
-        with pytest.raises(ImproperlyConfigured, match="BACKEND"):
-            PartialProtocolFactory.create_backend({"OPTIONS": {}})
+            assert isinstance(backend, PartialProtocolBackend)
+            assert backend.options == {"VERSION": "pinned"}
 
+    def test_default_backend_serves_an_unconfigured_project(self) -> None:
+        # the bundled entry names the default protocol backend, so a project
+        # that lists no entry of its own still gets a working wire format
+        with override_settings(NEXT_FRAMEWORK={"PARTIAL_BACKENDS": []}):
+            assert isinstance(partial_backend_manager.get(), PartialProtocolBackend)
 
-class TestManager:
-    """The manager caches the first configured backend with a reset hook."""
-
-    def test_get_returns_default_backend(self) -> None:
-        manager = PartialBackendManager()
-        assert isinstance(manager.get(), PartialProtocolBackend)
-
-    def test_get_is_cached(self) -> None:
-        manager = PartialBackendManager()
-        assert manager.get() is manager.get()
-
-    def test_reset_drops_cache(self) -> None:
-        manager = PartialBackendManager()
-        first = manager.get()
-        manager.reset()
-        assert manager.get() is not first
-
-    def test_skips_non_dict_config(self) -> None:
-        manager = PartialBackendManager()
-        with override_settings(NEXT_FRAMEWORK={"PARTIAL_BACKENDS": ["bogus"]}):
-            settings_reloaded.send(sender=self.__class__)
-            assert isinstance(manager.get(), PartialProtocolBackend)
-
-    def test_global_manager_resets_on_settings_reloaded(self) -> None:
+    def test_reset_rebuilds_the_backend(self) -> None:
         first = partial_backend_manager.get()
+
+        partial_backend_manager.reset()
+
+        assert partial_backend_manager.get() is not first
+
+    def test_reset_lets_a_new_config_take_effect(self) -> None:
+        with _backend_options({"VERSION": "first"}):
+            partial_backend_manager.get()
+        with _backend_options({"VERSION": "second"}):
+            partial_backend_manager.reset()
+
+            assert partial_backend_manager.get().options == {"VERSION": "second"}
+
+    def test_settings_reloaded_drops_the_cached_backend(self) -> None:
+        first = partial_backend_manager.get()
+
         settings_reloaded.send(sender=self.__class__)
+
         assert partial_backend_manager.get() is not first

--- a/tests/static/conftest.py
+++ b/tests/static/conftest.py
@@ -99,6 +99,7 @@ def make_discovery() -> Callable[..., tuple[AssetDiscovery, StaticManager]]:
     ) -> tuple[AssetDiscovery, StaticManager]:
         manager = StaticManager()
         manager._backends = [backend]
+        manager._loaded = True
         manager._cached_page_roots = page_roots
         return AssetDiscovery(manager), manager
 

--- a/tests/static/test_backends.py
+++ b/tests/static/test_backends.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
-from django.test import override_settings
 
-from next.static import StaticBackend, StaticFilesBackend, StaticsFactory
+import next.static
+from next.static import StaticBackend, StaticFilesBackend
 from next.static.backends import StaticBackend as _StaticBackendDirect
-from next.static.signals import backend_loaded
 
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
     from pathlib import Path
 
     from django.http import HttpRequest
@@ -178,86 +176,11 @@ class TestStaticFilesBackendRegisterFile:
             backend.register_file(tmp_path / "x.css", "x", "css")
 
 
-class TestStaticsFactoryCreateBackend:
-    """StaticsFactory.create_backend instantiates backends from dict config."""
-
-    def test_uses_default_backend_when_missing(self) -> None:
-        backend = StaticsFactory.create_backend({})
-        assert isinstance(backend, StaticFilesBackend)
-
-    def test_instantiates_named_backend(self) -> None:
-        backend = StaticsFactory.create_backend(
-            {"BACKEND": "next.static.StaticFilesBackend"}
-        )
-        assert isinstance(backend, StaticFilesBackend)
-
-    def test_passes_full_config_to_backend(self) -> None:
-        config: Mapping[str, Any] = {
-            "BACKEND": "next.static.StaticFilesBackend",
-            "OPTIONS": {"css_tag": '<link href="{url}">'},
-        }
-        backend = StaticsFactory.create_backend(config)
-        assert backend.config == config
-        assert backend.render_link_tag("x") == '<link href="x">'
-
-    def test_rejects_non_subclass(self) -> None:
-        with pytest.raises(TypeError, match="not a StaticBackend subclass"):
-            StaticsFactory.create_backend({"BACKEND": "builtins.dict"})
-
-    def test_rejects_missing_import_path(self) -> None:
-        with pytest.raises(ImportError):
-            StaticsFactory.create_backend(
-                {"BACKEND": "next.static.does_not_exist.Backend"}
-            )
-
-    def test_fires_backend_loaded_signal(self) -> None:
-        received: list[dict[str, Any]] = []
-
-        def _listener(sender: object, **kwargs) -> None:
-            received.append({"sender": sender, **kwargs})
-
-        backend_loaded.connect(_listener)
-        try:
-            backend = StaticsFactory.create_backend(
-                {"BACKEND": "next.static.StaticFilesBackend", "OPTIONS": {}}
-            )
-        finally:
-            backend_loaded.disconnect(_listener)
-
-        assert len(received) == 1
-        assert received[0]["sender"] is StaticFilesBackend
-        assert received[0]["instance"] is backend
-        assert received[0]["config"] == {
-            "BACKEND": "next.static.StaticFilesBackend",
-            "OPTIONS": {},
-        }
-
-
 class TestStaticBackendReexport:
     """Public re-export from next.static matches the direct import."""
 
     def test_same_object(self) -> None:
         assert StaticBackend is _StaticBackendDirect
 
-
-class TestStaticsFactoryWithSettingsOverride:
-    """Factory respects NEXT_FRAMEWORK['STATIC_BACKENDS'] at construction."""
-
-    def test_build_from_settings_config(self) -> None:
-        with override_settings(
-            NEXT_FRAMEWORK={
-                "STATIC_BACKENDS": [
-                    {
-                        "BACKEND": "next.static.StaticFilesBackend",
-                        "OPTIONS": {"css_tag": '<link integrity href="{url}">'},
-                    }
-                ]
-            }
-        ):
-            backend = StaticsFactory.create_backend(
-                {
-                    "BACKEND": "next.static.StaticFilesBackend",
-                    "OPTIONS": {"css_tag": '<link integrity href="{url}">'},
-                }
-            )
-        assert backend.render_link_tag("x") == '<link integrity href="x">'
+    def test_factory_is_gone_from_the_public_surface(self) -> None:
+        assert not hasattr(next.static, "StaticsFactory")

--- a/tests/static/test_integration.py
+++ b/tests/static/test_integration.py
@@ -38,6 +38,7 @@ class _ManagerWithRoots(StaticManager):
 def wired_manager() -> StaticManager:
     manager = StaticManager()
     manager._backends = [StaticFilesBackend()]
+    manager._loaded = True
     return manager
 
 
@@ -66,6 +67,7 @@ class TestFullRenderPipeline:
 
         manager = _ManagerWithRoots((tmp_path.resolve(),))
         manager._backends = [StaticFilesBackend()]
+        manager._loaded = True
         manager.discover_page_assets(page_path, collector)
         out = manager.inject(HTML_SHELL, collector, page_path=page_path)
 

--- a/tests/static/test_manager.py
+++ b/tests/static/test_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import TYPE_CHECKING
 from unittest import mock
 
@@ -84,11 +85,87 @@ class TestReloadConfig:
             manager._reload_config()
         assert isinstance(manager.default_backend, StaticFilesBackend)
 
+    def test_class_outside_the_family_is_logged_and_skipped(self, caplog) -> None:
+        manager = StaticManager()
+        with (
+            caplog.at_level(logging.ERROR, logger="next.backends"),
+            override_settings(
+                NEXT_FRAMEWORK={
+                    "STATIC_BACKENDS": [
+                        {"BACKEND": "builtins.dict"},
+                        {"BACKEND": "next.static.StaticFilesBackend"},
+                    ]
+                }
+            ),
+        ):
+            manager._reload_config()
+        assert len(manager) == 1
+        assert "is not a StaticBackend subclass" in caplog.text
+
+    def test_entry_without_backend_uses_the_default_class(self) -> None:
+        manager = StaticManager()
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "STATIC_BACKENDS": [{"OPTIONS": {"css_tag": '<link href="{url}">'}}]
+            }
+        ):
+            manager._reload_config()
+        backend = manager.default_backend
+        assert isinstance(backend, StaticFilesBackend)
+        assert backend.render_link_tag("x") == '<link href="x">'
+
+    def test_non_dict_entries_are_ignored(self) -> None:
+        manager = StaticManager()
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "STATIC_BACKENDS": [
+                    "nope",
+                    {"BACKEND": "next.static.StaticFilesBackend"},
+                ]
+            }
+        ):
+            manager._reload_config()
+        assert len(manager) == 1
+
     def test_empty_backends_seeds_default(self) -> None:
         manager = StaticManager()
         with override_settings(NEXT_FRAMEWORK={"STATIC_BACKENDS": []}):
             manager._reload_config()
         assert len(manager) == 1
+
+
+class TestBackendsLoadedOnce:
+    """Settings are read once, whatever the load leaves behind."""
+
+    def test_empty_settings_do_not_reload_on_every_access(self) -> None:
+        manager = StaticManager()
+        with (
+            override_settings(NEXT_FRAMEWORK={"STATIC_BACKENDS": []}),
+            mock.patch(
+                "next.static.manager.load_backends", return_value=[]
+            ) as load_backends_mock,
+        ):
+            manager._ensure_backends()
+            manager._ensure_backends()
+            len(manager)
+        assert load_backends_mock.call_count == 1
+
+    def test_unusable_settings_do_not_reload_on_every_access(self) -> None:
+        manager = StaticManager()
+        with override_settings(
+            NEXT_FRAMEWORK={"STATIC_BACKENDS": [{"BACKEND": "builtins.dict"}]}
+        ):
+            manager._ensure_backends()
+            seeded = manager.default_backend
+            manager._ensure_backends()
+        assert manager.default_backend is seeded
+
+    def test_a_caller_emptying_the_list_does_not_trigger_a_reload(self) -> None:
+        manager = StaticManager()
+        manager._ensure_backends()
+        manager._backends.clear()
+        manager._ensure_backends()
+        assert manager._backends == []
 
 
 class TestInjectStyles:

--- a/tests/static/test_manager.py
+++ b/tests/static/test_manager.py
@@ -139,16 +139,14 @@ class TestBackendsLoadedOnce:
 
     def test_empty_settings_do_not_reload_on_every_access(self) -> None:
         manager = StaticManager()
-        with (
-            override_settings(NEXT_FRAMEWORK={"STATIC_BACKENDS": []}),
-            mock.patch(
-                "next.static.manager.load_backends", return_value=[]
-            ) as load_backends_mock,
-        ):
+        with override_settings(NEXT_FRAMEWORK={"STATIC_BACKENDS": []}):
             manager._ensure_backends()
-            manager._ensure_backends()
-            len(manager)
-        assert load_backends_mock.call_count == 1
+            with mock.patch.object(
+                StaticManager, "_reload_config", autospec=True
+            ) as reload_mock:
+                manager._ensure_backends()
+                len(manager)
+        reload_mock.assert_not_called()
 
     def test_unusable_settings_do_not_reload_on_every_access(self) -> None:
         manager = StaticManager()

--- a/tests/static/test_signals.py
+++ b/tests/static/test_signals.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import pytest
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 
 from next.static import (
     AssetDiscovery,
@@ -11,7 +11,6 @@ from next.static import (
     StaticCollector,
     StaticFilesBackend,
     StaticManager,
-    StaticsFactory,
 )
 from next.static.signals import (
     asset_registered,
@@ -205,77 +204,55 @@ class TestHtmlInjectedSignal:
         assert capture_html_injected[0]["request"] is sentinel
 
 
-class TestLegacyReceiverCompat:
-    """Receivers written before the `request` payload was added still work."""
-
-    def test_collector_finalized_accepts_legacy_receiver(
-        self, fresh_manager: StaticManager
-    ) -> None:
-        """A receiver with `(sender, **kwargs)` consumes the new `request` kwarg."""
-        seen: list[dict[str, object]] = []
-
-        def legacy(sender: object, **kwargs) -> None:
-            seen.append({"sender": sender, **kwargs})
-
-        collector_finalized.connect(legacy)
-        try:
-            collector = StaticCollector()
-            fresh_manager.inject(
-                "<body/>", collector, request=RequestFactory().get("/")
-            )
-        finally:
-            collector_finalized.disconnect(legacy)
-
-        assert len(seen) == 1
-        assert "request" in seen[0]
-        assert "page_path" in seen[0]
-
-    def test_html_injected_accepts_legacy_receiver(
-        self, fresh_manager: StaticManager
-    ) -> None:
-        """A receiver with `(sender, **kwargs)` consumes the new `request` kwarg."""
-        seen: list[dict[str, object]] = []
-
-        def legacy(sender: object, **kwargs) -> None:
-            seen.append({"sender": sender, **kwargs})
-
-        html_injected.connect(legacy)
-        try:
-            collector = StaticCollector()
-            collector.add(StaticAsset(url="https://cdn/a.css", kind="css"))
-            fresh_manager.inject(
-                f"<head>{STYLES_PLACEHOLDER}</head>",
-                collector,
-                request=RequestFactory().get("/"),
-            )
-        finally:
-            html_injected.disconnect(legacy)
-
-        assert len(seen) == 1
-        assert "request" in seen[0]
-        assert "html_before" in seen[0]
-        assert "html_after" in seen[0]
-
-
 class TestBackendLoadedSignal:
-    def test_fired_from_factory(
-        self, capture_backend_loaded: list[dict[str, Any]]
+    def test_fired_for_each_configured_backend(
+        self, fresh_manager: StaticManager, capture_backend_loaded: list[dict[str, Any]]
     ) -> None:
         config = {"BACKEND": "next.static.StaticFilesBackend", "OPTIONS": {}}
-        backend = StaticsFactory.create_backend(config)
+        with override_settings(NEXT_FRAMEWORK={"STATIC_BACKENDS": [config]}):
+            fresh_manager._ensure_backends()
 
         assert len(capture_backend_loaded) == 1
         event = capture_backend_loaded[0]
         assert event["sender"] is StaticFilesBackend
-        assert event["instance"] is backend
+        assert event["instance"] is fresh_manager.default_backend
         assert event["config"] == config
 
     def test_sender_class_allows_filtering(
-        self, capture_backend_loaded: list[dict[str, Any]]
+        self, fresh_manager: StaticManager, capture_backend_loaded: list[dict[str, Any]]
     ) -> None:
-        StaticsFactory.create_backend({"BACKEND": "next.static.StaticFilesBackend"})
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "STATIC_BACKENDS": [{"BACKEND": "next.static.StaticFilesBackend"}]
+            }
+        ):
+            fresh_manager._ensure_backends()
         senders = [e["sender"] for e in capture_backend_loaded]
         assert all(s is StaticFilesBackend for s in senders)
+
+    def test_seeded_fallback_announces_itself(
+        self, fresh_manager: StaticManager, capture_backend_loaded: list[dict[str, Any]]
+    ) -> None:
+        with override_settings(NEXT_FRAMEWORK={"STATIC_BACKENDS": []}):
+            fresh_manager._ensure_backends()
+
+        assert isinstance(fresh_manager.default_backend, StaticFilesBackend)
+        assert [event["sender"] for event in capture_backend_loaded] == [
+            StaticFilesBackend
+        ]
+
+    def test_seed_after_a_skipped_entry_announces_itself(
+        self, fresh_manager: StaticManager, capture_backend_loaded: list[dict[str, Any]]
+    ) -> None:
+        with override_settings(
+            NEXT_FRAMEWORK={"STATIC_BACKENDS": [{"BACKEND": "builtins.dict"}]}
+        ):
+            fresh_manager._ensure_backends()
+
+        assert isinstance(fresh_manager.default_backend, StaticFilesBackend)
+        assert [event["instance"] for event in capture_backend_loaded] == [
+            fresh_manager.default_backend
+        ]
 
 
 class TestSignalsAreDjangoSignals:

--- a/tests/support/backends.py
+++ b/tests/support/backends.py
@@ -2,8 +2,10 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import Any, ClassVar
 
+from django.core.exceptions import ImproperlyConfigured
 
-class KitBackend:
+
+class FakeBackend:
     """Base of the fake backend family the loader builds in these tests."""
 
     def __init__(self, config: Mapping[str, Any]) -> None:
@@ -11,11 +13,11 @@ class KitBackend:
         self.config = config
 
 
-class AlphaBackend(KitBackend):
+class AlphaBackend(FakeBackend):
     """A valid backend of the family."""
 
 
-class BetaBackend(KitBackend):
+class BetaBackend(FakeBackend):
     """A second valid backend, used to assert ordering and rebuilds."""
 
 
@@ -27,10 +29,12 @@ class ForeignBackend:
         self.config = config
 
 
-class RaisingBackend(KitBackend):
+class RaisingBackend(FakeBackend):
     """A backend whose construction fails with the error its entry names."""
 
     ERRORS: ClassVar[dict[str, type[Exception]]] = {
+        "config": ImproperlyConfigured,
+        "import": ImportError,
         "type": TypeError,
         "value": ValueError,
     }
@@ -41,7 +45,7 @@ class RaisingBackend(KitBackend):
         raise self.ERRORS[str(config["ERROR"])](msg)
 
 
-class CountingBackend(KitBackend):
+class CountingBackend(FakeBackend):
     """A backend counting how many times the family instantiated it."""
 
     instances: ClassVar[int] = 0
@@ -52,7 +56,7 @@ class CountingBackend(KitBackend):
         CountingBackend.instances += 1
 
 
-class AbstractKitBackend(ABC):
+class AbstractFakeBackend(ABC):
     """An abstract family root, like the contracts the real areas declare."""
 
     def __init__(self, config: Mapping[str, Any]) -> None:
@@ -64,7 +68,7 @@ class AbstractKitBackend(ABC):
         """Return whatever the family asks its members for."""
 
 
-class ConcreteKitBackend(AbstractKitBackend):
+class ConcreteFakeBackend(AbstractFakeBackend):
     """The instantiable member of the abstract family."""
 
     def run(self) -> str:
@@ -72,7 +76,7 @@ class ConcreteKitBackend(AbstractKitBackend):
         return "ok"
 
 
-def not_a_class(config: Mapping[str, Any]) -> KitBackend:
+def not_a_class(config: Mapping[str, Any]) -> FakeBackend:
     """Return a backend, so only the class check can reject this dotted path."""
     return AlphaBackend(config)
 
@@ -82,6 +86,6 @@ BETA = f"{__name__}.BetaBackend"
 FOREIGN = f"{__name__}.ForeignBackend"
 RAISING = f"{__name__}.RaisingBackend"
 COUNTING = f"{__name__}.CountingBackend"
-CONCRETE = f"{__name__}.ConcreteKitBackend"
+CONCRETE = f"{__name__}.ConcreteFakeBackend"
 NOT_A_CLASS = f"{__name__}.not_a_class"
 MISSING = f"{__name__}.NoSuchBackend"

--- a/tests/support/backends.py
+++ b/tests/support/backends.py
@@ -1,0 +1,87 @@
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from typing import Any, ClassVar
+
+
+class KitBackend:
+    """Base of the fake backend family the loader builds in these tests."""
+
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        """Keep the settings entry the backend was built from."""
+        self.config = config
+
+
+class AlphaBackend(KitBackend):
+    """A valid backend of the family."""
+
+
+class BetaBackend(KitBackend):
+    """A second valid backend, used to assert ordering and rebuilds."""
+
+
+class ForeignBackend:
+    """A backend outside the family, so the base check rejects it."""
+
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        """Accept the settings entry like a real backend would."""
+        self.config = config
+
+
+class RaisingBackend(KitBackend):
+    """A backend whose construction fails with the error its entry names."""
+
+    ERRORS: ClassVar[dict[str, type[Exception]]] = {
+        "type": TypeError,
+        "value": ValueError,
+    }
+
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        """Raise the error class named under `ERROR`."""
+        msg = "boom"
+        raise self.ERRORS[str(config["ERROR"])](msg)
+
+
+class CountingBackend(KitBackend):
+    """A backend counting how many times the family instantiated it."""
+
+    instances: ClassVar[int] = 0
+
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        """Record one more instantiation."""
+        super().__init__(config)
+        CountingBackend.instances += 1
+
+
+class AbstractKitBackend(ABC):
+    """An abstract family root, like the contracts the real areas declare."""
+
+    def __init__(self, config: Mapping[str, Any]) -> None:
+        """Keep the settings entry the backend was built from."""
+        self.config = config
+
+    @abstractmethod
+    def run(self) -> str:
+        """Return whatever the family asks its members for."""
+
+
+class ConcreteKitBackend(AbstractKitBackend):
+    """The instantiable member of the abstract family."""
+
+    def run(self) -> str:
+        """Answer for the family."""
+        return "ok"
+
+
+def not_a_class(config: Mapping[str, Any]) -> KitBackend:
+    """Return a backend, so only the class check can reject this dotted path."""
+    return AlphaBackend(config)
+
+
+ALPHA = f"{__name__}.AlphaBackend"
+BETA = f"{__name__}.BetaBackend"
+FOREIGN = f"{__name__}.ForeignBackend"
+RAISING = f"{__name__}.RaisingBackend"
+COUNTING = f"{__name__}.CountingBackend"
+CONCRETE = f"{__name__}.ConcreteKitBackend"
+NOT_A_CLASS = f"{__name__}.not_a_class"
+MISSING = f"{__name__}.NoSuchBackend"

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -15,12 +15,12 @@ from tests.support.backends import (
     MISSING,
     NOT_A_CLASS,
     RAISING,
-    AbstractKitBackend,
+    AbstractFakeBackend,
     AlphaBackend,
     BetaBackend,
-    ConcreteKitBackend,
+    ConcreteFakeBackend,
     CountingBackend,
-    KitBackend,
+    FakeBackend,
 )
 
 
@@ -46,42 +46,42 @@ class _Recorder:
 
 def _manager(
     setting: str = _DICT_SETTING, default: str | None = None
-) -> SingleBackendManager[KitBackend]:
-    return SingleBackendManager(setting, base=KitBackend, default=default)
+) -> SingleBackendManager[FakeBackend]:
+    return SingleBackendManager(setting, base=FakeBackend, default=default)
 
 
 class TestResolveBackendClass:
     """The dotted path under BACKEND resolves to a class of the family."""
 
     def test_valid_entry_returns_the_named_class(self) -> None:
-        klass = resolve_backend_class({"BACKEND": ALPHA}, base=KitBackend)
+        klass = resolve_backend_class({"BACKEND": ALPHA}, base=FakeBackend)
         assert klass is AlphaBackend
 
     def test_missing_backend_without_default_is_improperly_configured(self) -> None:
         with pytest.raises(ImproperlyConfigured, match="under BACKEND"):
-            resolve_backend_class({"OPTIONS": {}}, base=KitBackend)
+            resolve_backend_class({"OPTIONS": {}}, base=FakeBackend)
 
     def test_empty_backend_is_improperly_configured(self) -> None:
         # an empty dotted path would otherwise reach the importer and fail
         # with a message about module paths rather than about the entry
         with pytest.raises(ImproperlyConfigured, match="under BACKEND"):
-            resolve_backend_class({"BACKEND": ""}, base=KitBackend)
+            resolve_backend_class({"BACKEND": ""}, base=FakeBackend)
 
     def test_missing_backend_falls_back_to_the_default(self) -> None:
-        klass = resolve_backend_class({}, base=KitBackend, default=BETA)
+        klass = resolve_backend_class({}, base=FakeBackend, default=BETA)
         assert klass is BetaBackend
 
     def test_explicit_backend_wins_over_the_default(self) -> None:
-        klass = resolve_backend_class({"BACKEND": ALPHA}, base=KitBackend, default=BETA)
+        klass = resolve_backend_class({"BACKEND": ALPHA}, base=FakeBackend, default=BETA)
         assert klass is AlphaBackend
 
     def test_class_outside_the_family_is_improperly_configured(self) -> None:
-        with pytest.raises(ImproperlyConfigured, match="is not a KitBackend subclass"):
-            resolve_backend_class({"BACKEND": FOREIGN}, base=KitBackend)
+        with pytest.raises(ImproperlyConfigured, match="is not a FakeBackend subclass"):
+            resolve_backend_class({"BACKEND": FOREIGN}, base=FakeBackend)
 
     def test_dotted_path_naming_a_function_is_improperly_configured(self) -> None:
-        with pytest.raises(ImproperlyConfigured, match="is not a KitBackend subclass"):
-            resolve_backend_class({"BACKEND": NOT_A_CLASS}, base=KitBackend)
+        with pytest.raises(ImproperlyConfigured, match="is not a FakeBackend subclass"):
+            resolve_backend_class({"BACKEND": NOT_A_CLASS}, base=FakeBackend)
 
 
 class TestLoadBackends:
@@ -89,55 +89,68 @@ class TestLoadBackends:
 
     def test_returns_instances_in_config_order(self) -> None:
         backends = load_backends(
-            [{"BACKEND": BETA}, {"BACKEND": ALPHA}], base=KitBackend
+            [{"BACKEND": BETA}, {"BACKEND": ALPHA}], base=FakeBackend
         )
         assert [type(backend) for backend in backends] == [BetaBackend, AlphaBackend]
 
     def test_instance_keeps_its_own_config_entry(self) -> None:
         entry = {"BACKEND": ALPHA, "OPTIONS": {"a": 1}}
-        (backend,) = load_backends([entry], base=KitBackend)
+        (backend,) = load_backends([entry], base=FakeBackend)
         assert backend.config == entry
 
     def test_entries_without_backend_use_the_default(self) -> None:
-        backends = load_backends([{}], base=KitBackend, default=ALPHA)
+        backends = load_backends([{}], base=FakeBackend, default=ALPHA)
         assert [type(backend) for backend in backends] == [AlphaBackend]
 
     def test_unimportable_entry_is_logged_and_skipped(self, caplog) -> None:
         with caplog.at_level(logging.ERROR, logger="next.backends"):
             backends = load_backends(
-                [{"BACKEND": MISSING}, {"BACKEND": ALPHA}], base=KitBackend
+                [{"BACKEND": MISSING}, {"BACKEND": ALPHA}], base=FakeBackend
             )
         assert [type(backend) for backend in backends] == [AlphaBackend]
-        assert "error creating KitBackend from config" in caplog.text
+        assert "error resolving FakeBackend from config" in caplog.text
 
     def test_entry_outside_the_family_is_logged_and_skipped(self, caplog) -> None:
         with caplog.at_level(logging.ERROR, logger="next.backends"):
             backends = load_backends(
-                [{"BACKEND": FOREIGN}, {"BACKEND": ALPHA}], base=KitBackend
+                [{"BACKEND": FOREIGN}, {"BACKEND": ALPHA}], base=FakeBackend
             )
         assert [type(backend) for backend in backends] == [AlphaBackend]
-        assert "error creating KitBackend from config" in caplog.text
+        assert "error resolving FakeBackend from config" in caplog.text
 
-    @pytest.mark.parametrize("kind", ["type", "value"])
-    def test_failing_construction_is_logged_and_skipped(self, kind, caplog) -> None:
+    def test_backend_reporting_bad_config_is_logged_and_skipped(self, caplog) -> None:
         with caplog.at_level(logging.ERROR, logger="next.backends"):
             backends = load_backends(
-                [{"BACKEND": RAISING, "ERROR": kind}, {"BACKEND": ALPHA}],
-                base=KitBackend,
+                [{"BACKEND": RAISING, "ERROR": "config"}, {"BACKEND": ALPHA}],
+                base=FakeBackend,
             )
         assert [type(backend) for backend in backends] == [AlphaBackend]
+        assert "error creating FakeBackend from config" in caplog.text
         assert "boom" in caplog.text
+
+    @pytest.mark.parametrize(
+        ("kind", "error"),
+        [("type", TypeError), ("value", ValueError), ("import", ImportError)],
+    )
+    def test_other_errors_from_construction_escape(self, kind, error) -> None:
+        # a constructor failing for anything but its own config is a bug,
+        # not an entry to skip
+        with pytest.raises(error, match="boom"):
+            load_backends(
+                [{"BACKEND": RAISING, "ERROR": kind}, {"BACKEND": ALPHA}],
+                base=FakeBackend,
+            )
 
     def test_unexpected_error_from_construction_escapes(self) -> None:
         with pytest.raises(KeyError):
-            load_backends([{"BACKEND": RAISING}], base=KitBackend)
+            load_backends([{"BACKEND": RAISING}], base=FakeBackend)
 
     def test_no_signal_sends_nothing(self) -> None:
         signal = Signal()
         recorder = _Recorder()
         signal.connect(recorder, weak=False)
 
-        load_backends([{"BACKEND": ALPHA}], base=KitBackend)
+        load_backends([{"BACKEND": ALPHA}], base=FakeBackend)
 
         assert recorder.calls == []
 
@@ -147,7 +160,7 @@ class TestLoadBackends:
         signal.connect(recorder, weak=False)
         entries = [{"BACKEND": ALPHA, "OPTIONS": {"a": 1}}, {"BACKEND": BETA}]
 
-        first, second = load_backends(entries, base=KitBackend, signal=signal)
+        first, second = load_backends(entries, base=FakeBackend, signal=signal)
 
         assert recorder.calls == [
             (AlphaBackend, entries[0], first),
@@ -160,7 +173,7 @@ class TestLoadBackends:
         signal.connect(recorder, weak=False)
         entry = {"BACKEND": ALPHA}
 
-        load_backends([entry], base=KitBackend, signal=signal)
+        load_backends([entry], base=FakeBackend, signal=signal)
 
         assert recorder.calls[0][1] == entry
         assert recorder.calls[0][1] is not entry
@@ -171,18 +184,18 @@ class TestLoadBackends:
         signal.connect(recorder, weak=False)
 
         with caplog.at_level(logging.ERROR, logger="next.backends"):
-            load_backends([{"BACKEND": MISSING}], base=KitBackend, signal=signal)
+            load_backends([{"BACKEND": MISSING}], base=FakeBackend, signal=signal)
 
         assert recorder.calls == []
 
     def test_empty_config_list_loads_nothing(self) -> None:
-        assert load_backends([], base=KitBackend) == []
+        assert load_backends([], base=FakeBackend) == []
 
     def test_each_entry_gets_its_own_instance(self) -> None:
         CountingBackend.instances = 0
 
         backends = load_backends(
-            [{"BACKEND": COUNTING}, {"BACKEND": COUNTING}], base=KitBackend
+            [{"BACKEND": COUNTING}, {"BACKEND": COUNTING}], base=FakeBackend
         )
 
         assert CountingBackend.instances == 2
@@ -193,26 +206,26 @@ class TestAbstractFamilyRoot:
     """An abstract root serves as the family base, as the real areas declare it."""
 
     def test_resolve_returns_the_concrete_member(self) -> None:
-        klass = resolve_backend_class({"BACKEND": CONCRETE}, base=AbstractKitBackend)
-        assert klass is ConcreteKitBackend
+        klass = resolve_backend_class({"BACKEND": CONCRETE}, base=AbstractFakeBackend)
+        assert klass is ConcreteFakeBackend
 
     def test_resolve_names_the_abstract_root_in_its_messages(self) -> None:
         with pytest.raises(
-            ImproperlyConfigured, match="is not a AbstractKitBackend subclass"
+            ImproperlyConfigured, match="is not a AbstractFakeBackend subclass"
         ):
-            resolve_backend_class({"BACKEND": ALPHA}, base=AbstractKitBackend)
+            resolve_backend_class({"BACKEND": ALPHA}, base=AbstractFakeBackend)
 
     def test_load_builds_an_instance_of_the_concrete_member(self) -> None:
-        (backend,) = load_backends([{"BACKEND": CONCRETE}], base=AbstractKitBackend)
+        (backend,) = load_backends([{"BACKEND": CONCRETE}], base=AbstractFakeBackend)
 
-        assert type(backend) is ConcreteKitBackend
+        assert type(backend) is ConcreteFakeBackend
         assert backend.run() == "ok"
 
     def test_load_names_the_abstract_root_in_its_log(self, caplog) -> None:
         with caplog.at_level(logging.ERROR, logger="next.backends"):
-            assert load_backends([{"BACKEND": MISSING}], base=AbstractKitBackend) == []
+            assert load_backends([{"BACKEND": MISSING}], base=AbstractFakeBackend) == []
 
-        assert "error creating AbstractKitBackend from config" in caplog.text
+        assert "error resolving AbstractFakeBackend from config" in caplog.text
 
 
 class TestConfigSelection:
@@ -273,7 +286,7 @@ class TestFailuresPropagate:
     def test_backend_outside_the_family_escapes(self) -> None:
         with (
             override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": FOREIGN}}),
-            pytest.raises(ImproperlyConfigured, match="is not a KitBackend subclass"),
+            pytest.raises(ImproperlyConfigured, match="is not a FakeBackend subclass"),
         ):
             _manager().get()
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,370 @@
+import logging
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.dispatch import Signal
+from django.test import override_settings
+
+from next.backends import SingleBackendManager, load_backends, resolve_backend_class
+from tests.support.backends import (
+    ALPHA,
+    BETA,
+    CONCRETE,
+    COUNTING,
+    FOREIGN,
+    MISSING,
+    NOT_A_CLASS,
+    RAISING,
+    AbstractKitBackend,
+    AlphaBackend,
+    BetaBackend,
+    ConcreteKitBackend,
+    CountingBackend,
+    KitBackend,
+)
+
+
+_DICT_SETTING = "FORM_WIZARD_BACKEND"
+_LIST_SETTING = "PARTIAL_BACKENDS"
+_UNKNOWN_SETTING = "NOT_A_FRAMEWORK_SETTING"
+
+_FAMILY_SHAPES = [
+    pytest.param(_DICT_SETTING, lambda entry: entry, id="dict-entry"),
+    pytest.param(_LIST_SETTING, lambda entry: [entry], id="list-of-entries"),
+]
+
+
+class _Recorder:
+    """Collects what a backend-loaded signal carried to its receivers."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, object, object]] = []
+
+    def __call__(self, sender, **kwargs) -> None:
+        self.calls.append((sender, kwargs.get("config"), kwargs.get("instance")))
+
+
+def _manager(
+    setting: str = _DICT_SETTING, default: str | None = None
+) -> SingleBackendManager[KitBackend]:
+    return SingleBackendManager(setting, base=KitBackend, default=default)
+
+
+class TestResolveBackendClass:
+    """The dotted path under BACKEND resolves to a class of the family."""
+
+    def test_valid_entry_returns_the_named_class(self) -> None:
+        klass = resolve_backend_class({"BACKEND": ALPHA}, base=KitBackend)
+        assert klass is AlphaBackend
+
+    def test_missing_backend_without_default_is_improperly_configured(self) -> None:
+        with pytest.raises(ImproperlyConfigured, match="under BACKEND"):
+            resolve_backend_class({"OPTIONS": {}}, base=KitBackend)
+
+    def test_empty_backend_is_improperly_configured(self) -> None:
+        # an empty dotted path would otherwise reach the importer and fail
+        # with a message about module paths rather than about the entry
+        with pytest.raises(ImproperlyConfigured, match="under BACKEND"):
+            resolve_backend_class({"BACKEND": ""}, base=KitBackend)
+
+    def test_missing_backend_falls_back_to_the_default(self) -> None:
+        klass = resolve_backend_class({}, base=KitBackend, default=BETA)
+        assert klass is BetaBackend
+
+    def test_explicit_backend_wins_over_the_default(self) -> None:
+        klass = resolve_backend_class({"BACKEND": ALPHA}, base=KitBackend, default=BETA)
+        assert klass is AlphaBackend
+
+    def test_class_outside_the_family_is_improperly_configured(self) -> None:
+        with pytest.raises(ImproperlyConfigured, match="is not a KitBackend subclass"):
+            resolve_backend_class({"BACKEND": FOREIGN}, base=KitBackend)
+
+    def test_dotted_path_naming_a_function_is_improperly_configured(self) -> None:
+        with pytest.raises(ImproperlyConfigured, match="is not a KitBackend subclass"):
+            resolve_backend_class({"BACKEND": NOT_A_CLASS}, base=KitBackend)
+
+
+class TestLoadBackends:
+    """A backend list is built entry by entry, bad entries costing only themselves."""
+
+    def test_returns_instances_in_config_order(self) -> None:
+        backends = load_backends(
+            [{"BACKEND": BETA}, {"BACKEND": ALPHA}], base=KitBackend
+        )
+        assert [type(backend) for backend in backends] == [BetaBackend, AlphaBackend]
+
+    def test_instance_keeps_its_own_config_entry(self) -> None:
+        entry = {"BACKEND": ALPHA, "OPTIONS": {"a": 1}}
+        (backend,) = load_backends([entry], base=KitBackend)
+        assert backend.config == entry
+
+    def test_entries_without_backend_use_the_default(self) -> None:
+        backends = load_backends([{}], base=KitBackend, default=ALPHA)
+        assert [type(backend) for backend in backends] == [AlphaBackend]
+
+    def test_unimportable_entry_is_logged_and_skipped(self, caplog) -> None:
+        with caplog.at_level(logging.ERROR, logger="next.backends"):
+            backends = load_backends(
+                [{"BACKEND": MISSING}, {"BACKEND": ALPHA}], base=KitBackend
+            )
+        assert [type(backend) for backend in backends] == [AlphaBackend]
+        assert "error creating KitBackend from config" in caplog.text
+
+    def test_entry_outside_the_family_is_logged_and_skipped(self, caplog) -> None:
+        with caplog.at_level(logging.ERROR, logger="next.backends"):
+            backends = load_backends(
+                [{"BACKEND": FOREIGN}, {"BACKEND": ALPHA}], base=KitBackend
+            )
+        assert [type(backend) for backend in backends] == [AlphaBackend]
+        assert "error creating KitBackend from config" in caplog.text
+
+    @pytest.mark.parametrize("kind", ["type", "value"])
+    def test_failing_construction_is_logged_and_skipped(self, kind, caplog) -> None:
+        with caplog.at_level(logging.ERROR, logger="next.backends"):
+            backends = load_backends(
+                [{"BACKEND": RAISING, "ERROR": kind}, {"BACKEND": ALPHA}],
+                base=KitBackend,
+            )
+        assert [type(backend) for backend in backends] == [AlphaBackend]
+        assert "boom" in caplog.text
+
+    def test_unexpected_error_from_construction_escapes(self) -> None:
+        with pytest.raises(KeyError):
+            load_backends([{"BACKEND": RAISING}], base=KitBackend)
+
+    def test_no_signal_sends_nothing(self) -> None:
+        signal = Signal()
+        recorder = _Recorder()
+        signal.connect(recorder, weak=False)
+
+        load_backends([{"BACKEND": ALPHA}], base=KitBackend)
+
+        assert recorder.calls == []
+
+    def test_signal_fires_once_per_loaded_backend(self) -> None:
+        signal = Signal()
+        recorder = _Recorder()
+        signal.connect(recorder, weak=False)
+        entries = [{"BACKEND": ALPHA, "OPTIONS": {"a": 1}}, {"BACKEND": BETA}]
+
+        first, second = load_backends(entries, base=KitBackend, signal=signal)
+
+        assert recorder.calls == [
+            (AlphaBackend, entries[0], first),
+            (BetaBackend, entries[1], second),
+        ]
+
+    def test_signal_carries_a_config_copy(self) -> None:
+        signal = Signal()
+        recorder = _Recorder()
+        signal.connect(recorder, weak=False)
+        entry = {"BACKEND": ALPHA}
+
+        load_backends([entry], base=KitBackend, signal=signal)
+
+        assert recorder.calls[0][1] == entry
+        assert recorder.calls[0][1] is not entry
+
+    def test_skipped_entry_sends_no_signal(self, caplog) -> None:
+        signal = Signal()
+        recorder = _Recorder()
+        signal.connect(recorder, weak=False)
+
+        with caplog.at_level(logging.ERROR, logger="next.backends"):
+            load_backends([{"BACKEND": MISSING}], base=KitBackend, signal=signal)
+
+        assert recorder.calls == []
+
+    def test_empty_config_list_loads_nothing(self) -> None:
+        assert load_backends([], base=KitBackend) == []
+
+    def test_each_entry_gets_its_own_instance(self) -> None:
+        CountingBackend.instances = 0
+
+        backends = load_backends(
+            [{"BACKEND": COUNTING}, {"BACKEND": COUNTING}], base=KitBackend
+        )
+
+        assert CountingBackend.instances == 2
+        assert backends[0] is not backends[1]
+
+
+class TestAbstractFamilyRoot:
+    """An abstract root serves as the family base, as the real areas declare it."""
+
+    def test_resolve_returns_the_concrete_member(self) -> None:
+        klass = resolve_backend_class({"BACKEND": CONCRETE}, base=AbstractKitBackend)
+        assert klass is ConcreteKitBackend
+
+    def test_resolve_names_the_abstract_root_in_its_messages(self) -> None:
+        with pytest.raises(
+            ImproperlyConfigured, match="is not a AbstractKitBackend subclass"
+        ):
+            resolve_backend_class({"BACKEND": ALPHA}, base=AbstractKitBackend)
+
+    def test_load_builds_an_instance_of_the_concrete_member(self) -> None:
+        (backend,) = load_backends([{"BACKEND": CONCRETE}], base=AbstractKitBackend)
+
+        assert type(backend) is ConcreteKitBackend
+        assert backend.run() == "ok"
+
+    def test_load_names_the_abstract_root_in_its_log(self, caplog) -> None:
+        with caplog.at_level(logging.ERROR, logger="next.backends"):
+            assert load_backends([{"BACKEND": MISSING}], base=AbstractKitBackend) == []
+
+        assert "error creating AbstractKitBackend from config" in caplog.text
+
+
+class TestConfigSelection:
+    """The bound settings key names one entry, whatever shape the family uses."""
+
+    def test_dict_setting_is_used_as_the_entry(self) -> None:
+        with override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": ALPHA}}):
+            assert type(_manager().get()) is AlphaBackend
+
+    def test_list_setting_uses_the_first_entry(self) -> None:
+        with override_settings(
+            NEXT_FRAMEWORK={_LIST_SETTING: [{"BACKEND": BETA}, {"BACKEND": ALPHA}]}
+        ):
+            assert type(_manager(_LIST_SETTING).get()) is BetaBackend
+
+    def test_list_setting_skips_entries_that_are_not_mappings(self) -> None:
+        with override_settings(
+            NEXT_FRAMEWORK={_LIST_SETTING: ["not-an-entry", {"BACKEND": ALPHA}]}
+        ):
+            assert type(_manager(_LIST_SETTING).get()) is AlphaBackend
+
+    def test_backend_keeps_the_selected_entry(self) -> None:
+        entry = {"BACKEND": ALPHA, "OPTIONS": {"a": 1}}
+        with override_settings(NEXT_FRAMEWORK={_LIST_SETTING: [entry]}):
+            assert _manager(_LIST_SETTING).get().config == entry
+
+    def test_empty_list_setting_without_default_raises(self) -> None:
+        with (
+            override_settings(NEXT_FRAMEWORK={_LIST_SETTING: []}),
+            pytest.raises(ImproperlyConfigured, match="under BACKEND"),
+        ):
+            _manager(_LIST_SETTING).get()
+
+    def test_empty_list_setting_falls_back_to_the_default(self) -> None:
+        with override_settings(NEXT_FRAMEWORK={_LIST_SETTING: []}):
+            manager = _manager(_LIST_SETTING, default=ALPHA)
+            assert type(manager.get()) is AlphaBackend
+
+    def test_unknown_settings_key_without_default_raises(self) -> None:
+        with pytest.raises(ImproperlyConfigured, match="under BACKEND"):
+            _manager(_UNKNOWN_SETTING).get()
+
+    def test_unknown_settings_key_falls_back_to_the_default(self) -> None:
+        manager = _manager(_UNKNOWN_SETTING, default=BETA)
+        assert type(manager.get()) is BetaBackend
+
+
+class TestFailuresPropagate:
+    """A single-backend family has no fallback, so a bad entry raises out of get()."""
+
+    def test_unimportable_backend_escapes(self) -> None:
+        with (
+            override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": MISSING}}),
+            pytest.raises(ImportError),
+        ):
+            _manager().get()
+
+    def test_backend_outside_the_family_escapes(self) -> None:
+        with (
+            override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": FOREIGN}}),
+            pytest.raises(ImproperlyConfigured, match="is not a KitBackend subclass"),
+        ):
+            _manager().get()
+
+
+class TestCachingAndReset:
+    """The backend is built on first use and rebuilt only after invalidation."""
+
+    def test_repeated_get_returns_the_cached_backend(self) -> None:
+        CountingBackend.instances = 0
+        with override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": COUNTING}}):
+            manager = _manager()
+            first = manager.get()
+
+            assert manager.get() is first
+            assert CountingBackend.instances == 1
+
+    def test_settings_are_not_read_before_the_first_get(self) -> None:
+        CountingBackend.instances = 0
+        with override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": COUNTING}}):
+            _manager()
+
+            assert CountingBackend.instances == 0
+
+    def test_reset_only_invalidates(self) -> None:
+        CountingBackend.instances = 0
+        with override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": COUNTING}}):
+            manager = _manager()
+            manager.get()
+
+            manager.reset()
+
+            # invalidation costs no instantiation, the rebuild waits for get()
+            assert CountingBackend.instances == 1
+            manager.get()
+            assert CountingBackend.instances == 2
+
+    def test_get_after_reset_rereads_the_setting(self) -> None:
+        manager = _manager()
+        with override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": ALPHA}}):
+            assert type(manager.get()) is AlphaBackend
+
+        manager.reset()
+        with override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": BETA}}):
+            assert type(manager.get()) is BetaBackend
+
+    def test_without_reset_a_changed_setting_is_ignored(self) -> None:
+        manager = _manager()
+        with override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": ALPHA}}):
+            manager.get()
+
+        with override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": BETA}}):
+            assert type(manager.get()) is AlphaBackend
+
+    def test_reset_before_any_get_is_harmless(self) -> None:
+        with override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": ALPHA}}):
+            manager = _manager()
+            manager.reset()
+
+            assert type(manager.get()) is AlphaBackend
+
+
+@pytest.mark.parametrize(("setting", "shape"), _FAMILY_SHAPES)
+class TestFamilyShapes:
+    """Every single-backend family gets the same lifecycle, whatever its shape."""
+
+    def test_get_builds_the_named_backend_once(self, setting, shape) -> None:
+        CountingBackend.instances = 0
+        with override_settings(NEXT_FRAMEWORK={setting: shape({"BACKEND": COUNTING})}):
+            manager = _manager(setting)
+            first = manager.get()
+
+            assert manager.get() is first
+            assert CountingBackend.instances == 1
+
+    def test_reset_forces_reinstantiation(self, setting, shape) -> None:
+        with override_settings(NEXT_FRAMEWORK={setting: shape({"BACKEND": ALPHA})}):
+            manager = _manager(setting)
+            first = manager.get()
+
+            manager.reset()
+
+            assert manager.get() is not first
+
+    def test_configured_entry_reaches_the_backend(self, setting, shape) -> None:
+        entry = {"BACKEND": ALPHA, "OPTIONS": {"flag": True}}
+        with override_settings(NEXT_FRAMEWORK={setting: shape(entry)}):
+            assert _manager(setting).get().config == entry
+
+    def test_entry_without_a_dotted_path_is_refused(self, setting, shape) -> None:
+        with (
+            override_settings(NEXT_FRAMEWORK={setting: shape({"BACKEND": None})}),
+            pytest.raises(ImproperlyConfigured, match="under BACKEND"),
+        ):
+            _manager(setting).get()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -5,7 +5,12 @@ from django.core.exceptions import ImproperlyConfigured
 from django.dispatch import Signal
 from django.test import override_settings
 
-from next.backends import SingleBackendManager, load_backends, resolve_backend_class
+from next.backends import (
+    SingleBackendManager,
+    backend_entries,
+    load_backends,
+    resolve_backend_class,
+)
 from tests.support.backends import (
     ALPHA,
     BETA,
@@ -72,7 +77,9 @@ class TestResolveBackendClass:
         assert klass is BetaBackend
 
     def test_explicit_backend_wins_over_the_default(self) -> None:
-        klass = resolve_backend_class({"BACKEND": ALPHA}, base=FakeBackend, default=BETA)
+        klass = resolve_backend_class(
+            {"BACKEND": ALPHA}, base=FakeBackend, default=BETA
+        )
         assert klass is AlphaBackend
 
     def test_class_outside_the_family_is_improperly_configured(self) -> None:
@@ -228,6 +235,28 @@ class TestAbstractFamilyRoot:
         assert "error resolving AbstractFakeBackend from config" in caplog.text
 
 
+class TestBackendEntries:
+    """backend_entries reads one list-valued settings key defensively."""
+
+    def test_returns_the_dict_entries(self) -> None:
+        entries = [{"BACKEND": ALPHA}, {"BACKEND": BETA}]
+        with override_settings(NEXT_FRAMEWORK={_LIST_SETTING: entries}):
+            assert backend_entries(_LIST_SETTING) == entries
+
+    def test_non_dict_entries_are_filtered(self) -> None:
+        with override_settings(
+            NEXT_FRAMEWORK={_LIST_SETTING: ["not-an-entry", {"BACKEND": ALPHA}, 42]}
+        ):
+            assert backend_entries(_LIST_SETTING) == [{"BACKEND": ALPHA}]
+
+    def test_non_list_value_returns_no_entries(self) -> None:
+        # FORM_WIZARD_BACKEND merges to a dict, never a list of entries.
+        assert backend_entries(_DICT_SETTING) == []
+
+    def test_missing_key_returns_no_entries(self) -> None:
+        assert backend_entries(_UNKNOWN_SETTING) == []
+
+
 class TestConfigSelection:
     """The bound settings key names one entry, whatever shape the family uses."""
 
@@ -276,10 +305,13 @@ class TestConfigSelection:
 class TestFailuresPropagate:
     """A single-backend family has no fallback, so a bad entry raises out of get()."""
 
-    def test_unimportable_backend_escapes(self) -> None:
+    def test_unimportable_backend_names_the_settings_key(self) -> None:
         with (
             override_settings(NEXT_FRAMEWORK={_DICT_SETTING: {"BACKEND": MISSING}}),
-            pytest.raises(ImportError),
+            pytest.raises(
+                ImproperlyConfigured,
+                match=rf"NEXT_FRAMEWORK\['{_DICT_SETTING}'\].*cannot be imported",
+            ),
         ):
             _manager().get()
 

--- a/tests/testing/test_isolation.py
+++ b/tests/testing/test_isolation.py
@@ -54,6 +54,7 @@ class TestResetFormActions:
             form_action_manager.default_backend._uid_to_name.update(saved_uids)
 
     def test_clear_registries_skips_backends_without_method(self) -> None:
+        form_action_manager._ensure_backends()
         manager_backends = form_action_manager._backends
         stub = _BackendWithoutClear()
         form_action_manager._backends = [*manager_backends, stub]

--- a/tests/testing/test_rendering.py
+++ b/tests/testing/test_rendering.py
@@ -47,16 +47,17 @@ class TestRenderComponentByName:
 
         config = {"DIRS": [str(root)], "COMPONENTS_DIR": "_components"}
         backend = FileComponentsBackend(config)
-        previous = list(components_manager._backends)
-        components_manager._backends.clear()
-        components_manager._backends.append(backend)
+        previous = components_manager._backends
+        previously_loaded = components_manager._loaded
+        components_manager._backends = [backend]
+        components_manager._loaded = True
         try:
             html = render_component_by_name(
                 "greeter", at=tmp_path / "page.djx", context={"name": "World"}
             )
         finally:
-            components_manager._backends.clear()
-            components_manager._backends.extend(previous)
+            components_manager._backends = previous
+            components_manager._loaded = previously_loaded
         assert "<b>World</b>" in html
 
     def test_accepts_str_anchor(self, tmp_path: Path) -> None:

--- a/tests/testing/test_rendering.py
+++ b/tests/testing/test_rendering.py
@@ -1,9 +1,10 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from django.test import RequestFactory
 
-from next.components import FileComponentsBackend, components_manager
+from next.components import ComponentInfo, FileComponentsBackend, components_manager
 from next.pages.manager import page
 from next.testing.rendering import render_component_by_name, render_page
 
@@ -63,3 +64,40 @@ class TestRenderComponentByName:
     def test_accepts_str_anchor(self, tmp_path: Path) -> None:
         with pytest.raises(LookupError):
             render_component_by_name("nope", at=str(tmp_path / "page.djx"))
+
+    @staticmethod
+    def _info(tmp_path: Path, module_path: Path | None) -> ComponentInfo:
+        (tmp_path / "widget.djx").write_text("[{{ current_component_module_path }}]")
+        return ComponentInfo(
+            name="widget",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=tmp_path / "widget.djx",
+            module_path=module_path,
+            is_simple=True,
+        )
+
+    def test_sets_component_module_path_from_info(self, tmp_path: Path) -> None:
+        module_path = tmp_path / "widget" / "component.py"
+        info = self._info(tmp_path, module_path)
+        with patch.object(components_manager, "get_component", return_value=info):
+            html = render_component_by_name("widget", at=tmp_path / "page.djx")
+        assert f"[{module_path}]" in html
+
+    def test_module_less_component_sets_none(self, tmp_path: Path) -> None:
+        info = self._info(tmp_path, None)
+        with patch.object(components_manager, "get_component", return_value=info):
+            html = render_component_by_name("widget", at=tmp_path / "page.djx")
+        assert "[None]" in html
+
+    def test_renderer_stamp_overrides_caller_value(self, tmp_path: Path) -> None:
+        module_path = tmp_path / "widget" / "component.py"
+        info = self._info(tmp_path, module_path)
+        with patch.object(components_manager, "get_component", return_value=info):
+            html = render_component_by_name(
+                "widget",
+                at=tmp_path / "page.djx",
+                context={"current_component_module_path": "caller-anchor"},
+            )
+        assert f"[{module_path}]" in html
+        assert "caller-anchor" not in html


### PR DESCRIPTION
## Description

Seven hand-written twins did the same thing: read a dotted path from a settings entry, import the class, instantiate it. Each had drifted — a different exception on a broken config, a different validation, a differently named reset, a different signal contract. Any fix had to be made N times, and the 0.10 ws-consumer and 0.12 route-serializer would have added the eighth and ninth copy.

`next/backends.py` now holds one contract for both shapes. `resolve_backend_class` does the single validation (`BACKEND` with an optional default, `import_class_cached`, `issubclass` against the family root, `ImproperlyConfigured` on failure). `load_backends` wraps it for the list families (forms actions, components, static) and emits an optional per-instance signal. `SingleBackendManager[T]` is a lazy holder for the single families (partial protocol, form wizard), reading either a dict setting or the first dict of a list setting, with `get()` and an invalidate-only `reset()`. `backend_entries()` owns the raw-settings normalization (list of dicts, everything else dropped) that the three list managers and both autoreload scans previously filtered by hand.

An empty backend list is a legitimate load result, so each list manager carries a `_loaded` flag instead of reading the list itself as a cache marker. A site whose entries all fail no longer rereads settings on every call, and the forms manager stops bumping the version token that invalidates the urlpatterns cache. The components receiver for `settings_reloaded` only invalidates now, the rebuild waits for the next access instead of running inside the signal — that alone removes 86 pointless backend rebuilds per test-suite run.

Review of that refactor found three ways a misconfigured site stays quiet or lies about the reason, all fixed here.

The loader resolved the dotted path and called the constructor under one `except`, so a `TypeError` from a backend `__init__` was logged as a configuration error while an `OSError` from the same line propagated. The two phases now have their own small `try`: an entry is skipped when its path does not resolve into the family, or when the backend itself answers `ImproperlyConfigured`, and anything else a constructor raises reaches the caller. Each phase logs under its own message, so `error resolving` and `error creating` name what actually failed.

`FormActionManager` cached a load that produced nothing, so a typo in a dotted path surfaced as `No form action backends configured. Add at least one entry ...` — advice that was wrong, since the entry existed — and a corrected setting never took effect. An empty settings list is still cached, a list whose entries all failed is not, and the raised message now counts the entries that were tried and points at the `next.backends` logger. The manager still has no `settings_reloaded` receiver, because dropping its backends would drop the actions registered on them.

`PARTIAL_BACKENDS` had no shape check. The settings layer merges the key only from a list, so a tuple or a bare dict was dropped and the default protocol backend loaded in place of the configured one, while `next.E073` and `next.W071` both read the merged value and stayed silent — server and client ended up on different wire formats with no diagnostic anywhere. `next.E067` reports the shape against the raw setting, matching how `next.E044` already guards `FORM_ACTION_BACKENDS`.

Drops `FormActionFactory`, `ComponentsFactory`, `StaticsFactory`, `PartialProtocolFactory`, `PartialBackendManager` and `WizardBackendManager`. The `partial_backend_manager` and `wizard_backend_manager` singletons keep their names and their `get` and `reset` methods.

### Component-anchored actions reach the template tags

A page-scoped form or `@action` declared in `component.py` registered under the component.py path, but `{% form %}` and `{% action_url %}` only ever passed the page.py path, and the shared-only fallback rejected page-scoped entries — a component-anchored action was unreachable from every template and rendering failed with `FormActionNotFoundError`. The tags now resolve a name against the nearest anchor first: the component's own `component.py`, then the enclosing page's `page.py`, then the shared registry. Slot bodies and free children render in the page context and keep the page anchor. Everything that resolved before resolves identically, the fix only adds the previously unreachable tier.

The mechanics: the component render strategies stamp `current_component_module_path` into the template context (which also covers `ComponentWidget` renders and isolated `render_component_by_name` calls), and `resolve_component_anchor` in the forms manager tells an exact anchor hit apart from the path-independent shared fallback by the stored scope. The backend protocol is untouched — that invariant is now documented on `FormActionBackend.get_meta`. The lookup stays at one to two registry probes on page templates and two to three inside components.

The same review pass hardened the checks: `next.E032` now imports a `COMPONENT_BACKENDS` dotted path and verifies the `ComponentsBackend` subclass at `manage.py check` time (a typo'd path previously vanished into a log line at first render), and `SingleBackendManager` wraps a resolve-time `ImportError` into `ImproperlyConfigured` naming the settings key, matching Django's own single-backend loaders.

### Documentation review and sentence-case headings

A full docs review against `next/` fixed 126 confirmed findings across all 147 pages: wrong signatures in copyable examples (unannotated `request` in `on_valid`/`get_initial`), mirrored layout-composition claims, an uncopyable `COMPONENT_BACKENDS` snippet, stale check-code lists, contradictory `DJANGO_SETTINGS_MODULE` guidance, plus verbosity, semicolon, and legacy sweeps. `ref/backends.rst` now documents the shared loader. The style guide switched headings from Title Case to sentence case (matching the Django docs convention and the Google/Microsoft style guides), all 1128 headings, rubrics, and toctree captions were converted, and prose references to renamed sections were updated. Spec names such as Content Security Policy and Subresource Integrity keep their capitalization.

### Breaking

- `component_backend_loaded` sends `sender=<backend class>`, `config=dict` and `instance=`, matching `backend_loaded`. Receivers bound to `sender=ComponentsManager` or reading the `backend` kwarg stop firing.
- Removed public names: `FormActionFactory`, `ComponentsFactory`, `StaticsFactory`, `PartialProtocolFactory`, `PartialBackendManager`, `WizardBackendManager`. `partial_backend_manager.version()` is now the free function `asset_version()`.
- A config entry that names no `BACKEND` raises `ImproperlyConfigured` in forms and wizard, and a class outside its family is refused across every area. Static refuses a non-subclass `BACKEND` the same way.
- A backend constructor raising anything but `ImproperlyConfigured` is no longer logged and swallowed. It reaches the caller, on the render path and during `manage.py check` alike.
- `backend_loaded` also fires for the staticfiles backend the static manager seeds when no entry survives.
- `PARTIAL_BACKENDS` that is not a list is now an error at `manage.py check` (`next.E067`) instead of being silently ignored.
- Load failures log under the `next.backends` logger.
- `next.E032` now fails `manage.py check` for a `COMPONENT_BACKENDS` entry whose `BACKEND` does not import or is not a `ComponentsBackend` subclass. Such a config previously passed checks and failed silently at render time.
- A bad dotted path in `FORM_WIZARD_BACKEND` or `PARTIAL_BACKENDS` raises `ImproperlyConfigured` naming the settings key instead of a raw `ImportError`.
- Inside a component's own template body, `{% form %}` and `{% action_url %}` prefer an action anchored to that component over a same-named page-scoped or shared action. Page templates and slot content are unaffected.

## How to test

`make lint`, `make type-check`, `make test` (3233 passed, 19 skipped, 100% coverage on `next/`), `make docs` (`-W`, warnings are errors) and `uv run doc8 docs/content` are green locally. The client toolchain was not run, since no TypeScript changed.

`make bench` is green at 153 benchmarks. The load path is touched at process start and on `settings_reloaded`, not per request. The anchor chain adds at most one dict-cheap registry probe inside component templates and none on page templates, and the form-tag rendering benchmarks show no regression.

To see the anchor fix by hand, declare a `DForm` subclass in a component's `component.py`, reference it with `{% form %}` inside that component's template, and render a page using the component — before this branch that render raised `FormActionNotFoundError`. To see the new checks, point `NEXT_FRAMEWORK["COMPONENT_BACKENDS"][0]["BACKEND"]` at a typo'd path or set `PARTIAL_BACKENDS` to a tuple and run `manage.py check`.

## Related issues

<!-- Fixes # -->

## Checklist

- [ ] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [ ] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable
