### PR TITLE
docs: cross-area contract tier, limitations page and honest backbone

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,10 +275,14 @@ Use **draft** PRs for work in progress.
 
 Maintainers check style with Ruff and mypy, review tests, and assess how the change fits `next/`. Response time depends on maintainer availability. This document does not define a fixed SLA.
 
+## First contributions
+
+Issues labeled [good first issue](https://github.com/next-dj/next-dj/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) are the entry point for newcomers — small, atomic tasks that touch one area and carry enough context to start without deep framework knowledge. Discuss questions and the intended approach in the issue thread before opening a PR.
+
 ## Help
 
 - Search [issues](https://github.com/next-dj/next-dj/issues) and prior PRs.
-- Mirror patterns in `next/` and `tests/` for similar features — each area is consistent with itself.
+- Areas share a backbone (`registry.py`, `manager.py`, `backends.py` where they apply), but each area picks its own module set — copy the closest existing area, not a fixed template.
 - For failing coverage after `make test`, inspect terminal output and `htmlcov/index.html`.
 - For quick test loops, run `uv run pytest tests/ -n auto` without coverage flags.
 - If `uv build` fails on the JS step with a clear `npm` error, ensure Node 24 is on `PATH` or set `NEXT_DJ_SKIP_JS_BUILD=1` when a valid bundle already exists.

--- a/docs/content/faq/general.rst
+++ b/docs/content/faq/general.rst
@@ -87,6 +87,10 @@ The ``next.testing`` submodules are documented that way, so :doc:`/content/intro
 
 Second, symbols whose names start with a single underscore are internal and may change without notice, even when they appear in a module ``__all__``.
 The underscore rule is binding and overrides any incidental re-export.
+
+A few underscore-free names carry a narrower cross-area contract, documented on the reference page of their subsystem (see :doc:`/content/ref/pages`).
+The underscore rule holds for them, so they are not removed without notice, but they do not promise the application-facing stability of the Stable tier.
+
 See :doc:`/content/ref/forms` for a concrete example of how the API tiers apply to ``next.forms``.
 
 See also

--- a/docs/content/internals/adding-an-area.rst
+++ b/docs/content/internals/adding-an-area.rst
@@ -1,0 +1,69 @@
+.. _internals-adding-an-area:
+
+Adding an area
+==============
+
+A new subsystem lands as a package ``next/<area>/`` with a mirror test package ``tests/<area>/``.
+This page states the contract such a package follows and separates the mandatory parts from the recurring conventions.
+
+.. contents::
+   :local:
+   :depth: 1
+
+What every area provides
+------------------------
+
+- A package under ``next/`` whose public surface is re-exported from its ``__init__.py``.
+- A mirror package ``tests/<area>/`` that holds the area tests.
+- A one-line module docstring at the top of every source module.
+- Type hints throughout, checked by mypy in strict mode.
+- A shallow layout of one-word modules.
+  A module grows into a package only when one concern splits across several bodies, as ``next/forms/dispatch/`` does with ``build``, ``permissions``, ``responses``, and ``wizard`` behind its façade.
+
+Recurring modules
+-----------------
+
+The recurring module names carry fixed meanings, but every one of them is optional.
+An area adds a module when it owns the concern, not to complete a template.
+
+``registry.py``
+   An ordered list of registrations plus a dict index over it.
+   Present in ``pages``, ``components``, and ``partial``.
+   A ``_version`` counter appears only where a derived cache needs invalidation, which today means ``next/components/registry.py`` alone.
+
+``manager.py``
+   A façade over the area with lazy backend initialisation.
+   Present in ``pages``, ``components``, ``forms``, ``partial``, ``static``, and ``urls``.
+
+``backends.py``
+   A Protocol or ABC contract with settings-driven selection.
+   Present in ``components``, ``forms``, ``partial``, ``static``, and ``urls``.
+
+``dispatch.py``, ``markers.py``, ``providers.py``, ``signals.py``, ``checks.py``
+   Appear when the area dispatches actions, declares frozen dataclass markers, provides dependencies, emits signals, or validates configuration.
+
+The number of submodules varies from a handful in ``conf`` to nearly twenty in ``partial``, so no area serves as a size template for another.
+
+Legitimate deviations
+---------------------
+
+Two existing areas depart from the recurring set on purpose.
+
+- ``next/pages/`` ships no ``backends.py`` at all.
+  Page loading offers no settings-driven choice between implementations, so a backend contract would guard nothing.
+- ``next/partial/`` configures exactly one protocol backend.
+  ``PARTIAL_BACKENDS`` activates the first entry, and a second entry is reported by the ``next.W071`` warning instead of joining a pool of interchangeable backends.
+
+Starting point
+--------------
+
+Copy the closest existing area in spirit rather than an abstract template.
+The module map in :doc:`overview` shows what every area currently ships, and the contract above lists the parts a copy keeps.
+
+See also
+--------
+
+.. seealso::
+
+   :doc:`contributing-notes` for the conventions the framework code follows.
+   :doc:`overview` for the module map of every existing area.

--- a/docs/content/internals/contributing-notes.rst
+++ b/docs/content/internals/contributing-notes.rst
@@ -33,7 +33,8 @@ Conventions
 Module layout
 ~~~~~~~~~~~~~
 
-Each subsystem keeps a shallow layout where every submodule is small.
+Each subsystem keeps a shallow layout, while the size and number of its submodules vary from area to area.
+:doc:`adding-an-area` states the backbone contract a new area follows.
 A new submodule joins ``__init__.py`` only when its public surface needs a shorter import path.
 A submodule grows into a package of its own only when one concern splits across several bodies, and its façade keeps the import path the callers already use.
 

--- a/docs/content/internals/index.rst
+++ b/docs/content/internals/index.rst
@@ -38,6 +38,9 @@ The partial rendering pipeline is traced in :doc:`/content/topics/partial-render
 :doc:`contributing-notes`
    Conventions the framework code follows.
 
+:doc:`adding-an-area`
+   Backbone contract for a new subsystem package.
+
 .. toctree::
    :hidden:
    :maxdepth: 1
@@ -52,3 +55,4 @@ The partial rendering pipeline is traced in :doc:`/content/topics/partial-render
    action-dispatch
    autoreload
    contributing-notes
+   adding-an-area

--- a/docs/content/internals/overview.rst
+++ b/docs/content/internals/overview.rst
@@ -145,6 +145,7 @@ Module map
 ----------
 
 Each subsystem keeps a shallow module layout, and a submodule becomes a package of its own only when one concern splits across several bodies, as the form dispatch pipeline does.
+The set of submodules differs by area, and :doc:`adding-an-area` states the contract a new area follows.
 
 .. list-table::
    :header-rows: 1

--- a/docs/content/intro/index.rst
+++ b/docs/content/intro/index.rst
@@ -39,6 +39,9 @@ The six tutorial parts build a small Notes application from there.
 :doc:`tutorial06`
    Make the index live with zones and partial rendering, with a no-JavaScript fallback.
 
+:doc:`limitations`
+   The deliberate boundaries of the framework, from the synchronous pipeline to the single partial backend.
+
 :doc:`whatsnext`
    Where to go for deeper topics, recipes, and reference material.
 
@@ -55,4 +58,5 @@ The six tutorial parts build a small Notes application from there.
    tutorial04
    tutorial05
    tutorial06
+   limitations
    whatsnext

--- a/docs/content/intro/limitations.rst
+++ b/docs/content/intro/limitations.rst
@@ -1,0 +1,36 @@
+.. _intro-limitations:
+
+Limitations
+===========
+
+next.dj draws a few deliberate boundaries.
+Knowing them up front prevents an architecture built on an assumption the framework does not hold.
+
+Synchronous only
+----------------
+
+The page and component pipeline is synchronous.
+There is no async view or async middleware support, every context callable, component render, and form action runs inside a synchronous request.
+An async workload lives outside the routed page tree, behind a task queue or an ordinary Django view.
+
+No suspense, no WebSockets
+--------------------------
+
+Zones are a lazy reveal and a poll, not an asynchronous streaming boundary.
+A ``lazy=`` zone fills through a later client round trip, and a ``poll=`` zone re-fetches on a client timer, so a slow zone holds its response instead of streaming a placeholder.
+Real-time delivery is Server-Sent Events only, one direction from server to client.
+There is no WebSocket transport, so client-to-server push over a persistent socket stays outside the model.
+
+Single partial backend
+----------------------
+
+``PartialBackendManager`` runs one protocol backend.
+``PARTIAL_BACKENDS`` activates its first entry, and a second entry does not fail ``manage.py check``, it is reported as the ``next.W071`` warning.
+See :doc:`/content/topics/partial-rendering/index` for the partial model and its own boundary list.
+
+Web-coupled dependency injection
+--------------------------------
+
+The dependency resolver is bound to the request and response cycle.
+``ResolutionContext.request`` is typed as :class:`django.http.HttpRequest` or ``None``, and providers resolve against the request in flight.
+A background job that wants injected dependencies builds a synthetic request first, there is no request-free resolution mode.

--- a/docs/content/intro/limitations.rst
+++ b/docs/content/intro/limitations.rst
@@ -10,14 +10,16 @@ Synchronous only
 ----------------
 
 The page and component pipeline is synchronous.
-There is no async view or async middleware support, every context callable, component render, and form action runs inside a synchronous request.
+There is no async view and no async middleware support.
+Every context callable, component render, and form action runs inside a synchronous request.
 An async workload lives outside the routed page tree, behind a task queue or an ordinary Django view.
 
 No suspense, no WebSockets
 --------------------------
 
 Zones are a lazy reveal and a poll, not an asynchronous streaming boundary.
-A ``lazy=`` zone fills through a later client round trip, and a ``poll=`` zone re-fetches on a client timer, so a slow zone holds its response instead of streaming a placeholder.
+A ``lazy=`` zone fills through a later client round trip, and a ``poll=`` zone re-fetches on a client timer.
+A slow zone holds its response instead of streaming a placeholder, because there is no server-side suspense flush.
 Real-time delivery is Server-Sent Events only, one direction from server to client.
 There is no WebSocket transport, so client-to-server push over a persistent socket stays outside the model.
 
@@ -25,7 +27,8 @@ Single partial backend
 ----------------------
 
 ``PartialBackendManager`` runs one protocol backend.
-``PARTIAL_BACKENDS`` activates its first entry, and a second entry does not fail ``manage.py check``, it is reported as the ``next.W071`` warning.
+``PARTIAL_BACKENDS`` activates its first entry.
+A second entry does not fail ``manage.py check`` and is reported as the ``next.W071`` warning instead.
 See :doc:`/content/topics/partial-rendering/index` for the partial model and its own boundary list.
 
 Web-coupled dependency injection
@@ -33,4 +36,4 @@ Web-coupled dependency injection
 
 The dependency resolver is bound to the request and response cycle.
 ``ResolutionContext.request`` is typed as :class:`django.http.HttpRequest` or ``None``, and providers resolve against the request in flight.
-A background job that wants injected dependencies builds a synthetic request first, there is no request-free resolution mode.
+There is no request-free resolution mode, so a background job that wants injected dependencies builds a synthetic request first.

--- a/docs/content/ref/index.rst
+++ b/docs/content/ref/index.rst
@@ -49,9 +49,10 @@ Reading ``page``, ``context``, ``component``, or ``action`` loads a much larger 
 
 .. rubric:: API tiers and the cross-area contract
 
-Subsystem pages carry their own tier vocabularies, and those vocabularies stay as they are.
+Subsystem pages carry their own tier vocabularies.
 :doc:`forms` and :doc:`partial` group their surface into Stable, Advanced, and Internal hooks, while :doc:`components` uses Application Imports, Framework Extension, and Internal Infrastructure.
-A fourth category sits beside those tiers, the cross-area contract, underscore-free methods that one ``next`` area calls on another.
+The cross-area contract is a fourth category beside those tiers and replaces none of them.
+It covers underscore-free methods that one ``next`` area calls on another.
 Such a method is safe from removal without notice, but it carries no Stable-tier guarantee for application code.
 :doc:`pages` lists the concrete methods.
 

--- a/docs/content/ref/index.rst
+++ b/docs/content/ref/index.rst
@@ -47,6 +47,14 @@ The laziness covers the package root, not the subsystems it fronts.
 Reading ``Depends`` imports ``next.deps``, which pulls in a small set of modules from ``django.dispatch`` and ``django.utils``.
 Reading ``page``, ``context``, ``component``, or ``action`` loads a much larger part of Django.
 
+.. rubric:: API tiers and the cross-area contract
+
+Subsystem pages carry their own tier vocabularies, and those vocabularies stay as they are.
+:doc:`forms` and :doc:`partial` group their surface into Stable, Advanced, and Internal hooks, while :doc:`components` uses Application Imports, Framework Extension, and Internal Infrastructure.
+A fourth category sits beside those tiers, the cross-area contract, underscore-free methods that one ``next`` area calls on another.
+Such a method is safe from removal without notice, but it carries no Stable-tier guarantee for application code.
+:doc:`pages` lists the concrete methods.
+
 .. rubric:: Subsystems
 
 :doc:`pages`

--- a/docs/content/ref/pages.rst
+++ b/docs/content/ref/pages.rst
@@ -29,6 +29,14 @@ Public API
 
 .. autodata:: next.pages.page
 
+Cross-area contract
+~~~~~~~~~~~~~~~~~~~
+
+Four ``Page`` methods carry no leading underscore because other framework areas call them, not because application code should.
+``composed_template_for``, ``build_render_context``, ``render_with_static_assets``, and ``authorization_outcome`` serve ``next.forms`` and ``next.partial``.
+They follow the underscore rule of :doc:`/content/faq/general`, so they are safe from removal without notice.
+They do not carry the application-facing stability of a Stable tier, and their signatures may drift as partial rendering evolves.
+
 Manager
 ~~~~~~~
 

--- a/next/pages/__init__.py
+++ b/next/pages/__init__.py
@@ -1,8 +1,9 @@
 """The pages subsystem covering templates, context, layouts, rendering, and URLs.
 
-This package exposes a narrow public surface. Internal helpers are
-available through deep imports from the submodules (`context`,
-`loaders`, `registry`, `processors`, `watch`, `manager`, `scan`).
+The names listed in `__all__` form the guaranteed public surface.
+A few underscore-free `Page` methods additionally serve `next.forms` and
+`next.partial` as a cross-area contract without a stability guarantee,
+as documented in the pages API reference.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Description

The docs sold the core more polished than it is, and in two places stated things the code contradicts. This PR makes the documented surface honest without changing any behavior or public API.

**Cross-area contract tier.** `next/pages/__init__.py` promised a "narrow public surface" while `next.forms` and `next.partial` routinely call four underscore-free `Page` methods (`composed_template_for`, `build_render_context`, `render_with_static_assets`, `authorization_outcome`) that carry no `__all__` status and no stability guarantee. The docstring is rewritten, the four methods are listed in a new "Cross-area contract" subsection on the pages reference page, the API index explains the category next to the three existing per-page tier vocabularies (which stay untouched and unrenamed), and the safe-symbols FAQ rule covers it explicitly so the underscore rule and the new category do not contradict each other.

**Limitations page.** New `intro/limitations.rst` names the deliberate boundaries up front: the synchronous page/component pipeline, no suspense and no WebSockets (real time is SSE only, one direction), the single partial protocol backend (a second `PARTIAL_BACKENDS` entry earns the `next.W071` warning, not an error), and the web-coupled dependency resolver (`ResolutionContext.request` is `HttpRequest | None`). Placed in the intro toctree between tutorial 6 and "What's next".

**Backbone honesty.** CONTRIBUTING claimed "each area is consistent with itself" and internals claimed "every submodule is small" — the module set actually varies by area (partial 18 files, conf 7). Both are rewritten to the honest contract: areas share a backbone (`registry.py`, `manager.py`, `backends.py` where they apply), the module set varies, copy the closest existing area. A new `internals/adding-an-area.rst` states that contract for future areas, marks every recurring module as optional (`_version` lives only where a derived cache needs invalidation, today `next/components/registry.py` alone), and names the two deliberate deviations: `pages` ships no backends, `partial` activates a single protocol backend. CONTRIBUTING also gains a short first-contributions section pointing at the good-first-issue label.

The planned README props fix (three examples claiming `{% component %}` props are literal strings) turned out to be already resolved on main by the docs sync in #158 — verified against `_parse_props` in `next/templatetags/components.py`, no README contradicts `topics/components.rst` anymore, so no example changes are part of this diff.

No API breaks: signatures, names, and exports are unchanged, and the four `Page` methods are deliberately not promoted to a guaranteed API while the contract still drifts.

## How to test

`make docs` (built with `-W`, zero warnings), `uv run ruff check`, `uv run mypy next/`, `make test` (100% coverage on `next/`), `make test-examples` — all green locally.

## Related issues

—

## Checklist

- [x] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [ ] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable
