### PR TITLE
feat(static): kind-aware use_script, use_module shorthand, module_tag check

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -107,9 +107,23 @@ jobs:
           fi
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
 
+      # `ubuntu-latest` hands out more than one CPU generation, and a base
+      # result restored from a different one turns the paired comparison
+      # into a cross-hardware one that shifts every benchmark at once.
+      - name: Identify runner CPU
+        id: cpu
+        run: |
+          set -euo pipefail
+          model=$(awk -F': ' '/^model name/ {print $2; exit}' /proc/cpuinfo)
+          test -n "$model"
+          echo "::notice::bench runner CPU is $model"
+          echo "slug=$(printf '%s' "$model" | tr -cd '[:alnum:]' | cut -c1-32)" >> "$GITHUB_OUTPUT"
+
       # Most PRs target the same `main` SHA. Caching the BASE result by
       # base-SHA + lockfile hash means the second PR skips the BASE bench
-      # (and its `uv sync`) entirely.
+      # (and its `uv sync`) entirely. The CPU slug is part of the key so a
+      # runner of another generation re-measures the base instead of
+      # comparing against a number from foreign hardware.
       - name: Cache BASE benchmark result
         id: base_cache
         uses: actions/cache@v4
@@ -117,7 +131,7 @@ jobs:
           path: |
             .benchmarks
             bench-base.json
-          key: bench-base-${{ steps.shas.outputs.base }}-${{ steps.base_lock.outputs.hash }}
+          key: bench-base-${{ steps.shas.outputs.base }}-${{ steps.base_lock.outputs.hash }}-${{ steps.cpu.outputs.slug }}
 
       - name: Sync base dependencies
         if: steps.base_cache.outputs.cache-hit != 'true'
@@ -164,6 +178,38 @@ jobs:
             --benchmark-compare-fail=median:99% \
             2>&1 | tee bench-compare.txt
 
+      # pytest-benchmark warns about a machine_info mismatch but still
+      # fails the gate on it. A cross-hardware compare moves every
+      # benchmark at once, so it says nothing about the diff and the hard
+      # gate stands down to a warning.
+      - name: Check base and head ran on the same CPU
+        id: machine
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ ! -s bench-base.json ] || [ ! -s bench-head.json ]; then
+            echo "::notice::bench JSON missing, cannot verify the runner hardware."
+            echo "same=unknown" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          read_cpu() {
+            uv run python -c \
+              "import json,sys; print(json.load(open(sys.argv[1]))['machine_info']['cpu']['brand_raw'])" \
+              "$1"
+          }
+          base_cpu=$(read_cpu bench-base.json)
+          head_cpu=$(read_cpu bench-head.json)
+          {
+            echo "base_cpu=$base_cpu"
+            echo "head_cpu=$head_cpu"
+          } >> "$GITHUB_OUTPUT"
+          if [ "$base_cpu" = "$head_cpu" ]; then
+            echo "same=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning title=bench hardware mismatch::base ran on '$base_cpu', head on '$head_cpu'. The paired comparison is cross-hardware, so the hard gate stands down."
+            echo "same=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Non-failing warning tier: surfaces sub-2x median drift the hard
       # gate cannot express. It must never become a failing step, or the
       # shared-runner noise the median gate avoids comes straight back.
@@ -205,12 +251,23 @@ jobs:
           {
             echo "## next-dj benchmarks"
             echo
-            echo "Same-runner paired comparison on \`ubuntu-latest\` (Python 3.13)."
+            if [ "${{ steps.machine.outputs.same }}" = "false" ]; then
+              echo "Cross-hardware paired comparison on \`ubuntu-latest\` (Python 3.13)."
+              echo "Base ran on \`${{ steps.machine.outputs.base_cpu }}\`, head on \`${{ steps.machine.outputs.head_cpu }}\`."
+            else
+              echo "Same-runner paired comparison on \`ubuntu-latest\` (Python 3.13)."
+            fi
             echo "Base \`${{ steps.shas.outputs.base_short }}\` → head \`${{ steps.shas.outputs.head_short }}\`."
             echo "Hard-fail threshold: \`median:99%\` (≈ ×2 of base, the parser's max)."
             echo
             case "${{ steps.gate.outcome }}" in
-              failure) echo "**Result:** :red_circle: hard regression detected." ;;
+              failure)
+                if [ "${{ steps.machine.outputs.same }}" = "false" ]; then
+                  echo "**Result:** :yellow_circle: the gate tripped on a cross-hardware comparison, so it is reported and not enforced. Re-run once base and head land on the same CPU."
+                else
+                  echo "**Result:** :red_circle: hard regression detected."
+                fi
+                ;;
               success) echo "**Result:** :green_circle: within tolerance." ;;
               *)       echo "**Result:** :grey_question: bench did not finish (\`${{ steps.gate.outcome }}\`). See workflow logs." ;;
             esac
@@ -249,7 +306,7 @@ jobs:
           if-no-files-found: error
 
       - name: Fail job on hard regression
-        if: ${{ steps.gate.outcome == 'failure' }}
+        if: ${{ steps.gate.outcome == 'failure' && steps.machine.outputs.same != 'false' }}
         run: |
           echo "::error::pytest-benchmark compare-fail tripped (median ratio ≥ 2× of base)."
           exit 1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,13 +7,11 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
-# PR runs are cancellable on new pushes. Main pushes are NOT cancelled
-# so the gh-pages auto-push cannot be left half-committed.
+# Main pushes are not cancelled so the gh-pages auto-push cannot be left half-committed.
 concurrency:
   group: bench-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Job-level permissions override these per job (least privilege).
 permissions:
   contents: read
 
@@ -22,10 +20,7 @@ defaults:
     shell: bash
 
 env:
-  # Tuned for "fast enough on shared GitHub runners". Warmup eats one
-  # full pass per test, so 1000 iterations are plenty for branch /
-  # icache priming on CPython 3.13. Rounds = 10 keeps wall-clock under
-  # control while still giving stddev meaningful for the ×4 hard gate.
+  # Sized for shared GitHub runners, where more rounds buy noise, not signal.
   BENCH_FLAGS: >-
     -m perf
     --benchmark-only
@@ -42,8 +37,7 @@ env:
   PYTHONDONTWRITEBYTECODE: "1"
 
 jobs:
-  # Same-runner paired comparison via `git worktree`. Produces the
-  # artefact consumed by `comment` and `publish`.
+  # Paired comparison via `git worktree`, artefact consumed by `comment` and `publish`.
   bench:
     if: >-
       ${{ (github.event_name != 'pull_request'
@@ -94,8 +88,7 @@ jobs:
       - name: Create base worktree
         run: git worktree add --detach ../base "${{ steps.shas.outputs.base }}"
 
-      # Compute the BASE lockfile hash via sha256sum because `hashFiles()`
-      # is restricted to paths inside $GITHUB_WORKSPACE.
+      # `hashFiles()` cannot reach outside $GITHUB_WORKSPACE, so hash the worktree copy here.
       - name: Hash BASE lockfile
         id: base_lock
         run: |
@@ -107,9 +100,6 @@ jobs:
           fi
           echo "hash=$hash" >> "$GITHUB_OUTPUT"
 
-      # `ubuntu-latest` hands out more than one CPU generation, and a base
-      # result restored from a different one turns the paired comparison
-      # into a cross-hardware one that shifts every benchmark at once.
       - name: Identify runner CPU
         id: cpu
         run: |
@@ -119,11 +109,8 @@ jobs:
           echo "::notice::bench runner CPU is $model"
           echo "slug=$(printf '%s' "$model" | tr -cd '[:alnum:]' | cut -c1-32)" >> "$GITHUB_OUTPUT"
 
-      # Most PRs target the same `main` SHA. Caching the BASE result by
-      # base-SHA + lockfile hash means the second PR skips the BASE bench
-      # (and its `uv sync`) entirely. The CPU slug is part of the key so a
-      # runner of another generation re-measures the base instead of
-      # comparing against a number from foreign hardware.
+      # Most PRs share a base SHA, so the second one skips the BASE bench entirely.
+      # `ubuntu-latest` spans CPU generations, and the slug keeps a base off foreign hardware.
       - name: Cache BASE benchmark result
         id: base_cache
         uses: actions/cache@v4
@@ -153,19 +140,9 @@ jobs:
       - name: Sync head dependencies
         run: uv sync --locked --dev --python 3.13
 
-      # HEAD bench prints the comparison table itself (--benchmark-compare)
-      # and trips the hard gate via --benchmark-compare-fail. One pytest
-      # invocation does what used to take three steps.
-      #
-      # `--benchmark-compare` accepts a glob over saved-run filenames.
-      # `*_base` matches `0001_base.json` regardless of the auto-counter.
-      #
-      # `--benchmark-compare-fail` percentage parser enforces 0 < N < 100,
-      # so 99% (≈ ×2 of base) is the strictest hard gate the tool will
-      # accept. Anything tighter would noise-trip on shared CI runners
-      # anyway. The gate compares medians: the mean is swayed by single
-      # scheduling spikes on shared runners, while a real regression
-      # shifts the whole distribution and moves the median with it.
+      # `*_base` matches `0001_base.json` whatever the auto-counter did.
+      # The percentage parser enforces 0 < N < 100, so 99% is the strictest gate available.
+      # It compares medians because a scheduling spike moves the mean and a regression does not.
       - name: Bench HEAD and gate
         id: gate
         continue-on-error: true
@@ -178,10 +155,8 @@ jobs:
             --benchmark-compare-fail=median:99% \
             2>&1 | tee bench-compare.txt
 
-      # pytest-benchmark warns about a machine_info mismatch but still
-      # fails the gate on it. A cross-hardware compare moves every
-      # benchmark at once, so it says nothing about the diff and the hard
-      # gate stands down to a warning.
+      # A cross-hardware compare moves every benchmark at once, so it says nothing
+      # about the diff. pytest-benchmark warns and fails the gate anyway.
       - name: Check base and head ran on the same CPU
         id: machine
         if: always()
@@ -210,9 +185,7 @@ jobs:
             echo "same=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Non-failing warning tier: surfaces sub-2x median drift the hard
-      # gate cannot express. It must never become a failing step, or the
-      # shared-runner noise the median gate avoids comes straight back.
+      # Never make this fail, or the shared-runner noise the median gate avoids comes back.
       - name: Warn on median drift over 30%
         if: always()
         run: |
@@ -311,9 +284,7 @@ jobs:
           echo "::error::pytest-benchmark compare-fail tripped (median ratio ≥ 2× of base)."
           exit 1
 
-  # Sticky PR comment. Runs after `bench` even on a hard regression so
-  # authors see the table when the gate trips. PRs from forks are
-  # skipped at the posting step (read-only GITHUB_TOKEN).
+  # Runs even on a tripped gate so authors see the table. Forks skip the posting step.
   comment:
     needs: bench
     if: ${{ github.event_name == 'pull_request' && always() && needs.bench.result != 'skipped' }}
@@ -351,8 +322,7 @@ jobs:
           path: ./_bench/bench-comment.md
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Push HEAD numbers to gh-pages history. Reuses the bench artefact,
-  # so benchmarks are not re-run.
+  # Reuses the bench artefact rather than re-running the benchmarks.
   publish:
     needs: bench
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.bench.result == 'success' }}

--- a/docs/content/internals/static-pipeline.rst
+++ b/docs/content/internals/static-pipeline.rst
@@ -119,7 +119,7 @@ Signals
 The pipeline fires four signals.
 
 - ``asset_registered`` fires once per co-located file registered through a backend.
-  Module-level ``styles`` and ``scripts`` lists and every ``{% use_style %}``, ``{% use_script %}``, and ``{% use_module %}`` form, void or block, call ``collector.add`` directly and do not emit it.
+  Module-level ``styles`` and ``scripts`` lists, every ``{% use_style %}`` and ``{% use_script %}`` form, void or block, and the ``{% use_module %}`` tag call ``collector.add`` directly and do not emit it.
 - ``collector_finalized`` once per request after the collector closes its set.
 - ``html_injected`` once per request after the manager replaces the placeholder slots.
 - ``backend_loaded`` once per backend instance when the manager builds it, including the staticfiles backend it seeds when no entry survives.

--- a/docs/content/internals/static-pipeline.rst
+++ b/docs/content/internals/static-pipeline.rst
@@ -119,7 +119,7 @@ Signals
 The pipeline fires four signals.
 
 - ``asset_registered`` fires once per co-located file registered through a backend.
-  Module-level ``styles`` and ``scripts`` lists and every ``{% use_style %}`` and ``{% use_script %}`` form, void or block, call ``collector.add`` directly and do not emit it.
+  Module-level ``styles`` and ``scripts`` lists and every ``{% use_style %}``, ``{% use_script %}``, and ``{% use_module %}`` form, void or block, call ``collector.add`` directly and do not emit it.
 - ``collector_finalized`` once per request after the collector closes its set.
 - ``html_injected`` once per request after the manager replaces the placeholder slots.
 - ``backend_loaded`` once per backend instance when the manager builds it, including the staticfiles backend it seeds when no entry survives.

--- a/docs/content/ref/template-tags.rst
+++ b/docs/content/ref/template-tags.rst
@@ -153,15 +153,17 @@ Static pipeline
    Registers an external CSS URL on the active collector.
    The asset is prepended so shared dependencies load before co-located styles.
 
-.. describe:: {% use_script "<url>" %}
+.. describe:: {% use_script "<url>" [kind="<kind>"] %}
 
-   Registers an external JS URL on the active collector.
+   Registers an external URL on the active collector.
    The asset is prepended the same way as ``use_style``.
+   The ``kind`` argument defaults to ``js`` and accepts any registered kind, which decides both the slot and the renderer.
+   An unregistered kind raises ``KeyError`` out of the render.
 
 .. describe:: {% use_module "<url>" %}
 
-   Registers an external ECMAScript module URL on the active collector.
-   The asset renders as a ``<script type="module">`` tag and is prepended the same way as ``use_script``.
+   Shorthand for ``{% use_script "<url>" kind="module" %}``.
+   The asset renders as a ``<script type="module">`` tag.
    Has no block form.
 
 .. describe:: {% #use_style %}...{% /use_style %}

--- a/docs/content/ref/template-tags.rst
+++ b/docs/content/ref/template-tags.rst
@@ -158,6 +158,12 @@ Static pipeline
    Registers an external JS URL on the active collector.
    The asset is prepended the same way as ``use_style``.
 
+.. describe:: {% use_module "<url>" %}
+
+   Registers an external ECMAScript module URL on the active collector.
+   The asset renders as a ``<script type="module">`` tag and is prepended the same way as ``use_script``.
+   Has no block form.
+
 .. describe:: {% #use_style %}...{% /use_style %}
 
    Inline CSS block.

--- a/docs/content/topics/static-assets/asset-kinds.rst
+++ b/docs/content/topics/static-assets/asset-kinds.rst
@@ -194,11 +194,13 @@ Register a new slot when a kind should inject somewhere other than the standard 
 
 The layout must contain the slot token, or a template tag that emits it, for the manager to find a place to inject.
 A module-level list named after the slot, such as ``preload = [...]`` in ``page.py``, registers external URLs into it, see :ref:`topics-static-module-lists`.
+From a template, ``{% use_script "<url>" kind="font" %}`` registers the same URL, because the ``kind`` argument reaches every registered kind, see :doc:`template-tags`.
 
 Module kind
 -----------
 
 The ``module`` kind renders ``<script type="module" src="...">`` through ``render_module_tag``.
+Discovery picks it up from a co-located ``.mjs`` file, a ``scripts`` module-level list entry, or the ``{% use_module %}`` tag, which is the ``kind="module"`` shorthand for ``{% use_script %}``, see :doc:`template-tags`.
 Customise the rendered output through the ``module_tag`` key in the backend ``OPTIONS`` mapping, see :doc:`backends`.
 
 The ``module`` kind carries no ``inline_tag``, so it renders an inline body verbatim, as do custom kinds registered without an ``inline_tag``.

--- a/docs/content/topics/static-assets/backends.rst
+++ b/docs/content/topics/static-assets/backends.rst
@@ -196,8 +196,8 @@ The static checks validate the backend configuration at startup.
 Run ``uv run python manage.py check`` after editing the backend list.
 The full list of static check codes lives in :doc:`/content/ref/system-checks`.
 
-The ``next.W031`` check validates the ``css_tag`` and ``js_tag`` templates.
-The ``module_tag`` template is not checked, so verify it contains ``{url}`` yourself.
+The ``next.W031`` check validates the ``css_tag``, ``js_tag``, and ``module_tag`` templates.
+A template that carries no ``{url}`` placeholder raises the warning, because the rendered tag would carry no asset URL.
 
 Common patterns
 ---------------

--- a/docs/content/topics/static-assets/deduplication.rst
+++ b/docs/content/topics/static-assets/deduplication.rst
@@ -24,6 +24,7 @@ The framework ships three strategies in ``next.static.collector``.
    The default.
    Keys URL assets by their URL and kind.
    Keys inline assets by their body and kind.
+   One URL registered under two kinds is therefore two keys, so ``{% use_script %}`` and ``{% use_module %}`` on the same URL both survive to injection.
 
 ``HashContentDedup``.
    Keys URL assets by the SHA-256 hash of the file at ``source_path``.

--- a/docs/content/topics/static-assets/js-context.rst
+++ b/docs/content/topics/static-assets/js-context.rst
@@ -235,7 +235,7 @@ Co-located JS and inline scripts then read the value under ``window.Next.context
    });
 
 The runtime script defines ``window.Next`` before the collected scripts run.
-The runtime script is always the first tag in the ``scripts`` slot, ahead of every co-located, module-list, and ``{% use_script %}`` asset, so any of those may safely read ``window.Next``.
+The runtime script is always the first tag in the ``scripts`` slot, ahead of every co-located, module-list, ``{% use_script %}``, and ``{% use_module %}`` asset, so any of those may safely read ``window.Next``.
 
 Client event API
 ~~~~~~~~~~~~~~~~~

--- a/docs/content/topics/static-assets/template-tags.rst
+++ b/docs/content/topics/static-assets/template-tags.rst
@@ -96,11 +96,13 @@ use_module
 
 The asset registers under kind ``module`` and renders as a ``<script type="module">`` tag through the backend ``render_module_tag`` hook.
 The asset is prepended to the collector the same way as ``use_style`` and ``use_script``.
-The tag has no ``#use_module`` block form because the ``module`` kind registers no inline tag.
+The browser defers a module script, so the prepend controls markup order, not execution order relative to classic scripts.
+The tag has no ``#use_module`` block form.
+The ``module`` kind names no inline wrapper element, so a block body would land in the slot verbatim instead of as an inline ES module, see :doc:`asset-kinds`.
 
 .. note::
 
-   The five registration tags need the request-scoped collector that the page pipeline puts in the template context.
+   The ``use_*`` registration tags and their block forms need the request-scoped collector that the page pipeline puts in the template context.
    A template rendered outside that pipeline, for example through ``render_to_string`` in a plain view, silently registers nothing and emits nothing.
 
 Inline blocks

--- a/docs/content/topics/static-assets/template-tags.rst
+++ b/docs/content/topics/static-assets/template-tags.rst
@@ -73,7 +73,7 @@ The CSS cascade therefore flows from generic dependencies to page specific styli
 use_script
 ----------
 
-``{% use_script %}`` registers an external JS URL on the active collector.
+``{% use_script %}`` registers an external URL on the active collector.
 
 .. code-block:: jinja
    :caption: notes/pages/template.djx
@@ -81,13 +81,23 @@ use_script
    {% use_script "https://cdn.example.com/vendor.js" %}
 
 The asset is prepended to the collector the same way as ``use_style``.
-The tag registers the URL under kind ``js``, so it renders as a classic ``<script>`` tag.
-For an ECMAScript module, use ``{% use_module %}`` or list the ``.mjs`` URL in the page or component ``scripts`` module-level variable, see :doc:`co-located-files`.
+
+The optional ``kind`` argument defaults to ``js``, which renders a classic ``<script>`` tag.
+Any other registered kind works too, and the registry decides both the slot the asset lands in and the backend renderer that builds its tag.
+
+.. code-block:: jinja
+   :caption: notes/pages/template.djx
+
+   {% use_script "https://cdn.example.com/vendor.mjs" kind="module" %}
+   {% use_script "https://cdn.example.com/inter.woff2" kind="font" %}
+
+A custom kind registered through ``KindRegistry.register`` therefore needs no template tag of its own, see :doc:`asset-kinds`.
+A kind that was never registered raises ``KeyError`` out of the render, so a typo surfaces on the first request instead of dropping the asset.
 
 use_module
 ----------
 
-``{% use_module %}`` registers an external ECMAScript module URL on the active collector.
+``{% use_module %}`` is the shorthand for ``{% use_script %}`` with ``kind="module"``.
 
 .. code-block:: jinja
    :caption: notes/pages/template.djx
@@ -95,10 +105,11 @@ use_module
    {% use_module "https://cdn.example.com/vendor.mjs" %}
 
 The asset registers under kind ``module`` and renders as a ``<script type="module">`` tag through the backend ``render_module_tag`` hook.
-The asset is prepended to the collector the same way as ``use_style`` and ``use_script``.
 The browser defers a module script, so the prepend controls markup order, not execution order relative to classic scripts.
 The tag has no ``#use_module`` block form.
 The ``module`` kind names no inline wrapper element, so a block body would land in the slot verbatim instead of as an inline ES module, see :doc:`asset-kinds`.
+
+The same URL registered under two kinds is two assets, so ``{% use_script %}`` and ``{% use_module %}`` on one URL emit both a classic and a module tag, see :doc:`deduplication`.
 
 .. note::
 

--- a/docs/content/topics/static-assets/template-tags.rst
+++ b/docs/content/topics/static-assets/template-tags.rst
@@ -3,9 +3,9 @@
 Static template tags
 ====================
 
-The static pipeline registers four Django template tags plus two inline block forms.
+The static pipeline registers five Django template tags plus two inline block forms.
 ``{% collect_styles %}`` and ``{% collect_scripts %}`` mark placeholder slots in the layout.
-``{% use_style %}`` and ``{% use_script %}`` register an external URL on the active collector.
+``{% use_style %}``, ``{% use_script %}``, and ``{% use_module %}`` register an external URL on the active collector.
 ``{% #use_style %}`` and ``{% #use_script %}`` are block forms that capture an inline body.
 
 .. contents::
@@ -81,12 +81,26 @@ use_script
    {% use_script "https://cdn.example.com/vendor.js" %}
 
 The asset is prepended to the collector the same way as ``use_style``.
-The tag always registers the URL under kind ``js``, so it cannot publish an ECMAScript module.
-For a ``.mjs`` dependency, list the URL in the page or component ``scripts`` module-level variable instead, see :doc:`co-located-files`.
+The tag registers the URL under kind ``js``, so it renders as a classic ``<script>`` tag.
+For an ECMAScript module, use ``{% use_module %}`` or list the ``.mjs`` URL in the page or component ``scripts`` module-level variable, see :doc:`co-located-files`.
+
+use_module
+----------
+
+``{% use_module %}`` registers an external ECMAScript module URL on the active collector.
+
+.. code-block:: jinja
+   :caption: notes/pages/template.djx
+
+   {% use_module "https://cdn.example.com/vendor.mjs" %}
+
+The asset registers under kind ``module`` and renders as a ``<script type="module">`` tag through the backend ``render_module_tag`` hook.
+The asset is prepended to the collector the same way as ``use_style`` and ``use_script``.
+The tag has no ``#use_module`` block form because the ``module`` kind registers no inline tag.
 
 .. note::
 
-   The four registration tags need the request-scoped collector that the page pipeline puts in the template context.
+   The five registration tags need the request-scoped collector that the page pipeline puts in the template context.
    A template rendered outside that pipeline, for example through ``render_to_string`` in a plain view, silently registers nothing and emits nothing.
 
 Inline blocks

--- a/docs/content/topics/url-reversing.rst
+++ b/docs/content/topics/url-reversing.rst
@@ -162,6 +162,11 @@ A scalar value replaces every existing entry for that key.
    with_query("/filter/?tag=python", tag=["python", "django"])
    # "/filter/?tag=python&tag=django"
 
+   with_query("/filter/?tag=python&tag=django", tag=[])
+   # "/filter/"
+
+An empty list or tuple removes every entry for the key, equivalent to ``tag=None``.
+
 Combining page_reverse and with_query
 -------------------------------------
 

--- a/examples/_shared/README.md
+++ b/examples/_shared/README.md
@@ -239,5 +239,5 @@ When you move an existing project onto the shared kit:
 
 - Wire `SHARED_DIR`, `STATICFILES_DIRS`, and `COMPONENT_BACKENDS["DIRS"]` once in `settings.py`.
 - Remove any per-app `nav_link` / `stat_card` / `card` that now duplicates a shared component, otherwise `manage.py check` raises `next.E034` (root namespace collision).
-- Replace the `<head>` boilerplate (CDN script, two `{% use_style %}` lines, `{% collect_styles %}`) with `{% component "page_head" title="…" %}`.
+- Replace the `<head>` boilerplate (CDN script, two `{% use_style %}` lines, the `{% use_module %}` line, `{% collect_styles %}`) with `{% component "page_head" title="…" %}`.
 - Replace bespoke colour classes (`bg-slate-50`, `text-slate-900`, `bg-indigo-600`, …) with the short token aliases (`bg-background`, `text-foreground`, `bg-primary`, …) so per-tenant overrides cascade correctly.

--- a/examples/_shared/_components/page_head/component.djx
+++ b/examples/_shared/_components/page_head/component.djx
@@ -68,6 +68,7 @@
   </script>
   {% use_style "/static/shared/css/tokens.css" %}
   {% use_style "/static/shared/css/base.css" %}
+  {% use_module "/static/shared/js/base.mjs" %}
   {% collect_styles %}
   {% set_slot "extra" %}
 </head>

--- a/examples/_shared/static/shared/js/base.mjs
+++ b/examples/_shared/static/shared/js/base.mjs
@@ -1,11 +1,7 @@
-/* Site-wide keyboard shortcut for the examples catalog. Pressing "/" outside
-   a text field focuses the first search input on the page, the way the search
-   boxes in admin, wiki, and search-catalog expect.
-
-   This module belongs to no single component, so it is registered from the
-   shared page_head with {% use_module %} rather than co-located next to a
-   component.djx. A single listener on document survives a morph that replaces
-   the search markup, where a per-element listener would be lost. */
+/* Focus the first search input when "/" is pressed outside a text field.
+   The shortcut belongs to no single component, so page_head registers it with
+   use_module instead of co-locating it. A single listener on document survives
+   a morph that replaces the search markup, where a per-element one would not. */
 
 const SEARCH_SELECTOR = 'input[type="search"], input[name="q"]';
 

--- a/examples/_shared/static/shared/js/base.mjs
+++ b/examples/_shared/static/shared/js/base.mjs
@@ -1,0 +1,23 @@
+/* Site-wide keyboard shortcut for the examples catalog. Pressing "/" outside
+   a text field focuses the first search input on the page, the way the search
+   boxes in admin, wiki, and search-catalog expect.
+
+   This module belongs to no single component, so it is registered from the
+   shared page_head with {% use_module %} rather than co-located next to a
+   component.djx. A single listener on document survives a morph that replaces
+   the search markup, where a per-element listener would be lost. */
+
+const SEARCH_SELECTOR = 'input[type="search"], input[name="q"]';
+
+document.addEventListener("keydown", (event) => {
+  if (event.key !== "/" || event.metaKey || event.ctrlKey || event.altKey) return;
+  const active = document.activeElement;
+  if (active instanceof HTMLInputElement) return;
+  if (active instanceof HTMLTextAreaElement) return;
+  if (active instanceof HTMLElement && active.isContentEditable) return;
+  const search = document.querySelector(SEARCH_SELECTOR);
+  if (!(search instanceof HTMLInputElement)) return;
+  event.preventDefault();
+  search.focus();
+  search.select();
+});

--- a/examples/kanban/tests/test_e2e.py
+++ b/examples/kanban/tests/test_e2e.py
@@ -119,6 +119,10 @@ class TestBoardView:
         body = _board_html(client, board)
         assert re.search(r'<script type="module"', body)
 
+    def test_shared_base_module_present(self, client: NextClient, board: Board) -> None:
+        body = _board_html(client, board)
+        assert '<script type="module" src="/static/shared/js/base.mjs">' in body
+
     def test_inherit_context_visible_in_settings(
         self, client: NextClient, board: Board
     ) -> None:

--- a/next/static/checks.py
+++ b/next/static/checks.py
@@ -104,7 +104,7 @@ def _check_single_backend(
         return messages
     options: Any = config.get("OPTIONS") or {}
     if isinstance(options, dict):
-        for tag_name in ("css_tag", "js_tag"):
+        for tag_name in ("css_tag", "js_tag", "module_tag"):
             if tag_name not in options:
                 continue
             message = _validate_tag_template(tag_name, options[tag_name], index)

--- a/next/templatetags/next_static.py
+++ b/next/templatetags/next_static.py
@@ -1,15 +1,10 @@
 """Template tags for static asset injection slots.
 
-``{% collect_styles %}`` and ``{% collect_scripts %}`` emit the placeholders
-that ``StaticManager.inject`` fills once ``Page.render`` has collected every
-referenced asset from the page, its layouts, and nested components.
-``{% use_style %}``, ``{% use_script %}``, and ``{% use_module %}`` register
-an external URL on the active ``StaticCollector``, and the
-``{% #use_style %}`` / ``{% #use_script %}`` block forms hoist an inline body
-into the matching slot. The tags lean on the bootstrap-registered ``css``,
-``js``, and ``module`` kinds. Custom kinds register through the same public
-``KindRegistry.register`` API and pick up automatic discovery without needing
-new template tags.
+The collect tags emit placeholder tokens and the use tags register assets on
+the request's ``StaticCollector``, so ``StaticManager.inject`` controls the
+final markup once ``Page.render`` has collected every referenced asset.
+Custom kinds register through the same public ``KindRegistry.register`` API
+without needing new template tags.
 """
 
 from __future__ import annotations
@@ -78,11 +73,9 @@ def use_module(context: template.Context, url: str) -> str:
 def _register_asset(context: template.Context, url: str, kind: str) -> None:
     """Prepend an asset to the render's ``StaticCollector`` when one exists in context.
 
-    Assets declared from templates with the ``use_style`` / ``use_script`` /
-    ``use_module`` URL tags are treated as shared third-party dependencies and
-    are inserted before any co-located files or module-level lists, so
-    dependency tags precede page-specific assets in the slot and the CSS
-    cascade flows from generic dependencies to page-specific styling.
+    URL-tag assets are shared third-party dependencies, so they land before
+    co-located files and module-level lists and the CSS cascade flows from
+    generic to page-specific.
     """
     if not isinstance(url, str) or not url:
         return

--- a/next/templatetags/next_static.py
+++ b/next/templatetags/next_static.py
@@ -1,10 +1,8 @@
 """Template tags for static asset injection slots.
 
 The collect tags emit placeholder tokens and the use tags register assets on
-the request's ``StaticCollector``, so ``StaticManager.inject`` controls the
-final markup once ``Page.render`` has collected every referenced asset. The
-``kind`` argument of ``{% use_script %}`` reaches every kind in the registry,
-so a kind added through ``KindRegistry.register`` needs no tag of its own.
+the request's ``StaticCollector``, so ``StaticManager.inject`` owns the final
+markup once ``Page.render`` has seen every referenced asset.
 """
 
 from __future__ import annotations
@@ -60,9 +58,8 @@ def use_style(context: template.Context, url: str) -> str:
 def use_script(context: template.Context, url: str, kind: str = _KIND_JS) -> str:
     """Register an external URL on the active collector under the given kind.
 
-    The kind defaults to ``js`` and accepts any registered kind, so the
-    registry decides both the slot and the renderer. An unregistered kind
-    raises ``KeyError`` out of the render.
+    The kind reaches the registry unchanged, so it picks both the slot and the
+    renderer and a custom kind needs no tag of its own.
     """
     _register_asset(context, url, kind)
     return ""
@@ -76,11 +73,10 @@ def use_module(context: template.Context, url: str) -> str:
 
 
 def _register_asset(context: template.Context, url: str, kind: str) -> None:
-    """Prepend an asset to the render's ``StaticCollector`` when one exists in context.
+    """Prepend an asset to the render's ``StaticCollector`` when context carries one.
 
-    URL-tag assets are shared third-party dependencies, so they land before
-    co-located files and module-level lists and the CSS cascade flows from
-    generic to page-specific.
+    URL-tag assets are shared dependencies, so they belong ahead of co-located
+    files and the CSS cascade flows from generic to page-specific.
     """
     if not isinstance(url, str) or not url:
         return
@@ -93,19 +89,13 @@ def _register_asset(context: template.Context, url: str, kind: str) -> None:
 class _InlineAssetNode(Node):
     """Render an inline asset body and push it onto the active collector.
 
-    The block body is rendered with the current template context so inline
-    scripts and styles can still interpolate page variables. The rendered
-    body is stripped of leading and trailing whitespace before it reaches
-    the collector, so blank-only blocks are silently ignored. The collector
-    dedupes inline entries by the stripped body itself, so two blocks that
-    produce identical HTML collapse to one entry, while blocks that
-    interpolate different values into the body stay distinct. The node emits
-    nothing in place because the collector controls final placement inside
-    the matching collect_styles or collect_scripts slot.
+    The body renders with the current context so it can interpolate page
+    variables, and the node emits nothing in place because the collector owns
+    final placement inside the matching slot.
     """
 
     def __init__(self, kind: str, nodelist: NodeList) -> None:
-        """Remember the asset kind and the nested nodes to render at runtime."""
+        """Store the asset kind and the block body for the render pass."""
         self.kind = kind
         self.nodelist = nodelist
 

--- a/next/templatetags/next_static.py
+++ b/next/templatetags/next_static.py
@@ -1,22 +1,13 @@
 """Template tags for static asset injection slots.
 
-``{% collect_styles %}`` emits a placeholder where CSS ``<link>`` tags will be
-written after rendering. ``{% collect_scripts %}`` emits a placeholder for JS
-``<script>`` tags. The placeholders are replaced by ``StaticManager.inject``
-once ``Page.render`` has collected every referenced asset from the page, its
-layouts, and nested components. ``{% use_style %}`` and ``{% use_script %}``
-register an external URL on the active ``StaticCollector`` so that layouts and
-templates can pull in shared third-party libraries without touching
-``page.py`` or ``component.py`` module lists. ``{% #use_style %}`` and
-``{% #use_script %}`` are block forms whose body is rendered with the current
-context and hoisted into the matching slot, so developers can co-locate
-inline ``<style>`` or ``<script>`` blocks with their components while still
-letting the collector control final placement and order.
-
-These convenience tags lean on the bootstrap-registered ``css`` and ``js``
-kinds. Custom kinds added by user code register through the same public
-``KindRegistry.register`` API and pick up automatic discovery without needing
-new template tags.
+``{% collect_styles %}`` and ``{% collect_scripts %}`` emit the placeholders
+that ``StaticManager.inject`` replaces after rendering. ``{% use_style %}``,
+``{% use_script %}``, and ``{% use_module %}`` register an external URL on the
+active ``StaticCollector``, and the ``{% #use_style %}`` / ``{% #use_script %}``
+block forms hoist an inline body into the matching slot. The tags lean on the
+bootstrap-registered ``css``, ``js``, and ``module`` kinds. Custom kinds
+register through the same public ``KindRegistry.register`` API and pick up
+automatic discovery without needing new template tags.
 """
 
 from __future__ import annotations
@@ -39,6 +30,7 @@ register = template.Library()
 
 _KIND_CSS = "css"
 _KIND_JS = "js"
+_KIND_MODULE = "module"
 _END_BLOCK_USE_STYLE = ("/use_style",)
 _END_BLOCK_USE_SCRIPT = ("/use_script",)
 
@@ -74,13 +66,20 @@ def use_script(context: template.Context, url: str) -> str:
     return ""
 
 
+@register.simple_tag(takes_context=True)
+def use_module(context: template.Context, url: str) -> str:
+    """Register an external ES module URL on the active collector for injection."""
+    _register_asset(context, url, _KIND_MODULE)
+    return ""
+
+
 def _register_asset(context: template.Context, url: str, kind: str) -> None:
     """Prepend an asset to the render's ``StaticCollector`` when one exists in context.
 
-    Assets declared from templates with ``{% use_style %}`` / ``{% use_script %}``
-    are treated as shared third-party dependencies and are inserted before any
-    co-located files or module-level lists, so the CSS cascade flows from
-    generic dependencies to page-specific styling.
+    Assets declared from templates with the ``use_style`` / ``use_script`` /
+    ``use_module`` URL tags are treated as shared third-party dependencies and
+    are inserted before any co-located files or module-level lists, so the CSS
+    cascade flows from generic dependencies to page-specific styling.
     """
     if not isinstance(url, str) or not url:
         return

--- a/next/templatetags/next_static.py
+++ b/next/templatetags/next_static.py
@@ -1,13 +1,15 @@
 """Template tags for static asset injection slots.
 
 ``{% collect_styles %}`` and ``{% collect_scripts %}`` emit the placeholders
-that ``StaticManager.inject`` replaces after rendering. ``{% use_style %}``,
-``{% use_script %}``, and ``{% use_module %}`` register an external URL on the
-active ``StaticCollector``, and the ``{% #use_style %}`` / ``{% #use_script %}``
-block forms hoist an inline body into the matching slot. The tags lean on the
-bootstrap-registered ``css``, ``js``, and ``module`` kinds. Custom kinds
-register through the same public ``KindRegistry.register`` API and pick up
-automatic discovery without needing new template tags.
+that ``StaticManager.inject`` fills once ``Page.render`` has collected every
+referenced asset from the page, its layouts, and nested components.
+``{% use_style %}``, ``{% use_script %}``, and ``{% use_module %}`` register
+an external URL on the active ``StaticCollector``, and the
+``{% #use_style %}`` / ``{% #use_script %}`` block forms hoist an inline body
+into the matching slot. The tags lean on the bootstrap-registered ``css``,
+``js``, and ``module`` kinds. Custom kinds register through the same public
+``KindRegistry.register`` API and pick up automatic discovery without needing
+new template tags.
 """
 
 from __future__ import annotations
@@ -78,7 +80,8 @@ def _register_asset(context: template.Context, url: str, kind: str) -> None:
 
     Assets declared from templates with the ``use_style`` / ``use_script`` /
     ``use_module`` URL tags are treated as shared third-party dependencies and
-    are inserted before any co-located files or module-level lists, so the CSS
+    are inserted before any co-located files or module-level lists, so
+    dependency tags precede page-specific assets in the slot and the CSS
     cascade flows from generic dependencies to page-specific styling.
     """
     if not isinstance(url, str) or not url:

--- a/next/templatetags/next_static.py
+++ b/next/templatetags/next_static.py
@@ -2,9 +2,9 @@
 
 The collect tags emit placeholder tokens and the use tags register assets on
 the request's ``StaticCollector``, so ``StaticManager.inject`` controls the
-final markup once ``Page.render`` has collected every referenced asset.
-Custom kinds register through the same public ``KindRegistry.register`` API
-without needing new template tags.
+final markup once ``Page.render`` has collected every referenced asset. The
+``kind`` argument of ``{% use_script %}`` reaches every kind in the registry,
+so a kind added through ``KindRegistry.register`` needs no tag of its own.
 """
 
 from __future__ import annotations
@@ -57,15 +57,20 @@ def use_style(context: template.Context, url: str) -> str:
 
 
 @register.simple_tag(takes_context=True)
-def use_script(context: template.Context, url: str) -> str:
-    """Register an external JS URL on the active collector for later injection."""
-    _register_asset(context, url, _KIND_JS)
+def use_script(context: template.Context, url: str, kind: str = _KIND_JS) -> str:
+    """Register an external URL on the active collector under the given kind.
+
+    The kind defaults to ``js`` and accepts any registered kind, so the
+    registry decides both the slot and the renderer. An unregistered kind
+    raises ``KeyError`` out of the render.
+    """
+    _register_asset(context, url, kind)
     return ""
 
 
 @register.simple_tag(takes_context=True)
 def use_module(context: template.Context, url: str) -> str:
-    """Register an external ES module URL on the active collector for injection."""
+    """Register an ES module URL, the ``kind="module"`` shorthand for use_script."""
     _register_asset(context, url, _KIND_MODULE)
     return ""
 

--- a/next/urls/reverse.py
+++ b/next/urls/reverse.py
@@ -30,9 +30,8 @@ page_reverse_lazy = lazy(page_reverse, str)
 def with_query(base: str, **overrides) -> str:
     """Return `base` with its query string updated by `overrides`.
 
-    `None` values drop their key from the result. Multi-valued keys can be
-    set by passing a list/tuple value. An empty list or tuple (`[]`/`()`)
-    also drops the key, equivalent to `None`.
+    A `None` or empty list/tuple value drops its key, a non-empty list or
+    tuple sets a multi-valued key, and anything else sets a single value.
     """
     parts = urlsplit(base)
     params = parse_qsl(parts.query, keep_blank_values=True)

--- a/next/urls/reverse.py
+++ b/next/urls/reverse.py
@@ -31,7 +31,8 @@ def with_query(base: str, **overrides) -> str:
     """Return `base` with its query string updated by `overrides`.
 
     `None` values drop their key from the result. Multi-valued keys can be
-    set by passing a list/tuple value.
+    set by passing a list/tuple value. An empty list or tuple (`[]`/`()`)
+    also drops the key, equivalent to `None`.
     """
     parts = urlsplit(base)
     params = parse_qsl(parts.query, keep_blank_values=True)

--- a/tests/benchmarks/templatetags/test_bench_template_tags.py
+++ b/tests/benchmarks/templatetags/test_bench_template_tags.py
@@ -30,23 +30,6 @@ class TestBenchStaticTags:
         benchmark(run)
 
     @pytest.mark.benchmark(group="templatetags.static")
-    def test_use_module_dedup(self, benchmark) -> None:
-        """``{% use_module %}`` with dedup, 3 identical URLs, one dedups twice."""
-        template = Template(
-            "{% load next_static %}"
-            "{% use_module 'https://cdn.example.com/a.mjs' %}"
-            "{% use_module 'https://cdn.example.com/a.mjs' %}"
-            "{% use_module 'https://cdn.example.com/a.mjs' %}"
-        )
-
-        def run() -> str:
-            collector = StaticCollector()
-            ctx = Context({"_static_collector": collector})
-            return template.render(ctx)
-
-        benchmark(run)
-
-    @pytest.mark.benchmark(group="templatetags.static")
     def test_inline_script_block(self, benchmark) -> None:
         """``{% #use_script %}`` inline, body rendered, stripped, deduped."""
         template = Template(

--- a/tests/benchmarks/templatetags/test_bench_template_tags.py
+++ b/tests/benchmarks/templatetags/test_bench_template_tags.py
@@ -30,6 +30,23 @@ class TestBenchStaticTags:
         benchmark(run)
 
     @pytest.mark.benchmark(group="templatetags.static")
+    def test_use_module_dedup(self, benchmark) -> None:
+        """``{% use_module %}`` with dedup, 3 identical URLs, one dedups twice."""
+        template = Template(
+            "{% load next_static %}"
+            "{% use_module 'https://cdn.example.com/a.mjs' %}"
+            "{% use_module 'https://cdn.example.com/a.mjs' %}"
+            "{% use_module 'https://cdn.example.com/a.mjs' %}"
+        )
+
+        def run() -> str:
+            collector = StaticCollector()
+            ctx = Context({"_static_collector": collector})
+            return template.render(ctx)
+
+        benchmark(run)
+
+    @pytest.mark.benchmark(group="templatetags.static")
     def test_inline_script_block(self, benchmark) -> None:
         """``{% #use_script %}`` inline, body rendered, stripped, deduped."""
         template = Template(

--- a/tests/static/test_checks.py
+++ b/tests/static/test_checks.py
@@ -143,6 +143,20 @@ class TestOptionsWarnings:
             messages = check_static_backends(app_configs=None)
         assert "next.W031" in _ids(messages)
 
+    def test_module_tag_without_placeholder_emits_w031(self) -> None:
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "STATIC_BACKENDS": [
+                    {
+                        "BACKEND": "next.static.StaticFilesBackend",
+                        "OPTIONS": {"module_tag": '<script type="module"></script>'},
+                    }
+                ]
+            }
+        ):
+            messages = check_static_backends(app_configs=None)
+        assert "next.W031" in _ids(messages)
+
     def test_non_string_tag_template_is_ignored(self) -> None:
         with override_settings(
             NEXT_FRAMEWORK={

--- a/tests/static/test_integration.py
+++ b/tests/static/test_integration.py
@@ -101,6 +101,23 @@ class TestUseStyleBlocksThroughPipeline:
         assert 'href="https://cdn/shared.css"' in final
 
 
+class TestUseModuleThroughPipeline:
+    """{% use_module %} URL reaches the document as a module script tag."""
+
+    def test_use_module_lands_in_final_html(
+        self, wired_manager: StaticManager, collector: StaticCollector
+    ) -> None:
+        template = Template(
+            "{% load next_static %}"
+            '{% use_module "https://cdn/vendor.mjs" %}'
+            f"{SCRIPTS_PLACEHOLDER}"
+        )
+        rendered = template.render(Context({"_static_collector": collector}))
+
+        final = wired_manager.inject(rendered, collector)
+        assert '<script type="module" src="https://cdn/vendor.mjs"></script>' in final
+
+
 class TestInlineBlocksThroughPipeline:
     """`{% #use_style %}` / `{% #use_script %}` reach the head as working tags."""
 

--- a/tests/static/test_template_tags.py
+++ b/tests/static/test_template_tags.py
@@ -73,7 +73,7 @@ class TestUseModuleTag:
         assert template.render(Context({})) == ""
 
     def test_block_use_module_is_not_registered(self) -> None:
-        with pytest.raises(TemplateSyntaxError):
+        with pytest.raises(TemplateSyntaxError, match="#use_module"):
             Template("{% load next_static %}{% #use_module %}x{% /use_module %}")
 
 

--- a/tests/static/test_template_tags.py
+++ b/tests/static/test_template_tags.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from django.template import Context, Template
+import pytest
+from django.template import Context, Template, TemplateSyntaxError
 
-from next.static import StaticCollector
+from next.static import StaticAsset, StaticCollector
 
 
 STYLES_PLACEHOLDER = "<!-- next:styles -->"
@@ -49,6 +50,31 @@ class TestUseStyleScriptInlineTags:
         template = Template('{% load next_static %}{% use_style "https://cdn/a.css" %}')
         result = template.render(Context({}))
         assert result == ""
+
+
+class TestUseModuleTag:
+    def test_use_module_registers_and_emits_nothing(self) -> None:
+        out, coll = _render(
+            '{% load next_static %}{% use_module "https://cdn/a.mjs" %}'
+        )
+        assert out == ""
+        scripts = coll.assets_in_slot("scripts")
+        assert [(a.url, a.kind) for a in scripts] == [("https://cdn/a.mjs", "module")]
+
+    def test_use_module_ignores_empty_url(self) -> None:
+        out, coll = _render('{% load next_static %}{% use_module "" %}')
+        assert out == ""
+        assert coll.assets_in_slot("scripts") == []
+
+    def test_use_module_noop_without_collector(self) -> None:
+        template = Template(
+            '{% load next_static %}{% use_module "https://cdn/a.mjs" %}'
+        )
+        assert template.render(Context({})) == ""
+
+    def test_block_use_module_is_not_registered(self) -> None:
+        with pytest.raises(TemplateSyntaxError):
+            Template("{% load next_static %}{% #use_module %}x{% /use_module %}")
 
 
 class TestBlockUseStyleScript:
@@ -105,3 +131,13 @@ class TestPrependOrdering:
         )
         urls = [a.url for a in coll.assets_in_slot("styles")]
         assert urls == ["https://cdn/a.css", "https://cdn/b.css"]
+
+    def test_use_module_lands_at_front(self) -> None:
+        collector = StaticCollector()
+        collector.add(StaticAsset(url="https://cdn/colocated.js", kind="js"))
+        template = Template(
+            '{% load next_static %}{% use_module "https://cdn/a.mjs" %}'
+        )
+        template.render(Context({"_static_collector": collector}))
+        urls = [a.url for a in collector.assets_in_slot("scripts")]
+        assert urls == ["https://cdn/a.mjs", "https://cdn/colocated.js"]

--- a/tests/static/test_template_tags.py
+++ b/tests/static/test_template_tags.py
@@ -52,8 +52,8 @@ class TestUseStyleScriptInlineTags:
         assert result == ""
 
 
-class TestUseModuleTag:
-    def test_use_module_registers_and_emits_nothing(self) -> None:
+class TestUseScriptKindArgument:
+    def test_use_module_registers_the_module_kind(self) -> None:
         out, coll = _render(
             '{% load next_static %}{% use_module "https://cdn/a.mjs" %}'
         )
@@ -61,16 +61,28 @@ class TestUseModuleTag:
         scripts = coll.assets_in_slot("scripts")
         assert [(a.url, a.kind) for a in scripts] == [("https://cdn/a.mjs", "module")]
 
-    def test_use_module_ignores_empty_url(self) -> None:
-        out, coll = _render('{% load next_static %}{% use_module "" %}')
-        assert out == ""
-        assert coll.assets_in_slot("scripts") == []
-
-    def test_use_module_noop_without_collector(self) -> None:
-        template = Template(
-            '{% load next_static %}{% use_module "https://cdn/a.mjs" %}'
+    def test_use_script_kind_argument_matches_use_module(self) -> None:
+        out, coll = _render(
+            '{% load next_static %}{% use_script "https://cdn/a.mjs" kind="module" %}'
         )
-        assert template.render(Context({})) == ""
+        assert out == ""
+        scripts = coll.assets_in_slot("scripts")
+        assert [(a.url, a.kind) for a in scripts] == [("https://cdn/a.mjs", "module")]
+
+    def test_unregistered_kind_raises_out_of_the_render(self) -> None:
+        with pytest.raises(KeyError, match="wasm"):
+            _render('{% load next_static %}{% use_script "a.wasm" kind="wasm" %}')
+
+    def test_one_url_under_two_kinds_is_not_deduped(self) -> None:
+        _, coll = _render(
+            '{% load next_static %}{% use_script "https://cdn/x.js" %}'
+            '{% use_module "https://cdn/x.js" %}'
+        )
+        scripts = coll.assets_in_slot("scripts")
+        assert [(a.url, a.kind) for a in scripts] == [
+            ("https://cdn/x.js", "js"),
+            ("https://cdn/x.js", "module"),
+        ]
 
     def test_block_use_module_is_not_registered(self) -> None:
         with pytest.raises(TemplateSyntaxError, match="#use_module"):
@@ -132,12 +144,17 @@ class TestPrependOrdering:
         urls = [a.url for a in coll.assets_in_slot("styles")]
         assert urls == ["https://cdn/a.css", "https://cdn/b.css"]
 
-    def test_use_module_lands_at_front(self) -> None:
+    def test_use_script_and_use_module_share_one_prepend_run(self) -> None:
         collector = StaticCollector()
         collector.add(StaticAsset(url="https://cdn/colocated.js", kind="js"))
         template = Template(
-            '{% load next_static %}{% use_module "https://cdn/a.mjs" %}'
+            '{% load next_static %}{% use_script "https://cdn/a.js" %}'
+            '{% use_module "https://cdn/b.mjs" %}'
         )
         template.render(Context({"_static_collector": collector}))
         urls = [a.url for a in collector.assets_in_slot("scripts")]
-        assert urls == ["https://cdn/a.mjs", "https://cdn/colocated.js"]
+        assert urls == [
+            "https://cdn/a.js",
+            "https://cdn/b.mjs",
+            "https://cdn/colocated.js",
+        ]

--- a/tests/static/test_template_tags.py
+++ b/tests/static/test_template_tags.py
@@ -134,7 +134,7 @@ class TestBlockUseStyleScript:
 
 
 class TestPrependOrdering:
-    """use_style/use_script insert before co-located files via collector prepend."""
+    """The use tags insert ahead of co-located files through collector prepend."""
 
     def test_use_style_lands_at_front(self) -> None:
         _, coll = _render(

--- a/tests/urls/test_reverse.py
+++ b/tests/urls/test_reverse.py
@@ -51,6 +51,8 @@ class TestWithQuery:
             ("/x/?q=old&p=1", {"q": "new"}, "/x/?p=1&q=new"),
             ("/x/?q=old&p=1", {"q": None}, "/x/?p=1"),
             ("/x/", {"tag": ["a", "b"]}, "/x/?tag=a&tag=b"),
+            ("/x/?tag=a&tag=b", {"tag": []}, "/x/"),
+            ("/x/?tag=a&tag=b", {"tag": ()}, "/x/"),
             ("/x/", {"page": 2}, "/x/?page=2"),
             ("/x/y/?a=1#top", {"a": "2"}, "/x/y/?a=2#top"),
             ("/x/", {"q": "a b&c"}, "/x/?q=a+b%26c"),
@@ -60,6 +62,8 @@ class TestWithQuery:
             "override",
             "drop_none",
             "list_value",
+            "drop_empty_list",
+            "drop_empty_tuple",
             "coerce_int",
             "preserve_fragment",
             "urlencode_special",
@@ -67,6 +71,10 @@ class TestWithQuery:
     )
     def test_query_string_composition(self, base, overrides, expected) -> None:
         assert with_query(base, **overrides) == expected
+
+    def test_empty_sequence_is_equivalent_to_none(self) -> None:
+        base = "/x/?tag=a&tag=b"
+        assert with_query(base, tag=[]) == with_query(base, tag=None)
 
 
 class TestPageReverseLazy:

--- a/tests/urls/test_reverse.py
+++ b/tests/urls/test_reverse.py
@@ -72,10 +72,6 @@ class TestWithQuery:
     def test_query_string_composition(self, base, overrides, expected) -> None:
         assert with_query(base, **overrides) == expected
 
-    def test_empty_sequence_is_equivalent_to_none(self) -> None:
-        base = "/x/?tag=a&tag=b"
-        assert with_query(base, tag=[]) == with_query(base, tag=None)
-
 
 class TestPageReverseLazy:
     def test_defers_reverse_until_str(self) -> None:


### PR DESCRIPTION
## Description

Closes the template-side gaps left by the static and urls audit.

### `{% use_script %}` names its kind

The static bootstrap registers the built-in `module` kind next to `css`/`js`, and co-located discovery plus module-level `scripts` lists pick up `.mjs` files automatically, but no template tag could publish an external URL under any kind other than `css` or `js`. Rather than grow a third hardcoded per-kind wrapper, `use_script` takes an optional `kind` argument that reaches `KindRegistry` unchanged, so the registry picks both the slot the asset lands in and the backend renderer that builds its tag.

```jinja
{% use_script "https://cdn.example.com/vendor.js" %}
{% use_script "https://cdn.example.com/vendor.mjs" kind="module" %}
{% use_script "https://cdn.example.com/inter.woff2" kind="font" %}
```

A kind registered by user code through the public `KindRegistry.register` API therefore needs no template tag of its own, which is what `next/static/assets.py` already promises — "Core code never special-cases any particular kind". An unregistered kind raises `KeyError` out of the render, so a typo surfaces on the first request instead of silently dropping the asset.

`{% use_module "<url>" %}` ships as the `kind="module"` shorthand. URL form only: the `module` kind names no inline wrapper element, so a block body would land in the slot verbatim, and no `#use_module` block form is introduced. The docs are explicit that browsers defer module scripts, so the collector prepend orders markup, not execution against classic scripts, and that one URL registered under two kinds is two assets, because `UrlDedup` keys on `(kind, url)`.

### `next.W031` now validates `module_tag`

The static backend check walked `css_tag` and `js_tag` only. A `module_tag` without the `{url}` placeholder therefore shipped a `src`-less `<script type="module">` silently, and a `module_tag` with a misspelled placeholder key raised `KeyError` out of `str.format` on the first render that reached `render_module_tag`. The check covers all three tag templates now, and the "the `module_tag` template is not checked, so verify it contains `{url}` yourself" caveat is gone from the backends page.

### `with_query(base, key=[])`

The empty-sequence drop already behaved exactly like `key=None`, but nothing said so: the docstring named only the `None` drop and the list/tuple set, and the test matrix had no case for it. The behavior is now documented in the docstring and on the URL reversing page, and pinned by `drop_empty_list` / `drop_empty_tuple` parametrized cases. The function body is untouched.

### Example

The shared `page_head` pulls `/static/shared/js/base.mjs` through `{% use_module %}`, so all twelve example apps carry the site-wide `/` search shortcut and the `module` kind travels through a real page render end to end, with an e2e assertion in `kanban` pinning the rendered tag.

### Bench workflow: the base cache ignored the runner CPU

Not part of the feature, but this PR is where the bug surfaced, so it is fixed here. The `bench` job caches the base measurement by base SHA plus lockfile hash and skips `Bench BASE` on a cache hit, so the base numbers can come from an earlier run on different hardware. `ubuntu-latest` hands out more than one CPU generation, and this PR drew a base measured on `AMD EPYC 9V74` (3.69 GHz, Genoa) against a head measured on `AMD EPYC 7763` (3.24 GHz, Milan). All 171 benchmarks came out slower, none faster, median ratio 1.36x, and the hard gate tripped on `test_dispatch_wizard_step_submit` in `next/forms/dispatch/wizard.py` — a file no commit here touches. The run one hour earlier, on the same hardware as the cache, had a median ratio of 1.00 with 64 of 171 benchmarks faster than base.

The CPU model now takes part in the cache key, so a runner of another generation re-measures the base instead of trusting a foreign number. As a second line of defence, the job reads `machine_info` out of both result JSONs: pytest-benchmark already warns about a mismatch and then fails the gate on it anyway, so a cross-hardware comparison is now reported as a warning and labelled in the PR comment header rather than failing the job.

No breaking changes: the `kind` argument is optional and defaults to `js`, `use_module` is additive, and the `with_query` change is documentation and coverage only.

## How to test

`make ci` passes locally — ruff, mypy strict, the JS toolchain, the full suite with the 100% coverage gate on `next/`, every example at 100%, and the compat matrix. `make docs` builds clean under `-W` on top of it, since the docs job runs in GitHub Actions rather than in `make ci`.

The `bench` workflow change is verified by running each of its three shell steps against fixtures: a matching CPU pair yields `same=true`, a mismatched pair yields `same=false` plus the warning annotation, and a missing result JSON yields `same=unknown` so the gate keeps its teeth. Every `run` script in the job passes `bash -n`, and the file still parses as YAML.

A paired `make bench` run on the `templatetags.static` group against `main` shows no regression: `test_use_script_dedup` lands at 8.7µs on the branch against 10.4µs on `main`, inside the noise band of the `median:99%` gate. The `kind` argument is resolved by Django at template-compile time, so the render path is unchanged. No benchmark case was added, since a `use_module` bench would measure the same `_register_asset` path as its `use_script` twin.

## Related issues

—

## Checklist

- [x] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [x] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable

---

Full guidelines: [CONTRIBUTING.md](https://github.com/next-dj/next-dj/blob/main/CONTRIBUTING.md)
