### PR TITLE
feat(urls): contract-only registry lookup and route introspection docs

### DIFF
--- a/docs/content/internals/url-router.rst
+++ b/docs/content/internals/url-router.rst
@@ -35,6 +35,7 @@ Modules
 
 ``next.urls.backends``.
    ``RouterBackend`` is the abstract contract.
+   Its concrete ``page_roots``, ``components_folder_name``, and ``skip_dir_names`` methods form the route introspection contract described below.
    ``FileRouterBackend`` implements file based routing.
    ``RouterFactory`` looks up backends by dotted path.
 
@@ -45,6 +46,7 @@ Modules
 
 ``next.urls.manager``.
    ``RouterManager`` builds the active pattern list, exposes ``reload``, and emits the ``router_reloaded`` signal.
+   Its ``backends`` property is the public read of the loaded backend tuple in routing order.
    The module-level ``urlpatterns`` is a list with one ``TrieURLResolver`` wrapping the lazy router and form-action pattern sequence.
 
 ``next.urls.resolver``.
@@ -129,6 +131,30 @@ If two routes convert to exactly the same Django path string the ``check_url_pat
 The comparison is string equality after bracket conversion, so semantic overlap between typed converters, such as ``posts/[int:id]`` next to ``posts/[id]``, is not reported.
 The same collection pass owns the duplicate parameter report, failing with ``next.E028`` and listing every conflicting name in one message, and reports a router whose collection raises as ``next.E016``.
 ``check_reverse_name_collisions`` reuses the collection but drops its errors, so ``next.E016`` and ``next.E028`` never appear twice.
+
+Route introspection
+-------------------
+
+Beside the abstract ``generate_urls``, ``RouterBackend`` carries three concrete route introspection methods.
+
+- ``page_roots()`` returns the labelled page trees the backend routes, as ``PageRoot`` entries.
+- ``components_folder_name()`` returns the folder name the backend registers components from, or ``None`` for a backend that registers none.
+- ``skip_dir_names()`` returns the directory names the backend's own walk refuses to enter.
+
+The three methods are a public contract in their own right.
+The system checks and the development watcher read only this contract and never touch a backend's private state.
+The checks walk the reported trees themselves with the reported skip set, and the watcher derives its watch specs from the same reads.
+
+The defaults are safe rather than participating.
+A backend that overrides none of the methods raises nowhere, but it reports an empty tree list, names no components folder, and skips nothing.
+Such a backend stays out of every page-tree check and out of the watcher, so overriding the methods is what opts a backend in.
+``FileRouterBackend`` overrides all three.
+
+``RouterManager.backends`` is the public read of the loaded backend list, a tuple in routing order.
+Reading the property builds nothing.
+The list appears after the first iteration of the manager or after ``reload()``, so a caller that needs the configured set asks after one of those.
+
+See :doc:`/content/howto/write-a-router-backend` for the contract from a backend author's side and :doc:`autoreload` for how the watcher consumes the reads.
 
 Extension points
 ----------------

--- a/docs/content/internals/url-router.rst
+++ b/docs/content/internals/url-router.rst
@@ -46,7 +46,6 @@ Modules
 
 ``next.urls.manager``.
    ``RouterManager`` builds the active pattern list, exposes ``reload``, and emits the ``router_reloaded`` signal.
-   Its ``backends`` property is the public read of the loaded backend tuple in routing order.
    The module-level ``urlpatterns`` is a list with one ``TrieURLResolver`` wrapping the lazy router and form-action pattern sequence.
 
 ``next.urls.resolver``.
@@ -135,26 +134,14 @@ The same collection pass owns the duplicate parameter report, failing with ``nex
 Route introspection
 -------------------
 
-Beside the abstract ``generate_urls``, ``RouterBackend`` carries three concrete route introspection methods.
+Beside the abstract ``generate_urls``, ``RouterBackend`` carries three concrete introspection methods, ``page_roots``, ``components_folder_name``, and ``skip_dir_names``.
+They are a public contract, the only thing the system checks and the development watcher read from a backend, and :doc:`/content/howto/write-a-router-backend` is the canonical description of each method and of the safe defaults that make overriding them the opt-in.
 
-- ``page_roots()`` returns the labelled page trees the backend routes, as ``PageRoot`` entries.
-- ``components_folder_name()`` returns the folder name the backend registers components from, or ``None`` for a backend that registers none.
-- ``skip_dir_names()`` returns the directory names the backend's own walk refuses to enter.
-
-The three methods are a public contract in their own right.
-The system checks and the development watcher read only this contract and never touch a backend's private state.
-The checks walk the reported trees themselves with the reported skip set, and the watcher derives its watch specs from the same reads.
-
-The defaults are safe rather than participating.
-A backend that overrides none of the methods raises nowhere, but it reports an empty tree list, names no components folder, and skips nothing.
-Such a backend stays out of every page-tree check and out of the watcher, so overriding the methods is what opts a backend in.
-``FileRouterBackend`` overrides all three.
+The checks walk the reported trees themselves, refusing the names ``skip_dir_names`` returns plus the folder ``components_folder_name`` names, while the watcher derives its watch specs from ``page_roots`` and ``components_folder_name`` alone, as :doc:`autoreload` describes.
 
 ``RouterManager.backends`` is the public read of the loaded backend list, a tuple in routing order.
-Reading the property builds nothing.
+Reading the property loads no backends.
 The list appears after the first iteration of the manager or after ``reload()``, so a caller that needs the configured set asks after one of those.
-
-See :doc:`/content/howto/write-a-router-backend` for the contract from a backend author's side and :doc:`autoreload` for how the watcher consumes the reads.
 
 Extension points
 ----------------

--- a/next/urls/backends.py
+++ b/next/urls/backends.py
@@ -371,6 +371,15 @@ class RouterFactory:
         cls._backends[name] = backend_class
 
     @classmethod
+    def is_registered(cls, name: str) -> bool:
+        """Report whether `name` maps to a registered backend class.
+
+        Contract-only seam for system checks so adjacent areas never read
+        the class registry directly.
+        """
+        return name in cls._backends
+
+    @classmethod
     def create_backend(cls, config: dict[str, Any]) -> RouterBackend:
         """Instantiate the backend class named by `config["BACKEND"]`."""
         backend_name = config["BACKEND"]

--- a/next/urls/backends.py
+++ b/next/urls/backends.py
@@ -367,8 +367,16 @@ class RouterFactory:
 
     @classmethod
     def register_backend(cls, name: str, backend_class: type[RouterBackend]) -> None:
-        """Map a dotted backend path to a class for `create_backend`."""
-        cls._backends[name] = backend_class
+        """Map a dotted backend path to a class for `create_backend`.
+
+        Validates at registration so a bad class fails loudly here instead of
+        silently on the first `create_backend` during a router reload.
+        """
+        candidate: object = backend_class
+        if not isinstance(candidate, type) or not issubclass(candidate, RouterBackend):
+            msg = f"Backend {name!r} is not a RouterBackend subclass"
+            raise TypeError(msg)
+        cls._backends[name] = candidate
 
     @classmethod
     def is_registered(cls, name: str) -> bool:

--- a/next/urls/checks.py
+++ b/next/urls/checks.py
@@ -46,7 +46,7 @@ _CollectedPattern = tuple[str, str, str, frozenset[str]]
 
 def _router_backend_path_is_valid(backend_path: str) -> bool:
     """Return True when `backend_path` names a registered or importable backend."""
-    if backend_path in RouterFactory._backends:
+    if RouterFactory.is_registered(backend_path):
         return True
     try:
         resolved = import_string(backend_path)

--- a/tests/urls/conftest.py
+++ b/tests/urls/conftest.py
@@ -2,8 +2,21 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from next.urls import FileRouterBackend, RouterBackend, RouterManager
+from next.urls import FileRouterBackend, RouterBackend, RouterFactory, RouterManager
 from tests.support import named_temp_py
+
+
+@pytest.fixture(autouse=True)
+def _pristine_router_registry():
+    """Restore the process-global RouterFactory registry after each test.
+
+    Tests register backend classes into a ClassVar dict, so without a
+    snapshot the keys leak and poison run order.
+    """
+    snapshot = dict(RouterFactory._backends)
+    yield
+    RouterFactory._backends.clear()
+    RouterFactory._backends.update(snapshot)
 
 
 @pytest.fixture()

--- a/tests/urls/test_backends.py
+++ b/tests/urls/test_backends.py
@@ -858,7 +858,6 @@ class TestRouterFactory:
         """Registered name maps to the given class."""
         RouterFactory.register_backend("custom", custom_backend_class)
         assert RouterFactory.is_registered("custom")
-        assert RouterFactory._backends["custom"] == custom_backend_class
 
     def test_is_registered(self) -> None:
         """Built-in backend name is registered, unknown names are not."""
@@ -974,15 +973,20 @@ class TestRouterFactory:
         with pytest.raises(ValueError, match="Unsupported backend"):
             RouterFactory.create_backend(config)
 
-    def test_create_backend_typeerror_when_not_router_subclass(self) -> None:
-        """Registered class must be a RouterBackend subclass."""
+    def test_register_backend_typeerror_when_not_router_subclass(self) -> None:
+        """Registering a non RouterBackend class fails at registration time."""
 
         class Plain:
             pass
 
-        RouterFactory.register_backend("plain.not.Router", Plain)
         with pytest.raises(TypeError, match="RouterBackend"):
-            RouterFactory.create_backend({"BACKEND": "plain.not.Router"})
+            RouterFactory.register_backend("plain.not.Router", Plain)
+        assert not RouterFactory.is_registered("plain.not.Router")
+
+    def test_create_backend_typeerror_when_import_is_not_router_subclass(self) -> None:
+        """Importable BACKEND path that is not a RouterBackend raises TypeError."""
+        with pytest.raises(TypeError, match="RouterBackend"):
+            RouterFactory.create_backend({"BACKEND": "unittest.mock.MagicMock"})
 
     def test_create_backend_non_file_router_backend(self, custom_backend_class) -> None:
         """Custom registered backend is instantiated without FileRouterBackend fields."""

--- a/tests/urls/test_backends.py
+++ b/tests/urls/test_backends.py
@@ -857,8 +857,13 @@ class TestRouterFactory:
     def test_register_backend(self, custom_backend_class) -> None:
         """Registered name maps to the given class."""
         RouterFactory.register_backend("custom", custom_backend_class)
-        assert "custom" in RouterFactory._backends
+        assert RouterFactory.is_registered("custom")
         assert RouterFactory._backends["custom"] == custom_backend_class
+
+    def test_is_registered(self) -> None:
+        """Built-in backend name is registered, unknown names are not."""
+        assert RouterFactory.is_registered("next.urls.FileRouterBackend")
+        assert not RouterFactory.is_registered("app.routers.MissingBackend")
 
     @pytest.mark.parametrize(
         ("test_case", "config", "expected_type", "expected_attrs"),


### PR DESCRIPTION
## Description

Closes the last private read of router internals from an adjacent area: the PAGE_BACKENDS config check validated dotted backend paths via `RouterFactory._backends`. The factory now exposes `is_registered(name)`, and the check goes through it — system checks read routers strictly through the public contract.

Also adds the missing "Route introspection" section to the URL router internals page: `page_roots`, `components_folder_name` and `skip_dir_names` as a standalone public contract read by the system checks and the development watcher, the safe defaults that silently leave a non-overriding backend out of introspection, and the `RouterManager.backends` property. Cross-linked with the router-backend howto and the autoreload internals.

## How to test

`make ci` (ruff, mypy strict, full suite at 100% coverage, docs build with `-W` all pass locally). `make bench` run as well — the diff does not touch the request path, no regression.

## Related issues

—

## Checklist

- [x] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [ ] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable
