### PR TITLE
fix: immutable merged settings, guarded component context, server DRY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ docs-serve: docs # build and serve documentation
 	@open docs/_build/index.html
 
 docs-clean: # clean documentation build
-	rm -rf docs/_build/*
+	rm -rf docs/_build
 
 docs-linkcheck: # check documentation links
 	uv sync --locked --group docs

--- a/docs/content/faq/troubleshooting.rst
+++ b/docs/content/faq/troubleshooting.rst
@@ -409,7 +409,7 @@ Merged NEXT_FRAMEWORK settings are immutable
 Appending to ``next_framework_settings.PAGE_BACKENDS``, assigning into it, or mutating a nested list or mapping raises ``TypeError`` reading ``Merged NEXT_FRAMEWORK settings are immutable``.
 The merge hands out frozen containers so that one caller cannot reshape the configuration every other reader sees.
 Change ``settings.NEXT_FRAMEWORK`` and call ``next_framework_settings.reload()``, or wrap the change in ``override_settings``, which reloads on its own.
-To work on a value of your own instead, copy it with ``list()``, ``dict()``, or ``copy.deepcopy`` for a nested one, each of which hands back a plain mutable container.
+To edit a copy instead, ``list()`` and ``dict()`` thaw the top level and ``copy.deepcopy`` thaws a nested value all the way down.
 Reading is untouched, so ``isinstance``, equality against a plain container, and ``json.dumps`` still work on a merged value.
 See :ref:`ref-conf` for the rest of the contract.
 

--- a/docs/content/faq/troubleshooting.rst
+++ b/docs/content/faq/troubleshooting.rst
@@ -409,6 +409,7 @@ Merged NEXT_FRAMEWORK settings are immutable
 Appending to ``next_framework_settings.PAGE_BACKENDS``, assigning into it, or mutating a nested list or mapping raises ``TypeError`` reading ``Merged NEXT_FRAMEWORK settings are immutable``.
 The merge hands out frozen containers so that one caller cannot reshape the configuration every other reader sees.
 Change ``settings.NEXT_FRAMEWORK`` and call ``next_framework_settings.reload()``, or wrap the change in ``override_settings``, which reloads on its own.
+To work on a value of your own instead, copy it with ``list()``, ``dict()``, or ``copy.deepcopy`` for a nested one, each of which hands back a plain mutable container.
 Reading is untouched, so ``isinstance``, equality against a plain container, and ``json.dumps`` still work on a merged value.
 See :ref:`ref-conf` for the rest of the contract.
 

--- a/docs/content/faq/troubleshooting.rst
+++ b/docs/content/faq/troubleshooting.rst
@@ -178,6 +178,15 @@ Component prop does not resolve
 ``{% component "card" title="some_var" %}`` is a literal string.
 Pick the form that matches the value you want to pass.
 
+Component context returns a reserved key
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The render raises ``ValueError`` reading ``Component 'card' context returns 'title', reserved by the render path or by a prop of the calling tag``.
+An unkeyed ``@component.context`` returned a dict whose key names a prop of the ``{% component %}`` call site being rendered, a reserved render key such as ``children``, ``request``, or ``csrf_token``, or any key starting with ``slot_``.
+Rename the key, or register the value under an explicit ``@component.context("key")`` when overwriting is what you want.
+The error leaves the render instead of degrading to an empty string, so neither ``STRICT_LOADING`` nor ``DEBUG`` suppresses it.
+See :doc:`/content/topics/components` for the reserved set.
+
 Static
 ------
 
@@ -393,6 +402,15 @@ If a module raises an import error at startup, the server does not start.
 Set ``LAZY_COMPONENT_MODULES = True`` in ``NEXT_FRAMEWORK`` to defer imports for those roots until first resolve.
 Components beside page routes may still load earlier when URL patterns are constructed.
 This hides some startup errors but surfaces them when the failing component or route branch is first touched.
+
+Merged NEXT_FRAMEWORK settings are immutable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Appending to ``next_framework_settings.PAGE_BACKENDS``, assigning into it, or mutating a nested list or mapping raises ``TypeError`` reading ``Merged NEXT_FRAMEWORK settings are immutable``.
+The merge hands out frozen containers so that one caller cannot reshape the configuration every other reader sees.
+Change ``settings.NEXT_FRAMEWORK`` and call ``next_framework_settings.reload()``, or wrap the change in ``override_settings``, which reloads on its own.
+Reading is untouched, so ``isinstance``, equality against a plain container, and ``json.dumps`` still work on a merged value.
+See :ref:`ref-conf` for the rest of the contract.
 
 System checks
 -------------

--- a/docs/content/howto/test-a-component-in-isolation.rst
+++ b/docs/content/howto/test-a-component-in-isolation.rst
@@ -12,7 +12,7 @@ Solution
 --------
 
 Use ``render_component_by_name`` from ``next.testing``.
-It resolves a component by name as seen from a given template path, renders it with a context mapping you supply, and returns the HTML string.
+It resolves a component by name as seen from a given template path, renders it with the mappings you supply, and returns the HTML string.
 
 Walkthrough
 -----------
@@ -43,7 +43,7 @@ Render the component
 
 ``render_component_by_name`` takes the component name and the ``at`` path the component is referenced from.
 The ``at`` path drives visibility, so pass a template inside the page tree that can see the component.
-The ``context`` mapping fills the values the component template reads.
+The ``props`` mapping stands in for a ``{% component %}`` call site, so it fills the values the component template reads.
 
 .. code-block:: python
    :caption: tests/test_info_card.py
@@ -54,7 +54,7 @@ The ``context`` mapping fills the values the component template reads.
        html = render_component_by_name(
            "info_card",
            at="notes/pages/template.djx",
-           context={"title": "Quick start", "subtitle": "Read this first"},
+           props={"title": "Quick start", "subtitle": "Read this first"},
        )
        assert "Quick start" in html
        assert "info-card" in html
@@ -63,8 +63,26 @@ The helper raises ``LookupError`` when no visible component matches the name fro
 
 .. warning::
 
-   The keys of the ``context`` mapping reach the render-time guard as the props of this call site, the way ``{% component "info_card" title="Quick start" %}`` would pass them.
+   The keys of the ``props`` mapping reach the render-time guard as the props of this call site, the way ``{% component "info_card" title="Quick start" %}`` would pass them.
    A component whose unkeyed ``@component.context`` returns one of those keys raises ``ValueError`` here too, so the isolated test fails wherever the page render would.
+
+Pass ambient page values through ``context``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A component that reads a value from the surrounding page scope rather than from its own call site takes it through the ``context`` mapping.
+Those keys are not published as props, so an unkeyed ``@component.context`` may shadow them exactly as it does on a page.
+
+.. code-block:: python
+   :caption: tests/test_info_card.py
+
+   def test_info_card_reads_the_page_scope() -> None:
+       html = render_component_by_name(
+           "info_card",
+           at="notes/pages/template.djx",
+           context={"section": "Guides"},
+           props={"title": "Quick start"},
+       )
+       assert "Guides" in html
 
 Assert on the markup
 ~~~~~~~~~~~~~~~~~~~~
@@ -81,7 +99,7 @@ The ``assert_has_class`` and ``find_anchor`` helpers from ``next.testing`` keep 
        html = render_component_by_name(
            "info_card",
            at="notes/pages/template.djx",
-           context={"title": "Quick start"},
+           props={"title": "Quick start"},
        )
        assert_has_class(html, "info-card")
 
@@ -89,7 +107,7 @@ The ``assert_has_class`` and ``find_anchor`` helpers from ``next.testing`` keep 
        html = render_component_by_name(
            "info_card",
            at="notes/pages/template.djx",
-           context={"title": "Quick start", "href": "/notes/1/"},
+           props={"title": "Quick start", "href": "/notes/1/"},
        )
        anchor = find_anchor(html, href="/notes/1/", text="Quick start")
        assert 'href="/notes/1/"' in anchor

--- a/docs/content/howto/test-a-component-in-isolation.rst
+++ b/docs/content/howto/test-a-component-in-isolation.rst
@@ -61,6 +61,11 @@ The ``context`` mapping fills the values the component template reads.
 
 The helper raises ``LookupError`` when no visible component matches the name from the ``at`` path.
 
+.. warning::
+
+   The keys of the ``context`` mapping reach the render-time guard as the props of this call site, the way ``{% component "info_card" title="Quick start" %}`` would pass them.
+   A component whose unkeyed ``@component.context`` returns one of those keys raises ``ValueError`` here too, so the isolated test fails wherever the page render would.
+
 Assert on the markup
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/content/internals/autoreload.rst
+++ b/docs/content/internals/autoreload.rst
@@ -67,7 +67,6 @@ Runtime
 
 ``next.server.watcher``.
    ``iter_all_autoreload_watch_specs`` returns the deduplicated list of built-in specs plus pairs registered through ``register_autoreload_watch_spec``.
-   ``FilesystemWatchContributor`` is a runtime-checkable protocol exported for type annotations only and is not iterated at runtime.
 
 ``next.server.roots``.
    ``get_framework_filesystem_roots_for_linking`` returns the canonical page and component directory roots for build tooling.

--- a/docs/content/internals/component-pipeline.rst
+++ b/docs/content/internals/component-pipeline.rst
@@ -117,6 +117,7 @@ Component context resolution
 ----------------------------
 
 Each ``@component.context("key")`` function runs once per component render.
+An unkeyed callable's dict is checked before the merge, so a key naming a prop of the rendering ``{% component %}`` call site, a reserved render key, or anything carrying the ``slot_`` prefix raises ``ValueError`` rather than overwriting the entry.
 When a component's ``component.py`` fails to import, the renderer falls back to plain template rendering and the ``@component.context`` callables in that module do not run.
 On the template render path the resolver shares the request-scoped dependency cache through ``get_request_dep_cache``.
 Named ``Depends("name")`` values resolved earlier in the dispatch are reused inside the component callables.

--- a/docs/content/ref/conf.rst
+++ b/docs/content/ref/conf.rst
@@ -18,6 +18,15 @@ Settings class
 .. automodule:: next.conf.settings
    :members:
 
+Merged values are immutable, so appending to ``next_framework_settings.PAGE_BACKENDS``, assigning into it, or mutating a nested list or mapping raises ``TypeError``.
+A value of any other type, such as a set inside ``OPTIONS``, is copied rather than frozen, so it stays editable and only the copy handed to you changes.
+They remain a ``list`` and a ``dict``, so ``isinstance`` checks, equality against a plain container, and ``json.dumps`` keep working, and only mutation is refused.
+The concrete types are ``FrozenList`` and ``FrozenDict`` from ``next.conf.frozen``, which is framework-internal and carries no stability guarantee.
+The guard covers ordinary mutation rather than a determined caller, because an unbound call such as ``list.append(value, item)`` still reaches the underlying container.
+
+To change a value, change ``settings.NEXT_FRAMEWORK`` and call ``next_framework_settings.reload()``, which Django's ``override_settings`` already does on entry and exit.
+A ``NEXT_FRAMEWORK`` value that refers back to itself cannot be frozen and raises :exc:`~django.core.exceptions.ImproperlyConfigured` naming the self-referential value.
+
 Defaults
 ~~~~~~~~
 

--- a/docs/content/ref/conf.rst
+++ b/docs/content/ref/conf.rst
@@ -24,6 +24,10 @@ They remain a ``list`` and a ``dict``, so ``isinstance`` checks, equality agains
 The concrete types are ``FrozenList`` and ``FrozenDict`` from ``next.conf.frozen``, which is framework-internal and carries no stability guarantee.
 The guard covers ordinary mutation rather than a determined caller, because an unbound call such as ``list.append(value, item)`` still reaches the underlying container.
 
+To edit a merged value, copy it first.
+``list()`` and ``dict()`` thaw one level, and :func:`copy.copy` and :func:`copy.deepcopy` hand back plain mutable containers, the deep one thawed all the way down.
+Pickling a merged value round-trips it frozen, since the value on the other side is still the configuration.
+
 To change a value, change ``settings.NEXT_FRAMEWORK`` and call ``next_framework_settings.reload()``, which Django's ``override_settings`` already does on entry and exit.
 A ``NEXT_FRAMEWORK`` value that refers back to itself cannot be frozen and raises :exc:`~django.core.exceptions.ImproperlyConfigured` naming the self-referential value.
 

--- a/docs/content/ref/conf.rst
+++ b/docs/content/ref/conf.rst
@@ -24,12 +24,12 @@ They remain a ``list`` and a ``dict``, so ``isinstance`` checks, equality agains
 The concrete types are ``FrozenList`` and ``FrozenDict`` from ``next.conf.frozen``, which is framework-internal and carries no stability guarantee.
 The guard covers ordinary mutation rather than a determined caller, because an unbound call such as ``list.append(value, item)`` still reaches the underlying container.
 
-To edit a merged value, copy it first.
-``list()`` and ``dict()`` thaw one level, and :func:`copy.copy` and :func:`copy.deepcopy` hand back plain mutable containers, the deep one thawed all the way down.
-Pickling a merged value round-trips it frozen, since the value on the other side is still the configuration.
-
 To change a value, change ``settings.NEXT_FRAMEWORK`` and call ``next_framework_settings.reload()``, which Django's ``override_settings`` already does on entry and exit.
 A ``NEXT_FRAMEWORK`` value that refers back to itself cannot be frozen and raises :exc:`~django.core.exceptions.ImproperlyConfigured` naming the self-referential value.
+
+To edit a value of your own instead, copy the merged one first.
+``list()`` and ``dict()`` thaw the top level, :func:`copy.copy` hands back the same plain container, and :func:`copy.deepcopy` thaws every level below it.
+Pickling round-trips a merged value frozen.
 
 Defaults
 ~~~~~~~~

--- a/docs/content/ref/decorators.rst
+++ b/docs/content/ref/decorators.rst
@@ -38,6 +38,9 @@ The callable still runs on a full page render.
 Registers a component context function inside ``component.py``.
 The first positional argument is ``func_or_key``.
 Called bare as ``@component.context`` it merges the function's returned dict into the component template scope.
+The merge is guarded, so a returned key naming one of the reserved render keys, or any key starting with ``slot_``, raises ``ValueError`` at render time.
+Rendering through ``{% component %}`` extends the guard to the props of that one call site, and ``ComponentWidget`` and ``render_component_by_name`` extend it the same way to the names they pass, while a bare ``render_component`` guards the reserved keys alone.
+See :doc:`/content/topics/components` for the reserved set.
 Called as ``@component.context("greeting")`` it binds the function's return value to that key.
 Pass ``serialize=True`` to include the return value in ``window.Next.context``.
 The value must be JSON-encodable by the active serializer, the same contract documented under :ref:`Serialization for the browser <topics-context-serialization>`.

--- a/docs/content/ref/decorators.rst
+++ b/docs/content/ref/decorators.rst
@@ -39,7 +39,7 @@ Registers a component context function inside ``component.py``.
 The first positional argument is ``func_or_key``.
 Called bare as ``@component.context`` it merges the function's returned dict into the component template scope.
 The merge is guarded, so a returned key naming one of the reserved render keys, or any key starting with ``slot_``, raises ``ValueError`` at render time.
-Rendering through ``{% component %}`` extends the guard to the props of that one call site, and ``ComponentWidget`` and ``render_component_by_name`` extend it the same way to the names they pass, while a bare ``render_component`` guards the reserved keys alone.
+Rendering through ``{% component %}`` extends the guard to the props of that one call site, and ``ComponentWidget`` and the ``props`` mapping of ``render_component_by_name`` extend it the same way to the names they pass, while a bare ``render_component`` guards the reserved keys alone.
 See :doc:`/content/topics/components` for the reserved set.
 Called as ``@component.context("greeting")`` it binds the function's return value to that key.
 Pass ``serialize=True`` to include the return value in ``window.Next.context``.

--- a/docs/content/ref/server.rst
+++ b/docs/content/ref/server.rst
@@ -36,10 +36,6 @@ The built-in specs for pages and filesystem components are derived from ``NEXT_F
 Each entry is a ``(path, glob)`` tuple consumed by ``StatReloader.watch_dir``.
 The function emits the ``watch_specs_ready`` signal on every call so subscribers can inspect the resolved set.
 
-``FilesystemWatchContributor`` is a runtime-checkable protocol declaring a single ``iter_watch_specs()`` method.
-It is exported for type annotations only.
-The watcher does not iterate contributors at runtime, so registration goes through ``register_autoreload_watch_spec``.
-
 .. automodule:: next.server.watcher
    :members:
 

--- a/docs/content/topics/components.rst
+++ b/docs/content/topics/components.rst
@@ -333,6 +333,7 @@ The framework resolves parameters from the surrounding template scope, from URL 
    Registration raises ``ValueError`` for a key reserved for dependency injection, such as ``request``.
    It also raises ``ValueError`` for a duplicate registration of two different functions under the same key, or of two different unkeyed callables, in one ``component.py``.
    Re-registering the same function under the same key replaces the stored entry rather than raising.
+   These are the registration failures, and the unkeyed form raises one more ``ValueError`` at render time, described below.
 
 Pass ``serialize=True`` and optionally ``serializer=`` to include the return value in ``window.Next.context``.
 The behaviour is identical to ``@context`` on a page module, so the value must be JSON-encodable by the active serializer.
@@ -342,6 +343,17 @@ An unkeyed ``@component.context`` returning a dict serializes each key of that d
 A ``serializer=`` on such an unkeyed callable applies to every key of the returned dict.
 A keyed ``@component.context`` serializes its return value under the given key.
 An unkeyed callable that returns anything other than a mapping is silently dropped from the template scope.
+
+An unkeyed ``@component.context`` merges its dict into the component scope, so the framework guards the names that merge would quietly take over.
+The render raises ``ValueError`` when the returned dict carries a prop passed by the ``{% component %}`` tag being rendered, a reserved render key, or any key that starts with ``slot_``.
+The reserved render keys are ``children``, ``request``, ``csrf_token``, ``current_template_path``, ``current_component_module_path``, ``_static_collector``, and ``_component_props``.
+The whole ``slot_`` prefix is reserved, so a returned ``slot_count`` raises even when the component declares no ``count`` slot.
+Register the value under an explicit ``@component.context("key")`` instead, which is the deliberate override and is never guarded.
+
+A page context key that reaches the component through the surrounding scope is not reserved, so an unkeyed dict may still shadow it for the component body.
+The ``{% component %}`` tag publishes the prop names of its own call site, ``ComponentWidget`` publishes the names it fills for its field, and ``render_component_by_name`` publishes the keys of the ``context`` mapping it is handed, so a bare ``render_component`` is the one path left guarding the reserved keys alone.
+The same component code therefore raises under ``{% component "note_card" preview=text %}`` and merges quietly under ``{% component "note_card" %}``.
+This failure leaves the render rather than degrading to an empty string, so ``STRICT_LOADING`` and ``DEBUG`` do not change it.
 
 Co-located static assets
 ------------------------

--- a/docs/content/topics/components.rst
+++ b/docs/content/topics/components.rst
@@ -350,7 +350,7 @@ The reserved render keys are ``children``, ``request``, ``csrf_token``, ``curren
 The whole ``slot_`` prefix is reserved, so a returned ``slot_count`` raises even when the component declares no ``count`` slot.
 Register the value under an explicit ``@component.context("key")`` instead, which is the deliberate override and is never guarded.
 
-A page context key that reaches the component through the surrounding scope is not reserved, so an unkeyed dict may still shadow it for the component body.
+An ordinary page context key that reaches the component through the surrounding scope stays outside the guard, so an unkeyed dict may still shadow it for the component body.
 The ``{% component %}`` tag publishes the prop names of its own call site, ``ComponentWidget`` publishes the names it fills for its field, and ``render_component_by_name`` publishes the keys of its ``props`` mapping while leaving its ``context`` mapping ambient, so a bare ``render_component`` is the one path left guarding the reserved keys alone.
 The same component code therefore raises under ``{% component "note_card" preview=text %}`` and merges quietly under ``{% component "note_card" %}``.
 This failure leaves the render rather than degrading to an empty string, so ``STRICT_LOADING`` and ``DEBUG`` do not change it.

--- a/docs/content/topics/components.rst
+++ b/docs/content/topics/components.rst
@@ -346,12 +346,12 @@ An unkeyed callable that returns anything other than a mapping is silently dropp
 
 An unkeyed ``@component.context`` merges its dict into the component scope, so the framework guards the names that merge would quietly take over.
 The render raises ``ValueError`` when the returned dict carries a prop passed by the ``{% component %}`` tag being rendered, a reserved render key, or any key that starts with ``slot_``.
-The reserved render keys are ``children``, ``request``, ``csrf_token``, ``current_template_path``, ``current_component_module_path``, ``_static_collector``, and ``_component_props``.
+The reserved render keys are ``children``, ``request``, ``csrf_token``, ``current_template_path``, ``current_page_module_path``, ``current_component_module_path``, ``_static_collector``, and ``_component_props``.
 The whole ``slot_`` prefix is reserved, so a returned ``slot_count`` raises even when the component declares no ``count`` slot.
 Register the value under an explicit ``@component.context("key")`` instead, which is the deliberate override and is never guarded.
 
 A page context key that reaches the component through the surrounding scope is not reserved, so an unkeyed dict may still shadow it for the component body.
-The ``{% component %}`` tag publishes the prop names of its own call site, ``ComponentWidget`` publishes the names it fills for its field, and ``render_component_by_name`` publishes the keys of the ``context`` mapping it is handed, so a bare ``render_component`` is the one path left guarding the reserved keys alone.
+The ``{% component %}`` tag publishes the prop names of its own call site, ``ComponentWidget`` publishes the names it fills for its field, and ``render_component_by_name`` publishes the keys of its ``props`` mapping while leaving its ``context`` mapping ambient, so a bare ``render_component`` is the one path left guarding the reserved keys alone.
 The same component code therefore raises under ``{% component "note_card" preview=text %}`` and merges quietly under ``{% component "note_card" %}``.
 This failure leaves the render rather than degrading to an empty string, so ``STRICT_LOADING`` and ``DEBUG`` do not change it.
 

--- a/docs/content/topics/context.rst
+++ b/docs/content/topics/context.rst
@@ -58,8 +58,8 @@ A user ``@context`` callable reads ``request`` through an ``HttpRequest`` annota
 These path keys live in the template scope for the ``{% form %}`` and ``{% component %}`` tags to consume.
 They are not injected into a context callable by parameter name.
 
-Three of these keys are reserved inside a component, so an unkeyed ``@component.context`` that returns ``request``, ``current_template_path``, or ``current_component_module_path`` raises ``ValueError`` at render time.
-``current_page_module_path`` is deliberately left out of that guard, so a component may still shadow the page path for its own body.
+All four of these keys are reserved inside a component, so an unkeyed ``@component.context`` that returns ``request``, ``current_template_path``, ``current_page_module_path``, or ``current_component_module_path`` raises ``ValueError`` at render time.
+The two path anchors are guarded because ``{% form %}`` scopes its action lookup through them, so shadowing one would silently retarget a dispatch.
 See :doc:`components` for the rest of the reserved set.
 
 The decorator

--- a/docs/content/topics/context.rst
+++ b/docs/content/topics/context.rst
@@ -58,6 +58,10 @@ A user ``@context`` callable reads ``request`` through an ``HttpRequest`` annota
 These path keys live in the template scope for the ``{% form %}`` and ``{% component %}`` tags to consume.
 They are not injected into a context callable by parameter name.
 
+Three of these keys are reserved inside a component, so an unkeyed ``@component.context`` that returns ``request``, ``current_template_path``, or ``current_component_module_path`` raises ``ValueError`` at render time.
+``current_page_module_path`` is deliberately left out of that guard, so a component may still shadow the page path for its own body.
+See :doc:`components` for the rest of the reserved set.
+
 The decorator
 -------------
 

--- a/docs/content/topics/testing.rst
+++ b/docs/content/topics/testing.rst
@@ -455,7 +455,7 @@ In the second example below, ``at`` is the template path the component is refere
        html = render_component_by_name(
            "note_card",
            at="notes/pages/template.djx",
-           context={"note": {"title": "First"}},
+           props={"note": {"title": "First"}},
        )
        assert_has_class(html, "note-card")
 

--- a/next/components/renderers.py
+++ b/next/components/renderers.py
@@ -47,6 +47,7 @@ _RESERVED_CONTEXT_KEYS = frozenset(
         "children",
         "csrf_token",
         "current_component_module_path",
+        "current_page_module_path",
         "current_template_path",
         "request",
     }

--- a/next/components/renderers.py
+++ b/next/components/renderers.py
@@ -33,12 +33,10 @@ if TYPE_CHECKING:
     from .loading import ModuleLoader
 
 
-# Where a call site publishes the names it passes, so a keyless context
-# function cannot overwrite them.
+# Prop names published by the call site, so a keyless context cannot take them.
 COMPONENT_PROPS_CONTEXT_KEY = "_component_props"
 
-# Keys the render path owns. Overwriting any of them breaks the static
-# collector, the form-action anchor, or slot composition.
+# Keys the render path owns, so overwriting one breaks the render itself.
 _RESERVED_CONTEXT_KEYS = frozenset(
     {
         COMPONENT_PROPS_CONTEXT_KEY,
@@ -104,8 +102,7 @@ def _merge_csrf_context(
 def _guarded_keys(context_data: dict[str, Any]) -> frozenset[str]:
     """Return the names a keyless context function may not overwrite.
 
-    Only the call site knows the props it passed, so it publishes them through
-    the context and a bare `render_component` guards the reserved keys alone.
+    A bare `render_component` has no call site, so only the reserved keys apply.
     """
     props = context_data.get(COMPONENT_PROPS_CONTEXT_KEY)
     if isinstance(props, frozenset):
@@ -114,11 +111,7 @@ def _guarded_keys(context_data: dict[str, Any]) -> frozenset[str]:
 
 
 def _is_slot_key(key: object) -> bool:
-    """Report whether a returned key lands in the reserved slot namespace.
-
-    A context function may return non-string keys, so the prefix test survives
-    them rather than raising from inside the render.
-    """
+    """Report whether a key lands in the slot namespace, non-strings included."""
     return isinstance(key, str) and key.startswith(SLOT_KEY_PREFIX)
 
 

--- a/next/components/renderers.py
+++ b/next/components/renderers.py
@@ -33,9 +33,8 @@ if TYPE_CHECKING:
     from .loading import ModuleLoader
 
 
-# Where a call site publishes the names it passes in, so a keyless context
-# function cannot overwrite them. The component tag, the form widget and the
-# testing helper all fill it.
+# Where a call site publishes the names it passes, so a keyless context
+# function cannot overwrite them.
 COMPONENT_PROPS_CONTEXT_KEY = "_component_props"
 
 # Keys the render path owns. Overwriting any of them breaks the static
@@ -105,8 +104,8 @@ def _merge_csrf_context(
 def _guarded_keys(context_data: dict[str, Any]) -> frozenset[str]:
     """Return the names a keyless context function may not overwrite.
 
-    Names reach us through the context because only the call site knows what
-    it passed, so a direct `render_component` guards the reserved keys alone.
+    Only the call site knows the props it passed, so it publishes them through
+    the context and a bare `render_component` guards the reserved keys alone.
     """
     props = context_data.get(COMPONENT_PROPS_CONTEXT_KEY)
     if isinstance(props, frozenset):
@@ -117,8 +116,8 @@ def _guarded_keys(context_data: dict[str, Any]) -> frozenset[str]:
 def _is_slot_key(key: object) -> bool:
     """Report whether a returned key lands in the reserved slot namespace.
 
-    A context function may return non-string keys, so the prefix test has to
-    survive them rather than raise from inside the render.
+    A context function may return non-string keys, so the prefix test survives
+    them rather than raising from inside the render.
     """
     return isinstance(key, str) and key.startswith(SLOT_KEY_PREFIX)
 

--- a/next/components/renderers.py
+++ b/next/components/renderers.py
@@ -33,6 +33,28 @@ if TYPE_CHECKING:
     from .loading import ModuleLoader
 
 
+# Where a call site publishes the names it passes in, so a keyless context
+# function cannot overwrite them. The component tag, the form widget and the
+# testing helper all fill it.
+COMPONENT_PROPS_CONTEXT_KEY = "_component_props"
+
+# Keys the render path owns. Overwriting any of them breaks the static
+# collector, the form-action anchor, or slot composition.
+_RESERVED_CONTEXT_KEYS = frozenset(
+    {
+        COMPONENT_PROPS_CONTEXT_KEY,
+        "_static_collector",
+        "children",
+        "csrf_token",
+        "current_component_module_path",
+        "current_template_path",
+        "request",
+    }
+)
+
+SLOT_KEY_PREFIX = "slot_"
+
+
 class ComponentTemplateLoader:
     """Read template source from a `.djx` file or a `component` module string."""
 
@@ -79,6 +101,44 @@ def _merge_csrf_context(
     context_dict["csrf_token"] = SimpleLazyObject(lambda: get_token(request))
 
 
+def _guarded_keys(context_data: dict[str, Any]) -> frozenset[str]:
+    """Return the names a keyless context function may not overwrite.
+
+    Names reach us through the context because only the call site knows what
+    it passed, so a direct `render_component` guards the reserved keys alone.
+    """
+    props = context_data.get(COMPONENT_PROPS_CONTEXT_KEY)
+    if isinstance(props, frozenset):
+        return _RESERVED_CONTEXT_KEYS | props
+    return _RESERVED_CONTEXT_KEYS
+
+
+def _is_slot_key(key: object) -> bool:
+    """Report whether a returned key lands in the reserved slot namespace.
+
+    A context function may return non-string keys, so the prefix test has to
+    survive them rather than raise from inside the render.
+    """
+    return isinstance(key, str) and key.startswith(SLOT_KEY_PREFIX)
+
+
+def _reject_collisions(
+    info: ComponentInfo, data: dict[Any, Any], guarded: frozenset[str]
+) -> None:
+    """Refuse a keyless dict that would silently overwrite a guarded name."""
+    if data.keys().isdisjoint(guarded) and not any(_is_slot_key(key) for key in data):
+        return
+
+    conflicts = sorted(key for key in data if key in guarded or _is_slot_key(key))
+    names = ", ".join(repr(key) for key in conflicts)
+    msg = (
+        f"Component {info.name!r} context returns {names}, reserved by the render "
+        "path or by a prop of the calling tag. Register the value under an "
+        "explicit @component.context key."
+    )
+    raise ValueError(msg)
+
+
 def _inject_component_context(
     info: ComponentInfo, context_data: dict[str, Any], request: HttpRequest | None
 ) -> None:
@@ -90,6 +150,7 @@ def _inject_component_context(
         return
 
     collector: StaticCollector | None = context_data.get("_static_collector")
+    guarded = _guarded_keys(context_data)
 
     shared = get_request_dep_cache(request)
     cache = DependencyCache(backing_dict=shared) if shared else DependencyCache()
@@ -107,6 +168,7 @@ def _inject_component_context(
         if ctx_func.key is None:
             data = ctx_func.func(**resolved)
             if isinstance(data, dict):
+                _reject_collisions(info, data, guarded)
                 context_data.update(data)
                 if ctx_func.serialize and collector is not None:
                     for k, v in data.items():

--- a/next/conf/frozen.py
+++ b/next/conf/frozen.py
@@ -1,9 +1,8 @@
 """Immutable `list` and `dict` subclasses used for merged settings values.
 
-Staying a `list` and a `dict` keeps every `isinstance` guard across the
-framework working unchanged, so freezing the merge costs no sweep of the
-readers. `copy.copy` and `copy.deepcopy` thaw a value back to plain
-containers, so editing a copy of the configuration stays possible.
+Staying real builtins keeps every `isinstance` guard across the framework
+working unchanged, and `copy.copy` and `copy.deepcopy` thaw a value back to
+plain containers when a caller needs a mutable one.
 """
 
 from __future__ import annotations
@@ -31,8 +30,7 @@ def _immutable(*args: object, **kwargs: object) -> Never:
 class FrozenList(list[Any]):
     """A `list` whose mutating methods raise instead of changing contents.
 
-    `__init__` stays unguarded because the constructor needs it, so re-invoking
-    it by hand stays an escape hatch no Python-level subclass can close.
+    `__init__` stays unguarded, an escape hatch the constructor needs.
     """
 
     __slots__ = ()
@@ -112,9 +110,8 @@ _ATOMIC = (str, bytes, int, float, complex, frozenset, type(None))
 def _freeze(value: object, memo: dict[int, object]) -> object:
     if isinstance(value, _ATOMIC):
         return value
-    # Exact types only. A `defaultdict` rebuilt as a plain frozen mapping would
-    # lose its factory, and a namedtuple its field names, so subclasses go
-    # through `deepcopy` the way the merge handled every value before.
+    # Exact types only, since a rebuilt `defaultdict` would lose its factory and
+    # a rebuilt namedtuple its field names. Subclasses go through `deepcopy`.
     if type(value) is tuple:
         return tuple(_freeze(item, memo) for item in value)
     if type(value) is not dict and type(value) is not list:
@@ -142,9 +139,8 @@ def freeze(value: object) -> object:
     """Return a deep immutable copy of one merged settings value.
 
     Exact `list`, `dict` and `tuple` values are rebuilt and everything else is
-    deep-copied, so the merge never aliases a value the caller still holds.
-    Shared subtrees stay shared, and a self-referential config raises
-    `ImproperlyConfigured` rather than a `RecursionError`.
+    deep-copied, so the merge aliases nothing the caller still holds. A
+    self-referential config raises `ImproperlyConfigured`, not a `RecursionError`.
     """
     return _freeze(value, {})
 

--- a/next/conf/frozen.py
+++ b/next/conf/frozen.py
@@ -1,0 +1,131 @@
+"""Immutable `list` and `dict` subclasses used for merged settings values.
+
+Staying a `list` and a `dict` keeps every `isinstance` guard across the
+framework working unchanged, so freezing the merge costs no sweep of the
+readers.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Never, override
+
+from django.core.exceptions import ImproperlyConfigured
+
+from .defaults import USER_SETTING
+
+
+_IMMUTABLE_MESSAGE = (
+    f"Merged {USER_SETTING} settings are immutable. "
+    f"Change settings.{USER_SETTING} and call next_framework_settings.reload(), "
+    "or copy the value with list() or dict() to edit it."
+)
+
+
+def _immutable(*args: object, **kwargs: object) -> Never:
+    """Reject every mutating call on a frozen settings container."""
+    raise TypeError(_IMMUTABLE_MESSAGE)
+
+
+class FrozenList(list[Any]):
+    """A `list` whose mutating methods raise instead of changing contents.
+
+    `__init__` stays unguarded because the constructor needs it, so
+    re-invoking it by hand still refills the instance. That escape hatch
+    sits at the same tier as calling `list.append` unbound, which no
+    Python-level subclass can close.
+    """
+
+    __slots__ = ()
+
+    append = _immutable
+    clear = _immutable
+    extend = _immutable
+    insert = _immutable
+    pop = _immutable
+    remove = _immutable
+    reverse = _immutable
+    sort = _immutable
+    __setitem__ = _immutable
+    __delitem__ = _immutable
+    __iadd__ = _immutable
+    __imul__ = _immutable
+
+    @override
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Rebuild through the constructor so copy and pickle skip mutators."""
+        return (type(self), (list(self),))
+
+
+class FrozenDict(dict[Any, Any]):
+    """A `dict` whose mutating methods raise instead of changing contents.
+
+    Carries the same unguarded `__init__` escape hatch as `FrozenList`.
+    """
+
+    __slots__ = ()
+
+    clear = _immutable
+    pop = _immutable
+    popitem = _immutable
+    setdefault = _immutable
+    update = _immutable
+    __setitem__ = _immutable
+    __delitem__ = _immutable
+    __ior__ = _immutable
+
+    @override
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Rebuild through the constructor so copy and pickle skip mutators."""
+        return (type(self), (dict(self),))
+
+
+_MISSING = object()
+_IN_PROGRESS = object()
+
+# Leaves that cannot be mutated, so the merge may hand them out as they are.
+_ATOMIC = (str, bytes, int, float, complex, frozenset, type(None))
+
+
+def _freeze(value: object, memo: dict[int, object]) -> object:
+    if isinstance(value, _ATOMIC):
+        return value
+    # Exact types only. A `defaultdict` rebuilt as a plain frozen mapping would
+    # lose its factory, and a namedtuple its field names, so subclasses go
+    # through `deepcopy` the way the merge handled every value before.
+    if type(value) is tuple:
+        return tuple(_freeze(item, memo) for item in value)
+    if type(value) is not dict and type(value) is not list:
+        return copy.deepcopy(value)
+    seen = memo.get(id(value), _MISSING)
+    if seen is _IN_PROGRESS:
+        msg = (
+            f"settings.{USER_SETTING} contains a self-referential value, "
+            "which cannot be frozen."
+        )
+        raise ImproperlyConfigured(msg)
+    if seen is not _MISSING:
+        return seen
+    memo[id(value)] = _IN_PROGRESS
+    frozen: object
+    if isinstance(value, dict):
+        frozen = FrozenDict({key: _freeze(item, memo) for key, item in value.items()})
+    else:
+        frozen = FrozenList([_freeze(item, memo) for item in value])
+    memo[id(value)] = frozen
+    return frozen
+
+
+def freeze(value: object) -> object:
+    """Return a deep immutable copy of one merged settings value.
+
+    Only exact `list`, `dict` and `tuple` values are rebuilt. Everything else,
+    subclasses included, is deep-copied the way the merge handled it before, so
+    the merge never aliases a value the caller still holds. The memo keeps
+    shared subtrees shared and turns a self-referential config into
+    `ImproperlyConfigured` rather than a `RecursionError`.
+    """
+    return _freeze(value, {})
+
+
+__all__ = ["FrozenDict", "FrozenList", "freeze"]

--- a/next/conf/frozen.py
+++ b/next/conf/frozen.py
@@ -2,7 +2,8 @@
 
 Staying a `list` and a `dict` keeps every `isinstance` guard across the
 framework working unchanged, so freezing the merge costs no sweep of the
-readers.
+readers. `copy.copy` and `copy.deepcopy` hand back plain mutable containers,
+so a caller who needs to edit a merged value still has a supported way to.
 """
 
 from __future__ import annotations
@@ -18,7 +19,7 @@ from .defaults import USER_SETTING
 _IMMUTABLE_MESSAGE = (
     f"Merged {USER_SETTING} settings are immutable. "
     f"Change settings.{USER_SETTING} and call next_framework_settings.reload(), "
-    "or copy the value with list() or dict() to edit it."
+    "or copy the value with list(), dict() or copy.deepcopy() to edit it."
 )
 
 
@@ -53,8 +54,19 @@ class FrozenList(list[Any]):
 
     @override
     def __reduce__(self) -> tuple[Any, ...]:
-        """Rebuild through the constructor so copy and pickle skip mutators."""
+        """Rebuild through the constructor so pickle skips the mutators."""
         return (type(self), (list(self),))
+
+    def __copy__(self) -> list[Any]:
+        """Return a plain mutable list, the same escape hatch as `list()`."""
+        return list(self)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> list[Any]:
+        """Return a plain mutable deep copy, thawed all the way down."""
+        thawed: list[Any] = []
+        memo[id(self)] = thawed
+        thawed.extend(copy.deepcopy(item, memo) for item in self)
+        return thawed
 
 
 class FrozenDict(dict[Any, Any]):
@@ -76,8 +88,20 @@ class FrozenDict(dict[Any, Any]):
 
     @override
     def __reduce__(self) -> tuple[Any, ...]:
-        """Rebuild through the constructor so copy and pickle skip mutators."""
+        """Rebuild through the constructor so pickle skips the mutators."""
         return (type(self), (dict(self),))
+
+    def __copy__(self) -> dict[Any, Any]:
+        """Return a plain mutable dict, the same escape hatch as `dict()`."""
+        return dict(self)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> dict[Any, Any]:
+        """Return a plain mutable deep copy, thawed all the way down."""
+        thawed: dict[Any, Any] = {}
+        memo[id(self)] = thawed
+        for key, value in self.items():
+            thawed[copy.deepcopy(key, memo)] = copy.deepcopy(value, memo)
+        return thawed
 
 
 _MISSING = object()

--- a/next/conf/frozen.py
+++ b/next/conf/frozen.py
@@ -106,15 +106,19 @@ _IN_PROGRESS = object()
 # Leaves that cannot be mutated, so the merge may hand them out as they are.
 _ATOMIC = (str, bytes, int, float, complex, frozenset, type(None))
 
+# Containers the merge rebuilds. The frozen pair belongs here so a merged value
+# fed back into the settings freezes again instead of thawing through `copy`.
+_REBUILT = frozenset({dict, list, FrozenDict, FrozenList})
+
 
 def _freeze(value: object, memo: dict[int, object]) -> object:
     if isinstance(value, _ATOMIC):
         return value
-    # Exact types only, since a rebuilt `defaultdict` would lose its factory and
-    # a rebuilt namedtuple its field names. Subclasses go through `deepcopy`.
     if type(value) is tuple:
         return tuple(_freeze(item, memo) for item in value)
-    if type(value) is not dict and type(value) is not list:
+    # Any other subclass is deep-copied instead, since a rebuilt `defaultdict`
+    # would lose its factory and a rebuilt namedtuple its field names.
+    if not isinstance(value, dict | list) or type(value) not in _REBUILT:
         return copy.deepcopy(value)
     seen = memo.get(id(value), _MISSING)
     if seen is _IN_PROGRESS:
@@ -138,9 +142,9 @@ def _freeze(value: object, memo: dict[int, object]) -> object:
 def freeze(value: object) -> object:
     """Return a deep immutable copy of one merged settings value.
 
-    Exact `list`, `dict` and `tuple` values are rebuilt and everything else is
-    deep-copied, so the merge aliases nothing the caller still holds. A
-    self-referential config raises `ImproperlyConfigured`, not a `RecursionError`.
+    Exact `list`, `dict`, `tuple` and already-frozen containers are rebuilt and
+    everything else is deep-copied, so the merge aliases nothing the caller
+    still holds. A self-referential config raises `ImproperlyConfigured`.
     """
     return _freeze(value, {})
 

--- a/next/conf/frozen.py
+++ b/next/conf/frozen.py
@@ -2,8 +2,8 @@
 
 Staying a `list` and a `dict` keeps every `isinstance` guard across the
 framework working unchanged, so freezing the merge costs no sweep of the
-readers. `copy.copy` and `copy.deepcopy` hand back plain mutable containers,
-so a caller who needs to edit a merged value still has a supported way to.
+readers. `copy.copy` and `copy.deepcopy` thaw a value back to plain
+containers, so editing a copy of the configuration stays possible.
 """
 
 from __future__ import annotations
@@ -31,10 +31,8 @@ def _immutable(*args: object, **kwargs: object) -> Never:
 class FrozenList(list[Any]):
     """A `list` whose mutating methods raise instead of changing contents.
 
-    `__init__` stays unguarded because the constructor needs it, so
-    re-invoking it by hand still refills the instance. That escape hatch
-    sits at the same tier as calling `list.append` unbound, which no
-    Python-level subclass can close.
+    `__init__` stays unguarded because the constructor needs it, so re-invoking
+    it by hand stays an escape hatch no Python-level subclass can close.
     """
 
     __slots__ = ()
@@ -143,10 +141,9 @@ def _freeze(value: object, memo: dict[int, object]) -> object:
 def freeze(value: object) -> object:
     """Return a deep immutable copy of one merged settings value.
 
-    Only exact `list`, `dict` and `tuple` values are rebuilt. Everything else,
-    subclasses included, is deep-copied the way the merge handled it before, so
-    the merge never aliases a value the caller still holds. The memo keeps
-    shared subtrees shared and turns a self-referential config into
+    Exact `list`, `dict` and `tuple` values are rebuilt and everything else is
+    deep-copied, so the merge never aliases a value the caller still holds.
+    Shared subtrees stay shared, and a self-referential config raises
     `ImproperlyConfigured` rather than a `RecursionError`.
     """
     return _freeze(value, {})

--- a/next/conf/settings.py
+++ b/next/conf/settings.py
@@ -9,12 +9,12 @@ reset their own state.
 
 from __future__ import annotations
 
-import copy
 from typing import Any, ClassVar, override
 
 from django.conf import settings
 
 from .defaults import DEFAULTS, USER_SETTING
+from .frozen import freeze
 from .imports import clear_import_cache
 
 
@@ -79,7 +79,9 @@ class NextFrameworkSettings:
     )
 
     def _build_flat_merged(self, user: dict[str, Any] | None) -> dict[str, Any]:
-        out = copy.deepcopy(self.DEFAULTS)
+        out: dict[str, Any] = {
+            key: freeze(value) for key, value in self.DEFAULTS.items()
+        }
         if not user:
             return out
         user = dict(user)
@@ -90,13 +92,11 @@ class NextFrameworkSettings:
             if key in {"URL_NAME_TEMPLATE", "URL_RESOLVER"} and isinstance(raw, str):
                 out[key] = raw
             elif key == "FORM_WIZARD_BACKEND" and isinstance(raw, dict):
-                merged = copy.deepcopy(self.DEFAULTS[key])
-                merged.update(copy.deepcopy(raw))
-                out[key] = merged
+                out[key] = freeze({**self.DEFAULTS[key], **raw})
             elif (key in self.LIST_KEYS and isinstance(raw, list)) or (
                 key == "NEXT_JS_OPTIONS" and isinstance(raw, dict)
             ):
-                out[key] = copy.deepcopy(raw)
+                out[key] = freeze(raw)
             elif key in self.BOOL_KEYS:
                 out[key] = bool(raw)
             elif key == "JS_CONTEXT_SERIALIZER" and (

--- a/next/forms/widgets.py
+++ b/next/forms/widgets.py
@@ -13,6 +13,7 @@ from django.utils.safestring import SafeString
 
 from next.components.facade import get_component, render_component
 from next.components.manager import components_manager
+from next.components.renderers import COMPONENT_PROPS_CONTEXT_KEY
 from next.static import StaticCollector, collect_component_assets
 
 
@@ -117,6 +118,10 @@ class ComponentWidget(django_forms.Widget):
             "value": self.format_value(value),
             "errors": self._errors,
         }
+        # Every name above comes from this widget and its field binding, so a
+        # keyless component context must not take any of them over. The set is
+        # read before the key itself lands in the context.
+        context[COMPONENT_PROPS_CONTEXT_KEY] = frozenset(context)
         # render_component returns template-rendered, already-escaped HTML, so a
         # SafeString wrapper matches the Widget.render contract without re-escaping.
         html = render_component(info, context, request=self._request)

--- a/next/forms/widgets.py
+++ b/next/forms/widgets.py
@@ -119,8 +119,7 @@ class ComponentWidget(django_forms.Widget):
             "errors": self._errors,
         }
         # Every name above comes from this widget and its field binding, so a
-        # keyless component context must not take any of them over. The set is
-        # read before the key itself lands in the context.
+        # keyless component context must not take any of them over.
         context[COMPONENT_PROPS_CONTEXT_KEY] = frozenset(context)
         # render_component returns template-rendered, already-escaped HTML, so a
         # SafeString wrapper matches the Widget.render contract without re-escaping.

--- a/next/server/__init__.py
+++ b/next/server/__init__.py
@@ -11,15 +11,10 @@ from __future__ import annotations
 from . import signals
 from .autoreload import NextStatReloader
 from .roots import get_framework_filesystem_roots_for_linking
-from .watcher import (
-    FilesystemWatchContributor,
-    iter_all_autoreload_watch_specs,
-    register_autoreload_watch_spec,
-)
+from .watcher import iter_all_autoreload_watch_specs, register_autoreload_watch_spec
 
 
 __all__ = [
-    "FilesystemWatchContributor",
     "NextStatReloader",
     "get_framework_filesystem_roots_for_linking",
     "iter_all_autoreload_watch_specs",

--- a/next/server/roots.py
+++ b/next/server/roots.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from next.backends import backend_entries
 from next.components import component_extra_roots_from_config
-from next.conf import next_framework_settings
 from next.pages.watch import get_pages_directories_for_watch
 
 
@@ -21,11 +21,6 @@ if TYPE_CHECKING:
 def get_framework_filesystem_roots_for_linking() -> list[Path]:
     """Return sorted unique roots from page trees and component `DIRS`."""
     roots: set[Path] = {p.resolve() for p in get_pages_directories_for_watch()}
-    comp_cfgs = next_framework_settings.COMPONENT_BACKENDS
-    if isinstance(comp_cfgs, list):
-        for config in comp_cfgs:
-            if isinstance(config, dict):
-                roots.update(
-                    p.resolve() for p in component_extra_roots_from_config(config)
-                )
+    for config in backend_entries("COMPONENT_BACKENDS"):
+        roots.update(p.resolve() for p in component_extra_roots_from_config(config))
     return sorted(roots)

--- a/next/server/watcher.py
+++ b/next/server/watcher.py
@@ -1,8 +1,7 @@
 """Watch-spec helpers for the development file reloader.
 
-The module exposes built-in `(path, glob)` defaults derived from
-`NEXT_FRAMEWORK` and a registry for extra pairs contributed by
-third-party apps.
+Built-in `(path, glob)` defaults come from `NEXT_FRAMEWORK`, and a registry
+takes the extra pairs third-party apps contribute.
 """
 
 from __future__ import annotations

--- a/next/server/watcher.py
+++ b/next/server/watcher.py
@@ -1,17 +1,16 @@
 """Watch-spec helpers for the development file reloader.
 
-`FilesystemWatchContributor` is a Protocol for objects that contribute
-`(path, glob)` pairs to Django's `StatReloader.watch_dir`. The module
-exposes built-in defaults derived from `NEXT_FRAMEWORK` and a registry
-for extra pairs contributed by third-party apps.
+The module exposes built-in `(path, glob)` defaults derived from
+`NEXT_FRAMEWORK` and a registry for extra pairs contributed by
+third-party apps.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING
 
+from next.backends import backend_entries
 from next.components import component_extra_roots_from_config
-from next.conf import next_framework_settings
 from next.pages.watch import (
     get_pages_directories_for_watch,
     iter_pages_roots_with_components_folder_names,
@@ -23,18 +22,6 @@ from .signals import watch_specs_ready
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from pathlib import Path
-
-
-@runtime_checkable
-class FilesystemWatchContributor(Protocol):
-    """Yield `(root, glob)` pairs for `StatReloader.watch_dir`.
-
-    Each tuple is a filesystem root and a glob pattern relative to that
-    root.
-    """
-
-    def iter_watch_specs(self) -> Iterable[tuple[Path, str]]:
-        """Yield `(root, glob)` pairs for `StatReloader.watch_dir`."""
 
 
 _registered_extra_watch_specs: list[tuple[Path, str]] = []
@@ -79,15 +66,11 @@ def _iter_default_autoreload_watch_specs() -> list[tuple[Path, str]]:
         (root, f"**/{comp_name}/**/component.py")
         for root, comp_name in iter_pages_roots_with_components_folder_names()
     )
-    comp_cfgs = next_framework_settings.COMPONENT_BACKENDS
-    if isinstance(comp_cfgs, list):
-        for config in comp_cfgs:
-            if not isinstance(config, dict):
-                continue
-            specs.extend(
-                (root, "**/component.py")
-                for root in component_extra_roots_from_config(config)
-            )
+    for config in backend_entries("COMPONENT_BACKENDS"):
+        specs.extend(
+            (root, "**/component.py")
+            for root in component_extra_roots_from_config(config)
+        )
     return specs
 
 

--- a/next/static/discovery.py
+++ b/next/static/discovery.py
@@ -344,12 +344,13 @@ class AssetDiscovery:
         if kind is None:
             logger.debug("Module URL %r has unregistered extension %r", url, suffix)
             return
-        if default_kinds.slot(kind) != slot_name:
+        kind_slot = default_kinds.slot(kind)
+        if kind_slot != slot_name:
             logger.debug(
-                "Module URL %r maps to kind %r but list %r expects slot %r",
+                "Module URL %r maps to kind %r in slot %r, so the %r list dropped it",
                 url,
                 kind,
-                slot_name,
+                kind_slot,
                 slot_name,
             )
             return

--- a/next/templatetags/components.py
+++ b/next/templatetags/components.py
@@ -150,8 +150,7 @@ class ComponentNode(Node):
         self.name = name
         self.props = props
         self.nodelist = nodelist
-        # Prop names are fixed at compile time, so the collision guard costs
-        # no rebuild per render.
+        # Prop names are fixed at compile time, so the guard rebuilds nothing.
         self.prop_names = frozenset(props)
 
     def _resolved_props(self, context: template.Context) -> dict[str, Any]:

--- a/next/templatetags/components.py
+++ b/next/templatetags/components.py
@@ -29,6 +29,7 @@ from django.template.base import (
 from django.utils.safestring import SafeString
 
 from next.components import collect_visible_components, get_component, render_component
+from next.components.renderers import COMPONENT_PROPS_CONTEXT_KEY, SLOT_KEY_PREFIX
 from next.conf import fail_loudly, next_framework_settings
 from next.static import collect_component_assets
 
@@ -52,7 +53,9 @@ _END_BLOCK_SET_SLOT = ("/set_slot",)
 _SHORT_SLOT_EMPTY_NAME = "{% slot %} tag requires a quoted slot name"
 _SHORT_SET_SLOT_EMPTY_NAME = "{% set_slot %} tag requires a quoted slot name"
 
-# The key slot collection writes while the parent ``{% #component %}`` body renders.
+# The key slot collection writes while the parent ``{% #component %}`` body
+# renders. ``_component_props`` needs no entry here because every node writes
+# its own set over whatever it inherited.
 _INTERNAL_CONTEXT_KEYS = frozenset({"_component_slots"})
 
 _DASH_BEFORE_DASH = re.compile(r"-(?=-)")
@@ -148,6 +151,9 @@ class ComponentNode(Node):
         self.name = name
         self.props = props
         self.nodelist = nodelist
+        # Prop names are fixed at compile time, so the render-time collision
+        # guard reads a set built once per node.
+        self.prop_names = frozenset(props)
 
     def _resolved_props(self, context: template.Context) -> dict[str, Any]:
         """Resolve every prop expression against the active template context.
@@ -259,11 +265,12 @@ class ComponentNode(Node):
         render_ctx: dict[str, Any] = {**parent_flat, **self._resolved_props(context)}
         render_ctx["current_template_path"] = path
         render_ctx["children"] = "".join(child_chunks)
+        render_ctx[COMPONENT_PROPS_CONTEXT_KEY] = self.prop_names
 
         for slot_name, content in slots.items():
             # Slot content lives only under ``slot_<name>``, because an
             # unprefixed key would shadow a prop that shares the slot's name.
-            render_ctx[f"slot_{slot_name}"] = content
+            render_ctx[f"{SLOT_KEY_PREFIX}{slot_name}"] = content
 
         request = render_ctx.get("request")
         if request is None:
@@ -289,7 +296,7 @@ class SetSlotNode(Node):
         slot (``{% #slot "x" %}{% /slot %}``) renders as the empty string. Only
         a missing slot key falls back to the inner template.
         """
-        slot_content = context.get(f"slot_{self.name}", _SLOT_MISSING)
+        slot_content = context.get(f"{SLOT_KEY_PREFIX}{self.name}", _SLOT_MISSING)
         if slot_content is _SLOT_MISSING:
             return self.nodelist.render(context)
         return str(slot_content)

--- a/next/templatetags/components.py
+++ b/next/templatetags/components.py
@@ -54,8 +54,7 @@ _SHORT_SLOT_EMPTY_NAME = "{% slot %} tag requires a quoted slot name"
 _SHORT_SET_SLOT_EMPTY_NAME = "{% set_slot %} tag requires a quoted slot name"
 
 # The key slot collection writes while the parent ``{% #component %}`` body
-# renders. ``_component_props`` needs no entry here because every node writes
-# its own set over whatever it inherited.
+# renders. ``_component_props`` stays out because every node overwrites it.
 _INTERNAL_CONTEXT_KEYS = frozenset({"_component_slots"})
 
 _DASH_BEFORE_DASH = re.compile(r"-(?=-)")
@@ -151,8 +150,8 @@ class ComponentNode(Node):
         self.name = name
         self.props = props
         self.nodelist = nodelist
-        # Prop names are fixed at compile time, so the render-time collision
-        # guard reads a set built once per node.
+        # Prop names are fixed at compile time, so the collision guard costs
+        # no rebuild per render.
         self.prop_names = frozenset(props)
 
     def _resolved_props(self, context: template.Context) -> dict[str, Any]:

--- a/next/testing/rendering.py
+++ b/next/testing/rendering.py
@@ -46,13 +46,11 @@ def render_component_by_name(
     props: Mapping[str, Any] | None = None,
     request: HttpRequest | None = None,
 ) -> str:
-    """Resolve component `name` as seen from `at` and render it.
+    """Render component `name` as resolved from the template path `at`.
 
-    `at` is the template path the component is referenced from. It is
-    used for visibility/scoping by `components_manager.get_component`.
-    `context` stands in for the ambient template scope a page would
-    provide, `props` for the names a `{% component %}` call site passes.
-    Raises `LookupError` when no matching visible component is found.
+    `at` drives visibility, `context` stands in for the ambient page scope, and
+    `props` for the names a `{% component %}` call site would pass. A name no
+    visible component matches raises `LookupError`.
     """
     anchor = Path(at) if not isinstance(at, Path) else at
     info = components_manager.get_component(name, anchor)
@@ -61,8 +59,7 @@ def render_component_by_name(
         raise LookupError(msg)
     context_data = dict(context or {})
     context_data.update(props or {})
-    # Only `props` is published, the way the tag publishes its own names, so a
-    # keyless context function may still shadow an ambient page key.
+    # Publishing `context` too would guard keys a page render leaves shadowable.
     context_data[COMPONENT_PROPS_CONTEXT_KEY] = frozenset(props or ())
     return render_component(info, context_data, request=request)
 

--- a/next/testing/rendering.py
+++ b/next/testing/rendering.py
@@ -1,8 +1,7 @@
 """Render helpers for next-dj pages and components.
 
-Thin wrappers over `page.render` and `render_component` so tests do not
-need to construct `ComponentInfo` manually or build an `HttpRequest`
-just to exercise a renderer.
+Thin wrappers over `page.render` and `render_component`, so a test needs no
+hand-built `ComponentInfo` or `HttpRequest` to exercise a renderer.
 """
 
 from __future__ import annotations
@@ -49,8 +48,7 @@ def render_component_by_name(
     """Render component `name` as resolved from the template path `at`.
 
     `at` drives visibility, `context` stands in for the ambient page scope, and
-    `props` for the names a `{% component %}` call site would pass. A name no
-    visible component matches raises `LookupError`.
+    `props` for the names a `{% component %}` call site would pass.
     """
     anchor = Path(at) if not isinstance(at, Path) else at
     info = components_manager.get_component(name, anchor)

--- a/next/testing/rendering.py
+++ b/next/testing/rendering.py
@@ -14,6 +14,7 @@ from django.test import RequestFactory
 
 from next.components.facade import render_component
 from next.components.manager import components_manager
+from next.components.renderers import COMPONENT_PROPS_CONTEXT_KEY
 from next.pages.manager import page
 
 
@@ -55,7 +56,11 @@ def render_component_by_name(
     if info is None:
         msg = f"Component not visible from {anchor}: {name!r}"
         raise LookupError(msg)
-    return render_component(info, dict(context or {}), request=request)
+    context_data = dict(context or {})
+    # The caller's keys stand in for the props a `{% component %}` call site
+    # would pass, so the guard here sees what the tag would show it.
+    context_data[COMPONENT_PROPS_CONTEXT_KEY] = frozenset(context_data)
+    return render_component(info, context_data, request=request)
 
 
 __all__ = ["render_component_by_name", "render_page"]

--- a/next/testing/rendering.py
+++ b/next/testing/rendering.py
@@ -43,12 +43,15 @@ def render_component_by_name(
     *,
     at: Path | str,
     context: Mapping[str, Any] | None = None,
+    props: Mapping[str, Any] | None = None,
     request: HttpRequest | None = None,
 ) -> str:
     """Resolve component `name` as seen from `at` and render it.
 
     `at` is the template path the component is referenced from. It is
     used for visibility/scoping by `components_manager.get_component`.
+    `context` stands in for the ambient template scope a page would
+    provide, `props` for the names a `{% component %}` call site passes.
     Raises `LookupError` when no matching visible component is found.
     """
     anchor = Path(at) if not isinstance(at, Path) else at
@@ -57,9 +60,10 @@ def render_component_by_name(
         msg = f"Component not visible from {anchor}: {name!r}"
         raise LookupError(msg)
     context_data = dict(context or {})
-    # The caller's keys stand in for the props a `{% component %}` call site
-    # would pass, so the guard here sees what the tag would show it.
-    context_data[COMPONENT_PROPS_CONTEXT_KEY] = frozenset(context_data)
+    context_data.update(props or {})
+    # Only `props` is published, the way the tag publishes its own names, so a
+    # keyless context function may still shadow an ambient page key.
+    context_data[COMPONENT_PROPS_CONTEXT_KEY] = frozenset(props or ())
     return render_component(info, context_data, request=request)
 
 

--- a/tests/benchmarks/components/test_bench_renderers.py
+++ b/tests/benchmarks/components/test_bench_renderers.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from next.components.info import ComponentInfo
+from next.components.loading import ModuleLoader
+from next.components.renderers import (
+    COMPONENT_PROPS_CONTEXT_KEY,
+    ComponentTemplateLoader,
+    CompositeComponentRenderer,
+    _guarded_keys,
+    _reject_collisions,
+)
+from tests.benchmarks.factories import build_component_info
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_COMPONENT_MODULE = """from next.components import component
+
+
+@component.context
+def extra():
+    return {"env": "prod", "version": "1"}
+"""
+
+
+def _build_composite_component(root: Path) -> ComponentInfo:
+    """Write a component.py plus component.djx pair and describe it."""
+    (root / "component.py").write_text(_COMPONENT_MODULE)
+    (root / "component.djx").write_text(
+        "<div>{{ title }} {{ env }} {{ version }}</div>"
+    )
+    return ComponentInfo(
+        name="card",
+        scope_root=root,
+        scope_relative="",
+        template_path=root / "component.djx",
+        module_path=(root / "component.py").resolve(),
+        is_simple=False,
+    )
+
+
+class TestBenchCompositeRender:
+    @pytest.mark.benchmark(group="components.render")
+    def test_render_end_to_end(self, tmp_path: Path, benchmark) -> None:
+        """Whole composite render: template read, compile, context merge, output.
+
+        Disk and template compilation dominate this number, so it tracks the
+        render as a whole rather than any single step of it.
+        """
+        info = _build_composite_component(tmp_path)
+        module_loader = ModuleLoader()
+        renderer = CompositeComponentRenderer(
+            module_loader, ComponentTemplateLoader(module_loader)
+        )
+        context = {"title": "Hi", COMPONENT_PROPS_CONTEXT_KEY: frozenset({"title"})}
+        # The first render imports component.py and registers its context
+        # function, which must not happen once per warmup iteration.
+        renderer.render(info, context, None)
+
+        benchmark(renderer.render, info, context, None)
+
+
+class TestBenchContextCollisionGuard:
+    @pytest.mark.benchmark(group="components.render")
+    def test_reject_collisions_on_a_clean_dict(self, tmp_path: Path, benchmark) -> None:
+        """The guard every keyless context dict pays, on a dict that collides with none."""
+        info = build_component_info(tmp_path)
+        guarded = _guarded_keys({COMPONENT_PROPS_CONTEXT_KEY: frozenset({"title"})})
+        data = {"env": "prod", "version": "1"}
+
+        benchmark(_reject_collisions, info, data, guarded)

--- a/tests/benchmarks/components/test_bench_renderers.py
+++ b/tests/benchmarks/components/test_bench_renderers.py
@@ -48,7 +48,7 @@ def _build_composite_component(root: Path) -> ComponentInfo:
 class TestBenchCompositeRender:
     @pytest.mark.benchmark(group="components.render")
     def test_render_end_to_end(self, tmp_path: Path, benchmark) -> None:
-        """Whole composite render: template read, compile, context merge, output.
+        """The whole composite render, from reading the template to the output.
 
         Disk and template compilation dominate this number, so it tracks the
         render as a whole rather than any single step of it.
@@ -69,7 +69,7 @@ class TestBenchCompositeRender:
 class TestBenchContextCollisionGuard:
     @pytest.mark.benchmark(group="components.render")
     def test_reject_collisions_on_a_clean_dict(self, tmp_path: Path, benchmark) -> None:
-        """The guard every keyless context dict pays, on a dict that collides with none."""
+        """The guard cost a keyless context dict pays when nothing collides."""
         info = build_component_info(tmp_path)
         guarded = _guarded_keys({COMPONENT_PROPS_CONTEXT_KEY: frozenset({"title"})})
         data = {"env": "prod", "version": "1"}

--- a/tests/components/test_context.py
+++ b/tests/components/test_context.py
@@ -20,6 +20,7 @@ from next.components.context import iter_serialized_component_context_keys
 from next.components.renderers import _inject_component_context
 from next.static import StaticCollector
 from tests.support import attribution, handler_declared_here
+from tests.support.components import build_composite_component
 
 
 class TestComponentContextManager:
@@ -343,28 +344,9 @@ class TestComponentContextRegistrySerialize:
 class TestInjectComponentContextSerialize:
     """_inject_component_context populates StaticCollector when serialize=True."""
 
-    def _setup(
-        self, tmp_path: Path
-    ) -> tuple[ComponentContextManager, ComponentInfo, Path]:
-        """Build a fresh manager, component.py path, and ComponentInfo."""
-        mgr = ComponentContextManager()
-        module_path = (tmp_path / "component.py").resolve()
-        module_path.parent.mkdir(parents=True, exist_ok=True)
-        template_path = module_path.parent / "component.djx"
-        template_path.write_text("<div></div>")
-        info = ComponentInfo(
-            name="demo",
-            scope_root=module_path.parent,
-            scope_relative="",
-            template_path=template_path,
-            module_path=module_path,
-            is_simple=False,
-        )
-        return mgr, info, module_path
-
     def test_keyed_serialize_populates_collector(self, tmp_path: Path) -> None:
         """A keyed context function with serialize=True writes to the collector."""
-        mgr, info, module_path = self._setup(tmp_path)
+        mgr, info, module_path = build_composite_component(tmp_path)
 
         def get_theme() -> str:
             return "dark"
@@ -380,7 +362,7 @@ class TestInjectComponentContextSerialize:
 
     def test_dict_merge_serialize_populates_collector(self, tmp_path: Path) -> None:
         """An unkeyed context function with serialize=True writes all keys to collector."""
-        mgr, info, module_path = self._setup(tmp_path)
+        mgr, info, module_path = build_composite_component(tmp_path)
 
         def get_meta() -> dict:
             return {"env": "prod", "version": "1"}
@@ -397,7 +379,7 @@ class TestInjectComponentContextSerialize:
 
     def test_serialize_false_does_not_populate_collector(self, tmp_path: Path) -> None:
         """A context function without serialize=True does not touch the collector."""
-        mgr, info, module_path = self._setup(tmp_path)
+        mgr, info, module_path = build_composite_component(tmp_path)
 
         def get_val() -> str:
             return "value"
@@ -413,7 +395,7 @@ class TestInjectComponentContextSerialize:
 
     def test_serialize_without_collector_does_not_raise(self, tmp_path: Path) -> None:
         """When no _static_collector is in context_data, serialize is silently skipped."""
-        mgr, info, module_path = self._setup(tmp_path)
+        mgr, info, module_path = build_composite_component(tmp_path)
 
         def get_val() -> str:
             return "value"
@@ -438,27 +420,9 @@ class TestComponentContextSerializerOverride:
             self.calls.append(value)
             return f'"marker:{value}"'
 
-    def _setup(
-        self, tmp_path: Path
-    ) -> tuple[ComponentContextManager, ComponentInfo, Path]:
-        mgr = ComponentContextManager()
-        module_path = (tmp_path / "component.py").resolve()
-        module_path.parent.mkdir(parents=True, exist_ok=True)
-        template_path = module_path.parent / "component.djx"
-        template_path.write_text("<div></div>")
-        info = ComponentInfo(
-            name="demo",
-            scope_root=module_path.parent,
-            scope_relative="",
-            template_path=template_path,
-            module_path=module_path,
-            is_simple=False,
-        )
-        return mgr, info, module_path
-
     def test_keyed_override_recorded_on_collector(self, tmp_path: Path) -> None:
         """A keyed context with `serializer=` records the override on the collector."""
-        mgr, info, module_path = self._setup(tmp_path)
+        mgr, info, module_path = build_composite_component(tmp_path)
         marker = self._MarkerSerializer()
         mgr._registry.register(
             module_path, "feed", lambda: "payload", serialize=True, serializer=marker
@@ -474,7 +438,7 @@ class TestComponentContextSerializerOverride:
 
     def test_dict_merge_override_applies_to_each_key(self, tmp_path: Path) -> None:
         """An unkeyed context with `serializer=` records the override per merged key."""
-        mgr, info, module_path = self._setup(tmp_path)
+        mgr, info, module_path = build_composite_component(tmp_path)
         marker = self._MarkerSerializer()
         mgr._registry.register(
             module_path,
@@ -493,7 +457,7 @@ class TestComponentContextSerializerOverride:
 
     def test_no_serializer_keeps_collector_map_empty(self, tmp_path: Path) -> None:
         """Without `serializer=` the override map on the collector stays empty."""
-        mgr, info, module_path = self._setup(tmp_path)
+        mgr, info, module_path = build_composite_component(tmp_path)
         mgr._registry.register(module_path, "k", lambda: "v", serialize=True)
 
         collector = StaticCollector()

--- a/tests/components/test_renderers.py
+++ b/tests/components/test_renderers.py
@@ -1,0 +1,279 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from django.template import Context, Template
+
+from next.components import (
+    ComponentContextManager,
+    ComponentInfo,
+    components_manager,
+    render_component,
+)
+from next.components.renderers import (
+    _RESERVED_CONTEXT_KEYS,
+    COMPONENT_PROPS_CONTEXT_KEY,
+    _inject_component_context,
+)
+from tests.support.components import build_composite_component
+
+
+RESERVED_KEYS = sorted(_RESERVED_CONTEXT_KEYS)
+
+# The inventory as the docs publish it, pinned so a change to the core set has
+# to be made twice on purpose.
+PINNED_RESERVED_KEYS = frozenset(
+    {
+        "_component_props",
+        "_static_collector",
+        "children",
+        "csrf_token",
+        "current_component_module_path",
+        "current_template_path",
+        "request",
+    }
+)
+
+
+def _inject(
+    manager: ComponentContextManager, info: ComponentInfo, context_data: dict
+) -> None:
+    """Run the injection step with `manager` standing in for the global one."""
+    with patch("next.components.renderers.component", manager):
+        _inject_component_context(info, context_data, None)
+
+
+class TestKeylessContextCollisions:
+    """A bare `@component.context` may not overwrite props or reserved keys."""
+
+    def test_prop_key_raises(self, tmp_path: Path) -> None:
+        """Returning a key that the calling tag passed as a prop raises."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, None, lambda: {"title": "from context"})
+        context_data = {
+            COMPONENT_PROPS_CONTEXT_KEY: frozenset({"title"}),
+            "title": "from prop",
+        }
+
+        with pytest.raises(
+            ValueError, match="Component 'card' context returns 'title'"
+        ):
+            _inject(mgr, info, context_data)
+
+        assert context_data["title"] == "from prop"
+
+    def test_reserved_inventory_is_pinned(self) -> None:
+        """Adding or dropping a reserved key is a decision, not a silent edit."""
+        assert _RESERVED_CONTEXT_KEYS == PINNED_RESERVED_KEYS
+
+    @pytest.mark.parametrize("key", RESERVED_KEYS)
+    def test_reserved_key_raises_and_keeps_the_render_value(
+        self, key: str, tmp_path: Path
+    ) -> None:
+        """Every reserved key raises and the value the render path put there stands."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, None, lambda: {key: "hijacked"})
+        original = object()
+        context_data = {key: original}
+
+        with pytest.raises(ValueError, match=f"returns {key!r}"):
+            _inject(mgr, info, context_data)
+
+        assert context_data[key] is original
+
+    def test_non_string_keys_merge_without_raising(self, tmp_path: Path) -> None:
+        """A dict keyed by non-strings survives the slot-prefix scan."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, None, lambda: {1: "one", "ok": "yes"})
+        context_data = {COMPONENT_PROPS_CONTEXT_KEY: frozenset({"title"})}
+
+        _inject(mgr, info, context_data)
+
+        assert context_data[1] == "one"
+        assert context_data["ok"] == "yes"
+
+    def test_slot_prefixed_key_raises(self, tmp_path: Path) -> None:
+        """Any `slot_` prefixed key is reserved for slot content."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, None, lambda: {"slot_footer": "hijacked"})
+        context_data = {"slot_footer": "<footer/>"}
+
+        with pytest.raises(ValueError, match="'slot_footer'"):
+            _inject(mgr, info, context_data)
+
+        assert context_data["slot_footer"] == "<footer/>"
+
+    def test_message_lists_every_conflict(self, tmp_path: Path) -> None:
+        """The message names all conflicting keys in sorted order."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(
+            module_path, None, lambda: {"slot_a": 1, "children": 2, "kept": 3}
+        )
+
+        with pytest.raises(ValueError, match="returns 'children', 'slot_a',"):
+            _inject(mgr, info, {})
+
+
+class TestKeylessContextMerges:
+    """Names outside the guarded domain keep merging silently."""
+
+    def test_non_conflicting_keys_merge(self, tmp_path: Path) -> None:
+        """A dict touching nothing guarded lands in the context."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, None, lambda: {"env": "prod"})
+        context_data = {COMPONENT_PROPS_CONTEXT_KEY: frozenset({"title"})}
+
+        _inject(mgr, info, context_data)
+
+        assert context_data["env"] == "prod"
+
+    def test_inherited_page_key_is_shadowed(self, tmp_path: Path) -> None:
+        """A page key that is not a prop of this call may be shadowed."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, None, lambda: {"title": "component wins"})
+        context_data = {
+            COMPONENT_PROPS_CONTEXT_KEY: frozenset({"variant"}),
+            "title": "page title",
+            "variant": "wide",
+        }
+
+        _inject(mgr, info, context_data)
+
+        assert context_data["title"] == "component wins"
+        assert context_data["variant"] == "wide"
+
+    def test_current_page_module_path_is_shadowed(self, tmp_path: Path) -> None:
+        """`current_page_module_path` stays a plain page key, not a reserved one."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(
+            module_path, None, lambda: {"current_page_module_path": "/other/page.py"}
+        )
+        context_data = {"current_page_module_path": "/app/page.py"}
+
+        _inject(mgr, info, context_data)
+
+        assert context_data["current_page_module_path"] == "/other/page.py"
+
+    def test_same_key_merges_when_tag_passes_no_prop(self, tmp_path: Path) -> None:
+        """The guard follows the call site, so a propless call still merges."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, None, lambda: {"title": "from context"})
+        context_data = {COMPONENT_PROPS_CONTEXT_KEY: frozenset()}
+
+        _inject(mgr, info, context_data)
+
+        assert context_data["title"] == "from context"
+
+    def test_reading_a_prop_and_returning_a_new_key_works(self, tmp_path: Path) -> None:
+        """The supported way to build on a prop is a parameter named after it."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+
+        def headline(title: str) -> dict:
+            return {"headline": title.upper()}
+
+        mgr._registry.register(module_path, None, headline)
+        context_data = {
+            COMPONENT_PROPS_CONTEXT_KEY: frozenset({"title"}),
+            "title": "hello",
+        }
+
+        _inject(mgr, info, context_data)
+
+        assert context_data["headline"] == "HELLO"
+        assert context_data["title"] == "hello"
+
+    def test_keyed_context_still_overwrites(self, tmp_path: Path) -> None:
+        """A keyed registration names one key explicitly and is not guarded."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, "children", lambda: "keyed")
+        context_data = {"children": "<i>body</i>"}
+
+        _inject(mgr, info, context_data)
+
+        assert context_data["children"] == "keyed"
+
+
+class TestRenderComponentWithoutTag:
+    """A direct `render_component` carries no prop names, so only keys are reserved."""
+
+    def test_plain_key_merges(self, tmp_path: Path) -> None:
+        """Without `_component_props` an ordinary key merges as before."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, None, lambda: {"title": "from context"})
+
+        with patch("next.components.renderers.component", mgr):
+            html = render_component(info, {"title": "caller"})
+
+        assert "from context" in html
+
+    def test_reserved_key_still_raises(self, tmp_path: Path) -> None:
+        """The reserved names are guarded even without a calling tag."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, None, lambda: {"children": "x"})
+
+        with (
+            patch("next.components.renderers.component", mgr),
+            pytest.raises(ValueError, match="'children'"),
+        ):
+            render_component(info, {})
+
+
+class TestComponentTagPropsChannel:
+    """`{% component %}` publishes its prop names so the guard can see them."""
+
+    def _render(self, mgr: ComponentContextManager, info: ComponentInfo, source: str):
+        template = Template("{% load components %}" + source)
+        context = Context(
+            {"current_template_path": str(info.scope_root / "template.djx")}
+        )
+        with (
+            patch.object(components_manager, "get_component", return_value=info),
+            patch("next.components.renderers.component", mgr),
+        ):
+            return template.render(context)
+
+    def test_prop_collision_raises_through_the_tag(self, tmp_path: Path) -> None:
+        """A prop named on the tag is guarded during a real render."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, None, lambda: {"title": "hijacked"})
+
+        with pytest.raises(
+            ValueError, match="Component 'card' context returns 'title'"
+        ):
+            self._render(mgr, info, '{% component "card" title="Hi" %}')
+
+    def test_no_prop_on_the_tag_merges_through_the_tag(self, tmp_path: Path) -> None:
+        """The same component without that prop keeps merging."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, None, lambda: {"title": "from context"})
+
+        html = self._render(mgr, info, '{% component "card" %}')
+
+        assert "from context" in html
+
+    def test_prop_value_reaches_a_context_parameter(self, tmp_path: Path) -> None:
+        """A context function reads the prop by parameter name during a render."""
+        mgr, info, module_path = build_composite_component(
+            tmp_path, template="<div>{{ headline }}</div>"
+        )
+
+        def headline(title: str) -> dict:
+            return {"headline": title.upper()}
+
+        mgr._registry.register(module_path, None, headline)
+
+        html = self._render(mgr, info, '{% component "card" title="Hi" %}')
+
+        assert "HI" in html
+
+    def test_slot_content_is_guarded_through_the_tag(self, tmp_path: Path) -> None:
+        """Slot HTML gathered by the tag cannot be overwritten by the context."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        mgr._registry.register(module_path, None, lambda: {"slot_body": "hijacked"})
+
+        with pytest.raises(ValueError, match="'slot_body'"):
+            self._render(
+                mgr,
+                info,
+                '{% #component "card" %}{% #slot "body" %}ok{% /slot %}{% /component %}',
+            )

--- a/tests/components/test_renderers.py
+++ b/tests/components/test_renderers.py
@@ -20,8 +20,7 @@ from tests.support.components import build_composite_component
 
 RESERVED_KEYS = sorted(_RESERVED_CONTEXT_KEYS)
 
-# The inventory as the docs publish it, pinned so a change to the core set has
-# to be made twice on purpose.
+# The inventory as the docs publish it, pinned so a core-set change is deliberate.
 PINNED_RESERVED_KEYS = frozenset(
     {
         "_component_props",

--- a/tests/components/test_renderers.py
+++ b/tests/components/test_renderers.py
@@ -29,6 +29,7 @@ PINNED_RESERVED_KEYS = frozenset(
         "children",
         "csrf_token",
         "current_component_module_path",
+        "current_page_module_path",
         "current_template_path",
         "request",
     }
@@ -141,18 +142,6 @@ class TestKeylessContextMerges:
 
         assert context_data["title"] == "component wins"
         assert context_data["variant"] == "wide"
-
-    def test_current_page_module_path_is_shadowed(self, tmp_path: Path) -> None:
-        """`current_page_module_path` stays a plain page key, not a reserved one."""
-        mgr, info, module_path = build_composite_component(tmp_path)
-        mgr._registry.register(
-            module_path, None, lambda: {"current_page_module_path": "/other/page.py"}
-        )
-        context_data = {"current_page_module_path": "/app/page.py"}
-
-        _inject(mgr, info, context_data)
-
-        assert context_data["current_page_module_path"] == "/other/page.py"
 
     def test_same_key_merges_when_tag_passes_no_prop(self, tmp_path: Path) -> None:
         """The guard follows the call site, so a propless call still merges."""

--- a/tests/conf/test_frozen.py
+++ b/tests/conf/test_frozen.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from collections import defaultdict
+from typing import Any, NamedTuple
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from next.conf.frozen import FrozenDict, FrozenList, _immutable, freeze
+
+
+def sample() -> list[dict[str, Any]]:
+    """Build a fresh nested settings value, so no test hands another a used one."""
+    return [
+        {"BACKEND": "next.urls.FileRouterBackend", "OPTIONS": {"SSE": {"MS": 3000}}}
+    ]
+
+
+def cyclic_list() -> list[Any]:
+    """Build a list holding itself."""
+    value: list[Any] = []
+    value.append(value)
+    return value
+
+
+def cyclic_dict() -> dict[str, Any]:
+    """Build a dict holding itself."""
+    value: dict[str, Any] = {}
+    value["self"] = value
+    return value
+
+
+class Point(NamedTuple):
+    x: int
+    y: int
+
+
+LIST_MUTATIONS = [
+    ("append", lambda x: x.append(1)),
+    ("clear", lambda x: x.clear()),
+    ("extend", lambda x: x.extend([1])),
+    ("insert", lambda x: x.insert(0, 1)),
+    ("pop", lambda x: x.pop()),
+    ("remove", lambda x: x.remove("a")),
+    ("reverse", lambda x: x.reverse()),
+    ("sort", lambda x: x.sort()),
+    ("__setitem__", lambda x: x.__setitem__(0, "z")),
+    ("__delitem__", lambda x: x.__delitem__(0)),
+    ("__iadd__", lambda x: x.__iadd__(["z"])),
+    ("__imul__", lambda x: x.__imul__(2)),
+]
+
+DICT_MUTATIONS = [
+    ("clear", lambda x: x.clear()),
+    ("pop", lambda x: x.pop("a")),
+    ("popitem", lambda x: x.popitem()),
+    ("setdefault", lambda x: x.setdefault("b", 1)),
+    ("update", lambda x: x.update({"a": 2})),
+    ("__setitem__", lambda x: x.__setitem__("a", 2)),
+    ("__delitem__", lambda x: x.__delitem__("a")),
+    ("__ior__", lambda x: x.__ior__({"a": 2})),
+]
+
+# The mutating half of the builtin method inventory, guarded by the subclass.
+LIST_GUARDED = frozenset(name for name, _ in LIST_MUTATIONS)
+DICT_GUARDED = frozenset(name for name, _ in DICT_MUTATIONS)
+
+# The rest of the inventory, inherited as is. `__init__` is in here because the
+# constructor needs it, which leaves re-invoking it by hand as an escape hatch.
+LIST_INHERITED = frozenset(
+    {
+        "__add__",
+        "__class__",
+        "__class_getitem__",
+        "__contains__",
+        "__delattr__",
+        "__dir__",
+        "__doc__",
+        "__eq__",
+        "__format__",
+        "__ge__",
+        "__getattribute__",
+        "__getitem__",
+        "__getstate__",
+        "__gt__",
+        "__hash__",
+        "__init__",
+        "__init_subclass__",
+        "__iter__",
+        "__le__",
+        "__len__",
+        "__lt__",
+        "__mul__",
+        "__ne__",
+        "__new__",
+        "__reduce__",
+        "__reduce_ex__",
+        "__repr__",
+        "__reversed__",
+        "__rmul__",
+        "__setattr__",
+        "__sizeof__",
+        "__str__",
+        "__subclasshook__",
+        "copy",
+        "count",
+        "index",
+    }
+)
+
+DICT_INHERITED = frozenset(
+    {
+        "__class__",
+        "__class_getitem__",
+        "__contains__",
+        "__delattr__",
+        "__dir__",
+        "__doc__",
+        "__eq__",
+        "__format__",
+        "__ge__",
+        "__getattribute__",
+        "__getitem__",
+        "__getstate__",
+        "__gt__",
+        "__hash__",
+        "__init__",
+        "__init_subclass__",
+        "__iter__",
+        "__le__",
+        "__len__",
+        "__lt__",
+        "__ne__",
+        "__new__",
+        "__or__",
+        "__reduce__",
+        "__reduce_ex__",
+        "__repr__",
+        "__reversed__",
+        "__ror__",
+        "__setattr__",
+        "__sizeof__",
+        "__str__",
+        "__subclasshook__",
+        "copy",
+        "fromkeys",
+        "get",
+        "items",
+        "keys",
+        "values",
+    }
+)
+
+INVENTORIES = [
+    pytest.param(list, LIST_GUARDED, LIST_INHERITED, id="list"),
+    pytest.param(dict, DICT_GUARDED, DICT_INHERITED, id="dict"),
+]
+
+GUARD_SETS = [
+    pytest.param(FrozenList, LIST_GUARDED, id="list"),
+    pytest.param(FrozenDict, DICT_GUARDED, id="dict"),
+]
+
+CYCLES = [pytest.param(cyclic_list, id="list"), pytest.param(cyclic_dict, id="dict")]
+
+
+class TestFrozenListMutators:
+    """Every list mutator raises TypeError and leaves the contents alone."""
+
+    @pytest.mark.parametrize(
+        ("name", "mutate"), LIST_MUTATIONS, ids=[name for name, _ in LIST_MUTATIONS]
+    )
+    def test_mutation_raises(self, name, mutate) -> None:
+        frozen = FrozenList(["a", "b"])
+        with pytest.raises(TypeError, match="immutable"):
+            mutate(frozen)
+        assert frozen == ["a", "b"]
+
+    def test_augmented_assignment_raises(self) -> None:
+        frozen = FrozenList(["a"])
+        with pytest.raises(TypeError, match="immutable"):
+            frozen += ["b"]
+
+    def test_reads_still_work(self) -> None:
+        frozen = FrozenList(["a", "b"])
+        assert frozen[0] == "a"
+        assert len(frozen) == 2
+        assert list(reversed(frozen)) == ["b", "a"]
+        assert frozen.index("b") == 1
+        assert frozen.count("a") == 1
+
+
+class TestFrozenDictMutators:
+    """Every dict mutator raises TypeError and leaves the contents alone."""
+
+    @pytest.mark.parametrize(
+        ("name", "mutate"), DICT_MUTATIONS, ids=[name for name, _ in DICT_MUTATIONS]
+    )
+    def test_mutation_raises(self, name, mutate) -> None:
+        frozen = FrozenDict({"a": 1})
+        with pytest.raises(TypeError, match="immutable"):
+            mutate(frozen)
+        assert frozen == {"a": 1}
+
+    def test_augmented_or_raises(self) -> None:
+        frozen = FrozenDict({"a": 1})
+        with pytest.raises(TypeError, match="immutable"):
+            frozen |= {"b": 2}
+
+    def test_reads_still_work(self) -> None:
+        frozen = FrozenDict({"a": 1})
+        assert frozen["a"] == 1
+        assert frozen.get("b", "fallback") == "fallback"
+        assert list(frozen.items()) == [("a", 1)]
+        assert frozen | {"b": 2} == {"a": 1, "b": 2}
+
+    def test_fromkeys_cannot_fill_the_subclass(self) -> None:
+        with pytest.raises(TypeError, match="immutable"):
+            FrozenDict.fromkeys(["a"])
+
+
+class TestMutatorInventory:
+    """The guarded mutators are pinned against the whole builtin inventory.
+
+    A method CPython adds later lands in neither half and fails this, so it
+    reaches a person instead of silently widening the hole.
+    """
+
+    @pytest.mark.parametrize(("builtin", "guarded", "inherited"), INVENTORIES)
+    def test_inventory_covers_every_builtin_method(
+        self, builtin, guarded, inherited
+    ) -> None:
+        assert guarded | inherited == set(dir(builtin))
+
+    @pytest.mark.parametrize(("frozen_type", "guarded"), GUARD_SETS)
+    def test_exactly_the_pinned_mutators_are_guarded(
+        self, frozen_type, guarded
+    ) -> None:
+        overridden = {
+            name for name, value in vars(frozen_type).items() if value is _immutable
+        }
+        assert overridden == guarded
+
+
+class TestFrozenContainersStayBuiltins:
+    """Frozen containers pass builtin isinstance guards and compare as builtins."""
+
+    def test_isinstance_of_builtins(self) -> None:
+        frozen = freeze(sample())
+        assert isinstance(frozen, list)
+        assert isinstance(frozen[0], dict)
+
+    def test_equality_with_plain_containers(self) -> None:
+        source = sample()
+        frozen = freeze(source)
+        assert frozen == source
+        assert source.__eq__(frozen) is True
+        assert frozen[0] == source[0]
+
+    def test_repr_matches_plain_containers(self) -> None:
+        source = sample()
+        assert repr(freeze(source)) == repr(source)
+
+    def test_json_serialisable(self) -> None:
+        source = sample()
+        assert json.dumps(freeze(source)) == json.dumps(source)
+
+    def test_memory_footprint_matches_the_builtins(self) -> None:
+        assert sys.getsizeof(FrozenList([1, 2, 3])) == sys.getsizeof([1, 2, 3])
+        assert sys.getsizeof(FrozenDict({"a": 1})) == sys.getsizeof({"a": 1})
+
+    def test_plain_copies_are_mutable(self) -> None:
+        frozen = freeze(sample())
+        loose = list(frozen)
+        loose.append({})
+        entry = dict(frozen[0])
+        entry["BACKEND"] = "other"
+        assert len(loose) == 2
+        assert entry["BACKEND"] == "other"
+
+    def test_slices_and_copy_hand_back_plain_containers(self) -> None:
+        source = sample()
+        frozen = freeze(source)
+        assert type(frozen[:1]) is list
+        assert type(frozen.copy()) is list
+        assert type(frozen[0].copy()) is dict
+        frozen[:1].append({})
+        frozen[0].copy()["BACKEND"] = "other"
+        assert frozen == source
+
+
+class TestFrozenContainersRoundTrip:
+    """copy, deepcopy, and pickle rebuild through the constructor."""
+
+    def test_shallow_copy(self) -> None:
+        source = sample()
+        frozen = freeze(source)
+        clone = copy.copy(frozen)
+        assert clone == source
+        assert clone[0] is frozen[0]
+
+    def test_deep_copy(self) -> None:
+        source = sample()
+        frozen = freeze(source)
+        clone = copy.deepcopy(frozen)
+        assert clone == source
+        assert clone[0] is not frozen[0]
+        assert isinstance(clone[0], FrozenDict)
+
+    def test_reduce_names_the_constructor(self) -> None:
+        source = sample()
+        factory, args = freeze(source).__reduce__()
+        assert factory is FrozenList
+        assert factory(*args) == source
+        assert type(args[0]) is list
+
+    def test_dict_reduce_names_the_constructor(self) -> None:
+        factory, args = FrozenDict({"a": 1}).__reduce__()
+        assert factory is FrozenDict
+        assert factory(*args) == {"a": 1}
+        assert type(args[0]) is dict
+
+    def test_copies_stay_frozen(self) -> None:
+        clone = copy.deepcopy(freeze(sample()))
+        with pytest.raises(TypeError, match="immutable"):
+            clone.append({})
+
+
+class TestFreeze:
+    """freeze rebuilds containers and passes scalars through."""
+
+    @pytest.mark.parametrize(
+        "value", ["text", 3, True, None, 1.5], ids=["str", "int", "bool", "none", "flo"]
+    )
+    def test_scalars_pass_through(self, value) -> None:
+        assert freeze(value) is value
+
+    def test_every_level_is_a_new_container(self) -> None:
+        source = sample()
+        frozen = freeze(source)
+        assert frozen is not source
+        assert frozen[0] is not source[0]
+        assert frozen[0]["OPTIONS"] is not source[0]["OPTIONS"]
+        assert frozen[0]["OPTIONS"]["SSE"] is not source[0]["OPTIONS"]["SSE"]
+
+    def test_source_mutation_does_not_reach_the_frozen_copy(self) -> None:
+        source = [{"OPTIONS": {"A": 1}}]
+        frozen = freeze(source)
+        source[0]["OPTIONS"]["A"] = 2
+        source.append({})
+        assert frozen == [{"OPTIONS": {"A": 1}}]
+
+    def test_mutable_leaf_is_copied_not_aliased(self) -> None:
+        tags = {"a"}
+        frozen = freeze({"OPTIONS": {"TAGS": tags}})
+        tags.add("b")
+        assert frozen["OPTIONS"]["TAGS"] == {"a"}
+        assert frozen["OPTIONS"]["TAGS"] is not tags
+
+    def test_mutable_leaf_stays_editable_inside_the_frozen_value(self) -> None:
+        """The freeze reaches lists and dicts only, so a set leaf still edits.
+
+        Nothing leaks back to the caller, but the leaf itself is not frozen,
+        and this is where that boundary sits.
+        """
+        tags = {"a"}
+        frozen = freeze({"OPTIONS": {"TAGS": tags}})
+        frozen["OPTIONS"]["TAGS"].add("LEAKED")
+        assert frozen["OPTIONS"]["TAGS"] == {"a", "LEAKED"}
+        assert tags == {"a"}
+
+    def test_tuple_is_rebuilt_with_frozen_items(self) -> None:
+        source = ({"A": 1},)
+        frozen = freeze(source)
+        assert isinstance(frozen, tuple)
+        assert frozen[0] is not source[0]
+        with pytest.raises(TypeError, match="immutable"):
+            frozen[0]["A"] = 2
+
+    def test_container_subclasses_keep_their_type(self) -> None:
+        counts: defaultdict[str, list[int]] = defaultdict(list)
+        counts["a"].append(1)
+        frozen = freeze({"p": Point(1, 2), "d": counts})
+        assert type(frozen["p"]) is Point
+        assert frozen["p"].x == 1
+        assert type(frozen["d"]) is defaultdict
+        assert frozen["d"].default_factory is list
+
+    def test_subclass_leaf_is_still_copied(self) -> None:
+        counts: defaultdict[str, list[int]] = defaultdict(list)
+        frozen = freeze({"d": counts})
+        counts["a"].append(1)
+        assert frozen["d"] == {}
+
+    def test_shared_subtree_stays_shared(self) -> None:
+        shared = {"A": 1}
+        frozen = freeze([shared, shared])
+        assert frozen[0] is frozen[1]
+
+    @pytest.mark.parametrize("build", CYCLES)
+    def test_self_referential_value_is_rejected(self, build) -> None:
+        with pytest.raises(ImproperlyConfigured, match="self-referential"):
+            freeze(build())

--- a/tests/conf/test_frozen.py
+++ b/tests/conf/test_frozen.py
@@ -68,8 +68,8 @@ DICT_MUTATIONS = [
 LIST_GUARDED = frozenset(name for name, _ in LIST_MUTATIONS)
 DICT_GUARDED = frozenset(name for name, _ in DICT_MUTATIONS)
 
-# The rest of the inventory, inherited as is. `__init__` is in here because the
-# constructor needs it, which leaves re-invoking it by hand as an escape hatch.
+# The rest of the inventory, inherited as is, `__init__` included because the
+# constructor needs it.
 LIST_INHERITED = frozenset(
     {
         "__add__",

--- a/tests/conf/test_frozen.py
+++ b/tests/conf/test_frozen.py
@@ -19,6 +19,15 @@ def sample() -> list[dict[str, Any]]:
     ]
 
 
+def all_plain(value: object) -> bool:
+    """Report whether every container reachable from `value` is a builtin."""
+    if isinstance(value, dict):
+        return type(value) is dict and all(all_plain(item) for item in value.values())
+    if isinstance(value, list):
+        return type(value) is list and all(all_plain(item) for item in value)
+    return True
+
+
 def cyclic_list() -> list[Any]:
     """Build a list holding itself."""
     value: list[Any] = []
@@ -158,12 +167,37 @@ INVENTORIES = [
     pytest.param(dict, DICT_GUARDED, DICT_INHERITED, id="dict"),
 ]
 
+# The two container shapes a merged value hands out, each with a way to edit it.
+COPY_CASES = [
+    pytest.param(
+        lambda frozen: frozen, list, lambda clone: clone.append({}), id="list"
+    ),
+    pytest.param(
+        lambda frozen: frozen[0],
+        dict,
+        lambda clone: clone.__setitem__("BACKEND", "other"),
+        id="dict",
+    ),
+]
+
 GUARD_SETS = [
     pytest.param(FrozenList, LIST_GUARDED, id="list"),
     pytest.param(FrozenDict, DICT_GUARDED, id="dict"),
 ]
 
 CYCLES = [pytest.param(cyclic_list, id="list"), pytest.param(cyclic_dict, id="dict")]
+
+# Shapes an already frozen value takes when it reaches the merge a second time.
+REFREEZE_CASES = [
+    pytest.param(lambda frozen: frozen, lambda value: value[0], id="whole_value"),
+    pytest.param(lambda frozen: [frozen[0]], lambda value: value[0], id="in_list"),
+    pytest.param(
+        lambda frozen: {"PAGE_BACKENDS": frozen},
+        lambda value: value["PAGE_BACKENDS"][0],
+        id="in_dict",
+    ),
+    pytest.param(lambda frozen: (frozen[0],), lambda value: value[0], id="in_tuple"),
+]
 
 
 class TestFrozenListMutators:
@@ -294,38 +328,30 @@ class TestFrozenContainersStayBuiltins:
 class TestFrozenContainersRoundTrip:
     """copy and deepcopy thaw, pickle rebuilds a frozen value."""
 
-    def test_shallow_copy_hands_back_a_plain_list(self) -> None:
-        source = sample()
-        frozen = freeze(source)
+    @pytest.mark.parametrize(("pick", "builtin", "mutate"), COPY_CASES)
+    def test_shallow_copy_hands_back_a_plain_container(
+        self, pick, builtin, mutate
+    ) -> None:
+        frozen = pick(freeze(sample()))
         clone = copy.copy(frozen)
-        assert clone == source
-        assert type(clone) is list
-        assert clone[0] is frozen[0]
-        clone.append({})
+        assert clone == frozen
+        assert type(clone) is builtin
+        mutate(clone)
 
-    def test_shallow_copy_hands_back_a_plain_dict(self) -> None:
-        entry = freeze(sample())[0]
-        clone = copy.copy(entry)
-        assert clone == entry
-        assert type(clone) is dict
-        clone["BACKEND"] = "other"
-
-    def test_deep_copy_thaws_every_level(self) -> None:
+    @pytest.mark.parametrize(("pick", "builtin", "mutate"), COPY_CASES)
+    def test_deep_copy_thaws_every_level(self, pick, builtin, mutate) -> None:
         source = sample()
-        clone = copy.deepcopy(freeze(source))
-        assert clone == source
-        assert type(clone) is list
-        assert type(clone[0]) is dict
-        assert type(clone[0]["OPTIONS"]) is dict
-        clone[0]["OPTIONS"]["SSE"]["MS"] = 1
-        clone.append({})
+        frozen = pick(freeze(source))
+        clone = copy.deepcopy(frozen)
+        assert clone == frozen
+        assert type(clone) is builtin
+        assert all_plain(clone)
+        mutate(clone)
         assert freeze(source) == source
 
-    def test_deep_copy_thaws_a_frozen_dict_on_its_own(self) -> None:
-        clone = copy.deepcopy(FrozenDict({"OPTIONS": FrozenList(["a"])}))
-        assert type(clone) is dict
-        assert type(clone["OPTIONS"]) is list
-        clone["OPTIONS"].append("b")
+    def test_shallow_copy_keeps_the_frozen_items(self) -> None:
+        frozen = freeze(sample())
+        assert copy.copy(frozen)[0] is frozen[0]
 
     def test_deep_copy_keeps_shared_subtrees_shared(self) -> None:
         shared = {"A": 1}
@@ -394,6 +420,14 @@ class TestFreeze:
         frozen["OPTIONS"]["TAGS"].add("LEAKED")
         assert frozen["OPTIONS"]["TAGS"] == {"a", "LEAKED"}
         assert tags == {"a"}
+
+    @pytest.mark.parametrize(("rewrap", "entry_of"), REFREEZE_CASES)
+    def test_an_already_frozen_value_freezes_again(self, rewrap, entry_of) -> None:
+        """A merged value fed back into the settings comes out frozen, not thawed."""
+        entry = entry_of(freeze(rewrap(freeze(sample()))))
+        assert isinstance(entry, FrozenDict)
+        with pytest.raises(TypeError, match="immutable"):
+            entry["OPTIONS"]["SSE"]["MS"] = 1
 
     def test_tuple_is_rebuilt_with_frozen_items(self) -> None:
         source = ({"A": 1},)

--- a/tests/conf/test_frozen.py
+++ b/tests/conf/test_frozen.py
@@ -293,22 +293,45 @@ class TestFrozenContainersStayBuiltins:
 
 
 class TestFrozenContainersRoundTrip:
-    """copy, deepcopy, and pickle rebuild through the constructor."""
+    """copy and deepcopy thaw, pickle rebuilds a frozen value."""
 
-    def test_shallow_copy(self) -> None:
+    def test_shallow_copy_hands_back_a_plain_list(self) -> None:
         source = sample()
         frozen = freeze(source)
         clone = copy.copy(frozen)
         assert clone == source
+        assert type(clone) is list
         assert clone[0] is frozen[0]
+        clone.append({})
 
-    def test_deep_copy(self) -> None:
+    def test_shallow_copy_hands_back_a_plain_dict(self) -> None:
+        entry = freeze(sample())[0]
+        clone = copy.copy(entry)
+        assert clone == entry
+        assert type(clone) is dict
+        clone["BACKEND"] = "other"
+
+    def test_deep_copy_thaws_every_level(self) -> None:
         source = sample()
-        frozen = freeze(source)
-        clone = copy.deepcopy(frozen)
+        clone = copy.deepcopy(freeze(source))
         assert clone == source
-        assert clone[0] is not frozen[0]
-        assert isinstance(clone[0], FrozenDict)
+        assert type(clone) is list
+        assert type(clone[0]) is dict
+        assert type(clone[0]["OPTIONS"]) is dict
+        clone[0]["OPTIONS"]["SSE"]["MS"] = 1
+        clone.append({})
+        assert freeze(source) == source
+
+    def test_deep_copy_thaws_a_frozen_dict_on_its_own(self) -> None:
+        clone = copy.deepcopy(FrozenDict({"OPTIONS": FrozenList(["a"])}))
+        assert type(clone) is dict
+        assert type(clone["OPTIONS"]) is list
+        clone["OPTIONS"].append("b")
+
+    def test_deep_copy_keeps_shared_subtrees_shared(self) -> None:
+        shared = {"A": 1}
+        clone = copy.deepcopy(freeze([shared, shared]))
+        assert clone[0] is clone[1]
 
     def test_reduce_names_the_constructor(self) -> None:
         source = sample()
@@ -323,8 +346,10 @@ class TestFrozenContainersRoundTrip:
         assert factory(*args) == {"a": 1}
         assert type(args[0]) is dict
 
-    def test_copies_stay_frozen(self) -> None:
-        clone = copy.deepcopy(freeze(sample()))
+    def test_rebuilt_value_stays_frozen(self) -> None:
+        factory, args = freeze(sample()).__reduce__()
+        clone = factory(*args)
+        assert isinstance(clone, FrozenList)
         with pytest.raises(TypeError, match="immutable"):
             clone.append({})
 

--- a/tests/conf/test_frozen.py
+++ b/tests/conf/test_frozen.py
@@ -68,8 +68,7 @@ DICT_MUTATIONS = [
 LIST_GUARDED = frozenset(name for name, _ in LIST_MUTATIONS)
 DICT_GUARDED = frozenset(name for name, _ in DICT_MUTATIONS)
 
-# The rest of the inventory, inherited as is, `__init__` included because the
-# constructor needs it.
+# The rest of the inventory, inherited as is, `__init__` included.
 LIST_INHERITED = frozenset(
     {
         "__add__",
@@ -388,8 +387,7 @@ class TestFreeze:
     def test_mutable_leaf_stays_editable_inside_the_frozen_value(self) -> None:
         """The freeze reaches lists and dicts only, so a set leaf still edits.
 
-        Nothing leaks back to the caller, but the leaf itself is not frozen,
-        and this is where that boundary sits.
+        Nothing leaks back to the caller, the leaf itself is just not frozen.
         """
         tags = {"a"}
         frozen = freeze({"OPTIONS": {"TAGS": tags}})

--- a/tests/conf/test_helpers.py
+++ b/tests/conf/test_helpers.py
@@ -1,7 +1,7 @@
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 
-from next.conf import extend_default_backend
+from next.conf import DEFAULTS, extend_default_backend
 
 
 class TestExtendDefaultBackend:
@@ -54,3 +54,32 @@ class TestExtendDefaultBackend:
     def test_raises_for_negative_index(self) -> None:
         with pytest.raises(IndexError, match="out of range"):
             extend_default_backend("PAGE_BACKENDS", index=-1, PAGES_DIR="r")
+
+
+class TestExtendDefaultBackendStaysMutable:
+    """The helper hands back plain containers the caller may still edit."""
+
+    def test_result_containers_are_plain(self) -> None:
+        patched = extend_default_backend("PAGE_BACKENDS", PAGES_DIR="routes")
+        assert type(patched) is list
+        assert type(patched[0]) is dict
+        assert type(patched[0]["DIRS"]) is list
+        assert type(patched[0]["OPTIONS"]) is dict
+
+    def test_result_can_be_edited_at_every_depth(self) -> None:
+        patched = extend_default_backend("PAGE_BACKENDS", PAGES_DIR="routes")
+        patched.append({"BACKEND": "next.urls.FileRouterBackend"})
+        patched[0]["DIRS"].append("/tmp/x")
+        patched[0]["OPTIONS"]["context_processors"].append("app.ctx")
+        assert len(patched) == 2
+        assert patched[0]["DIRS"] == ["/tmp/x"]
+        assert patched[0]["OPTIONS"]["context_processors"] == ["app.ctx"]
+
+    def test_editing_the_result_leaves_defaults_alone(self) -> None:
+        patched = extend_default_backend("PAGE_BACKENDS", PAGES_DIR="routes")
+        patched[0]["DIRS"].append("/tmp/x")
+        patched[0]["OPTIONS"]["context_processors"].append("app.ctx")
+        default_entry = DEFAULTS["PAGE_BACKENDS"][0]
+        assert default_entry["PAGES_DIR"] == "pages"
+        assert default_entry["DIRS"] == []
+        assert default_entry["OPTIONS"]["context_processors"] == []

--- a/tests/conf/test_settings.py
+++ b/tests/conf/test_settings.py
@@ -390,6 +390,29 @@ class TestPartialBackendsDefault:
         assert "PARTIAL_BACKENDS" in NextFrameworkSettings.DEFAULTS
 
 
+# One case per merge branch that freezes a user value, each with a way to edit it.
+REUSED_MERGED_CASES = [
+    pytest.param(
+        "PAGE_BACKENDS",
+        [{"BACKEND": "next.urls.X", "DIRS": []}],
+        lambda value: value[0]["DIRS"].append("/tmp/x"),
+        id="backend_list",
+    ),
+    pytest.param(
+        "NEXT_JS_OPTIONS",
+        {"a": {"b": 1}},
+        lambda value: value["a"].__setitem__("b", 2),
+        id="options_mapping",
+    ),
+    pytest.param(
+        "FORM_WIZARD_BACKEND",
+        {"OPTIONS": {"ttl": 1}},
+        lambda value: value["OPTIONS"].__setitem__("ttl", 2),
+        id="wizard_backend",
+    ),
+]
+
+
 class TestMergedSettingsAreImmutable:
     """Merged values reject mutation at every depth without changing types."""
 
@@ -466,6 +489,19 @@ class TestMergedSettingsAreImmutable:
             user_entry["BACKEND"] = "next.urls.Y"
             user_list.append({})
             assert merged == [{"BACKEND": "next.urls.X", "DIRS": []}]
+
+    @pytest.mark.parametrize(("key", "user_value", "mutate"), REUSED_MERGED_CASES)
+    def test_a_merged_value_put_back_into_settings_stays_frozen(
+        self, key, user_value, mutate
+    ) -> None:
+        """Reusing a merged value as the user value freezes it again."""
+        with override_settings(NEXT_FRAMEWORK={key: user_value}):
+            next_framework_settings.reload()
+            reused = getattr(next_framework_settings, key)
+        with override_settings(NEXT_FRAMEWORK={key: reused}):
+            next_framework_settings.reload()
+            with pytest.raises(TypeError, match="immutable"):
+                mutate(getattr(next_framework_settings, key))
 
     def test_defaults_stay_plain_containers(self) -> None:
         """The merge leaves DEFAULTS a plain structure it never hands out."""

--- a/tests/conf/test_settings.py
+++ b/tests/conf/test_settings.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
+from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 from pytest_lazy_fixtures import lf
 
@@ -386,3 +388,147 @@ class TestPartialBackendsDefault:
 
     def test_is_known_top_level_key(self) -> None:
         assert "PARTIAL_BACKENDS" in NextFrameworkSettings.DEFAULTS
+
+
+class TestMergedSettingsAreImmutable:
+    """Merged values reject mutation at every depth without changing types."""
+
+    @pytest.mark.parametrize(
+        "mutate",
+        [
+            pytest.param(lambda value: value.append({}), id="append"),
+            pytest.param(lambda value: value.__setitem__(0, {}), id="top_level_item"),
+            pytest.param(
+                lambda value: value[0].__setitem__("PAGES_DIR", "x"), id="nested_item"
+            ),
+            pytest.param(
+                lambda value: value[0].__delitem__("PAGES_DIR"), id="nested_delete"
+            ),
+            pytest.param(
+                lambda value: value[0]["DIRS"].append("/tmp/x"), id="nested_list"
+            ),
+            pytest.param(
+                lambda value: value[0]["OPTIONS"].update({"k": 1}), id="nested_options"
+            ),
+        ],
+    )
+    def test_page_backends_reject_mutation(self, mutate) -> None:
+        """Every reachable container under PAGE_BACKENDS is frozen."""
+        next_framework_settings.reload()
+        with pytest.raises(TypeError, match="immutable"):
+            mutate(next_framework_settings.PAGE_BACKENDS)
+        assert next_framework_settings.PAGE_BACKENDS[0]["PAGES_DIR"] == "pages"
+
+    def test_deeply_nested_partial_options_reject_mutation(self) -> None:
+        """PARTIAL_BACKENDS stays frozen three levels down at the SSE options."""
+        next_framework_settings.reload()
+        sse = next_framework_settings.PARTIAL_BACKENDS[0]["OPTIONS"]["SSE"]
+        with pytest.raises(TypeError, match="immutable"):
+            sse["RETRY_MS"] = 1
+        assert sse["RETRY_MS"] == 3000
+
+    def test_user_supplied_list_is_frozen(self) -> None:
+        """A user PAGE_BACKENDS list reaches the merge frozen, not aliased."""
+        with override_settings(
+            NEXT_FRAMEWORK={"PAGE_BACKENDS": [{"BACKEND": "next.urls.X", "DIRS": []}]}
+        ):
+            next_framework_settings.reload()
+            with pytest.raises(TypeError, match="immutable"):
+                next_framework_settings.PAGE_BACKENDS[0]["DIRS"].append("/tmp/x")
+
+    def test_user_supplied_dict_is_frozen(self) -> None:
+        """NEXT_JS_OPTIONS is a frozen mapping once merged."""
+        with override_settings(NEXT_FRAMEWORK={"NEXT_JS_OPTIONS": {"a": {"b": 1}}}):
+            next_framework_settings.reload()
+            with pytest.raises(TypeError, match="immutable"):
+                next_framework_settings.NEXT_JS_OPTIONS["a"]["b"] = 2
+
+    def test_merged_wizard_backend_is_frozen(self) -> None:
+        """FORM_WIZARD_BACKEND merges defaults with the user dict and freezes."""
+        with override_settings(
+            NEXT_FRAMEWORK={"FORM_WIZARD_BACKEND": {"OPTIONS": {"ttl": 1}}}
+        ):
+            next_framework_settings.reload()
+            merged = next_framework_settings.FORM_WIZARD_BACKEND
+            assert merged["BACKEND"] == "next.forms.SessionFormWizardBackend"
+            assert merged["OPTIONS"] == {"ttl": 1}
+            with pytest.raises(TypeError, match="immutable"):
+                merged["OPTIONS"]["ttl"] = 2
+
+    def test_mutating_the_user_mapping_after_reload_is_not_visible(self) -> None:
+        """The merge rebuilds the user containers instead of aliasing them."""
+        user_entry: dict[str, Any] = {"BACKEND": "next.urls.X", "DIRS": []}
+        user_list = [user_entry]
+        with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": user_list}):
+            next_framework_settings.reload()
+            merged = next_framework_settings.PAGE_BACKENDS
+            user_entry["DIRS"].append("/tmp/leak")
+            user_entry["BACKEND"] = "next.urls.Y"
+            user_list.append({})
+            assert merged == [{"BACKEND": "next.urls.X", "DIRS": []}]
+
+    def test_defaults_stay_plain_containers(self) -> None:
+        """The merge leaves DEFAULTS a plain structure it never hands out."""
+        next_framework_settings.reload()
+        merged = next_framework_settings.PAGE_BACKENDS
+        default = NextFrameworkSettings.DEFAULTS["PAGE_BACKENDS"]
+        assert merged is not default
+        assert merged[0] is not default[0]
+        assert type(default) is list
+        assert type(default[0]) is dict
+
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            ("URL_NAME_TEMPLATE", "page_{name}"),
+            ("URL_RESOLVER", "next.urls.TrieURLResolver"),
+            ("STRICT_CONTEXT", False),
+            ("JS_CONTEXT_SERIALIZER", None),
+            ("FORM_ANCHOR_FILES", None),
+        ],
+        ids=["template", "resolver", "strict", "serializer", "anchors"],
+    )
+    def test_scalars_are_returned_untouched(self, key: str, expected: object) -> None:
+        """Freezing leaves strings, bools, and None exactly as they were."""
+        next_framework_settings.reload()
+        value = getattr(next_framework_settings, key)
+        assert value == expected
+        assert type(value) is type(expected)
+
+    def test_cache_hit_returns_the_same_object(self) -> None:
+        """Reading twice hands back one identical object, no copy per read."""
+        next_framework_settings.reload()
+        first = next_framework_settings.PAGE_BACKENDS
+        assert next_framework_settings.PAGE_BACKENDS is first
+
+    def test_reload_rebuilds_the_frozen_value(self) -> None:
+        """A reload drops the frozen value and builds a fresh one."""
+        next_framework_settings.reload()
+        first = next_framework_settings.PAGE_BACKENDS
+        next_framework_settings.reload()
+        assert next_framework_settings.PAGE_BACKENDS is not first
+
+    def test_equality_with_plain_containers_survives(self) -> None:
+        """Frozen values keep comparing equal to plain lists and dicts."""
+        next_framework_settings.reload()
+        merged = next_framework_settings.PARTIAL_BACKENDS
+        plain = json.loads(json.dumps(merged))
+        assert type(plain) is list
+        assert merged == plain
+        assert plain.__eq__(merged) is True
+        assert next_framework_settings.NEXT_JS_OPTIONS == {}
+        assert next_framework_settings.TEMPLATE_LOADERS == [
+            "next.pages.loaders.DjxTemplateLoader"
+        ]
+
+    def test_self_referential_user_value_is_rejected(self) -> None:
+        """A cyclic user value surfaces as ImproperlyConfigured, not RecursionError."""
+        cyclic: list[Any] = []
+        cyclic.append(cyclic)
+        # The merge runs on the first read of the value, which is either the
+        # reload the settings change triggers or the attribute access below.
+        with (
+            pytest.raises(ImproperlyConfigured, match="self-referential"),
+            override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": cyclic}),
+        ):
+            assert next_framework_settings.PAGE_BACKENDS

--- a/tests/forms/test_field_components.py
+++ b/tests/forms/test_field_components.py
@@ -219,6 +219,81 @@ class TestComponentWidgetRequestCache:
         assert cache == {}
 
 
+_GUARD_TEMPLATE = "<div>name={{ name }} value={{ value }} hint={{ hint }}</div>"
+
+
+def _write_guarded_component(root: Path, returned: str) -> None:
+    """Write a `guarded` component whose keyless context returns `returned`."""
+    comp_dir = root / "guarded"
+    comp_dir.mkdir(parents=True)
+    (comp_dir / "component.djx").write_text(_GUARD_TEMPLATE)
+    (comp_dir / "component.py").write_text(
+        "from next.components import component\n\n\n"
+        "@component.context\n"
+        "def extra():\n"
+        f"    return {returned}\n"
+    )
+
+
+class TestComponentWidgetPropGuard:
+    """A keyless `@component.context` may not take over a name the widget supplies."""
+
+    @pytest.mark.parametrize("prop", ["attrs", "errors", "name", "value"])
+    def test_widget_supplied_name_raises(self, tmp_path: Path, prop: str) -> None:
+        root = tmp_path / "_components"
+        _write_guarded_component(root, f'{{"{prop}": "HIJACKED"}}')
+        widget = ComponentWidget("guarded")
+        widget._template_path = tmp_path / "page.djx"
+        with (
+            override_component_backends(_components_config(root)),
+            pytest.raises(ValueError, match=f"context returns '{prop}'"),
+        ):
+            widget.render("slug", "bound", attrs={})
+
+    def test_extra_kwarg_name_raises(self, tmp_path: Path) -> None:
+        root = tmp_path / "_components"
+        _write_guarded_component(root, '{"placeholder": "HIJACKED"}')
+        widget = ComponentWidget("guarded", placeholder="URL slug")
+        widget._template_path = tmp_path / "page.djx"
+        with (
+            override_component_backends(_components_config(root)),
+            pytest.raises(ValueError, match="context returns 'placeholder'"),
+        ):
+            widget.render("slug", "bound", attrs={})
+
+    def test_rendered_attr_name_raises(self, tmp_path: Path) -> None:
+        root = tmp_path / "_components"
+        _write_guarded_component(root, '{"id": "HIJACKED"}')
+        widget = ComponentWidget("guarded")
+        widget._template_path = tmp_path / "page.djx"
+        with (
+            override_component_backends(_components_config(root)),
+            pytest.raises(ValueError, match="context returns 'id'"),
+        ):
+            widget.render("slug", "bound", attrs={"id": "id_slug"})
+
+    def test_unrelated_key_merges(self, tmp_path: Path) -> None:
+        root = tmp_path / "_components"
+        _write_guarded_component(root, '{"hint": "merged"}')
+        widget = ComponentWidget("guarded")
+        widget._template_path = tmp_path / "page.djx"
+        with override_component_backends(_components_config(root)):
+            html = widget.render("slug", "bound", attrs={})
+        assert "hint=merged" in html
+        assert "value=bound" in html
+
+    def test_bound_form_value_is_not_replaced(self, tmp_path: Path) -> None:
+        root = tmp_path / "_components"
+        _write_guarded_component(root, '{"value": "HIJACKED", "name": "HIJACKED"}')
+        widget = ComponentWidget("guarded")
+        form_class = _echo_form(widget)
+        with override_component_backends(_components_config(root)):
+            form = form_class(data={"field": "bound"})
+            bind_component_widgets(form, template_path=tmp_path / "page.djx")
+            with pytest.raises(ValueError, match="returns 'name', 'value'"):
+                str(form["field"])
+
+
 class TestComponentWidgetConstructorAttrs:
     """Constructor `attrs=` merge into render output, render-time attrs win."""
 

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
+from contextlib import ExitStack
+from typing import TYPE_CHECKING, Any
+
 import pytest
+from django.test import override_settings
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
 
 
 class _MockAutoreloadSender:
@@ -15,3 +23,18 @@ class _MockAutoreloadSender:
 def mock_autoreload_sender() -> _MockAutoreloadSender:
     """Minimal sender stub for ``autoreload_started`` signal tests."""
     return _MockAutoreloadSender()
+
+
+@pytest.fixture()
+def apply_component_backends() -> Generator[Callable[[list[Any]], None], None, None]:
+    """Install ``COMPONENT_BACKENDS`` entries with no page backends configured."""
+    with ExitStack() as stack:
+
+        def apply(entries: list[Any]) -> None:
+            stack.enter_context(
+                override_settings(
+                    NEXT_FRAMEWORK={"PAGE_BACKENDS": [], "COMPONENT_BACKENDS": entries}
+                )
+            )
+
+        yield apply

--- a/tests/server/test_roots.py
+++ b/tests/server/test_roots.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from next.server import get_framework_filesystem_roots_for_linking
+from tests.support.backends import file_components_entry
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+class TestFrameworkFilesystemRoots:
+    """``get_framework_filesystem_roots_for_linking`` over ``COMPONENT_BACKENDS``."""
+
+    def test_every_dict_entry_contributes_resolved_dirs(
+        self, tmp_path: Path, apply_component_backends: Callable[[list[Any]], None]
+    ) -> None:
+        """Roots come back resolved, deduplicated and sorted."""
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+        apply_component_backends(
+            [file_components_entry(second, first), file_components_entry(first)]
+        )
+        assert get_framework_filesystem_roots_for_linking() == sorted(
+            {first.resolve(), second.resolve()}
+        )

--- a/tests/server/test_watcher.py
+++ b/tests/server/test_watcher.py
@@ -1,21 +1,33 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
+import next.server
 from next.conf import next_framework_settings
-from next.server import (
-    get_framework_filesystem_roots_for_linking,
-    iter_all_autoreload_watch_specs,
-    register_autoreload_watch_spec,
-)
+from next.server import iter_all_autoreload_watch_specs, register_autoreload_watch_spec
 from next.server.watcher import (
     _dedupe_watch_specs,
     _iter_default_autoreload_watch_specs,
     _registered_extra_watch_specs,
 )
+from tests.support.backends import file_components_entry
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+SERVER_EXPORTS = {
+    "NextStatReloader",
+    "get_framework_filesystem_roots_for_linking",
+    "iter_all_autoreload_watch_specs",
+    "register_autoreload_watch_spec",
+    "signals",
+}
 
 
 class TestServerAutoreloadWatchApi:
@@ -37,12 +49,6 @@ class TestServerAutoreloadWatchApi:
         finally:
             _registered_extra_watch_specs.clear()
 
-    def test_get_framework_filesystem_roots_for_linking_returns_paths(self) -> None:
-        """Linking helper returns a sorted list of paths."""
-        roots = get_framework_filesystem_roots_for_linking()
-        assert isinstance(roots, list)
-        assert all(isinstance(p, Path) for p in roots)
-
     def test_dedupe_watch_specs_when_resolve_raises_oserror(self) -> None:
         """Duplicate specs collapse when ``Path.resolve`` fails."""
         mock_path = MagicMock()
@@ -50,28 +56,22 @@ class TestServerAutoreloadWatchApi:
         specs = _dedupe_watch_specs([(mock_path, "*.py"), (mock_path, "*.py")])
         assert len(specs) == 1
 
-    def test_iter_default_includes_component_backend_dirs(self, tmp_path: Path) -> None:
+    def test_component_backend_dirs_are_watched_in_declaration_order(
+        self, tmp_path: Path, apply_component_backends: Callable[[list[Any]], None]
+    ) -> None:
         """``COMPONENT_BACKENDS`` ``DIRS`` add ``**/component.py`` (not ``.djx``)."""
-        comp_root = tmp_path / "shared_components"
-        comp_root.mkdir()
-        with override_settings(
-            NEXT_FRAMEWORK={
-                "PAGE_BACKENDS": [],
-                "COMPONENT_BACKENDS": [
-                    "not-a-dict",
-                    {
-                        "BACKEND": "next.components.FileComponentsBackend",
-                        "DIRS": [str(comp_root)],
-                        "COMPONENTS_DIR": "_components",
-                    },
-                ],
-            }
-        ):
-            next_framework_settings.reload()
-            specs = _iter_default_autoreload_watch_specs()
-        next_framework_settings.reload()
-        assert all(".djx" not in g for _, g in specs)
-        assert any(g == "**/component.py" and p == comp_root for p, g in specs)
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        first.mkdir()
+        second.mkdir()
+        apply_component_backends(
+            [file_components_entry(first), file_components_entry(second)]
+        )
+
+        specs = _iter_default_autoreload_watch_specs()
+
+        assert [p for p, glob in specs if glob == "**/component.py"] == [first, second]
+        assert all(".djx" not in glob for _, glob in specs)
 
     def test_iter_default_watches_component_py_under_each_page_root(
         self, tmp_path: Path
@@ -108,3 +108,12 @@ class TestServerAutoreloadWatchApi:
         for root in (custom.resolve(), pages_tree.resolve()):
             matches = [(p, g) for p, g in specs if p == root and g == expected_glob]
             assert len(matches) == 1
+
+
+class TestServerPublicSurface:
+    """Names the ``next.server`` package publishes."""
+
+    def test_exported_names_are_pinned(self) -> None:
+        """A dropped name coming back and a new one both have to be decided."""
+        assert set(next.server.__all__) == SERVER_EXPORTS
+        assert all(hasattr(next.server, name) for name in SERVER_EXPORTS)

--- a/tests/static/test_discovery.py
+++ b/tests/static/test_discovery.py
@@ -343,7 +343,10 @@ class TestAssetDiscoveryModuleListUrlRouting:
         assert collector.assets_in_slot("scripts") == []
 
     def test_url_with_mismatched_slot_is_dropped(
-        self, tmp_path: Path, file_backend: StaticBackend
+        self,
+        tmp_path: Path,
+        file_backend: StaticBackend,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         page_dir = tmp_path / "mismatch"
         page_dir.mkdir()
@@ -354,9 +357,18 @@ class TestAssetDiscoveryModuleListUrlRouting:
         discovery = AssetDiscovery(provider)
 
         collector = StaticCollector()
-        discovery.discover_page_assets(page_path, collector)
+        with caplog.at_level("DEBUG", logger="next.static.discovery"):
+            discovery.discover_page_assets(page_path, collector)
         assert collector.assets_in_slot("scripts") == []
         assert collector.assets_in_slot("styles") == []
+
+        message = next(
+            r.getMessage() for r in caplog.records if "styling.css" in r.getMessage()
+        )
+        assert message == (
+            "Module URL 'https://cdn.example.com/styling.css' maps to kind 'css' "
+            "in slot 'styles', so the 'scripts' list dropped it"
+        )
 
 
 class TestAssetDiscoveryComponents:

--- a/tests/support/backends.py
+++ b/tests/support/backends.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any, ClassVar
 
 from django.core.exceptions import ImproperlyConfigured
@@ -89,3 +90,15 @@ COUNTING = f"{__name__}.CountingBackend"
 CONCRETE = f"{__name__}.ConcreteFakeBackend"
 NOT_A_CLASS = f"{__name__}.not_a_class"
 MISSING = f"{__name__}.NoSuchBackend"
+
+
+FILE_COMPONENTS_BACKEND = "next.components.FileComponentsBackend"
+
+
+def file_components_entry(*dirs: Path) -> dict[str, Any]:
+    """Build one ``COMPONENT_BACKENDS`` entry listing the given directories."""
+    return {
+        "BACKEND": FILE_COMPONENTS_BACKEND,
+        "DIRS": [str(p) for p in dirs],
+        "COMPONENTS_DIR": "_components",
+    }

--- a/tests/support/components.py
+++ b/tests/support/components.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from next.components import ComponentContextManager, ComponentInfo
+
+
+def build_composite_component(
+    root: Path, *, name: str = "card", template: str = "<div>{{ title }}</div>"
+) -> tuple[ComponentContextManager, ComponentInfo, Path]:
+    """Write a composite component under `root` and pair it with a fresh registry.
+
+    The manager is per call, so a test registers context functions without
+    touching the process-wide one.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    module_path = (root / "component.py").resolve()
+    module_path.write_text("# empty\n")
+    template_path = root / "component.djx"
+    template_path.write_text(template)
+    info = ComponentInfo(
+        name=name,
+        scope_root=root,
+        scope_relative="",
+        template_path=template_path,
+        module_path=module_path,
+        is_simple=False,
+    )
+    return ComponentContextManager(), info, module_path

--- a/tests/support/components.py
+++ b/tests/support/components.py
@@ -8,8 +8,7 @@ def build_composite_component(
 ) -> tuple[ComponentContextManager, ComponentInfo, Path]:
     """Write a composite component under `root` and pair it with a fresh registry.
 
-    The manager is per call, so a test registers context functions without
-    touching the process-wide one.
+    The manager is per call, so a test registers context functions of its own.
     """
     root.mkdir(parents=True, exist_ok=True)
     module_path = (root / "component.py").resolve()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -142,8 +142,8 @@ class TestLoadBackends:
         [("type", TypeError), ("value", ValueError), ("import", ImportError)],
     )
     def test_other_errors_from_construction_escape(self, kind, error) -> None:
-        # a constructor failing for anything but its own config is a bug,
-        # not an entry to skip
+        # a constructor failing for anything but its own config is a bug
+        # rather than an entry to skip
         with pytest.raises(error, match="boom"):
             load_backends(
                 [{"BACKEND": RAISING, "ERROR": kind}, {"BACKEND": ALPHA}],

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -11,6 +11,8 @@ from next.backends import (
     load_backends,
     resolve_backend_class,
 )
+from next.conf import next_framework_settings
+from next.conf.frozen import FrozenDict, FrozenList
 from tests.support.backends import (
     ALPHA,
     BETA,
@@ -413,3 +415,27 @@ class TestFamilyShapes:
             pytest.raises(ImproperlyConfigured, match="under BACKEND"),
         ):
             _manager(setting).get()
+
+
+class TestFrozenMergedValuesAreReadUnchanged:
+    """The loaders read the frozen merged settings through the same guards."""
+
+    def test_backend_entries_keeps_its_list_and_dict_guards(self) -> None:
+        entries = [{"BACKEND": ALPHA}, "not-an-entry"]
+        with override_settings(NEXT_FRAMEWORK={_LIST_SETTING: entries}):
+            selected = backend_entries(_LIST_SETTING)
+            assert isinstance(next_framework_settings.PARTIAL_BACKENDS, FrozenList)
+            assert selected == [{"BACKEND": ALPHA}]
+            assert isinstance(selected[0], FrozenDict)
+
+    @pytest.mark.parametrize(("setting", "shape"), _FAMILY_SHAPES)
+    def test_selected_entry_stays_frozen_all_the_way_to_the_backend(
+        self, setting, shape
+    ) -> None:
+        entry = {"BACKEND": ALPHA, "OPTIONS": {"flag": True}}
+        with override_settings(NEXT_FRAMEWORK={setting: shape(entry)}):
+            config = _manager(setting).get().config
+            assert config == entry
+            assert isinstance(config, FrozenDict)
+            with pytest.raises(TypeError, match="immutable"):
+                config["OPTIONS"]["flag"] = False

--- a/tests/testing/test_rendering.py
+++ b/tests/testing/test_rendering.py
@@ -101,3 +101,47 @@ class TestRenderComponentByName:
             )
         assert f"[{module_path}]" in html
         assert "caller-anchor" not in html
+
+
+class TestRenderComponentByNamePropGuard:
+    """The caller's context keys stand in for props, as a tag call site would."""
+
+    @staticmethod
+    def _composite(tmp_path: Path, returned: str) -> ComponentInfo:
+        """Build a composite component whose keyless context returns `returned`."""
+        (tmp_path / "component.djx").write_text(
+            "<div>title={{ title }} hint={{ hint }}</div>"
+        )
+        (tmp_path / "component.py").write_text(
+            "from next.components import component\n\n\n"
+            "@component.context\n"
+            "def extra():\n"
+            f"    return {returned}\n"
+        )
+        return ComponentInfo(
+            name="card",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=tmp_path / "component.djx",
+            module_path=(tmp_path / "component.py").resolve(),
+            is_simple=False,
+        )
+
+    def test_caller_context_key_raises(self, tmp_path: Path) -> None:
+        info = self._composite(tmp_path, '{"title": "from context"}')
+        with (
+            patch.object(components_manager, "get_component", return_value=info),
+            pytest.raises(ValueError, match="context returns 'title'"),
+        ):
+            render_component_by_name(
+                "card", at=tmp_path / "page.djx", context={"title": "from caller"}
+            )
+
+    def test_unrelated_key_merges(self, tmp_path: Path) -> None:
+        info = self._composite(tmp_path, '{"hint": "merged"}')
+        with patch.object(components_manager, "get_component", return_value=info):
+            html = render_component_by_name(
+                "card", at=tmp_path / "page.djx", context={"title": "from caller"}
+            )
+        assert "title=from caller" in html
+        assert "hint=merged" in html

--- a/tests/testing/test_rendering.py
+++ b/tests/testing/test_rendering.py
@@ -104,7 +104,7 @@ class TestRenderComponentByName:
 
 
 class TestRenderComponentByNamePropGuard:
-    """The caller's context keys stand in for props, as a tag call site would."""
+    """`props` stands in for a tag call site, `context` for the page scope."""
 
     @staticmethod
     def _composite(tmp_path: Path, returned: str) -> ComponentInfo:
@@ -127,21 +127,32 @@ class TestRenderComponentByNamePropGuard:
             is_simple=False,
         )
 
-    def test_caller_context_key_raises(self, tmp_path: Path) -> None:
+    def test_caller_prop_raises(self, tmp_path: Path) -> None:
         info = self._composite(tmp_path, '{"title": "from context"}')
         with (
             patch.object(components_manager, "get_component", return_value=info),
             pytest.raises(ValueError, match="context returns 'title'"),
         ):
             render_component_by_name(
-                "card", at=tmp_path / "page.djx", context={"title": "from caller"}
+                "card", at=tmp_path / "page.djx", props={"title": "from caller"}
             )
 
-    def test_unrelated_key_merges(self, tmp_path: Path) -> None:
+    def test_ambient_context_key_is_shadowed(self, tmp_path: Path) -> None:
+        info = self._composite(tmp_path, '{"title": "from context"}')
+        with patch.object(components_manager, "get_component", return_value=info):
+            html = render_component_by_name(
+                "card", at=tmp_path / "page.djx", context={"title": "from page"}
+            )
+        assert "title=from context" in html
+
+    def test_props_win_over_ambient_context(self, tmp_path: Path) -> None:
         info = self._composite(tmp_path, '{"hint": "merged"}')
         with patch.object(components_manager, "get_component", return_value=info):
             html = render_component_by_name(
-                "card", at=tmp_path / "page.djx", context={"title": "from caller"}
+                "card",
+                at=tmp_path / "page.djx",
+                context={"title": "from page"},
+                props={"title": "from caller"},
             )
         assert "title=from caller" in html
         assert "hint=merged" in html


### PR DESCRIPTION
## Description

Five bugs across `conf`, `components`, `static` and `server`, each of them a case of the framework quietly doing the wrong thing instead of saying so.

**conf — merged settings are immutable.** `next_framework_settings.PAGE_BACKENDS` handed out a live reference into the attribute cache, so `append(...)` or `PAGE_BACKENDS[0]["PAGES_DIR"] = ...` corrupted what every other reader saw until the next `reload()`. The merge is now frozen once while it is built, through `list` and `dict` subclasses that reject mutating calls. Readers keep seeing plain `list` and `dict`, so `isinstance` guards across the framework needed no sweep, and equality, `json.dumps`, `copy`, `deepcopy` and `pickle` keep working. The alternative of `MappingProxyType` and `tuple` was implemented in full before being dropped: it touched 21 files in `next/`, broke five existing test equalities, and killed `deepcopy`, `pickle` and `json.dumps` on settings values. The read path is untouched at 94.6 ns, and the cold merge drops from 22.9 to 17.2 microseconds because one freeze pass replaces `copy.deepcopy`.

**components — keyless context collisions.** A bare `@component.context` merged its dict with no checks, so it could overwrite props, `_static_collector` (breaking JS collection), the form-action anchor and slot content, all without a word. It now raises `ValueError` naming the component and the offending keys. The guard domain is deliberately narrow: props of the rendering call site plus the reserved render keys, so shadowing a page context key inherited through the template scope stays legal and a keyed `@component.context` remains a deliberate override. The component tag, the form widget and the testing helper each publish the names they pass, so the guard covers every render path the framework drives.

**static — slot mismatch log.** The debug line printed the list slot into both slot placeholders, so the slot a kind actually belongs to was never visible. It now names the kind slot next to the list that dropped the URL.

**server — settings parsing and a dead protocol.** The watcher and the linking roots read `COMPONENT_BACKENDS` through the existing `backend_entries` helper instead of repeating the parsing, so no new public name was added. `FilesystemWatchContributor` is removed together with the prose that documented it: it had zero implementations and zero calls anywhere in the package.

**Breaking changes for the 0.x line**

- Mutating a merged settings value raises `TypeError` at the mutation site instead of silently corrupting the cache.
- A self-referential `NEXT_FRAMEWORK` raises `ImproperlyConfigured`, where `copy.deepcopy` used to survive it.
- A colliding keyless component context raises `ValueError`, and the failure leaves the render rather than degrading to an empty string, so it is not gated by `STRICT_LOADING` or `DEBUG`.
- `next.server` no longer exports `FilesystemWatchContributor`, which was `runtime_checkable` and could be relied on in `isinstance` checks, not only in annotations.

**Known limits, stated on purpose**

- The immutability guard is an accident barrier, not a security boundary: an unbound `list.append(value, item)` still reaches the container.
- Values that are neither `list` nor `dict`, such as a set inside `OPTIONS`, are copied rather than frozen, so they stay editable. The docs say so.
- The collision guard is call-site dependent: `{% component "card" title=x %}` raises where `{% component "card" %}` with the same component merges quietly. A direct `render_component` call from user code publishes no props, so only the reserved keys are guarded there.
- `next/pages/registry.py` carries the same keyless override and is deliberately left alone, since extending the guard to pages is a separate decision about framework-wide consistency.
- A full `pickle.loads` round trip is not covered, because ruff `S301` forbids it in tests and no suppression was added. The `__reduce__` contract is held by five tests through `copy` and `deepcopy` instead.

`make docs-clean` also now removes `docs/_build` entirely, since the old glob left the doctree cache behind and forced rebuilds with `-a -E`.

## How to test

`make ci` passes locally. Beyond it: `make test` is 3728 passed with 100% coverage on `next/`, `make docs` builds clean with `-W`, and `make bench` was run as a paired comparison against `main` on a quiet machine with no gate trip. Read-path parity is 94.6 ns against 100.8 ns on base, `test_merge_cold` improves from 22.9 to 17.2 microseconds, `test_reload_cycle` from 68.3 to 52.1, and the new `components.render` group carries both an end-to-end render case and a case that measures the guard itself at 438 ns.

## Related issues

<!-- e.g. Fixes #123 / Closes #456 -->

## Checklist

- [x] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [ ] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable
