### PR TITLE
perf(components): cache compiled templates and memoise render lookups

### DIFF
--- a/docs/content/internals/autoreload.rst
+++ b/docs/content/internals/autoreload.rst
@@ -121,8 +121,8 @@ The route set diff is taken by ``NextStatReloader`` from the configured page roo
 A custom router that builds routes from another source rebuilds them through ``router_manager.reload``, which is the public API covered in :doc:`/content/howto/reload-routes-from-code`.
 
 A ``.djx`` edit triggers neither path.
-Templates are re-read on render and their cached compilation is invalidated by source mtime inside the page and component layers.
-A saved edit shows up on the next request without a process restart.
+Templates are re-read on render, and under ``DEBUG`` the page and component layers invalidate their cached compilation against the source mtime.
+A saved edit shows up on the next request without a process restart, while a production process holds the compilation for its whole life.
 
 Signals
 -------

--- a/docs/content/internals/autoreload.rst
+++ b/docs/content/internals/autoreload.rst
@@ -122,7 +122,7 @@ A custom router that builds routes from another source rebuilds them through ``r
 
 A ``.djx`` edit triggers neither path.
 Templates are re-read on render, and under ``DEBUG`` the page and component layers invalidate their cached compilation against the source mtime.
-A saved edit shows up on the next request without a process restart, while a production process holds the compilation for its whole life.
+A saved edit shows up on the next request without a process restart, while with ``DEBUG`` off it takes one.
 
 Signals
 -------

--- a/docs/content/internals/component-pipeline.rst
+++ b/docs/content/internals/component-pipeline.rst
@@ -76,7 +76,7 @@ Modules
 ``next.components.manager``.
    ``ComponentsManager`` orchestrates the backends, shares one render pipeline between them, and builds the list with the shared ``load_backends`` helper.
    A ``settings_reloaded`` drops the cached backends, and the next access rebuilds them.
-   A Django ``TEMPLATES`` change drops the render pipeline the same way, because a compiled component template carries the engine that built it and would otherwise outlive the settings it was built under.
+   A Django ``TEMPLATES`` change drops the render pipeline the same way, because a compiled component template carries the engine that built it.
    ``next.components.watch`` resolves the same entries with ``resolve_backend_class`` and never instantiates them, because its scan is read-only.
 
 ``next.components.checks``.

--- a/docs/content/internals/component-pipeline.rst
+++ b/docs/content/internals/component-pipeline.rst
@@ -56,6 +56,7 @@ Modules
    ``ComponentRenderStrategy`` plus the simple and composite implementations.
    ``ComponentTemplateLoader`` reads the template body and compiles it on every render.
    ``CachedComponentTemplateLoader``, the loader the manager wires in, keeps that compilation and revalidates it against the mtime of the file the body came from, so a repeated render costs one ``stat`` under ``DEBUG`` and nothing at all in production.
+   The mtime is read before the body is, so a save that lands between the two reaches the next render rather than being filed under the text it replaced.
 
 ``next.components.facade``.
    Short helpers used from templates, including ``get_component``, ``load_component_template``, ``render_component``.
@@ -75,6 +76,7 @@ Modules
 ``next.components.manager``.
    ``ComponentsManager`` orchestrates the backends, shares one render pipeline between them, and builds the list with the shared ``load_backends`` helper.
    A ``settings_reloaded`` drops the cached backends, and the next access rebuilds them.
+   A Django ``TEMPLATES`` change drops the render pipeline the same way, because a compiled component template carries the engine that built it and would otherwise outlive the settings it was built under.
    ``next.components.watch`` resolves the same entries with ``resolve_backend_class`` and never instantiates them, because its scan is read-only.
 
 ``next.components.checks``.

--- a/docs/content/internals/component-pipeline.rst
+++ b/docs/content/internals/component-pipeline.rst
@@ -54,7 +54,8 @@ Modules
 
 ``next.components.renderers``.
    ``ComponentRenderStrategy`` plus the simple and composite implementations.
-   ``ComponentTemplateLoader`` reads the template body.
+   ``ComponentTemplateLoader`` reads the template body and compiles it on every render.
+   ``CachedComponentTemplateLoader``, the loader the manager wires in, keeps that compilation and revalidates it against the mtime of the file the body came from, so a repeated render costs one ``stat`` under ``DEBUG`` and nothing at all in production.
 
 ``next.components.facade``.
    Short helpers used from templates, including ``get_component``, ``load_component_template``, ``render_component``.

--- a/docs/content/internals/overview.rst
+++ b/docs/content/internals/overview.rst
@@ -181,7 +181,7 @@ The set of submodules differs by area, and :doc:`adding-an-area` states the cont
      - A single flat module holding the protocols and slots one subsystem calls another through.
        ``PartialShaper`` and ``partial_shaper_slot`` let the page and form paths shape partial responses without importing ``next.partial``.
    * - ``next.utils``
-     - A single flat module holding the path helpers, the ``PageRoot`` value object, and the declaration-site attribution that several subsystems share.
+     - A single flat module holding the path helpers, the ``PageRoot`` value object, the ``template_edits_watched`` predicate, and the declaration-site attribution that several subsystems share.
    * - ``next.signals``
      - A single flat module that re-exports every signal its owning subpackage declares, for a receiver that subscribes across subsystems.
    * - ``next.checks``

--- a/docs/content/internals/page-discovery.rst
+++ b/docs/content/internals/page-discovery.rst
@@ -100,7 +100,7 @@ A page whose body comes from ``render()`` resolves that body per request and cac
    No dynamic body enters the composed-source registry.
    Its own snapshot lives in ``_skeleton_source_mtimes``, so an eviction on the composed side never reads as freshness here.
 
-The snapshot is taken on every composition, and only the check reading it is gated on ``DEBUG`` through ``template_edits_watched``, read per call so an override takes effect at once and sees the sources of a composition built before it.
+The snapshot is taken on every composition, and only the check reading it is gated on ``DEBUG`` through ``next.utils.template_edits_watched``, read per call so an override takes effect at once and sees the sources of a composition built before it.
 The dev watcher deliberately ignores ``.djx``, so under ``DEBUG`` this is the only mechanism that makes a template edit visible without a restart, and with ``DEBUG`` off a warm read performs no stat and holds the composition for the life of the process.
 
 On each cache read ``_is_template_stale`` compares the current mtimes against the snapshot.

--- a/docs/content/ref/components.rst
+++ b/docs/content/ref/components.rst
@@ -101,8 +101,12 @@ Renderers
 .. autoclass:: next.components.ComponentTemplateLoader
    :members:
 
-``ComponentsManager`` wires a single ``ComponentTemplateLoader`` into its render pipeline.
-The loader is fixed and not pluggable, so a custom backend reads component template bodies through this class rather than substituting its own.
+.. autoclass:: next.components.CachedComponentTemplateLoader
+   :members:
+
+``ComponentsManager`` wires one ``CachedComponentTemplateLoader`` into its render pipeline, and the loader is fixed rather than configurable.
+It keeps the compiled ``Template`` of each component and revalidates it against the mtime of the file the body was read from, so a repeated render pays neither the read nor the parse.
+A component backend reads template bodies through that shared loader rather than substituting its own.
 
 Internal infrastructure
 -----------------------

--- a/docs/content/ref/components.rst
+++ b/docs/content/ref/components.rst
@@ -105,9 +105,10 @@ Renderers
    :members:
 
 ``ComponentsManager`` wires one ``CachedComponentTemplateLoader`` into its render pipeline, and the loader is fixed rather than configurable.
-It keeps the compiled ``Template`` of each component and revalidates it against the mtime of the file the body was read from, so a repeated render pays neither the read nor the parse.
-That mtime is taken before the body is read, so a save landing between the two expires the entry instead of hiding behind it.
-The cache holds the same 2048 entries the other path-keyed component caches do, and a ``TEMPLATES`` change drops it whole, because a compiled ``Template`` carries the engine that built it.
+It keeps the compiled ``Template`` of each component, so a repeated render pays neither the read nor the parse.
+Under ``DEBUG`` the entry is revalidated against the mtime of the file the body was read from, and an edit reaches the next render.
+With ``DEBUG`` off nothing stats that file, and the compilation stands until eviction drops it.
+The cache is bounded at 2048 compiled templates, the bound the visibility resolver also uses, and a ``TEMPLATES`` change drops it whole, because a compiled ``Template`` carries the engine that built it.
 A component backend reads template bodies through that shared loader rather than substituting its own.
 
 Internal infrastructure

--- a/docs/content/ref/components.rst
+++ b/docs/content/ref/components.rst
@@ -106,6 +106,8 @@ Renderers
 
 ``ComponentsManager`` wires one ``CachedComponentTemplateLoader`` into its render pipeline, and the loader is fixed rather than configurable.
 It keeps the compiled ``Template`` of each component and revalidates it against the mtime of the file the body was read from, so a repeated render pays neither the read nor the parse.
+That mtime is taken before the body is read, so a save landing between the two expires the entry instead of hiding behind it.
+The cache holds the same 2048 entries the other path-keyed component caches do, and a ``TEMPLATES`` change drops it whole, because a compiled ``Template`` carries the engine that built it.
 A component backend reads template bodies through that shared loader rather than substituting its own.
 
 Internal infrastructure

--- a/docs/content/ref/server.rst
+++ b/docs/content/ref/server.rst
@@ -20,7 +20,7 @@ In addition to watching ``.py`` mtimes, it diffs the discovered route set on eve
 A per-tree signature of directory mtimes and directory count gates the rescan, so an unchanged tree reuses the cached route set.
 A reload triggers when pages appear or disappear from the routing tree, even when no file mtime changed.
 ``.djx`` templates are not watched.
-They are re-read on render with mtime-based invalidation.
+They are re-read on render with mtime-based invalidation under ``DEBUG``.
 
 .. automodule:: next.server.autoreload
    :members:

--- a/docs/content/ref/utils.rst
+++ b/docs/content/ref/utils.rst
@@ -11,7 +11,7 @@ The rest of the module is framework machinery and is excluded from the listing b
 It backs decorator registration, attributing a decorated object to the file where it was declared, naming it for diagnostics, and collecting the registrations that landed on another file.
 It also holds ``walk_page_tree``, the depth-first page-tree walk the file router and the system checks both run, and ``page_roots_shape_error``, the shared shape probe a check runs over what a router reports.
 Both live here for the same reason ``PageRoot`` does.
-``template_edits_watched`` is here for the same reason, the ``DEBUG`` predicate the page, component, and static caches read before they stat anything.
+The ``DEBUG`` predicate ``template_edits_watched``, which the page, component, and static caches read before they stat anything, is here for the same reason.
 
 ``resolve_base_dir`` returns ``settings.BASE_DIR`` coerced to ``pathlib.Path``, or ``None`` when it is unset, for backends that resolve project-relative paths.
 ``classify_dirs_entries`` splits a backend ``DIRS`` list into existing directory roots and plain skip-name segments, the same split the file router applies.

--- a/docs/content/ref/utils.rst
+++ b/docs/content/ref/utils.rst
@@ -11,6 +11,7 @@ The rest of the module is framework machinery and is excluded from the listing b
 It backs decorator registration, attributing a decorated object to the file where it was declared, naming it for diagnostics, and collecting the registrations that landed on another file.
 It also holds ``walk_page_tree``, the depth-first page-tree walk the file router and the system checks both run, and ``page_roots_shape_error``, the shared shape probe a check runs over what a router reports.
 Both live here for the same reason ``PageRoot`` does.
+``template_edits_watched`` is here for the same reason, the ``DEBUG`` predicate the page, component, and static caches read before they stat anything.
 
 ``resolve_base_dir`` returns ``settings.BASE_DIR`` coerced to ``pathlib.Path``, or ``None`` when it is unset, for backends that resolve project-relative paths.
 ``classify_dirs_entries`` splits a backend ``DIRS`` list into existing directory roots and plain skip-name segments, the same split the file router applies.
@@ -22,7 +23,7 @@ Public API
 
 .. automodule:: next.utils
    :members:
-   :exclude-members: _classify_one_dir_entry, callable_name, defining_file, walk_page_tree, page_roots_shape_error, MisattributedContext, MisattributionLog
+   :exclude-members: _classify_one_dir_entry, callable_name, defining_file, walk_page_tree, page_roots_shape_error, template_edits_watched, MisattributedContext, MisattributionLog
 
 See also
 --------

--- a/docs/content/topics/components.rst
+++ b/docs/content/topics/components.rst
@@ -181,6 +181,11 @@ The component template renders ``{{ children }}`` to splice the content in.
 
 The ``card`` template renders this content wherever it places ``{{ children }}``.
 
+The markup is spliced in as written, exactly like slot content.
+Free children are finished HTML by the time the component runs, so escaping them a second time would only print the tags.
+The calling template, not the component, decides what happens to a variable inside that markup, so a caller that turns escaping off with ``{% autoescape off %}`` hands the component whatever the block produced.
+Values that arrive as props are a separate channel and stay autoescaped, so untrusted text belongs in a prop rather than in the child markup.
+
 .. _components-multiline-tags:
 
 Multiline tags

--- a/docs/content/topics/testing.rst
+++ b/docs/content/topics/testing.rst
@@ -81,6 +81,9 @@ The table below maps each testing goal to the helper and its import path.
    * - Drop the page template cache after rewriting template files on disk
      - ``reset_page_cache``
      - ``next.testing`` or ``next.testing.isolation``
+   * - Drop the compiled component templates after rewriting a component on disk
+     - ``reset_component_templates``
+     - ``next.testing`` or ``next.testing.isolation``
    * - Clear the form registries, diagnostics, and wizard backend
      - ``reset_form_registration_state``
      - ``next.testing`` or ``next.testing.isolation``
@@ -194,6 +197,10 @@ A third helper, ``reset_page_cache()``, resets no registry.
 It calls ``Page.clear_template_caches`` to drop the composed page template.
 The test environment runs with ``DEBUG`` off, and the composition cache stats its sources only under ``DEBUG``, so a template rewritten inside one process still renders from the composition built before the rewrite.
 Call ``reset_page_cache()`` after any such rewrite, or wrap the test in ``override_settings(DEBUG=True)`` to put the mtime check back on, which works on a composition built before the override because the snapshot it reads is taken either way.
+
+``reset_component_templates()`` is the component-side twin of that helper.
+It calls ``ComponentsManager.clear_template_caches`` to drop the compiled template of every component.
+A test that rewrites a ``.djx`` file or a ``component`` string in place needs that for the same reason.
 
 For tests that probe registration itself, ``reset_form_registration_state()`` clears every form registry, the registration diagnostics buffer, and resets the wizard backend in one call.
 

--- a/examples/_shared/_components/container.djx
+++ b/examples/_shared/_components/container.djx
@@ -1,1 +1,1 @@
-<div class="mx-auto w-full max-w-container px-4 {{ extra }}">{{ children|default:'' }}</div>
+<div class="mx-auto w-full max-w-container px-4 {{ extra }}">{{ children }}</div>

--- a/examples/admin/shadcn_admin/forms.py
+++ b/examples/admin/shadcn_admin/forms.py
@@ -283,12 +283,11 @@ class AdminInlineSpec:
 def _build_form_class(spec: AdminFormSpec) -> type[django_forms.Form]:
     """Wrap `ModelAdmin.get_form` so inline-formset errors surface on the main form.
 
-    `AdminForm.clean()` builds the inline formsets a second time bound to
-    the same POST data, calls `is_valid()` on each, and raises
-    `ValidationError` if any inline row is broken. The dispatcher catches
-    that through `form.is_valid() == False` and re-renders the origin page
-    — `form_state` then rebuilds the formsets and shows the errors next to
-    the bad rows.
+    `AdminForm.clean()` builds the inline formsets a second time bound to the
+    same POST data, calls `is_valid()` on each, and raises `ValidationError`
+    if any inline row is broken. The dispatcher catches that through
+    `form.is_valid() == False` and re-renders the origin page — `form_state`
+    then rebuilds the formsets and shows the errors next to the bad rows.
     """
     base = spec.model_admin.get_form(spec.request, spec.instance, change=spec.is_change)
 
@@ -414,9 +413,8 @@ def admin_inline_add_form_factory(
 def _render_inline_row(inline: AdminInlineSpec, obj: Model) -> str:
     """Render one clean keyed inline row form for a replace patch.
 
-    The change template path travels as `current_template_path` so the
-    `inline_row` component resolves the same way the change view render
-    does.
+    The change template path travels as `current_template_path` so the `inline_row`
+    component resolves the same way the change view render does.
     """
     row = inline._row(obj, None)
     return _ROW_TEMPLATE.render(
@@ -485,11 +483,10 @@ def handle_inline_add(
 ) -> HttpResponse:
     """Create one inline row and open its own editor in a result layer.
 
-    A live runtime opens the new row's standalone change view `record` zone
-    in a result layer, so the client fetches that zone and morphs the editor
-    into the modal for immediate detail edits, then refreshes the parent's
-    row-count badge in place. Without the runtime the builder falls back to
-    the parent change view.
+    A live runtime opens the new row's standalone change view `record` zone in a result
+    layer, so the client fetches that zone and morphs the editor into the modal for
+    immediate detail edits, then refreshes the parent's row-count badge in place.
+    Without the runtime the builder falls back to the parent change view.
     """
     inline = AdminInlineSpec.for_request(spec)
     if not inline.has_add_permission():

--- a/examples/kanban/kanban/backends.py
+++ b/examples/kanban/kanban/backends.py
@@ -20,12 +20,11 @@ logger = logging.getLogger(__name__)
 class ViteManifestBackend(StaticFilesBackend):
     """Dev/prod-aware backend for Vite-bundled co-located JSX assets.
 
-    With DEV_ORIGIN set, jsx assets resolve to the Vite dev server so
-    HMR works. Without DEV_ORIGIN, the Vite manifest is read to find
-    hashed built output and URL resolution is delegated to Django
-    staticfiles. Rendering is handled by the framework built-in
-    `render_module_tag` because jsx is registered under the `module`
-    renderer in `apps.py`.
+    With DEV_ORIGIN set, jsx assets resolve to the Vite dev server so HMR
+    works. Without DEV_ORIGIN, the Vite manifest is read to find hashed
+    built output and URL resolution is delegated to Django staticfiles.
+    Rendering is handled by the framework built-in `render_module_tag`
+    because jsx is registered under the `module` renderer in `apps.py`.
     """
 
     def __init__(self, config: Mapping[str, Any] | None = None) -> None:

--- a/examples/kanban/kanban/boards/board/[int:id]/page.py
+++ b/examples/kanban/kanban/boards/board/[int:id]/page.py
@@ -18,9 +18,8 @@ def board_object(active_board: DBoard[Board]) -> Board:
 def board_url_kwargs(active_board: DBoard[Board]) -> dict[str, int]:
     """Expose the reverse() kwargs for the current board route.
 
-    Shared by the nav_link calls in the board layout so the tabs link
-    back to themselves using `url_name` without hard-coding the URL
-    converter on the call site.
+    Shared by the nav_link calls in the board layout so the tabs link back to themselves
+    using `url_name` without hard-coding the URL converter on the call site.
     """
     return {"id": active_board.pk}
 

--- a/examples/kanban/kanban/signals.py
+++ b/examples/kanban/kanban/signals.py
@@ -24,14 +24,12 @@ def _dev_origin() -> str:
 def inject_vite_dev_assets(sender: object, **kwargs) -> None:
     """Prepend the React Refresh preamble and the Vite HMR client.
 
-    Both assets are added as URL-form module scripts because the
-    collector force-appends inline assets, and `@vitejs/plugin-react`
-    requires the preamble to execute before any jsx module loads. The
-    preamble JS is base64-encoded into a `data:` URL so it stays a
-    single self-contained module script tag. The receiver only fires on
-    pages that actually carry jsx scripts so the index page stays free
-    of Vite dev plumbing, and only while the backend points jsx at a
-    dev server.
+    Both assets are added as URL-form module scripts because the collector force-appends
+    inline assets, and `@vitejs/plugin-react` requires the preamble to execute before
+    any jsx module loads. The preamble JS is base64-encoded into a `data:` URL so it
+    stays a single self-contained module script tag. The receiver only fires on pages
+    that actually carry jsx scripts so the index page stays free of Vite dev plumbing,
+    and only while the backend points jsx at a dev server.
     """
     origin = _dev_origin()
     if not origin or not _has_module_assets(sender):

--- a/examples/live-polls/polls/broker.py
+++ b/examples/live-polls/polls/broker.py
@@ -98,16 +98,14 @@ class PollBroker:
     def changes(self, poll_id: int) -> Iterator[Change]:
         """Yield a `Change` for every poll mutation while the client stays open.
 
-        Each subscriber tracks its own `last_revision` so every wake
-        reads the same snapshot exactly once and no event is lost when
-        several tabs subscribe at once. A wake timeout loops without
-        yielding, the sync source under WSGI sending no keepalive,
-        which is the documented limitation the framework stream notes.
+        Each subscriber tracks its own `last_revision` so every wake reads the same
+        snapshot exactly once and no event is lost when several tabs subscribe at once.
+        A wake timeout loops without yielding, the sync source under WSGI sending no
+        keepalive, which is the documented limitation the framework stream notes.
 
-        On client disconnect the generator receives `GeneratorExit` and
-        stops looping. No per-subscriber bookkeeping needs unwinding
-        because the per-poll condition and revision counter are shared
-        state.
+        On client disconnect the generator receives `GeneratorExit` and stops looping.
+        No per-subscriber bookkeeping needs unwinding because the per-poll condition and
+        revision counter are shared state.
         """
         condition = self._conditions[poll_id]
         last_revision = self._revisions[poll_id]

--- a/examples/live-polls/polls/screens/polls/[int:id]/stream/page.py
+++ b/examples/live-polls/polls/screens/polls/[int:id]/stream/page.py
@@ -12,11 +12,10 @@ def patch_source(request: HttpRequest, poll_id: int) -> Iterator[Patches]:
     """Yield one refresh envelope for every poll change.
 
     The `refresh` invalidates the `poll-results` zone so every open tab
-    re-fetches it with its own cookies through the page view, no foreign
-    HTML travels on the stream and authorization is re-checked per
-    subscriber. The change's request id rides as the envelope echo so the
-    voter's own tab drops the fan-out, its own response already carried
-    the fresh zone.
+    re-fetches it with its own cookies through the page view, no foreign HTML
+    travels on the stream and authorization is re-checked per subscriber.
+    The change's request id rides as the envelope echo so the voter's own
+    tab drops the fan-out, its own response already carried the fresh zone.
     """
     for change in broker.changes(poll_id):
         yield Patches(request, echo_of=change.request_id).refresh(zone="poll-results")
@@ -25,11 +24,10 @@ def patch_source(request: HttpRequest, poll_id: int) -> Iterator[Patches]:
 def render(request: HttpRequest, poll: DPoll[Poll]) -> PatchEventStream:
     """Open the patch event stream for one poll.
 
-    The framework escape hatch returns this response verbatim, no
-    layout, no static collector, no template. The source is sync so the
-    stream sends no heartbeat, a documented limitation under WSGI. An
-    ASGI deployment swaps the broker wake primitive for an async one and
-    passes an async source for heartbeat support without touching this
-    page.
+    The framework escape hatch returns this response verbatim, no layout,
+    no static collector, no template. The source is sync so the stream
+    sends no heartbeat, a documented limitation under WSGI. An ASGI
+    deployment swaps the broker wake primitive for an async one and passes
+    an async source for heartbeat support without touching this page.
     """
     return PatchEventStream(request, patch_source(request, poll.pk))

--- a/examples/live-polls/polls/signals.py
+++ b/examples/live-polls/polls/signals.py
@@ -23,12 +23,11 @@ def broadcast_vote(
     """Publish a fresh snapshot for the poll that just received a vote.
 
     The receiver consumes the bound form the framework attaches to
-    `action_dispatched` to tell which poll changed without reissuing the
-    query, and the request to read the mutation's `X-Next-Request-Id`.
-    Threading that id to `broker.publish` lets the stream echo it so the
-    voter's own tab drops the fan-out update. Other payload fields are
-    absorbed by `**kwargs` because this listener needs only the form and
-    the request.
+    `action_dispatched` to tell which poll changed without reissuing the query,
+    and the request to read the mutation's `X-Next-Request-Id`. Threading
+    that id to `broker.publish` lets the stream echo it so the voter's
+    own tab drops the fan-out update. Other payload fields are absorbed by
+    `**kwargs` because this listener needs only the form and the request.
     """
     if action_name != VOTE_ACTION_NAME or form is None:
         return
@@ -48,11 +47,9 @@ def _has_module_assets(collector: StaticCollector) -> bool:
 def inject_vite_dev_client(sender: StaticCollector, **kwargs) -> None:
     """Prepend the Vite dev client so HMR can attach on pages with Vue assets.
 
-    Vue does not need a React Refresh preamble. The single
-    `@vite/client` module script is enough for HMR through
-    `@vitejs/plugin-vue`. The receiver fires only on pages that
-    already carry `vue` scripts so plain Django pages stay free of
-    dev plumbing.
+    Vue does not need a React Refresh preamble. The single `@vite/client` module script
+    is enough for HMR through `@vitejs/plugin-vue`. The receiver fires only on pages
+    that already carry `vue` scripts so plain Django pages stay free of dev plumbing.
     """
     if not _has_module_assets(sender):
         return

--- a/examples/live-polls/tests/test_e2e.py
+++ b/examples/live-polls/tests/test_e2e.py
@@ -96,10 +96,9 @@ def _consume_one_change(
 def primed_broker(poll: Poll) -> PollBroker:
     """Stand-alone broker with `poll`'s snapshot cached for change tests.
 
-    Tests use a local instance so revision counters do not leak across
-    cases. The cache is process-wide, so seeding through `store_snapshot`
-    is enough for a `changes` consumer to read the snapshot on its first
-    wake.
+    Tests use a local instance so revision counters do not leak across cases. The cache
+    is process-wide, so seeding through `store_snapshot` is enough for a `changes`
+    consumer to read the snapshot on its first wake.
     """
     store_snapshot(build_snapshot(poll))
     return PollBroker()
@@ -441,8 +440,7 @@ class TestBroadcastReceiver:
         The handler runs `UPDATE` only, so any wake of the SSE stream
         has to come from the `action_dispatched` receiver. Replacing
         `broker.publish` with a spy that delegates to the real method
-        keeps the cache state intact while making the call site
-        observable.
+        keeps the cache state intact while making the call site observable.
         """
         captured: list[Snapshot] = []
         real_publish = broker.publish
@@ -488,11 +486,10 @@ class TestStreamEndpoint:
     ) -> None:
         """The first byte frame is the retry hint, proving the page wires the stream.
 
-        Reading the leading frame off the actual streaming response is
-        the only way to verify the HTTP path end to end without blocking
-        on the broker condition. The frame is consumed in a `try/finally`
-        so the response closes even if the assertion fails before the
-        read.
+        Reading the leading frame off the actual streaming response is the only way to
+        verify the HTTP path end to end without blocking on the broker condition. The
+        frame is consumed in a `try/finally` so the response closes even if the
+        assertion fails before the read.
         """
         response = client.get(f"/polls/{poll.pk}/stream/")
         try:
@@ -581,10 +578,9 @@ class TestEchoThreading:
 class TestStreamPatchFrame:
     """A change over the open HTTP stream yields a refresh patch with the echo.
 
-    The poll is committed so the streaming response, consumed on a worker
-    thread, builds the envelope from its own database connection. The
-    refresh fan-out carries the change's request id so the initiator's
-    own tab drops the echo.
+    The poll is committed so the streaming response, consumed on a worker thread, builds
+    the envelope from its own database connection. The refresh fan-out carries the
+    change's request id so the initiator's own tab drops the echo.
     """
 
     def test_change_frame_carries_refresh_and_echo(self, client: NextClient) -> None:

--- a/examples/multi-tenant/README.md
+++ b/examples/multi-tenant/README.md
@@ -105,13 +105,15 @@ The `notes` Django app does not own its HTML shell. The root template lives unde
 "COMPONENT_BACKENDS": [
     {
         "BACKEND": "next.components.FileComponentsBackend",
-        "DIRS": [BASE_DIR / "root_blocks"],
+        "DIRS": [BASE_DIR / "root_blocks", SHARED_DIR / "_components"],
         "COMPONENTS_DIR": "_blocks",
     },
 ],
 ```
 
 This is the canonical way to share chrome across multiple Django apps. See [`docs/content/topics/project-layout.rst`](../../docs/content/topics/project-layout.rst) for the broader pattern.
+
+The `<main>` element in that layout delegates its width to the shared [`container`](../_shared/_components/container.djx) component. A wrapper with a single insertion point needs no named slot, so the layout calls it in block form. Everything between the opening and closing tag arrives as free children, which the component splices with `{{ children }}`. The `{% block template %}` of the page renders inside that call, so every page in the example lands in the same centred column.
 
 ### 4. Inherit context for the active tenant
 

--- a/examples/multi-tenant/config/urls.py
+++ b/examples/multi-tenant/config/urls.py
@@ -6,13 +6,12 @@ from django.urls import include, path, re_path
 def serve_tenant_static(request: HttpRequest, slug: str, path: str) -> HttpResponse:
     """Serve a co-located static asset under the per-tenant URL prefix.
 
-    The custom `TenantPrefixStaticBackend` rewrites every asset URL to
-    `/_t/<slug>/static/...` so a per-tenant CDN can cache them. In the
-    development server we still want the file to be served, so this
-    view forwards the request to Django's staticfiles serve view after
-    discarding the slug. A real deployment would point a CDN at
-    `STATIC_URL` and let the prefix decorate cache keys instead of
-    routing.
+    The custom `TenantPrefixStaticBackend` rewrites every asset URL
+    to `/_t/<slug>/static/...` so a per-tenant CDN can cache them.
+    In the development server we still want the file to be served, so
+    this view forwards the request to Django's staticfiles serve view
+    after discarding the slug. A real deployment would point a CDN at
+    `STATIC_URL` and let the prefix decorate cache keys instead of routing.
     """
     del slug
     return serve_static(request, path)

--- a/examples/multi-tenant/notes/context_processors.py
+++ b/examples/multi-tenant/notes/context_processors.py
@@ -12,10 +12,9 @@ if TYPE_CHECKING:
 def tenant_theme(request: HttpRequest) -> dict[str, object]:
     """Surface per-tenant CSS variables to every page template.
 
-    The middleware attaches the active `Tenant` to `request.tenant`.
-    On error pages where the middleware short-circuited, the attribute
-    is missing and we return an empty dict so templates can render
-    unbranded fallbacks.
+    The middleware attaches the active `Tenant` to `request.tenant`. On error pages
+    where the middleware short-circuited, the attribute is missing and we return an
+    empty dict so templates can render unbranded fallbacks.
     """
     tenant = get_active_tenant(request)
     if tenant is None:

--- a/examples/multi-tenant/root_pages/layout.djx
+++ b/examples/multi-tenant/root_pages/layout.djx
@@ -13,8 +13,10 @@
   <div class="accent-bar h-1 w-full"></div>
   {% component "header" %}
 
-  <main class="mx-auto w-full max-w-container flex-1 px-4 py-8">
-    {% block template %}{% endblock template %}
+  <main class="flex flex-1 flex-col">
+    {% #component "container" extra="flex-1 py-8" %}
+      {% block template %}{% endblock template %}
+    {% /component %}
   </main>
 
   {% component "footer" %}

--- a/examples/observability/tests/test_e2e.py
+++ b/examples/observability/tests/test_e2e.py
@@ -189,10 +189,9 @@ class TestWindowFilters:
 class TestJsxAssetPipeline:
     """`.jsx` files are emitted as `<script type="text/babel">` tags.
 
-    The overview page mounts the React sparkline through the custom
-    `BabelJsxBackend`. The Chart.js widget on `/stats/` continues to
-    travel through the regular `.js` path so both kinds coexist on the
-    same dashboard.
+    The overview page mounts the React sparkline through the custom `BabelJsxBackend`.
+    The Chart.js widget on `/stats/` continues to travel through the regular `.js` path
+    so both kinds coexist on the same dashboard.
     """
 
     def test_overview_emits_babel_script_tag(self, client) -> None:

--- a/examples/search-catalog/catalog/context_processors.py
+++ b/examples/search-catalog/catalog/context_processors.py
@@ -13,12 +13,11 @@ if TYPE_CHECKING:
 def active_filters(request: HttpRequest) -> dict[str, Any]:
     """Expose active-filter chips with a precomputed drop URL each.
 
-    Each chip carries `label`, `key`, `value`, and `drop_url`. The
-    `drop_url` is the query string that the chip's anchor clicks to,
-    reproducing the current URL with that single (key, value) pair
-    removed. Templates render the strip with
-    `<a href="?{{ chip.drop_url }}">{{ chip.label }}</a>` and never
-    look up the URL by hand.
+    Each chip carries `label`, `key`, `value`, and `drop_url`. The `drop_url`
+    is the query string that the chip's anchor clicks to, reproducing the
+    current URL with that single (key, value) pair removed. Templates render
+    the strip with `<a href="?{{ chip.drop_url }}">{{ chip.label }}</a>`
+    and never look up the URL by hand.
     """
     f = parse_filters(request)
     items: list[tuple[str, str]] = [

--- a/examples/shortener/shortener/routes/page.py
+++ b/examples/shortener/shortener/routes/page.py
@@ -78,9 +78,8 @@ def _create_link_with_unique_slug(url: str, length: int = 6) -> Link:
 def _render_row(link: Link, request: HttpRequest) -> str:
     """Render one keyed `link_row` for a prepend patch.
 
-    The page template path travels as `current_template_path` so the
-    component resolver finds `link_row` next to the page, the same way
-    the page render does.
+    The page template path travels as `current_template_path` so the component resolver
+    finds `link_row` next to the page, the same way the page render does.
     """
     return _ROW_TEMPLATE.render(
         Context(

--- a/examples/wiki/README.md
+++ b/examples/wiki/README.md
@@ -8,7 +8,7 @@ A wiki served from two stores at once. Some pages live as files in `wiki/routes/
 | --- | --- |
 | `/` | Index with a curated list of file documentation and every article in the database. |
 | `/docs/routing/` | File-backed page describing how the file router works. |
-| `/docs/components/` | File-backed page describing the composite component pattern. |
+| `/docs/components/` | File-backed page describing the composite component pattern and the block children channel. |
 | `/articles/new/` | Create form with a live Markdown preview pane. |
 | `/articles/edit/<slug>/` | Edit form for the given article with a live Markdown preview. |
 | `/wiki/<slug>/` | Public article view rendered from the database row. |
@@ -74,7 +74,13 @@ The search form carries `data-next-target="search-results"`, `data-next-trigger=
 
 `Article` carries a `locked` boolean. The edit form in `wiki/routes/articles/edit/[slug]/page.py` declares `has_object_permission(self)`, an object-level hook that the framework resolves like `on_valid` and runs after the form binds, so `self.instance` is the loaded target row. The override reads only what it needs from `self.instance` and returns `not self.instance.locked`. A locked article short-circuits to a bare 403 before validation runs, so there is no form re-render. The create form has no such hook and stays open.
 
-### 8. No nested layout
+### 8. Free children in the documentation figure
+
+Both file-backed doc pages wrap examples in [`wiki/routes/docs/_blocks/doc_figure/`](wiki/routes/docs/_blocks/doc_figure/). The component sits inside the page tree, so it is visible from every template under `/docs/` and from nowhere else. It has exactly one insertion point, so a named slot would be ceremony: the caller writes markup between `{% #component "doc_figure" %}` and `{% /component %}`, the framework hands it over as `children`, and the template splices it with `{{ children }}`.
+
+The two channels differ, and `/docs/components/` shows the difference on one call. The block body is spliced as written, so the `<em>` and `<strong>` runs inside it reach the page as markup — whether the values interpolated there were escaped is the calling template's business, exactly as with `{% include %}`. The `caption` prop carries the same snippet from `markup_sample` in `page.py` and is escaped like every prop, so the figcaption shows `<em>emphasis</em>` as text.
+
+### 9. No nested layout
 
 The example wires only one `layout.djx` at the routes root. A nested layout is not needed and would add noise. Examples that do need nested layouts are `examples/multi-tenant` and `examples/markdown-blog`.
 
@@ -84,3 +90,4 @@ The example wires only one `layout.djx` at the routes root. A nested layout is n
 - [next/urls/backends.py](../../next/urls/backends.py) — `FileRouterBackend.generate_urls` is the public extension surface.
 - [next/deps/providers.py](../../next/deps/providers.py) — DI provider contract used by `ArticleProvider`.
 - [next/components/context.py](../../next/components/context.py) — `@component.context` wiring used by `markdown_preview`.
+- [next/templatetags/components.py](../../next/templatetags/components.py) — the `{% #component %}` tag that collects slots and free children.

--- a/examples/wiki/tests/test_e2e.py
+++ b/examples/wiki/tests/test_e2e.py
@@ -82,6 +82,24 @@ class TestFileDocs:
         assert needle in response.content.decode()
 
 
+class TestDocFigureChildren:
+    """The docs figure splices its block body and escapes the caption prop."""
+
+    def test_children_render_as_markup_while_the_prop_escapes(
+        self, client: NextClient
+    ) -> None:
+        body = client.get(reverse("next:page_docs_components")).content.decode()
+        assert "this <em>emphasis</em> and this" in body
+        assert "<strong>bold run</strong>" in body
+        assert "&lt;em&gt;emphasis&lt;/em&gt;" in body
+        assert "<em>emphasis</em></figcaption>" not in body
+
+    def test_routing_page_reuses_the_figure(self, client: NextClient) -> None:
+        body = client.get(reverse("next:page_docs_routing")).content.decode()
+        assert "<figure" in body
+        assert "<li><code>routes/page.py</code> → <code>/</code></li>" in body
+
+
 class TestArticleCreation:
     """Posting the create form publishes a fresh `/wiki/<slug>/` URL."""
 

--- a/examples/wiki/wiki/backends.py
+++ b/examples/wiki/wiki/backends.py
@@ -23,13 +23,11 @@ PUBLIC_PREFIX = "wiki"
 class HybridRouterBackend(FileRouterBackend):
     """File router that also publishes one named URL per Article row.
 
-    The file route at ``wiki/routes/wiki/[slug]/page.py`` handles the
-    actual rendering through dependency injection. This backend appends
-    a named URL pattern for each existing article slug. The aliases
-    share the catchall view but bind a fixed ``slug`` kwarg, so the
-    ``DArticle`` provider sees the right URL parameter when called via
-    a reversed name. Each alias has a unique reverse name of
-    ``wiki_article_<slug>``.
+    The file route at ``wiki/routes/wiki/[slug]/page.py`` handles the actual rendering
+    through dependency injection. This backend appends a named URL pattern for each
+    existing article slug. The aliases share the catchall view but bind a fixed ``slug``
+    kwarg, so the ``DArticle`` provider sees the right URL parameter when called via a
+    reversed name. Each alias has a unique reverse name of ``wiki_article_<slug>``.
     """
 
     def generate_urls(self) -> list[URLPattern | URLResolver]:

--- a/examples/wiki/wiki/markdown_render.py
+++ b/examples/wiki/wiki/markdown_render.py
@@ -18,12 +18,11 @@ UNSAFE_HREF = re.compile(
 def render_markdown(text: str) -> SafeString:
     """Render Markdown text to safe HTML for the page or preview pane.
 
-    Inline HTML in the source is neutralised by escaping the body
-    before it reaches the Markdown renderer. Markdown syntax such as
-    headings, lists, fenced code, and links still resolves. After
-    rendering, ``href`` values pointing at ``javascript:``, ``data:``,
-    or ``vbscript:`` URLs are stripped because Markdown auto-link
-    parsing accepts them.
+    Inline HTML in the source is neutralised by escaping the body before
+    it reaches the Markdown renderer. Markdown syntax such as headings,
+    lists, fenced code, and links still resolves. After rendering, ``href``
+    values pointing at ``javascript:``, ``data:``, or ``vbscript:``
+    URLs are stripped because Markdown auto-link parsing accepts them.
     """
     body = text or ""
     if not body.strip():

--- a/examples/wiki/wiki/routes/docs/_blocks/doc_figure/component.djx
+++ b/examples/wiki/wiki/routes/docs/_blocks/doc_figure/component.djx
@@ -1,0 +1,6 @@
+<figure class="my-6 rounded-lg border border-border bg-muted/40 p-4">
+  <div class="text-sm text-foreground">{{ children }}</div>
+  {% if caption %}
+    <figcaption class="mt-3 border-t border-border pt-2 text-xs text-muted-foreground">{{ caption }}</figcaption>
+  {% endif %}
+</figure>

--- a/examples/wiki/wiki/routes/docs/components/page.py
+++ b/examples/wiki/wiki/routes/docs/components/page.py
@@ -5,3 +5,9 @@ from next import context
 def section() -> str:
     """Return the identifier used by the layout to mark the active doc section."""
     return "components"
+
+
+@context("markup_sample")
+def markup_sample() -> str:
+    """Return the snippet the page sends through the child and the prop channel."""
+    return "<em>emphasis</em>"

--- a/examples/wiki/wiki/routes/docs/components/template.djx
+++ b/examples/wiki/wiki/routes/docs/components/template.djx
@@ -18,4 +18,22 @@
     wires the textarea to the preview pane for keystroke updates without leaving
     the page.
   </p>
+
+  <h2>Block children</h2>
+  <p>
+    A wrapper with a single insertion point needs no named slot. Everything
+    written between {% verbatim %}<code>{% #component "doc_figure" %}</code>{% endverbatim %}
+    and its closing tag reaches the component as <code>children</code>, and
+    {% verbatim %}<code>{{ children }}</code>{% endverbatim %} splices it into the
+    figure as written. Props travel the other channel and are always escaped, so
+    the caption below shows the same snippet as plain text.
+  </p>
+
+  {% #component "doc_figure" caption=markup_sample %}
+    <p>
+      The body is spliced as written, so this <em>emphasis</em> and this
+      <strong>bold run</strong> reach the page as markup.
+    </p>
+    <p>The caption carries the same snippet through the <code>caption</code> prop.</p>
+  {% /component %}
 </article>

--- a/examples/wiki/wiki/routes/docs/routing/template.djx
+++ b/examples/wiki/wiki/routes/docs/routing/template.djx
@@ -8,6 +8,14 @@
     <code>[slug]</code> map to typed Django path converters.
   </p>
 
+  {% #component "doc_figure" caption="Every directory under wiki/routes/ owns one URL." %}
+    <ul class="m-0 list-none space-y-1 p-0 font-mono text-xs">
+      <li><code>routes/page.py</code> → <code>/</code></li>
+      <li><code>routes/docs/routing/page.py</code> → <code>/docs/routing/</code></li>
+      <li><code>routes/wiki/[slug]/page.py</code> → <code>/wiki/&lt;slug&gt;/</code></li>
+    </ul>
+  {% /component %}
+
   <h2>Hybrid sources</h2>
   <p>
     The example registers a <code>HybridRouterBackend</code> that subclasses the

--- a/examples/wiki/wiki/routes/page.py
+++ b/examples/wiki/wiki/routes/page.py
@@ -11,7 +11,8 @@ def file_pages() -> list[dict[str, str]]:
         "How file paths map to URL patterns and how the unified view runs."
     )
     components_summary = (
-        "Composite components with co-located CSS and JS plus markdown_preview."
+        "Composite components, co-located assets, and a block component "
+        "whose body arrives as children."
     )
     return [
         {

--- a/next/apps/autoreload.py
+++ b/next/apps/autoreload.py
@@ -1,12 +1,10 @@
 """Patch Django's autoreload to use next-dj's reloader and watch specs.
 
-Django does not expose a setting for overriding the reloader class, so
-this module still swaps `autoreload.StatReloader`. The swap is kept
-idempotent and records the class it replaces so tests (or other
-packages) can restore it. A warning is logged if another library has
-replaced `StatReloader` with a class that is not a `StatReloader`
-subclass, which suggests an incompatible override and makes our patch
-unsafe to apply.
+Django does not expose a setting for overriding the reloader class, so this module still
+swaps `autoreload.StatReloader`. The swap is kept idempotent and records the class it
+replaces so tests (or other packages) can restore it. A warning is logged if another
+library has replaced `StatReloader` with a class that is not a `StatReloader` subclass,
+which suggests an incompatible override and makes our patch unsafe to apply.
 """
 
 from __future__ import annotations
@@ -37,9 +35,8 @@ _state = _PatchState()
 def install() -> None:
     """Swap `StatReloader` for `NextStatReloader` and wire watch specs.
 
-    Safe to call more than once: subsequent calls are no-ops once the
-    current `autoreload.StatReloader` is already our subclass or one of
-    its descendants.
+    Safe to call more than once: subsequent calls are no-ops once the current
+    `autoreload.StatReloader` is already our subclass or one of its descendants.
     """
     current = autoreload.StatReloader
     if issubclass(current, NextStatReloader):

--- a/next/apps/checks.py
+++ b/next/apps/checks.py
@@ -39,11 +39,10 @@ def check_django_templates_backend_present(*args, **kwargs) -> list[CheckMessage
 def _iter_tag_library_modules() -> list[str]:
     """Return the dotted names of tag library modules under next.templatetags.
 
-    A module counts as a tag library when it exposes a `register` attribute
-    that is a Django `Library`, the same shape `get_installed_libraries`
-    loads. This walks the package only to discover the modules that exist
-    on disk, the builtin registration list itself stays the explicit
-    `_BUILTIN_MODULES` tuple.
+    A module counts as a tag library when it exposes a `register` attribute that is a
+    Django `Library`, the same shape `get_installed_libraries` loads. This walks the
+    package only to discover the modules that exist on disk, the builtin registration
+    list itself stays the explicit `_BUILTIN_MODULES` tuple.
     """
     found: list[str] = []
     package_path = next.templatetags.__path__
@@ -62,11 +61,10 @@ def _iter_tag_library_modules() -> list[str]:
 def check_builtin_tag_libraries_complete(*args, **kwargs) -> list[CheckMessage]:
     """Warn when a tag library is not registered as a builtin (`next.W063`).
 
-    The builtin registration list is the explicit `_BUILTIN_MODULES` tuple.
-    A tag library module added under `next.templatetags` but left out of
-    that tuple installs into no engine, so its tags silently fail to load.
-    This check pairs the explicit list with a completeness probe over the
-    modules that exist on disk.
+    The builtin registration list is the explicit `_BUILTIN_MODULES` tuple. A tag
+    library module added under `next.templatetags` but left out of that tuple installs
+    into no engine, so its tags silently fail to load. This check pairs the explicit
+    list with a completeness probe over the modules that exist on disk.
     """
     builtins = set(_BUILTIN_MODULES)
     return [

--- a/next/apps/components.py
+++ b/next/apps/components.py
@@ -8,9 +8,8 @@ from next.components import components_manager
 def install() -> None:
     """Load backends and run component discovery on app ready.
 
-    Discovery populates each backend registry. Unless `LAZY_COMPONENT_MODULES`
-    is set it also imports every `component.py` so decorators run before the
-    first request.
+    Discovery populates each backend registry. Unless `LAZY_COMPONENT_MODULES` is set it
+    also imports every `component.py` so decorators run before the first request.
     """
     for backend in components_manager.backends:
         backend.discover()

--- a/next/backends.py
+++ b/next/backends.py
@@ -45,9 +45,8 @@ def resolve_backend_class[T](
 def _instantiate_backend[T](klass: type[T], config: Mapping[str, Any]) -> T:
     """Build one backend from its config entry.
 
-    Every backend family takes the whole entry as its single argument, a
-    contract `type[T]` cannot express, so the class is called through a
-    factory signature.
+    Every backend family takes the whole entry as its single argument, a contract
+    `type[T]` cannot express, so the class is called through a factory signature.
     """
     factory = cast("Callable[[Mapping[str, Any]], T]", klass)
     return factory(config)
@@ -98,9 +97,8 @@ def load_backends[T](
 class SingleBackendManager[T]:
     """Instantiates the single backend named by one framework settings key.
 
-    A misconfigured entry raises out of `get()` rather than being logged
-    and skipped, because a family with one backend has nothing to fall
-    back to.
+    A misconfigured entry raises out of `get()` rather than being logged and skipped,
+    because a family with one backend has nothing to fall back to.
     """
 
     def __init__(
@@ -141,9 +139,8 @@ class SingleBackendManager[T]:
     def reset(self) -> None:
         """Drop the cached backend so the next `get()` rereads settings.
 
-        Invalidation only. The rebuild waits for a caller that asks for
-        the backend, so a settings reload nobody follows up on costs
-        nothing.
+        Invalidation only. The rebuild waits for a caller that asks for the backend, so
+        a settings reload nobody follows up on costs nothing.
         """
         self.__dict__.pop("_backend", None)
 

--- a/next/checks/__init__.py
+++ b/next/checks/__init__.py
@@ -1,10 +1,9 @@
 """Aggregate system-check registration for all `next-dj` subpackages.
 
-Importing a helper from this module triggers registration of all
-`@register` side effects by loading each subpackage's `checks` module.
-Re-exports are resolved lazily so that subpackage checks modules can
-freely import from `next.checks.common` without cycling back through
-this package.
+Importing a helper from this module triggers registration of all `@register` side
+effects by loading each subpackage's `checks` module. Re-exports are resolved lazily so
+that subpackage checks modules can freely import from `next.checks.common` without
+cycling back through this package.
 """
 
 from __future__ import annotations

--- a/next/checks/common.py
+++ b/next/checks/common.py
@@ -164,8 +164,8 @@ _COMPONENTS_MANAGER_CACHE: dict[str, ComponentsManager | None] = {"value": None}
 class _ScannedTrees:
     """The pages and the component folders one walk of a router's trees found.
 
-    Both come out of the same walk, because a second walk could disagree
-    with the first about either.
+    Both come out of the same walk, because a second
+    walk could disagree with the first about either.
     """
 
     pairs: tuple[tuple[str, Path], ...]
@@ -236,9 +236,8 @@ def reset_router_manager_cache(**kwargs) -> None:
 def get_components_manager() -> ComponentsManager:
     """Return a per-run cached `ComponentsManager` holding every component source.
 
-    The manager is the checks' own, because the live registry holds only what
-    requests have already made the router walk. Invalidated like
-    `get_router_manager`.
+    The manager is the checks' own, because the live registry holds only what requests
+    have already made the router walk. Invalidated like `get_router_manager`.
     """
     cached = _COMPONENTS_MANAGER_CACHE["value"]
     if cached is not None:
@@ -300,10 +299,9 @@ class PageRootsError(Exception):
 def read_page_roots(router: RouterBackend) -> list[PageRoot]:
     """Return the page trees `router` reports, raising `PageRootsError` on failure.
 
-    `page_roots` is third-party code that can raise anything and answer any
-    shape, and a check run has to survive both with a message rather than a
-    traceback, so either outcome becomes one framework exception the callers
-    handle narrowly.
+    `page_roots` is third-party code that can raise anything and answer any shape, and a
+    check run has to survive both with a message rather than a traceback, so either
+    outcome becomes one framework exception the callers handle narrowly.
     """
     try:
         roots = list(router.page_roots())
@@ -364,9 +362,9 @@ def _read_components_folder_name(router: RouterBackend) -> str | None:
 def _read_skip_dir_names(router: RouterBackend) -> frozenset[str]:
     """Return the directory names `router` refuses, dropping anything but names.
 
-    `skip_dir_names` is third-party code that can raise or answer the wrong
-    shape, and a check run survives both by refusing no directory rather than
-    by ending in a traceback.
+    `skip_dir_names` is third-party code that can raise or
+    answer the wrong shape, and a check run survives both by
+    refusing no directory rather than by ending in a traceback.
     """
     try:
         names: object = router.skip_dir_names()

--- a/next/components/__init__.py
+++ b/next/components/__init__.py
@@ -41,6 +41,7 @@ from .manager import (
 )
 from .registry import ComponentRegistry, ComponentVisibilityResolver
 from .renderers import (
+    CachedComponentTemplateLoader,
     ComponentRenderer,
     ComponentRenderStrategy,
     ComponentTemplateLoader,
@@ -53,6 +54,7 @@ from .watch import get_component_paths_for_watch
 
 __all__ = [
     "BoomBackend",
+    "CachedComponentTemplateLoader",
     "ComponentContextManager",
     "ComponentContextRegistry",
     "ComponentInfo",

--- a/next/components/backends.py
+++ b/next/components/backends.py
@@ -82,9 +82,9 @@ class ComponentsBackend(ABC):
     def global_component_roots(self) -> Iterable[Path]:
         """Return the scope roots whose root-scope components resolve everywhere.
 
-        A shared root makes its root-scope components visible from every
-        template, a page tree does not, and the cross-root name check reads
-        this to tell the two apart.
+        A shared root makes its root-scope components visible
+        from every template, a page tree does not, and the
+        cross-root name check reads this to tell the two apart.
         """
         return ()
 
@@ -95,9 +95,8 @@ class FileComponentsBackend(ComponentsBackend):
     def __init__(self, config: dict[str, Any]) -> None:
         """Build registry and scanner from the merged `DIRS` roots.
 
-        `COMPONENTS_DIR` is not read here. It names the folder the URL
-        router skips inside a page tree, and `FileRouterBackend` reads it
-        straight from the settings.
+        `COMPONENTS_DIR` is not read here. It names the folder the URL router skips
+        inside a page tree, and `FileRouterBackend` reads it straight from the settings.
         """
         self._extra_component_roots = component_extra_roots_from_config(config)
 

--- a/next/components/context.py
+++ b/next/components/context.py
@@ -51,6 +51,18 @@ class ComponentContextRegistry:
         """Create an empty path-keyed context-function mapping."""
         self._registry: dict[Path, dict[str | None, ContextFunction]] = {}
         self._misattributions = MisattributionLog()
+        self._version = 0
+        self._lookup_cache: dict[Path, tuple[ContextFunction, ...]] = {}
+        self._lookup_version = 0
+
+    @property
+    def version(self) -> int:
+        """Monotonic counter bumped on every write to the registry."""
+        return self._version
+
+    def _bump(self) -> None:
+        """Invalidate the lookup memo by advancing the registry version."""
+        self._version += 1
 
     def misattributed(self) -> tuple[MisattributedContext, ...]:
         """Return every registration bound to a file other than the one running it."""
@@ -106,15 +118,38 @@ class ComponentContextRegistry:
                 )
                 raise ValueError(msg)
 
-        component_registry[key] = ContextFunction(
+        entry = ContextFunction(
             func=func, key=key, serialize=serialize, serializer=serializer
         )
+        if component_registry.get(key) == entry:
+            # Re-registering an identical entry leaves the memo valid.
+            return
+
+        component_registry[key] = entry
+        self._bump()
+
+    def unregister(self, component_path: Path) -> None:
+        """Drop every context function registered for `component_path`."""
+        if self._registry.pop(component_path.resolve(), None) is not None:
+            self._bump()
 
     def get_functions(self, component_path: Path) -> Sequence[ContextFunction]:
-        """Return a tuple of registered context functions for `component_path`."""
-        path = component_path.resolve()
-        registry = self._registry.get(path, {})
-        return tuple(registry.values())
+        """Return a tuple of registered context functions for `component_path`.
+
+        Results are memoised under the path as passed and thrown away when
+        the registry version moves, so a render pays neither the resolve nor
+        the tuple build twice. The empty result is memoised too, because most
+        components register no context function at all.
+        """
+        if self._lookup_version != self._version:
+            self._lookup_cache.clear()
+            self._lookup_version = self._version
+        cached = self._lookup_cache.get(component_path)
+        if cached is not None:
+            return cached
+        functions = tuple(self._registry.get(component_path.resolve(), {}).values())
+        self._lookup_cache[component_path] = functions
+        return functions
 
     def _is_same_function(
         self, func1: Callable[..., Any], func2: Callable[..., Any]

--- a/next/components/context.py
+++ b/next/components/context.py
@@ -33,9 +33,8 @@ if TYPE_CHECKING:
 class ContextFunction:
     """One function registered to add variables before a component template runs.
 
-    The optional `serializer` overrides the global JS context
-    serializer for the value this callable produces, but only when
-    `serialize` is true.
+    The optional `serializer` overrides the global JS context serializer for the value
+    this callable produces, but only when `serialize` is true.
     """
 
     func: Callable[..., Any]

--- a/next/components/loading.py
+++ b/next/components/loading.py
@@ -51,7 +51,11 @@ class ModuleCache:
         self._order.clear()
 
     def __len__(self) -> int:
-        """Return the number of cached entries."""
+        """Return the number of cached entries.
+
+        An empty cache is therefore falsy, so a caller taking one as an
+        argument checks it against `None` rather than for truth.
+        """
         return len(self._order)
 
     def __contains__(self, path: Path) -> bool:
@@ -64,7 +68,7 @@ class ModuleLoader:
 
     def __init__(self, cache: ModuleCache | None = None) -> None:
         """Bind the loader to a shared or new `ModuleCache`."""
-        self._cache = cache or ModuleCache()
+        self._cache = cache if cache is not None else ModuleCache()
 
     def load(self, path: Path) -> ModuleType | None:
         """Return the module for `path`, loading it on cache miss."""

--- a/next/components/manager.py
+++ b/next/components/manager.py
@@ -1,4 +1,4 @@
-"""`ComponentsManager` and the settings_reloaded hook.
+"""`ComponentsManager` and the settings hooks that invalidate its caches.
 
 The manager loads configured backends lazily, shares a render pipeline
 between them, and subscribes to `settings_reloaded` so a fresh config
@@ -8,6 +8,8 @@ drops the cached state without reimporting this module.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
+
+from django.core.signals import setting_changed
 
 from next.backends import backend_entries, load_backends
 from next.conf.signals import settings_reloaded
@@ -182,7 +184,18 @@ def _on_settings_reloaded(**kwargs) -> None:
     components_manager._invalidate()
 
 
+def _on_setting_changed(*, setting: str, **kwargs) -> None:
+    """Drop the render pipeline when Django reports a `TEMPLATES` change.
+
+    A compiled template pins the engine that built it, and the `settings_reloaded`
+    hook beside this one fires for `NEXT_FRAMEWORK` alone.
+    """
+    if setting == "TEMPLATES":
+        components_manager._reset_render_pipeline()
+
+
 settings_reloaded.connect(_on_settings_reloaded)
+setting_changed.connect(_on_setting_changed)
 
 
 __all__ = [

--- a/next/components/manager.py
+++ b/next/components/manager.py
@@ -15,6 +15,7 @@ from next.conf.signals import settings_reloaded
 from .backends import _DEFAULT_BACKEND_PATH, ComponentsBackend
 from .loading import ModuleLoader
 from .renderers import (
+    CachedComponentTemplateLoader,
     ComponentRenderer,
     ComponentTemplateLoader,
     CompositeComponentRenderer,
@@ -48,7 +49,7 @@ class ComponentsManager:
 
         ml = ModuleLoader()
 
-        tl = ComponentTemplateLoader(ml)
+        tl = CachedComponentTemplateLoader(ml)
         self._template_loader = tl
         simple = SimpleComponentRenderer(tl)
         composite = CompositeComponentRenderer(ml, tl)
@@ -63,6 +64,14 @@ class ComponentsManager:
         """Return the shared `ComponentTemplateLoader` used for template reads."""
         self._ensure_render_pipeline()
         return cast("ComponentTemplateLoader", self._template_loader)
+
+    def clear_template_caches(self) -> None:
+        """Drop compiled component templates without rebuilding the pipeline.
+
+        Outside `DEBUG` the loader reuses a compiled template without checking its
+        source, so a caller that rewrote a component on disk drops it here.
+        """
+        self.template_loader.clear()
 
     @property
     def component_renderer(self) -> ComponentRenderer:

--- a/next/components/manager.py
+++ b/next/components/manager.py
@@ -82,9 +82,8 @@ class ComponentsManager:
     def _invalidate(self) -> None:
         """Drop cached backends and the render pipeline without rebuilding.
 
-        Settings reload far more often than a component renders, so the
-        rebuild waits for the next access instead of running in the
-        signal receiver.
+        Settings reload far more often than a component renders, so the rebuild waits
+        for the next access instead of running in the signal receiver.
         """
         self._reset_render_pipeline()
         self._backends = []
@@ -94,9 +93,8 @@ class ComponentsManager:
     def reload(self) -> None:
         """Rebuild the backends from the current `NEXT_FRAMEWORK` settings.
 
-        The render pipeline and the router-walk claims go with the old
-        backends, so the next render resolves against the freshly configured
-        sources.
+        The render pipeline and the router-walk claims go with the old backends, so the
+        next render resolves against the freshly configured sources.
         """
         self._invalidate()
         self._backends = load_backends(

--- a/next/components/registry.py
+++ b/next/components/registry.py
@@ -1,14 +1,13 @@
 """Component registry and visibility resolver.
 
 `ComponentRegistry` is the ordered collection of discovered
-`ComponentInfo` entries used by a backend. It tracks which scope
-roots were registered as globally visible and exposes a version
-counter used by `ComponentVisibilityResolver` to invalidate its
-caches.
+`ComponentInfo` entries used by a backend. It tracks which scope roots
+were registered as globally visible and exposes a version counter
+used by `ComponentVisibilityResolver` to invalidate its caches.
 
-`ComponentVisibilityResolver` decides which component names are in
-scope for a given template file path. It lazily builds a scope index
-from the registry and caches per-template results.
+`ComponentVisibilityResolver` decides which component names
+are in scope for a given template file path. It lazily builds a
+scope index from the registry and caches per-template results.
 """
 
 from __future__ import annotations
@@ -57,11 +56,10 @@ class ComponentRegistry:
     def register_many(self, components: Iterable[ComponentInfo]) -> None:
         """Index every component from the iterable in order.
 
-        Follows the Django bulk convention (`bulk_create` skips
-        per-instance `post_save`). Receivers that need per-item
-        events should subscribe to `components_registered` and read
-        the `infos` tuple. The singular `component_registered` is
-        not fired from this path.
+        Follows the Django bulk convention (`bulk_create` skips per-instance
+        `post_save`). Receivers that need per-item events should subscribe to
+        `components_registered` and read the `infos` tuple. The singular
+        `component_registered` is not fired from this path.
         """
         added = tuple(components)
         if not added:

--- a/next/components/renderers.py
+++ b/next/components/renderers.py
@@ -9,6 +9,7 @@ The Protocol `ComponentRenderStrategy` plus `SimpleComponentRenderer` and
 from __future__ import annotations
 
 import contextlib
+import threading
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, override
@@ -119,6 +120,33 @@ class _CompiledTemplate:
 # The template and module files that define one component.
 type _SourceKey = tuple[Path | None, Path | None]
 
+# Components one process keeps compiled, at the bound the path-keyed caches share.
+_COMPILED_TEMPLATE_CACHE_MAX_SIZE = 2048
+
+
+def _stat_ns(path: Path) -> int | None:
+    """Return the mtime of `path` in nanoseconds, or `None` when it does not stat."""
+    try:
+        return path.stat().st_mtime_ns
+    except OSError:
+        return None
+
+
+def _source_mtimes(info: ComponentInfo) -> dict[Path, int]:
+    """Stat every file a load may read for `info`, before any of them is read.
+
+    Reading first and stat-ing after would file the old text under the mtime of
+    a save that landed in between, hiding that edit until the next one.
+    """
+    mtimes: dict[Path, int] = {}
+    for candidate in (info.template_path, info.module_path):
+        if candidate is None or candidate in mtimes:
+            continue
+        mtime_ns = _stat_ns(candidate)
+        if mtime_ns is not None:
+            mtimes[candidate] = mtime_ns
+    return mtimes
+
 
 class CachedComponentTemplateLoader(ComponentTemplateLoader):
     """Reuse a compiled template until the file it was read from changes.
@@ -129,11 +157,17 @@ class CachedComponentTemplateLoader(ComponentTemplateLoader):
     arrives with the reload the autoreloader runs for `component.py`.
     """
 
-    def __init__(self, module_loader: ModuleLoader, maxsize: int = 128) -> None:
+    def __init__(
+        self,
+        module_loader: ModuleLoader,
+        maxsize: int = _COMPILED_TEMPLATE_CACHE_MAX_SIZE,
+    ) -> None:
         """Bind this loader to a shared `ModuleLoader` with an empty LRU cache."""
         super().__init__(module_loader)
         self._maxsize = maxsize
         self._compiled: OrderedDict[_SourceKey, _CompiledTemplate] = OrderedDict()
+        # Taken around the cache mutations alone, never around a read or a parse.
+        self._lock = threading.Lock()
 
     @override
     def load_template(self, info: ComponentInfo) -> Template | None:
@@ -145,45 +179,59 @@ class CachedComponentTemplateLoader(ComponentTemplateLoader):
         key = (info.template_path, info.module_path)
         entry = self._compiled.get(key)
         if entry is not None and self._is_fresh(entry):
-            self._compiled.move_to_end(key)
+            self._mark_used(key)
             return entry.template
         return self._compile(key, info)
 
     @override
     def clear(self) -> None:
         """Drop every compiled template."""
-        self._compiled.clear()
+        with self._lock:
+            self._compiled.clear()
+
+    def _mark_used(self, key: _SourceKey) -> None:
+        """Move `key` to the fresh end, unless a concurrent store already dropped it."""
+        with self._lock:
+            if key in self._compiled:
+                self._compiled.move_to_end(key)
 
     def _is_fresh(self, entry: _CompiledTemplate) -> bool:
         if not template_edits_watched():
             return True
-        try:
-            return entry.source_path.stat().st_mtime_ns == entry.mtime_ns
-        except OSError:
-            return False
+        return _stat_ns(entry.source_path) == entry.mtime_ns
 
     def _compile(self, key: _SourceKey, info: ComponentInfo) -> Template | None:
+        mtimes = _source_mtimes(info)
         source = self.load_source(info)
         if source is None:
-            self._compiled.pop(key, None)
+            self._drop(key)
             return None
 
         template = Template(source.text)
-        try:
-            mtime_ns = source.path.stat().st_mtime_ns
-        except OSError:
+        # A subclass may read a file neither `ComponentInfo` field names, so a
+        # path the pre-read stat missed is stat-ed here rather than left uncached.
+        mtime_ns = mtimes.get(source.path)
+        if mtime_ns is None:
+            mtime_ns = _stat_ns(source.path)
+        if mtime_ns is None:
             # Without an mtime the entry could never expire, so it is not kept.
-            self._compiled.pop(key, None)
+            self._drop(key)
             return template
 
         self._store(key, _CompiledTemplate(source.path, mtime_ns, template))
         return template
 
+    def _drop(self, key: _SourceKey) -> None:
+        """Forget the entry under `key`, whether or not one is stored."""
+        with self._lock:
+            self._compiled.pop(key, None)
+
     def _store(self, key: _SourceKey, entry: _CompiledTemplate) -> None:
-        if key not in self._compiled and len(self._compiled) >= self._maxsize:
-            self._compiled.popitem(last=False)
-        self._compiled[key] = entry
-        self._compiled.move_to_end(key)
+        with self._lock:
+            if key not in self._compiled and len(self._compiled) >= self._maxsize:
+                self._compiled.popitem(last=False)
+            self._compiled[key] = entry
+            self._compiled.move_to_end(key)
 
 
 def _stamp_component_anchor(info: ComponentInfo, context_dict: dict[str, Any]) -> None:

--- a/next/components/renderers.py
+++ b/next/components/renderers.py
@@ -1,15 +1,17 @@
 """Component renderers and render-time helpers.
 
-`ComponentTemplateLoader` reads the raw source for a component. The
-Protocol `ComponentRenderStrategy` plus `SimpleComponentRenderer` and
-`CompositeComponentRenderer` are the two built-in renderers chosen by
-`ComponentRenderer`.
+`ComponentTemplateLoader` reads the raw source for a component and
+`CachedComponentTemplateLoader` keeps its compilation between renders.
+The Protocol `ComponentRenderStrategy` plus `SimpleComponentRenderer` and
+`CompositeComponentRenderer` are the two renderers `ComponentRenderer` picks.
 """
 
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Any, Protocol
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, override
 
 from django.http import HttpResponse
 from django.middleware.csrf import get_token
@@ -18,12 +20,14 @@ from django.utils.functional import SimpleLazyObject
 
 from next.deps import get_request_dep_cache, resolver
 from next.deps.cache import DependencyCache
+from next.utils import template_edits_watched
 
 from .context import component
 
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
+    from pathlib import Path
 
     from django.http import HttpRequest
 
@@ -53,6 +57,14 @@ _RESERVED_CONTEXT_KEYS = frozenset(
 SLOT_KEY_PREFIX = "slot_"
 
 
+@dataclass(frozen=True, slots=True)
+class TemplateSource:
+    """Template text together with the file it was read from."""
+
+    text: str
+    path: Path
+
+
 class ComponentTemplateLoader:
     """Read template source from a `.djx` file or a `component` module string."""
 
@@ -60,22 +72,118 @@ class ComponentTemplateLoader:
         """Bind this loader to a shared `ModuleLoader`."""
         self._module_loader = module_loader
 
-    def load(self, info: ComponentInfo) -> str | None:
-        """Return raw template text for `info` or `None` when unavailable."""
+    def load_source(self, info: ComponentInfo) -> TemplateSource | None:
+        """Return the template text for `info` with the file it came from.
+
+        This is the one place that picks between the `.djx` body and the `component`
+        module string, so no caller has to guess which one a render used.
+        """
         if info.template_path is not None and info.template_path.suffix == ".djx":
             with contextlib.suppress(OSError, UnicodeDecodeError):
-                return info.template_path.read_text(encoding="utf-8")
+                text = info.template_path.read_text(encoding="utf-8")
+                return TemplateSource(text, info.template_path)
 
         if info.module_path is not None:
             module = self._module_loader.load(info.module_path)
-            if module is not None and hasattr(module, "component"):
-                return getattr(module, "component", None)
+            module_text: str | None = getattr(module, "component", None)
+            if module_text is not None:
+                return TemplateSource(module_text, info.module_path)
 
         return None
 
+    def load(self, info: ComponentInfo) -> str | None:
+        """Return raw template text for `info` or `None` when unavailable."""
+        source = self.load_source(info)
+        return source.text if source is not None else None
 
-def _render_template_string(template_str: str, context_dict: dict[str, Any]) -> str:
-    return Template(template_str).render(DjangoTemplateContext(context_dict))
+    def load_template(self, info: ComponentInfo) -> Template | None:
+        """Return the compiled template for `info` or `None` when unavailable."""
+        source = self.load_source(info)
+        if source is None:
+            return None
+        return Template(source.text)
+
+    def clear(self) -> None:
+        """Do nothing, because this loader holds no compiled state."""
+
+
+@dataclass(frozen=True, slots=True)
+class _CompiledTemplate:
+    """A compiled template with the file it came from and that file's mtime."""
+
+    source_path: Path
+    mtime_ns: int
+    template: Template
+
+
+# The template and module files that define one component.
+type _SourceKey = tuple[Path | None, Path | None]
+
+
+class CachedComponentTemplateLoader(ComponentTemplateLoader):
+    """Reuse a compiled template until the file it was read from changes.
+
+    A render then pays at most one `stat` instead of a read plus a full parse,
+    and an edited `.djx` still reaches the next render without a restart. A
+    `component` string comes from an already imported module, so its edit
+    arrives with the reload the autoreloader runs for `component.py`.
+    """
+
+    def __init__(self, module_loader: ModuleLoader, maxsize: int = 128) -> None:
+        """Bind this loader to a shared `ModuleLoader` with an empty LRU cache."""
+        super().__init__(module_loader)
+        self._maxsize = maxsize
+        self._compiled: OrderedDict[_SourceKey, _CompiledTemplate] = OrderedDict()
+
+    @override
+    def load_template(self, info: ComponentInfo) -> Template | None:
+        """Return the compiled template for `info` from the cache or a fresh read.
+
+        An entry is keyed by the files that define the component and
+        revalidated against the mtime of the one the body was read from.
+        """
+        key = (info.template_path, info.module_path)
+        entry = self._compiled.get(key)
+        if entry is not None and self._is_fresh(entry):
+            self._compiled.move_to_end(key)
+            return entry.template
+        return self._compile(key, info)
+
+    @override
+    def clear(self) -> None:
+        """Drop every compiled template."""
+        self._compiled.clear()
+
+    def _is_fresh(self, entry: _CompiledTemplate) -> bool:
+        if not template_edits_watched():
+            return True
+        try:
+            return entry.source_path.stat().st_mtime_ns == entry.mtime_ns
+        except OSError:
+            return False
+
+    def _compile(self, key: _SourceKey, info: ComponentInfo) -> Template | None:
+        source = self.load_source(info)
+        if source is None:
+            self._compiled.pop(key, None)
+            return None
+
+        template = Template(source.text)
+        try:
+            mtime_ns = source.path.stat().st_mtime_ns
+        except OSError:
+            # Without an mtime the entry could never expire, so it is not kept.
+            self._compiled.pop(key, None)
+            return template
+
+        self._store(key, _CompiledTemplate(source.path, mtime_ns, template))
+        return template
+
+    def _store(self, key: _SourceKey, entry: _CompiledTemplate) -> None:
+        if key not in self._compiled and len(self._compiled) >= self._maxsize:
+            self._compiled.popitem(last=False)
+        self._compiled[key] = entry
+        self._compiled.move_to_end(key)
 
 
 def _stamp_component_anchor(info: ComponentInfo, context_dict: dict[str, Any]) -> None:
@@ -188,7 +296,10 @@ class ComponentRenderStrategy(Protocol):
         context_data: Mapping[str, Any],
         request: HttpRequest | None,
     ) -> str:
-        """Return the rendered HTML for `info`."""
+        """Return the rendered HTML for `info`.
+
+        A strategy copies `context_data`, so the caller's mapping is left alone.
+        """
         raise NotImplementedError
 
 
@@ -210,15 +321,15 @@ class SimpleComponentRenderer:
         request: HttpRequest | None,
     ) -> str:
         """Render `info` by plain template string rendering."""
-        template_str = self._loader.load(info)
-        if template_str is None:
+        template = self._loader.load_template(info)
+        if template is None:
             return ""
         context_dict = dict(context_data)
         _stamp_component_anchor(info, context_dict)
         if request is not None:
             context_dict.setdefault("request", request)
             _merge_csrf_context(context_dict, request)
-        return _render_template_string(template_str, context_dict)
+        return template.render(DjangoTemplateContext(context_dict))
 
 
 class CompositeComponentRenderer:
@@ -264,10 +375,12 @@ class CompositeComponentRenderer:
         cache = DependencyCache()
         stack: list[str] = []
 
+        # Nothing here writes to the context, and the resolver copies what
+        # it injects, so this branch hands the mapping straight through.
         resolved = resolver.resolve_with_template_context(
             render_func,
             request=request,
-            template_context=dict(context_data),
+            template_context=context_data,
             _cache=cache,
             _stack=stack,
         )
@@ -284,8 +397,8 @@ class CompositeComponentRenderer:
         context_data: Mapping[str, Any],
         request: HttpRequest | None,
     ) -> str:
-        template_str = self._template_loader.load(info)
-        if template_str is None:
+        template = self._template_loader.load_template(info)
+        if template is None:
             return ""
 
         context_dict = dict(context_data)
@@ -296,17 +409,17 @@ class CompositeComponentRenderer:
 
         _inject_component_context(info, context_dict, request)
 
-        return _render_template_string(template_str, context_dict)
+        return template.render(DjangoTemplateContext(context_dict))
 
     def _fallback_to_template(
         self, info: ComponentInfo, context_data: Mapping[str, Any]
     ) -> str:
-        template_str = self._template_loader.load(info)
-        if template_str is None:
+        template = self._template_loader.load_template(info)
+        if template is None:
             return ""
         context_dict = dict(context_data)
         _stamp_component_anchor(info, context_dict)
-        return _render_template_string(template_str, context_dict)
+        return template.render(DjangoTemplateContext(context_dict))
 
 
 class ComponentRenderer:
@@ -331,9 +444,11 @@ class ComponentRenderer:
 
 
 __all__ = [
+    "CachedComponentTemplateLoader",
     "ComponentRenderStrategy",
     "ComponentRenderer",
     "ComponentTemplateLoader",
     "CompositeComponentRenderer",
     "SimpleComponentRenderer",
+    "TemplateSource",
 ]

--- a/next/components/renderers.py
+++ b/next/components/renderers.py
@@ -179,7 +179,10 @@ class CachedComponentTemplateLoader(ComponentTemplateLoader):
         key = (info.template_path, info.module_path)
         entry = self._compiled.get(key)
         if entry is not None and self._is_fresh(entry):
-            self._mark_used(key)
+            # Use order decides only who is evicted, so a cache with room to
+            # spare skips the bookkeeping every hit would otherwise pay.
+            if len(self._compiled) >= self._maxsize:
+                self._mark_used(key)
             return entry.template
         return self._compile(key, info)
 

--- a/next/components/scanner.py
+++ b/next/components/scanner.py
@@ -29,7 +29,9 @@ class ComponentScanner:
 
     def __init__(self, *, module_loader: ModuleLoader | None = None) -> None:
         """Wire a module loader for composite `component.py` files."""
-        self._module_loader = module_loader or ModuleLoader()
+        self._module_loader = (
+            module_loader if module_loader is not None else ModuleLoader()
+        )
 
     def scan_directory(
         self, directory: Path, scope_root: Path, scope_relative: str

--- a/next/conf/checks.py
+++ b/next/conf/checks.py
@@ -38,11 +38,11 @@ _TYPED_LIST_KEYS: frozenset[str] = NextFrameworkSettings.LIST_KEYS - {
     "FORM_ANCHOR_FILES",
     "PARTIAL_BACKENDS",
 }
-_KEY_TYPES: dict[str, type] = dict.fromkeys(sorted(_TYPED_LIST_KEYS), list) | {
-    "URL_NAME_TEMPLATE": str,
-    "URL_RESOLVER": str,
-    "NEXT_JS_OPTIONS": dict,
-}
+_KEY_TYPES: dict[str, type] = (
+    dict.fromkeys(sorted(_TYPED_LIST_KEYS), list)
+    | dict.fromkeys(sorted(NextFrameworkSettings.STR_KEYS), str)
+    | {"NEXT_JS_OPTIONS": dict}
+)
 
 _SILENCE_HINT = (
     "Fix the value in settings.NEXT_FRAMEWORK, or silence this check by "

--- a/next/conf/defaults.py
+++ b/next/conf/defaults.py
@@ -1,9 +1,8 @@
 """Framework-level defaults for the `settings.NEXT_FRAMEWORK` mapping.
 
-The values stored here are deep-copied into the merged view on every
-reload. Nothing in this module imports from the rest of the framework,
-which keeps the configuration layer at the bottom of the dependency
-graph.
+The values stored here are deep-copied into the merged view on every reload. Nothing in
+this module imports from the rest of the framework, which keeps the configuration layer
+at the bottom of the dependency graph.
 """
 
 from __future__ import annotations

--- a/next/conf/helpers.py
+++ b/next/conf/helpers.py
@@ -26,14 +26,12 @@ def extend_default_backend(
 ) -> list[dict[str, Any]]:
     """Return a `NEXT_FRAMEWORK[key]` list with one backend entry patched.
 
-    The returned list is a deep copy of the default entries with the
-    entry at `index` updated by `overrides`. Nested dicts such as
-    `OPTIONS` are merged instead of replaced so partial overrides do not
-    drop adjacent keys.
+    The returned list is a deep copy of the default entries with the entry at `index`
+    updated by `overrides`. Nested dicts such as `OPTIONS` are merged instead of
+    replaced so partial overrides do not drop adjacent keys.
 
-    Raises `ImproperlyConfigured` when `key` is not a known backend-list
-    setting. Raises `IndexError` when `index` is out of range for the
-    default list.
+    Raises `ImproperlyConfigured` when `key` is not a known backend-list setting. Raises
+    `IndexError` when `index` is out of range for the default list.
     """
     if key not in _BACKEND_LIST_KEYS:
         allowed = ", ".join(sorted(_BACKEND_LIST_KEYS))

--- a/next/conf/settings.py
+++ b/next/conf/settings.py
@@ -1,10 +1,9 @@
 """Merged view of `settings.NEXT_FRAMEWORK` with framework defaults.
 
-The `NextFrameworkSettings` class reads the user mapping lazily and
-merges it with `DEFAULTS` on first access. Merge results are cached
-until `reload()` drops the cache and emits `settings_reloaded`. Package
-managers that depend on the merged values subscribe to that signal and
-reset their own state.
+The `NextFrameworkSettings` class reads the user mapping lazily and merges it with
+`DEFAULTS` on first access. Merge results are cached until `reload()` drops the cache
+and emits `settings_reloaded`. Package managers that depend on the merged values
+subscribe to that signal and reset their own state.
 """
 
 from __future__ import annotations
@@ -32,9 +31,8 @@ class NextFrameworkSettings:
     def reload(self) -> None:
         """Drop merge and import caches and emit the reload signal.
 
-        Package-level managers listen to `settings_reloaded` and reset
-        their own state. This method only clears caches owned by the
-        settings object itself.
+        Package-level managers listen to `settings_reloaded` and reset their own state.
+        This method only clears caches owned by the settings object itself.
         """
         self._merged_cache = None
         self._attr_value_cache.clear()

--- a/next/conf/settings.py
+++ b/next/conf/settings.py
@@ -69,6 +69,9 @@ class NextFrameworkSettings:
             "FORM_ANCHOR_FILES",
         }
     )
+    STR_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {"URL_NAME_TEMPLATE", "URL_RESOLVER"}
+    )
     BOOL_KEYS: ClassVar[frozenset[str]] = frozenset(
         {
             "STRICT_CONTEXT",
@@ -89,7 +92,7 @@ class NextFrameworkSettings:
             if key not in user:
                 continue
             raw = user[key]
-            if key in {"URL_NAME_TEMPLATE", "URL_RESOLVER"} and isinstance(raw, str):
+            if key in self.STR_KEYS and isinstance(raw, str):
                 out[key] = raw
             elif key == "FORM_WIZARD_BACKEND" and isinstance(raw, dict):
                 out[key] = freeze({**self.DEFAULTS[key], **raw})

--- a/next/deps/context.py
+++ b/next/deps/context.py
@@ -1,10 +1,9 @@
 """Resolution-context snapshot passed to providers during DI resolution.
 
-`ResolutionContext` collects request, form, URL kwargs, and template
-context data into a single immutable view. Providers read from this
-object without mutating it. `RESERVED_KEYS` lists the kwarg names that
-`DependencyResolver.resolve_dependencies` treats as fixed inputs rather
-than URL kwargs.
+`ResolutionContext` collects request, form, URL kwargs, and template context data into a
+single immutable view. Providers read from this object without mutating it.
+`RESERVED_KEYS` lists the kwarg names that `DependencyResolver.resolve_dependencies`
+treats as fixed inputs rather than URL kwargs.
 """
 
 from __future__ import annotations

--- a/next/deps/resolver.py
+++ b/next/deps/resolver.py
@@ -19,7 +19,7 @@ from .providers import ParameterProvider, RegisteredParameterProvider
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
     from django.http import HttpRequest
 
@@ -302,7 +302,7 @@ class DependencyResolver:
         func: Callable[..., Any],
         *,
         request: HttpRequest | None = None,
-        template_context: dict[str, Any] | None = None,
+        template_context: Mapping[str, Any] | None = None,
         _cache: dict[str, Any] | DependencyCache | None = None,
         _stack: list[str] | None = None,
     ) -> dict[str, Any]:
@@ -313,7 +313,7 @@ class DependencyResolver:
         providers such as `HttpRequestProvider` on a parameter literally
         named `request`.
         """
-        tc: dict[str, Any] = dict(template_context or {})
+        tc: Mapping[str, Any] = template_context or {}
         injectable = {
             k: v for k, v in tc.items() if k not in self.EXPLICIT_RESOLVE_KEYS
         }

--- a/next/deps/resolver.py
+++ b/next/deps/resolver.py
@@ -131,9 +131,8 @@ class DependencyResolver:
     ) -> bool:
         """Return whether a registered provider fills `param` of `func` in `context`.
 
-        `func` travels along because a provider may read the callable to
-        resolve the annotation, and `EXPLICIT_RESOLVE_KEYS` is left to the
-        caller.
+        `func` travels along because a provider may read the callable to resolve the
+        annotation, and `EXPLICIT_RESOLVE_KEYS` is left to the caller.
         """
         self._ensure_providers()
         self._resolve_call_stack.append(func)
@@ -308,10 +307,9 @@ class DependencyResolver:
     ) -> dict[str, Any]:
         """Resolve `func` for component callables using template context.
 
-        Keys from `EXPLICIT_RESOLVE_KEYS` are stripped from the context
-        data so that name-based providers cannot shadow dedicated
-        providers such as `HttpRequestProvider` on a parameter literally
-        named `request`.
+        Keys from `EXPLICIT_RESOLVE_KEYS` are stripped from the context data so that
+        name-based providers cannot shadow dedicated providers such as
+        `HttpRequestProvider` on a parameter literally named `request`.
         """
         tc: Mapping[str, Any] = template_context or {}
         injectable = {

--- a/next/deps/signals.py
+++ b/next/deps/signals.py
@@ -1,9 +1,8 @@
 """Django signals emitted by the dependency-injection layer.
 
-`provider_registered` fires whenever a `RegisteredParameterProvider`
-subclass is added to the auto-registry. External code may listen to
-the signal to observe provider wiring, typically in tests or
-diagnostics.
+`provider_registered` fires whenever a `RegisteredParameterProvider` subclass is added
+to the auto-registry. External code may listen to the signal to observe provider wiring,
+typically in tests or diagnostics.
 """
 
 from django.dispatch import Signal

--- a/next/forms/__init__.py
+++ b/next/forms/__init__.py
@@ -1,16 +1,14 @@
 """Form actions and helpers for next-dj.
 
-Subclass `Form`, `ModelForm`, or `FormWizard` to auto-register an
-action through `__init_subclass__`. Use `@action` for form-less
-handlers. Each action gets a stable UID endpoint. Valid submissions
-run the handler. Invalid forms re-render with errors. CSRF is applied
-for posted forms.
+Subclass `Form`, `ModelForm`, or `FormWizard` to auto-register an action
+through `__init_subclass__`. Use `@action` for form-less handlers. Each
+action gets a stable UID endpoint. Valid submissions run the handler.
+Invalid forms re-render with errors. CSRF is applied for posted forms.
 
-Any public `django.forms` name resolves through `next.forms` unless
-next.dj deliberately overrides it. The formset and modelform factories
-plus `BoundField` are re-exported statically for type checkers, the
-rest of the `django.forms` passthrough resolves at runtime only.
-Framework machinery lives in the submodules, for example
+Any public `django.forms` name resolves through `next.forms` unless next.dj deliberately
+overrides it. The formset and modelform factories plus `BoundField` are re-exported
+statically for type checkers, the rest of the `django.forms` passthrough resolves at
+runtime only. Framework machinery lives in the submodules, for example
 `next.forms.dispatch` and `next.forms.manager`.
 """
 

--- a/next/forms/backends.py
+++ b/next/forms/backends.py
@@ -240,9 +240,9 @@ class RegistryBackendSnapshot:
 class ActionRegistration:
     """A form action to register with its name, declaration site, and target.
 
-    Exactly one of `handler`, `form_class`, or `wizard_class` is the action
-    target, except the `@action(form_class=...)` path which supplies a handler
-    and a form-factory together.
+    Exactly one of `handler`, `form_class`, or `wizard_class`
+    is the action target, except the `@action(form_class=...)`
+    path which supplies a handler and a form-factory together.
     """
 
     name: str

--- a/next/forms/dispatch/build.py
+++ b/next/forms/dispatch/build.py
@@ -135,9 +135,8 @@ def _resolve_form_class(
 ) -> "tuple[type[django_forms.Form], dict[str, Any]]":
     """Return `(form_class, init_kwargs)` for the dispatch.
 
-    A factory may return a `Form` subclass or `(cls, init_kwargs)`. The
-    latter bypasses `get_initial` and passes `**init_kwargs` to the form
-    constructor.
+    A factory may return a `Form` subclass or `(cls, init_kwargs)`. The latter bypasses
+    `get_initial` and passes `**init_kwargs` to the form constructor.
     """
     if isinstance(form_class, type):
         return cast("type[django_forms.Form]", form_class), {}

--- a/next/forms/dispatch/responses.py
+++ b/next/forms/dispatch/responses.py
@@ -120,10 +120,9 @@ def _origin_rerender_response(
 ) -> HttpResponse:
     """Re-render the origin page after a valid submission's handler returned None.
 
-    The success response carries no invalid-submission headers and never
-    re-enters `backend.shape_response`, so envelopes keyed off
-    `ActionOutcomeKind.INVALID` stay untouched. An unresolvable origin
-    yields 400.
+    The success response carries no invalid-submission headers and never re-enters
+    `backend.shape_response`, so envelopes keyed off `ActionOutcomeKind.INVALID` stay
+    untouched. An unresolvable origin yields 400.
     """
     origin_match = resolve_origin(request)
     if origin_match is None or origin_match.page_path is None:

--- a/next/forms/dispatch/wizard.py
+++ b/next/forms/dispatch/wizard.py
@@ -61,9 +61,8 @@ def _bind_wizard_step(
 ) -> "HttpResponse | tuple[FormWizard, str, django_forms.Form]":
     """Authorize the step POST and bind its form, or return an early response.
 
-    Both permission layers and the validate-only short circuit run here
-    before any storage write, so a guarded validator never runs for an
-    unauthorized caller.
+    Both permission layers and the validate-only short circuit run here before any
+    storage write, so a guarded validator never runs for an unauthorized caller.
     """
     if state.origin_match is None:
         return HttpResponseBadRequest("Missing or invalid _next_form_origin")

--- a/next/forms/origin.py
+++ b/next/forms/origin.py
@@ -48,10 +48,9 @@ def resolve_url_to_match(
 ) -> "OriginMatch | None":
     """Resolve a same-site URL against the URLconf to a page identity.
 
-    The URL travels through the same URLconf the request uses, with the
-    script prefix stripped. Set `filter_reserved` to keep the captured URL
-    kwargs raw when the caller needs every captured parameter rather than
-    only the DI-safe ones.
+    The URL travels through the same URLconf the request uses, with the script prefix
+    stripped. Set `filter_reserved` to keep the captured URL kwargs raw when the caller
+    needs every captured parameter rather than only the DI-safe ones.
     """
     path = url.partition("?")[0]
     prefix = get_script_prefix()

--- a/next/forms/signals.py
+++ b/next/forms/signals.py
@@ -1,63 +1,54 @@
 """Django signals emitted by the forms subsystem.
 
 The `action_registered` signal fires after the backend stores an action
-target for a name. The sender is the backend class. The keyword
-arguments are `action_name`, `uid`, `form_class`, `wizard_class`,
-`file_path`, `scope`, and `handler`. Exactly one of `handler`,
-`form_class`, or `wizard_class` identifies the registered target,
-except the `@action(form_class=...)` path which supplies a handler and
-a form factory together. `file_path` is the module the form, wizard, or
-handler was declared in and `scope` is `"page"` or `"shared"`. Together
-they give receivers a real grouping key under the file-scoped model.
+target for a name. The sender is the backend class. The keyword arguments are
+`action_name`, `uid`, `form_class`, `wizard_class`, `file_path`, `scope`, and
+`handler`. Exactly one of `handler`, `form_class`, or `wizard_class` identifies
+the registered target, except the `@action(form_class=...)` path which supplies
+a handler and a form factory together. `file_path` is the module the form,
+wizard, or handler was declared in and `scope` is `"page"` or `"shared"`.
+Together they give receivers a real grouping key under the file-scoped model.
 
 Every dispatch-time signal (`action_dispatched`, `form_validation_failed`,
-`wizard_step_submitted`, `wizard_completed`) carries `uid` and `request`.
-`uid` is the registry identity of the action, the same value the action
-URL and the `data-next-action` markup attribute carry, or `None` when a
-custom backend stores no uid in its meta. `request` is the live
-`HttpRequest` being dispatched and must not be retained past the
-receiver call.
+`wizard_step_submitted`, `wizard_completed`) carries `uid` and `request`. `uid` is the
+registry identity of the action, the same value the action URL and the
+`data-next-action` markup attribute carry, or `None` when a custom backend stores no uid
+in its meta. `request` is the live `HttpRequest` being dispatched and must not be
+retained past the receiver call.
 
-The `action_dispatched` signal fires after a handler runs and the
-response has been coerced. It also fires once per valid wizard step,
-where a step advance runs no handler and reports `duration_ms` as
-0.0. The sender is `FormActionDispatch`. The keyword arguments are
-`action_name`, `uid`, `request`, `form`, `url_kwargs`, `duration_ms`,
-`response_status`, and `dep_cache`. `form` is the bound form instance
-after successful validation, or `None` for handler-only actions
-registered without a `form_class`. `url_kwargs` is a copy of the URL
-kwargs the dispatcher resolved before invoking the handler.
-`dep_cache` is a snapshot of the dispatch DI cache so receivers can
-read named dependencies (`Depends("name")` values) resolved during
-this dispatch without re-running their providers.
+The `action_dispatched` signal fires after a handler runs and the response has
+been coerced. It also fires once per valid wizard step, where a step advance runs
+no handler and reports `duration_ms` as 0.0. The sender is `FormActionDispatch`.
+The keyword arguments are `action_name`, `uid`, `request`, `form`, `url_kwargs`,
+`duration_ms`, `response_status`, and `dep_cache`. `form` is the bound form
+instance after successful validation, or `None` for handler-only actions
+registered without a `form_class`. `url_kwargs` is a copy of the URL kwargs the
+dispatcher resolved before invoking the handler. `dep_cache` is a snapshot of
+the dispatch DI cache so receivers can read named dependencies (`Depends("name")`
+values) resolved during this dispatch without re-running their providers.
 
-The `form_validation_failed` signal fires when the bound form fails
-validation during dispatch. The sender is `FormActionDispatch`. The
-keyword arguments are `action_name`, `uid`, `request`, `error_count`,
-and `field_names`.
+The `form_validation_failed` signal fires when the bound form fails validation during
+dispatch. The sender is `FormActionDispatch`. The keyword arguments are `action_name`,
+`uid`, `request`, `error_count`, and `field_names`.
 
-The `wizard_step_submitted` signal fires after a FormWizard step
-validates during dispatch. The sender is the wizard class, so
-receivers connected with `sender=MyWizard` fire for that wizard only.
-The keyword arguments are `step`, `cleaned_data`, `uid`, and
-`request`. `cleaned_data` is a copy of the validated cleaned data for
-that step.
+The `wizard_step_submitted` signal fires after a FormWizard step validates during
+dispatch. The sender is the wizard class, so receivers connected with `sender=MyWizard`
+fire for that wizard only. The keyword arguments are `step`, `cleaned_data`, `uid`, and
+`request`. `cleaned_data` is a copy of the validated cleaned data for that step.
 
-The `wizard_completed` signal fires after the wizard `done` method
-runs for the final step and its response is below HTTP 400. An error
-response from `done` skips the signal and keeps the saved drafts for
-retry. The sender is the wizard class. The keyword arguments are
-`cleaned_data`, `uid`, and `request`. `cleaned_data` is the merged
-mapping passed to `done`.
+The `wizard_completed` signal fires after the wizard `done` method runs for
+the final step and its response is below HTTP 400. An error response from
+`done` skips the signal and keeps the saved drafts for retry. The sender
+is the wizard class. The keyword arguments are `cleaned_data`, `uid`,
+and `request`. `cleaned_data` is the merged mapping passed to `done`.
 
-The `form_access_denied` signal fires only when a dynamic permission
-hook denies a request, never on the static `ActionGuard` fast-path. The
-sender is `FormActionDispatch`. The keyword arguments are `action_name`,
-`uid`, `request`, `layer`, and `reason`. `layer` is `"view"` for a
-`check_permissions` denial or `"object"` for a `has_object_permission`
-denial. `reason` is `"raised"` when the hook raised `PermissionDenied`,
-`"denied"` when it returned `False`, or `"response"` when it returned an
-`HttpResponse` short-circuit.
+The `form_access_denied` signal fires only when a dynamic permission hook denies a
+request, never on the static `ActionGuard` fast-path. The sender is
+`FormActionDispatch`. The keyword arguments are `action_name`, `uid`, `request`,
+`layer`, and `reason`. `layer` is `"view"` for a `check_permissions` denial or
+`"object"` for a `has_object_permission` denial. `reason` is `"raised"` when the hook
+raised `PermissionDenied`, `"denied"` when it returned `False`, or `"response"` when it
+returned an `HttpResponse` short-circuit.
 """
 
 from django.dispatch import Signal

--- a/next/forms/wizard.py
+++ b/next/forms/wizard.py
@@ -479,10 +479,9 @@ class FormWizard:
     def current_step(self) -> str:
         """Return the active step from the URL kwarg, defaulting to the first.
 
-        URL kwargs that exist but lack the `Meta.url_param` key signal a
-        route whose step segment is named differently, which would pin the
-        wizard to its first step forever, so that misconfiguration raises
-        instead of falling back.
+        URL kwargs that exist but lack the `Meta.url_param` key signal a route whose
+        step segment is named differently, which would pin the wizard to its first step
+        forever, so that misconfiguration raises instead of falling back.
         """
         names = self.step_names()
         raw = self.url_kwargs.get(self.url_param)

--- a/next/pages/checks.py
+++ b/next/pages/checks.py
@@ -195,10 +195,9 @@ def _holds_a_page(directory: Path) -> bool:
 def check_unrouted_working_directory_pages(*args, **kwargs) -> list[CheckMessage]:
     """Warn when a pages tree beside the process is routed by nobody (`next.W002`).
 
-    A project that lists no root in `DIRS` keeps writing pages under a directory
-    the router never reaches, and the pages are never served. Nothing else
-    reports that, because the checks walk the trees the routers report and this
-    one is not among them.
+    A project that lists no root in `DIRS` keeps writing pages under a directory the
+    router never reaches, and the pages are never served. Nothing else reports that,
+    because the checks walk the trees the routers report and this one is not among them.
     """
     router_manager, _init_errors = get_router_manager()
     if router_manager is None:
@@ -605,11 +604,10 @@ def _check_context_function(
 ) -> CheckMessage | None:
     """Emit an error when keyless context callables are not annotated dict-like.
 
-    The check is static, because executing user code at ``manage.py check``
-    time is expensive and can hit databases that have not been migrated yet.
-    Callables without a return annotation are accepted.
-    The runtime emits a clear ``TypeError`` on first render if the result is
-    not a mapping.
+    The check is static, because executing user code at ``manage.py check`` time is
+    expensive and can hit databases that have not been migrated yet. Callables without a
+    return annotation are accepted. The runtime emits a clear ``TypeError`` on first
+    render if the result is not a mapping.
     """
     try:
         annotation = inspect.signature(func).return_annotation

--- a/next/pages/context.py
+++ b/next/pages/context.py
@@ -32,9 +32,8 @@ class Context:
 
     An empty `Context()` reads the parameter name from context_data. A
     string source reads that context key. A callable source is called
-    with DI-resolved arguments. Any other object becomes a constant.
-    The `default` keyword supplies a fallback when the context key is
-    missing.
+    with DI-resolved arguments. Any other object becomes a constant. The
+    `default` keyword supplies a fallback when the context key is missing.
     """
 
     source: object | None = None

--- a/next/pages/loaders.py
+++ b/next/pages/loaders.py
@@ -76,9 +76,8 @@ def has_load_errors() -> bool:
 def _record_load_error(file_path: Path, exc: Exception, mtime: float | None) -> None:
     """Remember the import failure keyed by the mtime taken before exec.
 
-    A `None` mtime means the file vanished before executing, so any
-    stale record is dropped instead of binding the failure to a file
-    that no longer exists.
+    A `None` mtime means the file vanished before executing, so any stale record is
+    dropped instead of binding the failure to a file that no longer exists.
     """
     if mtime is None:
         _LAST_LOAD_ERROR.pop(file_path, None)
@@ -116,9 +115,8 @@ def last_load_error(file_path: Path) -> PageModuleImportError | None:
 def _load_python_module(file_path: Path) -> types.ModuleType | None:
     """Load `file_path` as a module or return `None` on failure.
 
-    Whatever the module body raises is recorded through `_record_load_error`,
-    so callers tell a broken `page.py` from an absent one via
-    `last_load_error`.
+    Whatever the module body raises is recorded through `_record_load_error`, so callers
+    tell a broken `page.py` from an absent one via `last_load_error`.
     """
     try:
         spec = importlib.util.spec_from_file_location("page_module", file_path)
@@ -179,9 +177,8 @@ def _load_python_module_memo(file_path: Path) -> types.ModuleType | None:
 def reset_module_memo() -> None:
     """Drop every memoised module so the next load re-executes from disk.
 
-    The memo keys by mtime, so a rewrite landing on the same tick would
-    otherwise return a stale module. Recorded import failures share that
-    lifecycle and go with it.
+    The memo keys by mtime, so a rewrite landing on the same tick would otherwise return
+    a stale module. Recorded import failures share that lifecycle and go with it.
     """
     # Errors go first, so a load racing this reset can at worst leave a fresh
     # memo entry behind, never a memoised failure without its recorded error.
@@ -280,10 +277,9 @@ class TemplateLoader(ABC):
     def source_path(self, file_path: Path) -> Path | None:
         """Return the filesystem path this loader reads for `file_path`.
 
-        The page manager uses the result to snapshot file mtimes for
-        stale-cache detection. The default returns `None` for
-        non-file-based loaders. Subclasses override when they back a
-        sibling file.
+        The page manager uses the result to snapshot file mtimes for stale-cache
+        detection. The default returns `None` for non-file-based loaders. Subclasses
+        override when they back a sibling file.
         """
         del file_path
         return None
@@ -387,9 +383,8 @@ class LayoutTemplateLoader(TemplateLoader):
     def layout_sources(self, file_path: Path) -> tuple[list[Path], list[Path]]:
         """Return the layout files behind `file_path` and the directories watched.
 
-        A `layout.djx` appearing or disappearing moves the mtime of its
-        directory and of no tracked file, so a caller detecting change needs
-        the directories too.
+        A `layout.djx` appearing or disappearing moves the mtime of its directory and of
+        no tracked file, so a caller detecting change needs the directories too.
         """
         return self._walk_ancestors(
             file_path, self._watched_ancestor_depth(file_path.parent)

--- a/next/pages/manager.py
+++ b/next/pages/manager.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, overload
 
-from django.conf import settings
 from django.http import Http404, HttpRequest, HttpResponse
 from django.http.response import HttpResponseBase
 from django.template import Context as DjangoTemplateContext, Origin, Template
@@ -25,7 +24,7 @@ from django.urls import URLPattern, path
 from next.conf import fail_loudly, next_framework_settings
 from next.deps import DependencyResolver, resolver
 from next.ports import partial_shaper_slot
-from next.utils import defining_file
+from next.utils import defining_file, template_edits_watched
 
 from .loaders import (
     LayoutTemplateLoader,
@@ -56,15 +55,6 @@ logger = logging.getLogger(__name__)
 
 # Mtimes of every source behind one composition, keyed by its page path.
 type _SourceMtimes = dict[Path, dict[Path, float]]
-
-
-def template_edits_watched() -> bool:
-    """Whether the composition caches stat their sources to notice an edit.
-
-    Autoreload leaves `.djx` alone, so under `DEBUG` the stat is the only
-    thing making an edit visible. Read per call, so an override takes effect.
-    """
-    return bool(settings.DEBUG)
 
 
 class _RoutedPageView(Protocol):

--- a/next/pages/manager.py
+++ b/next/pages/manager.py
@@ -249,13 +249,11 @@ class Page:
     ) -> str:
         """Return the static body for `file_path` without invoking `render()`.
 
-        The `module.template` attribute wins when set to a non-`None`
-        string. Otherwise the framework consults registered
-        `TemplateLoader` instances in the order declared under
-        `NEXT_FRAMEWORK["TEMPLATE_LOADERS"]`. The first loader that can
-        load the path returns the body. An empty string is returned
-        when no source is present so an ancestor layout can still
-        render with an empty slot.
+        The `module.template` attribute wins when set to a non-`None` string. Otherwise
+        the framework consults registered `TemplateLoader` instances in the order
+        declared under `NEXT_FRAMEWORK["TEMPLATE_LOADERS"]`. The first loader that can
+        load the path returns the body. An empty string is returned when no source is
+        present so an ancestor layout can still render with an empty slot.
         """
         if module is not None:
             template_attr = getattr(module, "template", None)

--- a/next/pages/registry.py
+++ b/next/pages/registry.py
@@ -51,10 +51,9 @@ class PageContextEntry(NamedTuple):
 class ZoneBinding(NamedTuple):
     """One registered `@context` seen through its zone binding.
 
-    The zone diagnostics pair a bound callable with the callables reading
-    its key, so the zones travel next to the callable while the rest of the
-    entry stays inside the registry. A `zones` of `None` marks a callable
-    every render runs.
+    The zone diagnostics pair a bound callable with the callables reading its key, so
+    the zones travel next to the callable while the rest of the entry stays inside the
+    registry. A `zones` of `None` marks a callable every render runs.
     """
 
     key: str | None
@@ -229,14 +228,13 @@ class PageContextRegistry:
         """Merge inherited ancestor page.py context with this file's context callables.
 
         Inherited context comes from ``@context(..., inherit_context=True)``
-        callables in ancestor ``page.py`` files, not from layout files.
-        The returned `ContextResult` separates the full template context
-        from the JavaScript-serializable subset. The js_context uses
-        first-registration semantics so that page-level values always
-        take priority over inherited ones. A `_requested_zones` batch narrows
-        this file's callables to the zone-less ones plus those bound to a
-        named zone in the batch, a full render passes no batch and runs
-        every callable.
+        callables in ancestor ``page.py`` files, not from layout files. The
+        returned `ContextResult` separates the full template context from the
+        JavaScript-serializable subset. The js_context uses first-registration
+        semantics so that page-level values always take priority over
+        inherited ones. A `_requested_zones` batch narrows this file's
+        callables to the zone-less ones plus those bound to a named zone in
+        the batch, a full render passes no batch and runs every callable.
         """
         context_data: dict[str, Any] = {}
         js_context: dict[str, Any] = {}

--- a/next/pages/signals.py
+++ b/next/pages/signals.py
@@ -1,20 +1,18 @@
 """Signals emitted during template loading, context collection, and rendering.
 
-These signals let external subscribers observe the page rendering
-pipeline without subclassing internal collaborators.
+These signals let external subscribers observe the page rendering pipeline without
+subclassing internal collaborators.
 
-The `template_loaded` signal fires after a template source is
-registered on a page. The sender is `Page`. The keyword argument is
-`file_path`.
+The `template_loaded` signal fires after a template source is registered on a page. The
+sender is `Page`. The keyword argument is `file_path`.
 
 The `context_registered` signal fires after a context callable is
-attached to a page module. The sender is `PageContextRegistry`. The
-keyword arguments are `file_path` and `key`.
+attached to a page module. The sender is `PageContextRegistry`.
+The keyword arguments are `file_path` and `key`.
 
-The `page_rendered` signal fires after `Page.render` finishes
-producing HTML and injecting static assets. The sender is `Page`. The
-keyword arguments are `file_path`, `duration_ms`, `styles_count`,
-`scripts_count`, and `context_keys`.
+The `page_rendered` signal fires after `Page.render` finishes producing HTML and
+injecting static assets. The sender is `Page`. The keyword arguments are `file_path`,
+`duration_ms`, `styles_count`, `scripts_count`, and `context_keys`.
 """
 
 from django.dispatch import Signal

--- a/next/pages/watch.py
+++ b/next/pages/watch.py
@@ -1,9 +1,8 @@
 """Discovery helpers that list page roots and component folder pairs.
 
-`runserver`, `collectstatic` and the staticfiles finder all reach these
-helpers, so every read of third-party router code catches what that code
-raises and drops the backend from the answer rather than passing on a
-value of the wrong shape.
+`runserver`, `collectstatic` and the staticfiles finder all reach these helpers, so
+every read of third-party router code catches what that code raises and drops the
+backend from the answer rather than passing on a value of the wrong shape.
 """
 
 from __future__ import annotations

--- a/next/partial/backends.py
+++ b/next/partial/backends.py
@@ -18,12 +18,11 @@ _SSE_EVENT_NAME = "next-patches"
 class PartialProtocolBackend:
     """Owner of the wire format for patch envelopes.
 
-    The default backend serialises envelopes as a compact JSON envelope
-    under `application/vnd.next.patches+json`. A third party may swap the
-    wire format, for example to emulate Turbo Streams, by registering a
-    different backend through `PARTIAL_BACKENDS` without touching shaping
-    or the registries. Both `serialize_envelope` and `sse_event` operate
-    over the same JSON envelope.
+    The default backend serialises envelopes as a compact JSON envelope under
+    `application/vnd.next.patches+json`. A third party may swap the wire format, for
+    example to emulate Turbo Streams, by registering a different backend through
+    `PARTIAL_BACKENDS` without touching shaping or the registries. Both
+    `serialize_envelope` and `sse_event` operate over the same JSON envelope.
     """
 
     content_type: str = CONTENT_TYPE

--- a/next/partial/checks.py
+++ b/next/partial/checks.py
@@ -1,9 +1,8 @@
 """System checks for the partial-rendering subsystem.
 
-This module is excluded from coverage like every other area `checks.py`.
-The zone checks read the same compiled page templates the renderer uses,
-so a misconfigured zone is caught at `manage.py check` time rather than
-on a partial request.
+This module is excluded from coverage like every other area `checks.py`. The zone checks
+read the same compiled page templates the renderer uses, so a misconfigured zone is
+caught at `manage.py check` time rather than on a partial request.
 """
 
 import re
@@ -398,9 +397,8 @@ def _zones_directly_in_with(nodelist: NodeList) -> "Iterator[str]":
 def check_context_zone_names_exist(*args, **kwargs) -> list[CheckMessage]:
     """Error when a `@context(zone=)` names an undeclared zone (`next.E078`).
 
-    A full render runs every callable, so a misspelt zone name looks
-    healthy there and silently drops the callable from every zone
-    request instead.
+    A full render runs every callable, so a misspelt zone name looks healthy there and
+    silently drops the callable from every zone request instead.
     """
     messages: list[CheckMessage] = []
     # The composed-template walk imports each `page.py`, so read bindings after.
@@ -612,9 +610,9 @@ def _partial_backends_active() -> bool:
 def check_single_partial_backend(*args, **kwargs) -> list[CheckMessage]:
     """Warn when more than one partial protocol backend is configured (`next.W071`).
 
-    Partial rendering uses a single protocol backend. Only the first valid
-    PARTIAL_BACKENDS entry is instantiated, so a second entry is dead config
-    that silently never runs.
+    Partial rendering uses a single protocol backend. Only
+    the first valid PARTIAL_BACKENDS entry is instantiated,
+    so a second entry is dead config that silently never runs.
     """
     valid = [
         config for config in _partial_backend_configs() if isinstance(config, dict)

--- a/next/partial/manager.py
+++ b/next/partial/manager.py
@@ -56,12 +56,11 @@ def asset_version() -> str:
 def _resolve_asset_version() -> str:
     """Resolve the asset version from the backend options and the manifest.
 
-    An explicit `VERSION` option wins so a deployment may pin the version
-    to a release tag. The `"manifest"` sentinel resolves to a stable hash
-    of the staticfiles manifest when the active staticfiles storage hashes
-    its files, so the deploy-mismatch guard works out of the box. Without
-    a manifest storage the sentinel falls back to a stable default and the
-    guard never fires.
+    An explicit `VERSION` option wins so a deployment may pin the version to a release
+    tag. The `"manifest"` sentinel resolves to a stable hash of the staticfiles manifest
+    when the active staticfiles storage hashes its files, so the deploy-mismatch guard
+    works out of the box. Without a manifest storage the sentinel falls back to a stable
+    default and the guard never fires.
     """
     options = partial_backend_manager.get().options
     configured = options.get(_VERSION_OPTION, _MANIFEST_VERSION)

--- a/next/partial/patches.py
+++ b/next/partial/patches.py
@@ -81,11 +81,10 @@ class Patches:
     def __init__(self, request: HttpRequest, *, echo_of: str | None = None) -> None:
         """Start an empty builder bound to the request.
 
-        Pass `echo_of` with the originating mutation's request id so the
-        envelope carries it as `request_id`, letting an SSE subscriber
-        suppress its own echo. Only the stream path passes it, the HTTP
-        response path leaves it unset since the answer already reaches the
-        initiator.
+        Pass `echo_of` with the originating mutation's request id so the envelope
+        carries it as `request_id`, letting an SSE subscriber suppress its own echo.
+        Only the stream path passes it, the HTTP response path leaves it unset since the
+        answer already reaches the initiator.
         """
         self._init_state(request, asset_version(), echo_of)
 
@@ -93,9 +92,8 @@ class Patches:
     def versioned(cls, version: str, *, echo_of: str | None = None) -> "Patches":
         """Start an empty request-free builder stamped with a literal version.
 
-        The builder stays a low-level envelope assembler with no request,
-        used by paths that already hold the version and render their own
-        HTML.
+        The builder stays a low-level envelope assembler with no request, used by paths
+        that already hold the version and render their own HTML.
         """
         builder = cls.__new__(cls)
         builder._init_state(None, version, echo_of)
@@ -162,9 +160,9 @@ class Patches:
     ) -> "Patches":
         """Route a zone-selected morph to its local or foreign per-verb method.
 
-        A `url_kwargs` without a `page` names a foreign page's URL with no
-        page to render, so it is refused rather than dropped into a local
-        zone render that ignores it.
+        A `url_kwargs` without a `page` names a foreign page's
+        URL with no page to render, so it is refused rather
+        than dropped into a local zone render that ignores it.
         """
         if "page" in select:
             self._reject_extra_morph_keys(select, _FOREIGN_ZONE_MORPH_KEYS)
@@ -217,15 +215,13 @@ class Patches:
     ) -> "Patches":
         """Render a zone of a foreign page out of band, re-running its guards.
 
-        The page is named by its page path or by a URL of it, which is
-        resolved through the URLconf to the page that serves it. The
-        foreign page's body resolution runs first, so a redirect or a
-        denial short-circuits before any zone renders and raises instead
-        of morphing an empty body. A `render()` string body has no zone to
-        render standalone, so it is refused the same way the OOB view
-        branch refuses it. With the page authorized, the named zone renders
-        standalone with the foreign page's URL kwargs and morphs in place
-        addressed by zone name.
+        The page is named by its page path or by a URL of it, which is resolved through
+        the URLconf to the page that serves it. The foreign page's body resolution runs
+        first, so a redirect or a denial short-circuits before any zone renders and
+        raises instead of morphing an empty body. A `render()` string body has no zone
+        to render standalone, so it is refused the same way the OOB view branch refuses
+        it. With the page authorized, the named zone renders standalone with the foreign
+        page's URL kwargs and morphs in place addressed by zone name.
         """
         request = self._require_request()
         foreign_path = self._foreign_page_path(page)
@@ -323,12 +319,11 @@ class Patches:
     def context(self, **names) -> "Patches":
         """Merge named serialize provider values into the client context.
 
-        Only the names of registered `serialize=True` providers on the
-        origin page are accepted. A framework-owned init-payload key raises
-        `ReservedContextKeyError` whether or not the origin page registered
-        it, so the refusal does not depend on the collision the check warns
-        about. The values are serialized through `resolve_serializer()` so
-        the wire carries plain data.
+        Only the names of registered `serialize=True` providers on the origin page are
+        accepted. A framework-owned init-payload key raises `ReservedContextKeyError`
+        whether or not the origin page registered it, so the refusal does not depend on
+        the collision the check warns about. The values are serialized through
+        `resolve_serializer()` so the wire carries plain data.
         """
         reserved = RESERVED_PAYLOAD_KEYS & names.keys()
         if reserved:

--- a/next/partial/registry.py
+++ b/next/partial/registry.py
@@ -140,10 +140,9 @@ def _nested_names(partial: "ZonePartial") -> frozenset[str]:
 def zones_of(template: "Template") -> "Mapping[str, ZoneInfo]":
     """Return the named zones of a compiled template, memoised per object.
 
-    The cache keys on the compiled template object, so a recompiled
-    page gets a fresh entry while the stale object is collected. The
-    first read of a template announces its zones through
-    `zone_registered`.
+    The cache keys on the compiled template object, so a recompiled page gets a fresh
+    entry while the stale object is collected. The first read of a template announces
+    its zones through `zone_registered`.
     """
     cached = _zone_cache.get(template)
     if cached is not None:

--- a/next/partial/render.py
+++ b/next/partial/render.py
@@ -51,11 +51,10 @@ class ZoneRenderResult:
     """Rendered zones plus the assets their bodies collected.
 
     `html` maps each rendered zone name to its wrapped marker element and
-    `bodies` maps it to the bare inner body. A morph or replace addresses
-    the wrapped element, an append or prepend grafts the bare body into the
-    live zone. `collector` carries the co-located assets the bodies
-    registered so the caller can ship a manifest outward, past the no-op
-    inject.
+    `bodies` maps it to the bare inner body. A morph or replace addresses the
+    wrapped element, an append or prepend grafts the bare body into the live
+    zone. `collector` carries the co-located assets the bodies registered
+    so the caller can ship a manifest outward, past the no-op inject.
     """
 
     html: dict[str, str]
@@ -92,11 +91,10 @@ def render_zone(
 ) -> ZoneRenderResult:
     """Render the named zones of a page with the full page context.
 
-    The batch travels into the context build widened by the zones nested in
-    the requested bodies, so a `@context(zone=)` bound outside it never runs.
-    An unknown zone name is skipped so one stale name never poisons a batch,
-    while a batch of only unknown names raises and a single-zone request keeps
-    its 400.
+    The batch travels into the context build widened by the zones nested in the
+    requested bodies, so a `@context(zone=)` bound outside it never runs. An unknown
+    zone name is skipped so one stale name never poisons a batch, while a batch of only
+    unknown names raises and a single-zone request keeps its 400.
     """
     start = time.perf_counter()
     kwargs = url_kwargs or {}

--- a/next/partial/shaping.py
+++ b/next/partial/shaping.py
@@ -69,11 +69,10 @@ def shape_partial(
 ) -> HttpResponse:
     """Shape one action outcome as a patch envelope for a partial request.
 
-    The CSRF rotation marker is read here, before any form or zone
-    re-render mints a token and sets the marker as a side effect, so a
-    login on the submit path stamps the fresh token onto whichever shape
-    the outcome takes. Reading it after a re-render would flag every
-    response as rotated.
+    The CSRF rotation marker is read here, before any form or zone re-render mints a
+    token and sets the marker as a side effect, so a login on the submit path stamps the
+    fresh token onto whichever shape the outcome takes. Reading it after a re-render
+    would flag every response as rotated.
     """
     rotated = _csrf_rotated(request)
     if outcome.kind == ActionOutcomeKind.INVALID:
@@ -127,9 +126,8 @@ def shape_validate(
 def drain_messages(request: "HttpRequest", patches: Patches) -> Patches:
     """Drain pending contrib.messages into toast patches.
 
-    Iterating `get_messages` marks the messages read, so a later full
-    navigation does not replay them. The success message of an action
-    becomes a toast for free.
+    Iterating `get_messages` marks the messages read, so a later full navigation does
+    not replay them. The success message of an action becomes a toast for free.
     """
     for message in get_messages(request):
         variant = _MESSAGE_VARIANTS.get(message.level_tag, "info")
@@ -287,12 +285,11 @@ def _redirect_as_visit(
 ) -> HttpResponse:
     """Pack a handler redirect into a `visit`, full-navigating external hosts.
 
-    A same-site URL travels as an internal visit the validator approves.
-    A server-authored external URL such as an OAuth or payment gateway
-    travels with a full-navigation marker so it is not rejected by the
-    same-host validator. The external branch trusts the handler's redirect
-    target, so a handler must never build it from user input or the page
-    becomes an open redirect.
+    A same-site URL travels as an internal visit the validator approves. A
+    server-authored external URL such as an OAuth or payment gateway travels with a
+    full-navigation marker so it is not rejected by the same-host validator. The
+    external branch trusts the handler's redirect target, so a handler must never build
+    it from user input or the page becomes an open redirect.
     """
     href = redirect["Location"]
     internal = url_has_allowed_host_and_scheme(

--- a/next/partial/signals.py
+++ b/next/partial/signals.py
@@ -1,34 +1,30 @@
 """Django signals emitted by the partial-rendering subsystem.
 
-Every signal name is past tense and the sender is the owning class. The
-hot-path idiom is to send only when the signal has receivers, so a
-quiet deployment pays nothing.
+Every signal name is past tense and the sender is the owning class. The hot-path idiom
+is to send only when the signal has receivers, so a quiet deployment pays nothing.
 
-The `zone_registered` signal fires once per compiled composed template
-when its named zones are first read. The sender is the compiled
-template class. The keyword arguments are `template`, `zone_name`,
-`lazy`, and `poll`.
+The `zone_registered` signal fires once per compiled composed template when its named
+zones are first read. The sender is the compiled template class. The keyword arguments
+are `template`, `zone_name`, `lazy`, and `poll`.
 
-The `zone_rendered` signal fires after a zone body renders for a
-partial request. The sender is the `ZoneRenderResult` class. The keyword
-arguments are `zone_name`, `page_path`, `request`, and `duration_ms`.
+The `zone_rendered` signal fires after a zone body renders for a partial request. The
+sender is the `ZoneRenderResult` class. The keyword arguments are `zone_name`,
+`page_path`, `request`, and `duration_ms`.
 
-The `patch_op_registered` signal fires after a custom patch verb is
-registered through `register_patch_op`. The sender is
-`PatchOpRegistry`. The keyword argument is `name`.
+The `patch_op_registered` signal fires after a custom patch verb is registered through
+`register_patch_op`. The sender is `PatchOpRegistry`. The keyword argument is `name`.
 
-The `field_validated` signal fires after a validate-only pass runs,
-always behind the action guard so unauthenticated validate traffic
-never reaches telemetry. The sender is the backend class. The keyword
-arguments are `action_name`, `uid`, `request`, `field_names`, and
-`error_count`.
+The `field_validated` signal fires after a validate-only pass runs, always behind the
+action guard so unauthenticated validate traffic never reaches telemetry. The sender is
+the backend class. The keyword arguments are `action_name`, `uid`, `request`,
+`field_names`, and `error_count`.
 
-The `sse_stream_opened` signal fires when a patch event stream starts.
-The sender is `PatchEventStream`. The keyword argument is `request`.
+The `sse_stream_opened` signal fires when a patch event stream starts. The sender is
+`PatchEventStream`. The keyword argument is `request`.
 
-The `sse_stream_closed` signal fires when a patch event stream ends.
-The sender is `PatchEventStream`. The keyword arguments are `request`,
-`duration_ms`, and `envelopes_sent`.
+The `sse_stream_closed` signal fires when a patch event
+stream ends. The sender is `PatchEventStream`. The keyword
+arguments are `request`, `duration_ms`, and `envelopes_sent`.
 """
 
 from django.dispatch import Signal

--- a/next/partial/sse.py
+++ b/next/partial/sse.py
@@ -123,12 +123,11 @@ class PatchEventStream(StreamingHttpResponse):
     def _sync_stream(self, source: "Iterable[Patches]") -> "Iterator[bytes]":
         """Yield SSE bytes for a sync source, with no heartbeat.
 
-        A blocked `next()` on a sync source has nothing to interrupt it
-        without a thread, so a quiet sync stream sends no heartbeat. A
-        keepalive is the source's own job under WSGI. The close signal
-        fires once the source is exhausted or the client disconnects, after
-        the source generator is closed so it releases its resources like the
-        async path drives `aclose`.
+        A blocked `next()` on a sync source has nothing to interrupt it without a
+        thread, so a quiet sync stream sends no heartbeat. A keepalive is the source's
+        own job under WSGI. The close signal fires once the source is exhausted or the
+        client disconnects, after the source generator is closed so it releases its
+        resources like the async path drives `aclose`.
         """
         sent = 0
         yield self._retry_frame()
@@ -157,15 +156,13 @@ class PatchEventStream(StreamingHttpResponse):
     ) -> "AsyncIterator[bytes]":
         """Yield SSE bytes for an async source, interleaving heartbeats.
 
-        A single pull task is held across heartbeats so the source
-        generator is never re-entered while a pull is in flight and no
-        envelope is lost. A pull that outlasts `heartbeat_seconds`
-        yields a comment frame so a buffering proxy keeps the connection.
-        The close signal fires once the source is exhausted or the client
-        disconnects. A disconnect throws into the `await`, so the cleanup
-        cancels the in-flight pull and closes the source generator before
-        announcing the close, leaving no pending task or suspended
-        generator behind.
+        A single pull task is held across heartbeats so the source generator is never
+        re-entered while a pull is in flight and no envelope is lost. A pull that
+        outlasts `heartbeat_seconds` yields a comment frame so a buffering proxy keeps
+        the connection. The close signal fires once the source is exhausted or the
+        client disconnects. A disconnect throws into the `await`, so the cleanup cancels
+        the in-flight pull and closes the source generator before announcing the close,
+        leaving no pending task or suspended generator behind.
         """
         sent = 0
         yield self._retry_frame()

--- a/next/partial/view.py
+++ b/next/partial/view.py
@@ -60,9 +60,8 @@ def zone_response(
 def _version_conflict(intent: "PartialIntent", version: str) -> bool:
     """Return True when the client asserts a version that differs from the current.
 
-    An absent or empty client version asserts nothing, so the first partial
-    request of a page, made before the client has learned a version, never
-    conflicts.
+    An absent or empty client version asserts nothing, so the first partial request of a
+    page, made before the client has learned a version, never conflicts.
     """
     return bool(intent.version) and intent.version != version
 

--- a/next/partial/zone.py
+++ b/next/partial/zone.py
@@ -53,9 +53,8 @@ def _wrap_zone(tag: str, name: str, body: str, *, extra: str = "") -> SafeString
 class ZoneOptions:
     """Compile-time rendering options of one zone.
 
-    Both render paths derive their wrapper attributes from these options,
-    so a new mode cannot diverge the full render from the standalone
-    delivery.
+    Both render paths derive their wrapper attributes from these options, so a new mode
+    cannot diverge the full render from the standalone delivery.
     """
 
     tag: str = _DEFAULT_TAG

--- a/next/server/__init__.py
+++ b/next/server/__init__.py
@@ -1,9 +1,8 @@
 """Development-server helpers and autoreload integration.
 
-This package replaces Django's default `StatReloader` with
-`NextStatReloader`, exposes helpers that contribute watch specs to the
-file watcher, and lists filesystem roots for tooling that needs stable
-paths.
+This package replaces Django's default `StatReloader` with `NextStatReloader`, exposes
+helpers that contribute watch specs to the file watcher, and lists filesystem roots for
+tooling that needs stable paths.
 """
 
 from __future__ import annotations

--- a/next/server/autoreload.py
+++ b/next/server/autoreload.py
@@ -1,7 +1,7 @@
 """Custom `StatReloader` that also watches the discovered route set.
 
-`.djx` templates are deliberately left out of the watch. They are re-read
-on render with mtime-based invalidation inside pages and components.
+`.djx` templates are deliberately left out of the watch. Under `DEBUG` they are
+re-read on render with mtime-based invalidation inside pages and components.
 """
 
 from __future__ import annotations

--- a/next/server/watcher.py
+++ b/next/server/watcher.py
@@ -29,9 +29,9 @@ _registered_extra_watch_specs: list[tuple[Path, str]] = []
 def register_autoreload_watch_spec(path: Path, glob: str) -> None:
     """Register one extra directory and glob pair for the file watcher.
 
-    Built-in globs already come from `NEXT_FRAMEWORK`. Call this from
-    your own `AppConfig.ready` if you need more trees watched without
-    changing the `next` package.
+    Built-in globs already come from `NEXT_FRAMEWORK`.
+    Call this from your own `AppConfig.ready` if you need
+    more trees watched without changing the `next` package.
     """
     _registered_extra_watch_specs.append((path, glob))
 

--- a/next/signals.py
+++ b/next/signals.py
@@ -1,8 +1,8 @@
 """Aggregate re-export of every signal emitted by the framework.
 
-Signals also live on their owning subpackage (for example ``next.forms.signals``).
-Import from here when one module subscribes to several subsystems and prefers one
-import path.
+Signals also live on their owning subpackage (for example
+``next.forms.signals``). Import from here when one module
+subscribes to several subsystems and prefers one import path.
 """
 
 from next.components.signals import (

--- a/next/static/__init__.py
+++ b/next/static/__init__.py
@@ -1,26 +1,23 @@
 """Discover and inject co-located static assets for pages and components.
 
-Each `.djx` file may have matching `.css` and `.js` files (or any other
-registered kind) in the same directory. Pages and components may also
-declare URL list variables in their Python modules, named after a
-registered placeholder slot. During rendering, a shared
+Each `.djx` file may have matching `.css` and `.js` files (or any other registered kind)
+in the same directory. Pages and components may also declare URL list variables in their
+Python modules, named after a registered placeholder slot. During rendering, a shared
 `StaticCollector` gathers every referenced asset. After rendering,
-`StaticManager.inject` replaces every registered placeholder token with
-the rendered tags. Public URLs are resolved through Django staticfiles.
+`StaticManager.inject` replaces every registered placeholder token with the rendered
+tags. Public URLs are resolved through Django staticfiles.
 
-The `Next` JavaScript runtime is automatically injected on every page by
-default. `StaticManager.inject` prepends `next.min.js` as the first
-script and follows it with an inline init script that passes the
-serialized JS context to `Next._init`. Context values opt into
-JavaScript exposure by using `serialize=True` on their `@context`
-decorator. A preload hint is injected immediately before `</head>` so
-the browser downloads the file during HTML parsing. Users may switch to
-`ScriptInjectionPolicy.DISABLED` or `ScriptInjectionPolicy.MANUAL` to
-opt out.
+The `Next` JavaScript runtime is automatically injected on every page by default.
+`StaticManager.inject` prepends `next.min.js` as the first script and follows it with an
+inline init script that passes the serialized JS context to `Next._init`. Context values
+opt into JavaScript exposure by using `serialize=True` on their `@context` decorator. A
+preload hint is injected immediately before `</head>` so the browser downloads the file
+during HTML parsing. Users may switch to `ScriptInjectionPolicy.DISABLED` or
+`ScriptInjectionPolicy.MANUAL` to opt out.
 
-The subsystem is fully type-agnostic. Built-in kinds such as `css` and
-`js` are registered through the same public API exposed to user code,
-so adding a new kind like `jsx` is a one-call extension.
+The subsystem is fully type-agnostic. Built-in kinds such as `css` and `js` are
+registered through the same public API exposed to user code, so adding a new kind like
+`jsx` is a one-call extension.
 """
 
 from __future__ import annotations

--- a/next/static/assets.py
+++ b/next/static/assets.py
@@ -1,16 +1,14 @@
 """Value objects and kind registry for static assets.
 
-This module holds the leaf building blocks of the static subsystem. It
-defines a frozen value object for a single asset reference and a mutable
-registry that maps asset kinds to file extensions, placeholder slots,
-and renderer method names. The module has no internal dependencies and
-is safe to import before the Django app registry is ready.
+This module holds the leaf building blocks of the static subsystem. It defines a frozen
+value object for a single asset reference and a mutable registry that maps asset kinds
+to file extensions, placeholder slots, and renderer method names. The module has no
+internal dependencies and is safe to import before the Django app registry is ready.
 
-The registry ships empty. Built-in kinds such as `css` and `js` are
-registered by the framework bootstrap layer through the same public
-`register` call that user code uses to teach the framework about new
-file types like `jsx` or `wasm`. Core code never special-cases any
-particular kind.
+The registry ships empty. Built-in kinds such as `css` and `js` are registered by the
+framework bootstrap layer through the same public `register` call that user code uses to
+teach the framework about new file types like `jsx` or `wasm`. Core code never
+special-cases any particular kind.
 """
 
 from __future__ import annotations
@@ -91,16 +89,14 @@ class KindRegistry:
     ) -> None:
         """Register an asset kind and its dispatch metadata.
 
-        The `kind` argument must be a non-empty Python identifier. The
-        `extension` argument must begin with a dot. The `slot` and
-        `renderer` arguments must be non-empty strings. Any other input
-        raises `ValueError`. The optional `inline_tag` names the HTML
-        element that wraps a co-located inline body for this kind, for
-        example `"style"` or `"script"`. When omitted, inline bodies of
-        this kind render verbatim. A repeated call with identical
-        parameters is idempotent. A repeated call with different
-        parameters raises `ValueError` so silent re-registrations cannot
-        mask bugs.
+        The `kind` argument must be a non-empty Python identifier. The `extension`
+        argument must begin with a dot. The `slot` and `renderer` arguments must be
+        non-empty strings. Any other input raises `ValueError`. The optional
+        `inline_tag` names the HTML element that wraps a co-located inline body for this
+        kind, for example `"style"` or `"script"`. When omitted, inline bodies of this
+        kind render verbatim. A repeated call with identical parameters is idempotent. A
+        repeated call with different parameters raises `ValueError` so silent
+        re-registrations cannot mask bugs.
         """
         if not kind or not kind.isidentifier():
             msg = f"Invalid kind {kind!r}: must be a non-empty identifier"

--- a/next/static/backends.py
+++ b/next/static/backends.py
@@ -1,20 +1,18 @@
 """Pluggable backend contract and Django-staticfiles default implementation.
 
-A static backend turns co-located asset paths into public URLs and
-renders them through one of its named renderer methods. The default
-backend delegates URL resolution to Django staticfiles, so manifest
-hashing, S3 storage, and CDN configuration from Django settings apply
-automatically.
+A static backend turns co-located asset paths into public URLs and renders them through
+one of its named renderer methods. The default backend delegates URL resolution to
+Django staticfiles, so manifest hashing, S3 storage, and CDN configuration from Django
+settings apply automatically.
 
-The abstract `StaticBackend` only mandates `register_file`. Renderer
-methods are concrete on the default backend and selected per asset by
-`KindRegistry.renderer(kind)`. Custom backends extend the surface by
-adding more named methods such as `render_babel_script_tag` and
-registering kinds that point to them.
+The abstract `StaticBackend` only mandates `register_file`. Renderer methods are
+concrete on the default backend and selected per asset by `KindRegistry.renderer(kind)`.
+Custom backends extend the surface by adding more named methods such as
+`render_babel_script_tag` and registering kinds that point to them.
 
-Instances are built from `NEXT_FRAMEWORK['STATIC_BACKENDS']` entries by
-the static manager, which emits the `backend_loaded` signal for each one
-so user code may react to backend construction.
+Instances are built from `NEXT_FRAMEWORK['STATIC_BACKENDS']`
+entries by the static manager, which emits the `backend_loaded`
+signal for each one so user code may react to backend construction.
 """
 
 from __future__ import annotations
@@ -37,18 +35,15 @@ if TYPE_CHECKING:
 class StaticBackend(ABC):
     """Pluggable strategy for resolving asset files to URLs and rendering tags.
 
-    The constructor accepts the full backend entry from
-    `STATIC_BACKENDS`, which has the shape
-    `{"BACKEND": "...", "OPTIONS": {...}}`. The base class stores the
-    mapping on the `config` property. Subclasses are free to read any
-    keys they expose to users.
+    The constructor accepts the full backend entry from `STATIC_BACKENDS`, which has the
+    shape `{"BACKEND": "...", "OPTIONS": {...}}`. The base class stores the mapping on
+    the `config` property. Subclasses are free to read any keys they expose to users.
 
-    The only abstract requirement is `register_file`. Renderer methods
-    are added by subclasses and selected per asset through
+    The only abstract requirement is `register_file`. Renderer
+    methods are added by subclasses and selected per asset through
     `KindRegistry.renderer(kind)`. The default backend below ships
-    `render_link_tag` and `render_script_tag` for the built-in `css`
-    and `js` kinds. Custom backends register additional kinds and
-    expose matching methods.
+    `render_link_tag` and `render_script_tag` for the built-in `css` and `js`
+    kinds. Custom backends register additional kinds and expose matching methods.
     """
 
     def __init__(self, config: Mapping[str, Any] | None = None) -> None:
@@ -64,12 +59,11 @@ class StaticBackend(ABC):
     def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
         """Register a co-located asset file and return its public URL.
 
-        The `source_path` argument is the absolute path to the source
-        file on disk. The `logical_name` argument is the path without an
-        extension, for example `"about"` or `"components/card"`. The
-        `kind` argument must be a kind registered in the default kind
-        registry. The method raises `RuntimeError` when the asset
-        cannot be resolved to a URL.
+        The `source_path` argument is the absolute path to the source file on
+        disk. The `logical_name` argument is the path without an extension,
+        for example `"about"` or `"components/card"`. The `kind` argument
+        must be a kind registered in the default kind registry. The method
+        raises `RuntimeError` when the asset cannot be resolved to a URL.
         """
 
 
@@ -109,12 +103,11 @@ class StaticFilesBackend(StaticBackend):
         """Return the staticfiles URL for `next/<logical_name><suffix>`.
 
         The suffix is taken from `source_path.suffix`, so a single kind
-        can serve multiple file extensions if a custom backend wishes
-        to. Result is cached per `(logical_name, suffix)`. Missing
-        entries in the staticfiles manifest are reported as
-        `RuntimeError` with a hint about running `collectstatic`. The
-        `kind` argument is part of the contract and ignored here, the
-        suffix alone names the file.
+        can serve multiple file extensions if a custom backend wishes to.
+        Result is cached per `(logical_name, suffix)`. Missing entries
+        in the staticfiles manifest are reported as `RuntimeError` with
+        a hint about running `collectstatic`. The `kind` argument is part
+        of the contract and ignored here, the suffix alone names the file.
         """
         del kind
         suffix = source_path.suffix

--- a/next/static/collector.py
+++ b/next/static/collector.py
@@ -1,21 +1,18 @@
 """Collector, dedup strategies, JS context policies, and placeholder slots.
 
-Rendering flows are stateful. Every HTTP request spins up a fresh
-collector that rides along in the template context, absorbs every
-`{% use_style %}`, `{% #use_script %}`, co-located `template.css`, and
-`styles` or `scripts` list entry, then hands the accumulated set back to
-the static manager when the template finishes.
+Rendering flows are stateful. Every HTTP request spins up a fresh collector that rides
+along in the template context, absorbs every `{% use_style %}`, `{% #use_script %}`,
+co-located `template.css`, and `styles` or `scripts` list entry, then hands the
+accumulated set back to the static manager when the template finishes.
 
-The collector does not hardcode deduplication or merge semantics.
-Strategy objects plug in at construction time, so users can swap
-URL-based dedup for content-hash dedup or replace the default
-first-wins JS-context merge with a deep-merge policy without touching
-the collector source.
+The collector does not hardcode deduplication or merge semantics. Strategy objects plug
+in at construction time, so users can swap URL-based dedup for content-hash dedup or
+replace the default first-wins JS-context merge with a deep-merge policy without
+touching the collector source.
 
-The collector is also fully type-agnostic. Each asset routes to a
-slot named in `KindRegistry`, and the buckets live in a slot-keyed
-dictionary on the collector. There is no built-in knowledge of `css`,
-`js`, or any other specific kind here.
+The collector is also fully type-agnostic. Each asset routes to a slot named in
+`KindRegistry`, and the buckets live in a slot-keyed dictionary on the collector. There
+is no built-in knowledge of `css`, `js`, or any other specific kind here.
 """
 
 from __future__ import annotations
@@ -50,9 +47,8 @@ def _inline_dedup_key(asset: StaticAsset) -> tuple[str, str, str]:
 class DedupStrategy(Protocol):
     """Key-based dedup strategy consumed by the static collector.
 
-    Implementations return a hashable value that uniquely identifies an
-    asset for deduplication. The collector ignores any asset whose key
-    was already recorded.
+    Implementations return a hashable value that uniquely identifies an asset for
+    deduplication. The collector ignores any asset whose key was already recorded.
     """
 
     def key(self, asset: StaticAsset) -> Hashable:
@@ -77,10 +73,9 @@ class UrlDedup:
 class HashContentDedup:
     """Dedupe URL-form assets by sha256 of their disk content.
 
-    This is useful in production builds where identical CSS may be
-    emitted under different hashed filenames by a manifest storage. The
-    strategy falls back to URL-based dedup when the `source_path` is
-    missing.
+    This is useful in production builds where identical CSS may be emitted under
+    different hashed filenames by a manifest storage. The strategy falls back to
+    URL-based dedup when the `source_path` is missing.
     """
 
     def __init__(self) -> None:
@@ -201,10 +196,9 @@ class PlaceholderSlot:
     """Binding between a `{% collect_* %}` placeholder name and its token.
 
     The `name` field identifies the slot. Assets routed to this slot by
-    `KindRegistry.slot(asset.kind)` accumulate in the collector under
-    this name. The `token` field is the HTML comment marker emitted by
-    the matching template tag at render time and replaced by the static
-    manager during injection.
+    `KindRegistry.slot(asset.kind)` accumulate in the collector under this name. The
+    `token` field is the HTML comment marker emitted by the matching template tag at
+    render time and replaced by the static manager during injection.
     """
 
     name: str
@@ -214,10 +208,9 @@ class PlaceholderSlot:
 class PlaceholderRegistry:
     """Mutable registry of placeholder slots.
 
-    The registry ships empty. Framework bootstrap registers built-in
-    slots such as `styles` and `scripts`, and user code registers
-    additional slots with the same `register` call when introducing new
-    asset destinations.
+    The registry ships empty. Framework bootstrap registers built-in slots such as
+    `styles` and `scripts`, and user code registers additional slots with the same
+    `register` call when introducing new asset destinations.
     """
 
     def __init__(self) -> None:
@@ -227,9 +220,8 @@ class PlaceholderRegistry:
     def register(self, name: str, *, token: str) -> None:
         """Register the slot under its name with the given placeholder token.
 
-        A repeated call with the same token is idempotent. A repeated
-        call with a different token raises `ValueError` so silent
-        overrides cannot mask bugs.
+        A repeated call with the same token is idempotent. A repeated call with a
+        different token raises `ValueError` so silent overrides cannot mask bugs.
         """
         if not name:
             msg = "Slot name must be a non-empty string"
@@ -267,20 +259,18 @@ default_placeholders: PlaceholderRegistry = PlaceholderRegistry()
 class StaticCollector:
     """Accumulate static asset references during a single page render.
 
-    The optional `dedup` argument plugs in a custom dedup strategy. The
-    default is `UrlDedup`. The optional `js_context_policy` argument
-    plugs in a custom merge strategy for the JS context. The default is
-    `FirstWinsPolicy`, which ensures page-level context wins over
-    component-level context.
+    The optional `dedup` argument plugs in a custom dedup strategy. The default is
+    `UrlDedup`. The optional `js_context_policy` argument plugs in a custom merge
+    strategy for the JS context. The default is `FirstWinsPolicy`, which ensures
+    page-level context wins over component-level context.
 
-    Assets are added through the `add` method and later consumed by the
-    static manager during injection. The collector has no knowledge of
-    backends or rendering. It coordinates insertion order,
-    deduplication, and JS context merging.
+    Assets are added through the `add` method and later consumed by the static manager
+    during injection. The collector has no knowledge of backends or rendering. It
+    coordinates insertion order, deduplication, and JS context merging.
 
-    Buckets are keyed by slot name as resolved through `KindRegistry`.
-    The collector does not hardcode any specific slot, so adding new
-    asset kinds to the registry transparently produces new buckets.
+    Buckets are keyed by slot name as resolved through `KindRegistry`. The collector
+    does not hardcode any specific slot, so adding new asset kinds to the registry
+    transparently produces new buckets.
     """
 
     def __init__(
@@ -306,14 +296,12 @@ class StaticCollector:
     def add(self, asset: StaticAsset, *, prepend: bool = False) -> None:
         """Add the asset unless its dedup key was already recorded.
 
-        Inline assets always append because their dedup key derives
-        from the body. URL-form assets with `prepend=True` are inserted
-        before existing append entries while keeping registration
-        order among prepended items.
+        Inline assets always append because their dedup key derives from the body.
+        URL-form assets with `prepend=True` are inserted before existing append entries
+        while keeping registration order among prepended items.
 
-        The asset routes to the bucket named by
-        `KindRegistry.slot(asset.kind)`. Unregistered kinds raise
-        `KeyError` so misconfiguration surfaces immediately.
+        The asset routes to the bucket named by `KindRegistry.slot(asset.kind)`.
+        Unregistered kinds raise `KeyError` so misconfiguration surfaces immediately.
         """
         key = self._dedup.key(asset)
         if key in self._seen_keys:

--- a/next/static/defaults.py
+++ b/next/static/defaults.py
@@ -1,12 +1,11 @@
 """Bootstrap registrations for the built-in `css`, `js`, and `module` asset kinds.
 
-The static subsystem is type-agnostic. The built-in kinds are not
-privileged in core code, they are registered through the same public
-API that user projects use to teach the framework about additional file
-types like `jsx` or `wasm`.
+The static subsystem is type-agnostic. The built-in kinds are not privileged in core
+code, they are registered through the same public API that user projects use to teach
+the framework about additional file types like `jsx` or `wasm`.
 
-`register_defaults` is called from the framework `AppConfig.ready` so
-the defaults are in place before any request lands. Idempotent
+`register_defaults` is called from the framework `AppConfig.ready`
+so the defaults are in place before any request lands. Idempotent
 re-registration with identical parameters is allowed and lets test
 suites that swap settings during a session keep using the public API.
 """

--- a/next/static/discovery.py
+++ b/next/static/discovery.py
@@ -28,9 +28,8 @@ import os
 from collections import OrderedDict
 from typing import TYPE_CHECKING, NamedTuple, Protocol, runtime_checkable
 
-from django.conf import settings
-
 from next.pages import loaders as pages_loaders
+from next.utils import template_edits_watched
 
 from .assets import StaticAsset, default_kinds
 from .collector import default_placeholders
@@ -317,11 +316,10 @@ class AssetDiscovery:
     def _plan_stale(self, plan: _PageAssetPlan) -> bool:
         """Whether a directory the plan was read from has moved since.
 
-        Only `DEBUG` pays the stats. An asset created or deleted moves the
-        mtime of the directory holding it. Read per call, so an override
-        takes effect.
+        Only a process watching template edits pays the stats. An asset created or
+        deleted moves the mtime of the directory holding it.
         """
-        if not settings.DEBUG:
+        if not template_edits_watched():
             return False
         for directory, mtime in plan.directory_mtimes:
             try:

--- a/next/static/discovery.py
+++ b/next/static/discovery.py
@@ -86,10 +86,9 @@ def _url_suffix(url: str) -> str:
 def _rel_path_str(child: Path, root: Path) -> str | None:
     """Return the forward-slashed path of `child` relative to `root`.
 
-    Both operands must already be resolved absolute paths. Returns an
-    empty string when `child == root`, and `None` when `child` is not
-    nested under `root`. Skips the per-segment work of
-    `Path.relative_to().parts`.
+    Both operands must already be resolved absolute paths. Returns an empty string when
+    `child == root`, and `None` when `child` is not nested under `root`. Skips the
+    per-segment work of `Path.relative_to().parts`.
     """
     child_str = os.fspath(child)
     root_str = os.fspath(root)
@@ -367,10 +366,9 @@ class AssetDiscovery:
     ) -> list[_FoundAsset]:
         """Return the `{stem}{ext}` files that exist in `directory` for the role.
 
-        The set of extensions probed comes from `KindRegistry.kinds()`, so
-        registering a new kind during `AppConfig.ready` is enough to teach
-        discovery about it. Each hit carries its resolved path, because the
-        collector dedups on it.
+        The set of extensions probed comes from `KindRegistry.kinds()`, so registering a
+        new kind during `AppConfig.ready` is enough to teach discovery about it. Each
+        hit carries its resolved path, because the collector dedups on it.
         """
         found: list[_FoundAsset] = []
         for stem in self._stems.stems(role):
@@ -450,9 +448,8 @@ class AssetDiscovery:
     def _register_file(self, found: _FoundAsset, collector: StaticCollector) -> None:
         """Register a file with the backend and add the result to the collector.
 
-        Warnings are logged for `OSError` and `ValueError`. All other
-        exception types propagate so bugs in custom backends surface
-        loudly.
+        Warnings are logged for `OSError` and `ValueError`. All other exception types
+        propagate so bugs in custom backends surface loudly.
         """
         backend = self._provider.default_backend
         try:

--- a/next/static/finders.py
+++ b/next/static/finders.py
@@ -1,14 +1,12 @@
 """Django staticfiles finder that exposes next-dj co-located assets.
 
-The finder surfaces every `template.css`, `layout.js`, and
-`component.css` plus any stems registered on the stem registry under
-the `next/` staticfiles namespace. The usual `{% static "next/about.css" %}`
-call works without the user configuring anything.
+The finder surfaces every `template.css`, `layout.js`, and `component.css` plus any
+stems registered on the stem registry under the `next/` staticfiles namespace. The usual
+`{% static "next/about.css" %}` call works without the user configuring anything.
 
-The logical-path and source-file mapping is computed by the
-co-located asset discovery helper below, which shares the same
-`PathResolver` used at request-time discovery. The two layers agree on
-every URL.
+The logical-path and source-file mapping is computed by the co-located asset discovery
+helper below, which shares the same `PathResolver` used at request-time discovery. The
+two layers agree on every URL.
 """
 
 from __future__ import annotations

--- a/next/static/manager.py
+++ b/next/static/manager.py
@@ -1,15 +1,13 @@
 """Coordinate static backends, asset discovery, and placeholder injection.
 
-The static manager loads backends lazily on first use, owns the shared
-asset discovery instance, caches page-tree roots, and replaces every
-registered placeholder token with the rendered tags once rendering
-completes. It also injects the `next.min.js` wiring unless the
-injection policy is `DISABLED`.
+The static manager loads backends lazily on first use, owns the shared asset discovery
+instance, caches page-tree roots, and replaces every registered placeholder token with
+the rendered tags once rendering completes. It also injects the `next.min.js` wiring
+unless the injection policy is `DISABLED`.
 
-The module-level `default_manager` is a lazy handle around a single
-static manager instance, and `get_static_manager` hands out the instance
-it wraps. The settings-change hook in `next.conf` resets the wrapper when
-`NEXT_FRAMEWORK` changes.
+The module-level `default_manager` is a lazy handle around a single static manager
+instance, and `get_static_manager` hands out the instance it wraps. The settings-change
+hook in `next.conf` resets the wrapper when `NEXT_FRAMEWORK` changes.
 """
 
 from __future__ import annotations

--- a/next/static/scripts.py
+++ b/next/static/scripts.py
@@ -1,15 +1,14 @@
 """Pluggable builder for the `next.min.js` preload, script, and init tags.
 
-The builder produces the three HTML fragments that wire `window.Next`
-into the rendered page. The first fragment is a preload hint injected
-before `</head>` so the browser starts downloading during HTML parsing.
-The second fragment is a blocking script tag for the compiled runtime.
-The third fragment is an inline script that feeds the serialized JS
-context into `Next._init`.
+The builder produces the three HTML fragments that wire `window.Next` into the rendered
+page. The first fragment is a preload hint injected before `</head>` so the browser
+starts downloading during HTML parsing. The second fragment is a blocking script tag for
+the compiled runtime. The third fragment is an inline script that feeds the serialized
+JS context into `Next._init`.
 
-Every template is an instance attribute, so users can override any
-single tag without subclassing. An injection policy controls whether
-the static manager emits those tags at all.
+Every template is an instance attribute, so users can override
+any single tag without subclassing. An injection policy
+controls whether the static manager emits those tags at all.
 """
 
 from __future__ import annotations
@@ -95,14 +94,12 @@ def csrf_payload_for(request: HttpRequest | None) -> dict[str, str] | None:
 class ScriptInjectionPolicy(enum.Enum):
     """Controls whether `next.min.js` is automatically injected.
 
-    The `AUTO` value is the default. Under `AUTO` the static manager
-    emits the preload hint, the `<script>` tag, and the `Next._init`
-    call into every rendered page. The `DISABLED` value skips injection
-    entirely and is useful when a page does not need `window.Next`, for
-    example a raw API response rendered through the page machinery. The
-    `MANUAL` value skips automatic injection but still builds the
-    fragments on request so users can emit the tags themselves from a
-    template.
+    The `AUTO` value is the default. Under `AUTO` the static manager emits the preload
+    hint, the `<script>` tag, and the `Next._init` call into every rendered page. The
+    `DISABLED` value skips injection entirely and is useful when a page does not need
+    `window.Next`, for example a raw API response rendered through the page machinery.
+    The `MANUAL` value skips automatic injection but still builds the fragments on
+    request so users can emit the tags themselves from a template.
     """
 
     AUTO = "auto"

--- a/next/static/serializers.py
+++ b/next/static/serializers.py
@@ -1,12 +1,10 @@
 """Pluggable JS-context serializers for `@context(serialize=True)` values.
 
-`StaticCollector.add_js_context` delegates value encoding to a
-`JsContextSerializer`. The default implementation uses
-`DjangoJSONEncoder`, which handles the same set of types that the
-framework has always accepted. Applications that want to serialise
-pydantic models, msgspec structs, or any other type can point the
-`JS_CONTEXT_SERIALIZER` option at a class that implements the
-protocol.
+`StaticCollector.add_js_context` delegates value encoding to a `JsContextSerializer`.
+The default implementation uses `DjangoJSONEncoder`, which handles the same set of types
+that the framework has always accepted. Applications that want to serialise pydantic
+models, msgspec structs, or any other type can point the `JS_CONTEXT_SERIALIZER` option
+at a class that implements the protocol.
 """
 
 from __future__ import annotations
@@ -61,9 +59,8 @@ class JsonJsContextSerializer:
 class PydanticJsContextSerializer:
     """Serialise values through pydantic model dump when available.
 
-    Unknown types fall through to `DjangoJSONEncoder`, so lists and
-    dicts containing mixed pydantic and plain values still serialise
-    without a second code path.
+    Unknown types fall through to `DjangoJSONEncoder`, so lists and dicts containing
+    mixed pydantic and plain values still serialise without a second code path.
     """
 
     def __init__(self) -> None:

--- a/next/templatetags/components.py
+++ b/next/templatetags/components.py
@@ -10,6 +10,7 @@ short void ``{% set_slot "name" %}`` when there is no default slot body.
 from __future__ import annotations
 
 import difflib
+import functools
 import logging
 import re
 from dataclasses import dataclass
@@ -45,6 +46,10 @@ _COMPONENT_NAME_INDEX = 1
 _SLOT_ARG_COUNT = 2
 _COMPONENT_MIN_BITS = 2
 
+# Distinct ``current_template_path`` strings the process memoises, the same
+# bound the other path-keyed component caches use.
+_PATH_MEMO_MAX_ENTRIES = 2048
+
 _END_BLOCK_COMPONENT = ("/component",)
 _END_BLOCK_SLOT = ("/slot",)
 _END_BLOCK_SET_SLOT = ("/set_slot",)
@@ -65,6 +70,15 @@ _SLOT_MISSING: Any = object()
 
 def _strip_quotes(raw: str) -> str:
     return raw.strip("'\"").strip()
+
+
+@functools.lru_cache(maxsize=_PATH_MEMO_MAX_ENTRIES)
+def _resolve_template_path(raw: str) -> Path:
+    """Return the resolved file for a raw ``current_template_path`` string.
+
+    One page path reaches every node the page renders, so the memo is process-wide.
+    """
+    return Path(raw).resolve()
 
 
 def _comment_safe(text: str) -> str:
@@ -176,15 +190,13 @@ class ComponentNode(Node):
     def _template_path_from_context(self, context: template.Context) -> Path | None:
         """Return a resolved path from ``current_template_path``, or ``None``."""
         raw = context.get("current_template_path")
-        if raw is None:
-            return None
+        # A ``Path`` under this key was written by a render that already
+        # resolved it, so only the ``str`` spelling reaches the filesystem.
         if isinstance(raw, Path):
-            path = raw
-        elif isinstance(raw, str):
-            path = Path(raw)
-        else:
-            return None
-        return path.resolve()
+            return raw
+        if isinstance(raw, str):
+            return _resolve_template_path(raw)
+        return None
 
     def _close_match(self, path: Path) -> str | None:
         """Return the closest visible component name for a did-you-mean hint.
@@ -256,12 +268,17 @@ class ComponentNode(Node):
                 else:
                     child_chunks.append(node.render(context))
 
-        parent_flat = dict(cast("dict[str, Any]", context.flatten()))
+        # ``flatten`` returns a dict built for this call alone, so the render
+        # context is filled in place instead of through another copy.
+        render_ctx = cast("dict[str, Any]", context.flatten())
         for key in _INTERNAL_CONTEXT_KEYS:
-            parent_flat.pop(key, None)
-        render_ctx: dict[str, Any] = {**parent_flat, **self._resolved_props(context)}
+            render_ctx.pop(key, None)
+        render_ctx.update(self._resolved_props(context))
         render_ctx["current_template_path"] = path
-        render_ctx["children"] = "".join(child_chunks)
+        # Children arrive as finished markup, so the join is spliced in as
+        # written, the way slot content already is. Whether the values inside
+        # were escaped is the calling template's business.
+        render_ctx["children"] = SafeString("".join(child_chunks))
         render_ctx[COMPONENT_PROPS_CONTEXT_KEY] = self.prop_names
 
         for slot_name, content in slots.items():

--- a/next/testing/__init__.py
+++ b/next/testing/__init__.py
@@ -12,6 +12,7 @@ from .client import NextClient, PartialEnvelope, envelope_of
 from .deps import make_resolution_context, resolve_call
 from .html import assert_has_class, assert_missing_class, find_anchor
 from .isolation import (
+    reset_component_templates,
     reset_components,
     reset_form_actions,
     reset_form_registration_state,
@@ -62,6 +63,7 @@ __all__ = [
     "patch_static_collector",
     "render_component_by_name",
     "render_page",
+    "reset_component_templates",
     "reset_components",
     "reset_form_actions",
     "reset_form_registration_state",

--- a/next/testing/__init__.py
+++ b/next/testing/__init__.py
@@ -1,8 +1,7 @@
 """Framework-agnostic helpers for testing next-dj apps.
 
-The public surface is a small set of pure-Python utilities that work
-with Django `TestCase`, stdlib `unittest`, and pytest. Nothing in this
-package imports pytest.
+The public surface is a small set of pure-Python utilities that work with Django
+`TestCase`, stdlib `unittest`, and pytest. Nothing in this package imports pytest.
 """
 
 from __future__ import annotations

--- a/next/testing/actions.py
+++ b/next/testing/actions.py
@@ -14,9 +14,8 @@ if TYPE_CHECKING:
 def resolve_action_url(action_name: str) -> str:
     """Return the reverse URL for a registered form action by name.
 
-    Wraps `form_action_manager.get_action_url` so tests do not need to
-    import the manager singleton directly. Raises `FormActionNotFoundError`
-    for unknown actions.
+    Wraps `form_action_manager.get_action_url` so tests do not need to import the
+    manager singleton directly. Raises `FormActionNotFoundError` for unknown actions.
     """
     return form_action_manager.get_action_url(action_name)
 
@@ -26,10 +25,9 @@ def build_form_for(
 ) -> django_forms.Form:
     """Instantiate the form class registered for `action_name`.
 
-    Useful for unit-testing form validation without dispatching an HTTP
-    request. Raises `FormActionNotFoundError` with close-match suggestions when
-    the action is unknown and `LookupError` when the action is registered
-    without a form class.
+    Useful for unit-testing form validation without dispatching an HTTP request. Raises
+    `FormActionNotFoundError` with close-match suggestions when the action is unknown
+    and `LookupError` when the action is registered without a form class.
     """
     meta = form_action_manager.require_action_meta(action_name)
     form_class = meta.get("form_class")

--- a/next/testing/client.py
+++ b/next/testing/client.py
@@ -26,9 +26,8 @@ _VERSION_HEADER = f"HTTP_{VERSION.upper().replace('-', '_')}"
 class PartialEnvelope:
     """Structural view over a decoded patch envelope for test assertions.
 
-    The helpers read the JSON envelope and answer questions about ops
-    and their targets without any HTML regex, so tests assert the server
-    contract on structure alone.
+    The helpers read the JSON envelope and answer questions about ops and their targets
+    without any HTML regex, so tests assert the server contract on structure alone.
     """
 
     def __init__(self, data: dict[str, Any]) -> None:
@@ -128,11 +127,10 @@ class NextClient(Client):
     ) -> HttpResponse:
         """Resolve `action_name` and POST `data` to the resulting URL.
 
-        `origin` fills the `_next_form_origin` hidden field the form tag
-        emits, unless `data` already carries one. `partial` turns the
-        POST into a patch request by stamping `X-Next-Request`, `zones`
-        names the zone the form lives in, and `version` sets the client
-        asset version.
+        `origin` fills the `_next_form_origin` hidden field the form tag emits, unless
+        `data` already carries one. `partial` turns the POST into a patch request by
+        stamping `X-Next-Request`, `zones` names the zone the form lives in, and
+        `version` sets the client asset version.
         """
         url = resolve_action_url(action_name)
         payload: dict[str, Any] = dict(data or {})

--- a/next/testing/isolation.py
+++ b/next/testing/isolation.py
@@ -47,6 +47,16 @@ def reset_registries() -> None:
     reset_components()
 
 
+def reset_component_templates() -> None:
+    """Drop compiled component templates so the next render reads sources again.
+
+    Needed between renders against a component rewritten on disk (for
+    example in `tmp_path`), because outside `DEBUG` the loader reuses a
+    compiled template without checking its source for an edit.
+    """
+    components_manager.clear_template_caches()
+
+
 def reset_page_cache() -> None:
     """Drop the page template cache and source-mtime bookkeeping.
 
@@ -58,6 +68,7 @@ def reset_page_cache() -> None:
 
 
 __all__ = [
+    "reset_component_templates",
     "reset_components",
     "reset_form_actions",
     "reset_form_registration_state",

--- a/next/testing/loaders.py
+++ b/next/testing/loaders.py
@@ -3,8 +3,7 @@
 `eager_load_pages` walks a pages directory and imports every `page.py`
 file so that `@context` and `@forms.action` side effects register
 before a test dispatches HTTP requests. Results are memoised per
-absolute directory so repeated calls during a pytest session are
-cheap.
+absolute directory so repeated calls during a pytest session are cheap.
 """
 
 from __future__ import annotations
@@ -61,9 +60,8 @@ def _derive_module_name(path: Path) -> str:
 def clear_loaded_dirs() -> None:
     """Drop the memoisation cache so the next call reloads page modules.
 
-    Intended for self-tests of the loader. Production test suites do
-    not need to call this because each pytest session gets a fresh
-    interpreter.
+    Intended for self-tests of the loader. Production test suites do not need to call
+    this because each pytest session gets a fresh interpreter.
     """
     _loaded_dirs.clear()
 

--- a/next/urls/backends.py
+++ b/next/urls/backends.py
@@ -380,8 +380,8 @@ class RouterFactory:
     def is_registered(cls, name: str) -> bool:
         """Report whether `name` maps to a registered backend class.
 
-        Contract-only seam for system checks so adjacent areas never read
-        the class registry directly.
+        Contract-only seam for system checks so adjacent
+        areas never read the class registry directly.
         """
         return name in cls._backends
 

--- a/next/urls/parser.py
+++ b/next/urls/parser.py
@@ -80,10 +80,9 @@ class DuplicateURLParameterError(ValueError):
 class URLPatternParser:
     """Map bracket segments in a file-based path to Django path converters.
 
-    The `url_path` string is the logical URL trail built from
-    directory names. An empty string means the tree root. It is not a
-    `pathlib.Path`. The on-disk file is the second value from the
-    page-tree scanner.
+    The `url_path` string is the logical URL trail built from directory names. An empty
+    string means the tree root. It is not a `pathlib.Path`. The on-disk file is the
+    second value from the page-tree scanner.
     """
 
     duplicate_parameter_error: ClassVar[type[DuplicateURLParameterError]] = (

--- a/next/utils.py
+++ b/next/utils.py
@@ -1,4 +1,4 @@
-"""Path helpers, the page-tree value object, and declaration-site attribution.
+"""Cross-area helpers for paths, page trees, edit watching, and declaration sites.
 
 Everything here sits below the subpackages that share it, so a value
 object two of them build travels through this module rather than closing
@@ -64,6 +64,15 @@ def resolve_base_dir() -> Path | None:
     if isinstance(raw, str):
         return Path(raw)
     return None
+
+
+def template_edits_watched() -> bool:
+    """Whether the composition caches stat their sources to notice an edit.
+
+    Autoreload leaves `.djx` alone, so under `DEBUG` the stat is the only
+    thing making an edit visible. Read per call, so an override takes effect.
+    """
+    return bool(settings.DEBUG)
 
 
 def _classify_one_dir_entry(

--- a/tests/benchmarks/components/test_bench_renderers.py
+++ b/tests/benchmarks/components/test_bench_renderers.py
@@ -8,8 +8,10 @@ from next.components.info import ComponentInfo
 from next.components.loading import ModuleLoader
 from next.components.renderers import (
     COMPONENT_PROPS_CONTEXT_KEY,
+    CachedComponentTemplateLoader,
     ComponentTemplateLoader,
     CompositeComponentRenderer,
+    SimpleComponentRenderer,
     _guarded_keys,
     _reject_collisions,
 )
@@ -75,3 +77,80 @@ class TestBenchContextCollisionGuard:
         data = {"env": "prod", "version": "1"}
 
         benchmark(_reject_collisions, info, data, guarded)
+
+
+_PLAIN_MODULE = """def helper():
+    return "unused"
+"""
+
+
+def _build_simple_component(root: Path) -> ComponentInfo:
+    """Write a lone `.djx` file and describe it as a simple component."""
+    (root / "card.djx").write_text("<div>{{ title }}</div>")
+    return ComponentInfo(
+        name="card",
+        scope_root=root,
+        scope_relative="",
+        template_path=root / "card.djx",
+        module_path=None,
+        is_simple=True,
+    )
+
+
+def _build_plain_composite(root: Path) -> ComponentInfo:
+    """Write a composite whose `component.py` registers no context function."""
+    (root / "component.py").write_text(_PLAIN_MODULE)
+    (root / "component.djx").write_text("<div>{{ title }}</div>")
+    return ComponentInfo(
+        name="card",
+        scope_root=root,
+        scope_relative="",
+        template_path=root / "component.djx",
+        module_path=(root / "component.py").resolve(),
+        is_simple=False,
+    )
+
+
+class TestBenchWarmRender:
+    """Renders paying only what a warm production render pays.
+
+    The compiled template is cached and every module is imported before the
+    first timed call, so the rows price the render path itself.
+    """
+
+    @pytest.mark.benchmark(group="components.render")
+    def test_simple_render(self, tmp_path: Path, benchmark) -> None:
+        info = _build_simple_component(tmp_path)
+        renderer = SimpleComponentRenderer(
+            CachedComponentTemplateLoader(ModuleLoader())
+        )
+        context = {"title": "Hi", COMPONENT_PROPS_CONTEXT_KEY: frozenset({"title"})}
+        renderer.render(info, context, None)
+
+        benchmark(renderer.render, info, context, None)
+
+    @pytest.mark.benchmark(group="components.render")
+    def test_composite_template_render(self, tmp_path: Path, benchmark) -> None:
+        info = _build_plain_composite(tmp_path)
+        module_loader = ModuleLoader()
+        renderer = CompositeComponentRenderer(
+            module_loader, CachedComponentTemplateLoader(module_loader)
+        )
+        context = {"title": "Hi", COMPONENT_PROPS_CONTEXT_KEY: frozenset({"title"})}
+        renderer.render(info, context, None)
+
+        benchmark(renderer.render, info, context, None)
+
+    @pytest.mark.benchmark(group="components.render")
+    def test_composite_render_with_context_function(
+        self, tmp_path: Path, benchmark
+    ) -> None:
+        info = _build_composite_component(tmp_path)
+        module_loader = ModuleLoader()
+        renderer = CompositeComponentRenderer(
+            module_loader, CachedComponentTemplateLoader(module_loader)
+        )
+        context = {"title": "Hi", COMPONENT_PROPS_CONTEXT_KEY: frozenset({"title"})}
+        renderer.render(info, context, None)
+
+        benchmark(renderer.render, info, context, None)

--- a/tests/benchmarks/forms/test_bench_dispatch.py
+++ b/tests/benchmarks/forms/test_bench_dispatch.py
@@ -137,9 +137,9 @@ class TestBenchDispatchEndToEnd:
     def test_dispatch_unguarded_form_no_hook_overhead(self, benchmark) -> None:
         """A no-hook form pays no permission-hook resolve on the dispatch path.
 
-        Pins the zero-overhead promise that an undeclared check_permissions or
-        has_object_permission costs the dispatcher only the two ClassVar reads,
-        not a third resolver call.
+        Pins the zero-overhead promise that an undeclared
+        check_permissions or has_object_permission costs the dispatcher
+        only the two ClassVar reads, not a third resolver call.
         """
         backend = RegistryFormActionBackend()
         backend.register_action(
@@ -164,10 +164,9 @@ class TestBenchDispatchEndToEnd:
     def test_dispatch_through_subclassed_backend(self, benchmark) -> None:
         """Dispatch through a thin `RegistryFormActionBackend` subclass.
 
-        Pins the wrapper overhead for projects that inherit from the
-        registry backend (audit-trail, metrics, gating). Compare against
-        ``test_dispatch_valid_form`` to spot regressions in the
-        super-call path.
+        Pins the wrapper overhead for projects that inherit from the registry backend
+        (audit-trail, metrics, gating). Compare against ``test_dispatch_valid_form`` to
+        spot regressions in the super-call path.
         """
 
         class _SubclassedBackend(RegistryFormActionBackend):

--- a/tests/benchmarks/templatetags/test_bench_component_tags.py
+++ b/tests/benchmarks/templatetags/test_bench_component_tags.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from django.template import Context, Template, engines
+from django.template.engine import Engine
+
+from next.components import components_manager
+from next.components.backends import FileComponentsBackend
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from django.template.base import Template as CompiledTemplate
+
+
+# Touching the engines triggers the global init that registers the next tags,
+# so warm it up here and keep the bench body on render cost alone.
+engines.all()
+
+_CARD = '<article class="card"><h2>{{ title }}</h2><p>{{ body }}</p></article>'
+
+_COMPONENT_TAG = '{% component "card" title="Bench" body="Body text" %}'
+_INCLUDE_TAG = (
+    '{% with title="Bench" body="Body text" %}{% include "card.html" %}{% endwith %}'
+)
+_INCLUSION_TAG = '{% bench_card "Bench" "Body text" %}'
+
+_PAGE_TAG_COUNT = 10
+
+_CACHED_LOADER = (
+    "django.template.loaders.cached.Loader",
+    ["django.template.loaders.filesystem.Loader"],
+)
+
+
+def _component_page(
+    root: Path, monkeypatch: pytest.MonkeyPatch, count: int
+) -> tuple[CompiledTemplate, Context]:
+    """Serve `card` from a real file backend and compile a page of `count` tags."""
+    components = root / "components"
+    components.mkdir()
+    (components / "card.djx").write_text(_CARD)
+    backend = FileComponentsBackend({"DIRS": [str(components)], "COMPONENTS_DIR": "_c"})
+    backend.discover()
+    monkeypatch.setattr(components_manager, "_backends", [backend])
+    monkeypatch.setattr(components_manager, "_loaded", True)
+    monkeypatch.setattr(components_manager, "_walk_registered_folders", set())
+
+    page = root / "page.djx"
+    page.write_text("")
+    template = Template("{% load components %}" + _COMPONENT_TAG * count)
+    return template, Context({"current_template_path": str(page)})
+
+
+def _vanilla_page(root: Path, source: str, count: int) -> CompiledTemplate:
+    """Compile a page of `count` vanilla tags against a cached-loader engine."""
+    (root / "card.html").write_text(_CARD)
+    engine = Engine(
+        dirs=[str(root)],
+        loaders=[_CACHED_LOADER],
+        builtins=["tests.benchmarks.templatetags.vanilla"],
+    )
+    return engine.from_string(source * count)
+
+
+class TestBenchComponentTag:
+    """`{% component %}` on a page beside the vanilla tags it competes with.
+
+    One tag prices the whole path, ten tags the marginal tag, and the ``{% include %}``
+    and ``inclusion_tag`` rows price the same work in plain Django.
+    """
+
+    @pytest.mark.benchmark(group="templatetags.component")
+    def test_one_component_tag(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, benchmark
+    ) -> None:
+        template, context = _component_page(tmp_path, monkeypatch, 1)
+        template.render(context)
+
+        benchmark(template.render, context)
+
+    @pytest.mark.benchmark(group="templatetags.component")
+    def test_ten_component_tags(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, benchmark
+    ) -> None:
+        template, context = _component_page(tmp_path, monkeypatch, _PAGE_TAG_COUNT)
+        template.render(context)
+
+        benchmark(template.render, context)
+
+    @pytest.mark.benchmark(group="templatetags.component")
+    def test_one_vanilla_include(self, tmp_path: Path, benchmark) -> None:
+        template = _vanilla_page(tmp_path, _INCLUDE_TAG, 1)
+        context = Context({})
+        template.render(context)
+
+        benchmark(template.render, context)
+
+    @pytest.mark.benchmark(group="templatetags.component")
+    def test_ten_vanilla_includes(self, tmp_path: Path, benchmark) -> None:
+        template = _vanilla_page(tmp_path, _INCLUDE_TAG, _PAGE_TAG_COUNT)
+        context = Context({})
+        template.render(context)
+
+        benchmark(template.render, context)
+
+    @pytest.mark.benchmark(group="templatetags.component")
+    def test_one_vanilla_inclusion_tag(self, tmp_path: Path, benchmark) -> None:
+        template = _vanilla_page(tmp_path, _INCLUSION_TAG, 1)
+        context = Context({})
+        template.render(context)
+
+        benchmark(template.render, context)

--- a/tests/benchmarks/templatetags/vanilla.py
+++ b/tests/benchmarks/templatetags/vanilla.py
@@ -1,0 +1,10 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.inclusion_tag("card.html")
+def bench_card(title: str, body: str) -> dict[str, str]:
+    """Render the reference card the way a plain Django project would."""
+    return {"title": title, "body": body}

--- a/tests/compat/conftest.py
+++ b/tests/compat/conftest.py
@@ -14,9 +14,8 @@ def next_client():
 def _isolate_form_registries():
     """Snapshot and restore the form registry around each test.
 
-    Compat modules register forms and actions at import time, so the
-    snapshot taken here always includes them. Fixture-registered actions
-    are dropped on restore.
+    Compat modules register forms and actions at import time, so the snapshot taken here
+    always includes them. Fixture-registered actions are dropped on restore.
     """
     with isolated_form_registries():
         yield

--- a/tests/components/test_backends.py
+++ b/tests/components/test_backends.py
@@ -568,6 +568,21 @@ class TestModuleLoader:
         m2 = loader.load(path)
         assert m1 is m2
 
+    def test_empty_shared_cache_is_kept(self, tmp_path: Path) -> None:
+        """An empty ``ModuleCache`` handed in stays the loader's cache.
+
+        ``ModuleCache`` defines ``__len__``, so a fresh one is falsy and a
+        truthiness check would silently unshare it from other loaders.
+        """
+        path = tmp_path / "mod.py"
+        path.write_text("x = 1\n")
+        shared = ModuleCache()
+        assert len(shared) == 0
+        loaded = ModuleLoader(shared).load(path)
+        assert loaded is not None
+        assert path in shared
+        assert ModuleLoader(shared).load(path) is loaded
+
     def test_load_returns_none_when_spec_missing(self, tmp_path: Path) -> None:
         """_load_from_disk returns None when spec_from_file_location returns None."""
         path = tmp_path / "empty.py"

--- a/tests/components/test_context.py
+++ b/tests/components/test_context.py
@@ -19,7 +19,7 @@ from next.components import (
 from next.components.context import iter_serialized_component_context_keys
 from next.components.renderers import _inject_component_context
 from next.static import StaticCollector
-from tests.support import attribution, handler_declared_here
+from tests.support import attribution, handler_declared_here, record_path_calls
 from tests.support.components import build_composite_component
 
 
@@ -527,3 +527,140 @@ class TestSerializedComponentContextKeys:
 
     def test_backend_without_component_files_is_skipped(self, tmp_path: Path) -> None:
         assert self._keys(DummyBackend({})) == []
+
+
+class TestComponentContextRegistryLookupCache:
+    """Tests for the version-keyed `get_functions` memo."""
+
+    def test_repeated_lookup_does_not_resolve_again(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A warm lookup returns the same tuple without touching the filesystem."""
+        reg = ComponentContextRegistry()
+        module_path = tmp_path / "component.py"
+
+        def provide() -> int:
+            return 1
+
+        reg.register(module_path, "n", provide)
+        first = reg.get_functions(module_path)
+        seen = record_path_calls(monkeypatch, "resolve")
+        second = reg.get_functions(module_path)
+        assert [entry.func for entry in first] == [provide]
+        assert second == first
+        assert seen == []
+
+    def test_empty_result_is_cached_and_invalidated_by_registration(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty result is cached too, until a registration moves the version."""
+        reg = ComponentContextRegistry()
+        module_path = tmp_path / "component.py"
+        assert reg.get_functions(module_path) == ()
+        seen = record_path_calls(monkeypatch, "resolve")
+        assert reg.get_functions(module_path) == ()
+        assert seen == []
+        monkeypatch.undo()
+
+        def provide() -> int:
+            return 1
+
+        reg.register(module_path, "n", provide)
+        assert [entry.func for entry in reg.get_functions(module_path)] == [provide]
+
+    def test_registration_during_warm_cache_is_visible(self, tmp_path: Path) -> None:
+        """A second function registered after a warm lookup joins the next result."""
+        reg = ComponentContextRegistry()
+        module_path = tmp_path / "component.py"
+
+        def first() -> int:
+            return 1
+
+        def second() -> int:
+            return 2
+
+        reg.register(module_path, "a", first)
+        assert [entry.func for entry in reg.get_functions(module_path)] == [first]
+        reg.register(module_path, "b", second)
+        assert [entry.func for entry in reg.get_functions(module_path)] == [
+            first,
+            second,
+        ]
+
+    def test_manager_passes_lookups_through(self, tmp_path: Path) -> None:
+        """The manager façade returns the registry tuple unchanged."""
+        mgr = ComponentContextManager()
+        module_path = tmp_path / "component.py"
+
+        def provide() -> int:
+            return 1
+
+        mgr._registry.register(module_path, "n", provide)
+        assert mgr.get_functions(module_path) == mgr._registry.get_functions(
+            module_path
+        )
+
+    def test_unregister_drops_the_path_and_invalidates_the_memo(
+        self, tmp_path: Path
+    ) -> None:
+        """Removing a path bumps the version so the warm memo cannot serve it."""
+        reg = ComponentContextRegistry()
+        module_path = tmp_path / "component.py"
+
+        def provide() -> int:
+            return 1
+
+        reg.register(module_path, "n", provide)
+        assert [entry.func for entry in reg.get_functions(module_path)] == [provide]
+        reg.unregister(module_path)
+        assert reg.get_functions(module_path) == ()
+        assert len(reg) == 0
+
+    def test_unregister_of_an_unknown_path_leaves_the_version_alone(
+        self, tmp_path: Path
+    ) -> None:
+        """Nothing moved, so the memo of every other path survives."""
+        reg = ComponentContextRegistry()
+        module_path = tmp_path / "component.py"
+
+        def provide() -> int:
+            return 1
+
+        reg.register(module_path, "n", provide)
+        warm = reg.get_functions(module_path)
+        version = reg.version
+        reg.unregister(tmp_path / "other" / "component.py")
+        assert reg.version == version
+        assert reg.get_functions(module_path) is warm
+
+    def test_identical_reregistration_keeps_the_memo(self, tmp_path: Path) -> None:
+        """Re-registering the same callable moves nothing, so the memo stands."""
+        reg = ComponentContextRegistry()
+        module_path = tmp_path / "component.py"
+
+        def provide() -> int:
+            return 1
+
+        reg.register(module_path, "n", provide)
+        warm = reg.get_functions(module_path)
+        version = reg.version
+        reg.register(module_path, "n", provide)
+        assert reg.version == version
+        assert reg.get_functions(module_path) is warm
+
+    def test_reregistration_with_new_flags_invalidates_the_memo(
+        self, tmp_path: Path
+    ) -> None:
+        """A changed `serialize` flag is a different entry, so the memo rebuilds."""
+        reg = ComponentContextRegistry()
+        module_path = tmp_path / "component.py"
+
+        def provide() -> int:
+            return 1
+
+        reg.register(module_path, "n", provide)
+        warm = reg.get_functions(module_path)
+        reg.register(module_path, "n", provide, serialize=True)
+        rebuilt = reg.get_functions(module_path)
+        assert rebuilt is not warm
+        assert [entry.serialize for entry in rebuilt] == [True]

--- a/tests/components/test_manager.py
+++ b/tests/components/test_manager.py
@@ -1,11 +1,14 @@
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from django.template import Context, Template
 from django.test import RequestFactory, override_settings
 
 from next.components import (
+    CachedComponentTemplateLoader,
     ComponentInfo,
     ComponentRenderer,
     ComponentScanner,
@@ -24,13 +27,56 @@ from next.components import (
     render_component,
 )
 from next.components.manager import _on_settings_reloaded
-from next.components.renderers import _inject_component_context, _merge_csrf_context
+from next.components.renderers import (
+    TemplateSource,
+    _inject_component_context,
+    _merge_csrf_context,
+)
 from next.conf import next_framework_settings
 from tests.support import (
     RaisingRootsRouter,
     RootPagesRouter,
     next_framework_settings_component_backends_list as _next_framework_settings_component_backends_list,
 )
+
+
+def _bump_mtime(path: Path, seconds: int = 2) -> None:
+    """Move the file mtime forward so a same-second rewrite is still a change."""
+    shift = seconds * 1_000_000_000
+    stat = path.stat()
+    os.utime(path, ns=(stat.st_atime_ns + shift, stat.st_mtime_ns + shift))
+
+
+def _key(info: ComponentInfo) -> tuple[Path | None, Path | None]:
+    """Return the compiled-cache key of a component, its pair of source files."""
+    return (info.template_path, info.module_path)
+
+
+def _render_body(loader: ComponentTemplateLoader, info: ComponentInfo) -> str:
+    """Compile `info` through `loader` and render it against an empty context."""
+    template = loader.load_template(info)
+    assert template is not None
+    return template.render(Context({}))
+
+
+class CountingCachedLoader(CachedComponentTemplateLoader):
+    """Cached loader that records how often it read a source."""
+
+    def __init__(self, module_loader: ModuleLoader, maxsize: int = 128) -> None:
+        """Start with an empty compiled cache and a zeroed read counter."""
+        super().__init__(module_loader, maxsize)
+        self.reads = 0
+
+    def load_source(self, info: ComponentInfo) -> TemplateSource | None:
+        self.reads += 1
+        return super().load_source(info)
+
+
+class SyntheticSourceLoader(CachedComponentTemplateLoader):
+    """Cached loader whose bodies come from memory under a path that never stats."""
+
+    def load_source(self, info: ComponentInfo) -> TemplateSource | None:
+        return TemplateSource("<i>synthetic</i>", info.scope_root / "nowhere.djx")
 
 
 class TestComponentsManager:
@@ -639,7 +685,7 @@ class TestComponentRenderers:
         loader = ModuleLoader()
         tl = ComponentTemplateLoader(loader)
         r = CompositeComponentRenderer(loader, tl)
-        with patch.object(tl, "load", return_value=None):
+        with patch.object(tl, "load_template", return_value=None):
             assert r._render_with_template(info, {}, None) == ""
 
     def test_fallback_template_none_returns_empty(self, tmp_path: Path) -> None:
@@ -665,6 +711,273 @@ class TestComponentRenderers:
         html = sr.render(info, {}, request=req)
         assert "csrfmiddlewaretoken" in html
         assert "<b>" in html
+
+
+class TestComponentTemplateLoaderCompilation:
+    """``load_template`` on the plain loader compiles on every call."""
+
+    def test_compiles_a_fresh_template_per_call(self, tmp_path: Path) -> None:
+        """Without a cache each call parses the source again."""
+        (tmp_path / "card.djx").write_text("<i>{{ x }}</i>")
+        info = ComponentInfo("card", tmp_path, "", tmp_path / "card.djx", None, True)
+        loader = ComponentTemplateLoader(ModuleLoader())
+        first = loader.load_template(info)
+        second = loader.load_template(info)
+        assert first is not second
+        assert first is not None
+        assert first.render(Context({"x": 1})) == "<i>1</i>"
+
+    def test_returns_none_when_the_source_is_unavailable(self) -> None:
+        """A component with no readable source compiles nothing."""
+        info = ComponentInfo("x", Path("/none"), "", Path("/none/x.djx"), None, True)
+        assert ComponentTemplateLoader(ModuleLoader()).load_template(info) is None
+
+
+class TestCachedComponentTemplateLoader:
+    """Compiled templates are reused until the file they came from changes."""
+
+    @pytest.mark.usefixtures("watched_template_edits")
+    def test_second_render_reuses_the_compiled_template(self, tmp_path: Path) -> None:
+        """Two renders of one component read and compile the source once."""
+        (tmp_path / "card.djx").write_text("<h3>{{ title }}</h3>")
+        info = ComponentInfo("card", tmp_path, "", tmp_path / "card.djx", None, True)
+        loader = CountingCachedLoader(ModuleLoader())
+        renderer = SimpleComponentRenderer(loader)
+        with patch(
+            "next.components.renderers.Template", side_effect=Template
+        ) as compile_calls:
+            first = renderer.render(info, {"title": "one"}, None)
+            second = renderer.render(info, {"title": "two"}, None)
+        assert (first, second) == ("<h3>one</h3>", "<h3>two</h3>")
+        assert loader.reads == 1
+        assert compile_calls.call_count == 1
+
+    @pytest.mark.usefixtures("watched_template_edits")
+    def test_editing_the_djx_body_reaches_the_next_render(self, tmp_path: Path) -> None:
+        """A rewritten template renders its new body without a restart."""
+        path = tmp_path / "card.djx"
+        path.write_text("<h3>one</h3>")
+        info = ComponentInfo("card", tmp_path, "", path, None, True)
+        loader = CountingCachedLoader(ModuleLoader())
+        renderer = SimpleComponentRenderer(loader)
+        assert renderer.render(info, {}, None) == "<h3>one</h3>"
+        path.write_text("<h3>two</h3>")
+        _bump_mtime(path)
+        assert renderer.render(info, {}, None) == "<h3>two</h3>"
+        assert loader.reads == 2
+        assert loader._compiled[_key(info)].mtime_ns == path.stat().st_mtime_ns
+
+    @pytest.mark.usefixtures("watched_template_edits")
+    def test_a_module_string_follows_its_module(self, tmp_path: Path) -> None:
+        """An edited component.py expires the entry, so the body follows it.
+
+        The module cache has no mtime of its own, so the new body arrives with
+        the restart the autoreloader performs for a watched `component.py`.
+        """
+        module_dir = tmp_path / "mod"
+        module_dir.mkdir()
+        module = module_dir / "component.py"
+        module.write_text('component = "<i>one</i>"\n')
+        info = ComponentInfo("mod", tmp_path, "", None, module, False)
+        loader = CountingCachedLoader(ModuleLoader())
+        assert _render_body(loader, info) == "<i>one</i>"
+        module.write_text('component = "<b>two</b>"\n')
+        _bump_mtime(module)
+        assert _render_body(loader, info) == "<i>one</i>"
+        assert loader.reads == 2
+        restarted = CachedComponentTemplateLoader(ModuleLoader())
+        assert _render_body(restarted, info) == "<b>two</b>"
+
+    @pytest.mark.usefixtures("watched_template_edits")
+    def test_an_unreadable_djx_keys_the_cache_on_the_module(
+        self, tmp_path: Path
+    ) -> None:
+        """A body read from component.py is revalidated against component.py."""
+        module_dir = tmp_path / "mod"
+        module_dir.mkdir()
+        djx = module_dir / "component.djx"
+        djx.write_bytes(b"\xff\xfe not utf-8")
+        module = module_dir / "component.py"
+        module.write_text('component = "<b>one</b>"\n')
+        info = ComponentInfo("mod", tmp_path, "", djx, module, False)
+        loader = CountingCachedLoader(ModuleLoader())
+        assert _render_body(loader, info) == "<b>one</b>"
+        assert loader._compiled[_key(info)].source_path == module
+        module.write_text('component = "<b>two</b>"\n')
+        _bump_mtime(module)
+        assert _render_body(loader, info) == "<b>one</b>"
+        assert loader.reads == 2
+        restarted = CachedComponentTemplateLoader(ModuleLoader())
+        assert _render_body(restarted, info) == "<b>two</b>"
+
+    @pytest.mark.usefixtures("watched_template_edits")
+    def test_a_missing_djx_caches_the_module_string(self, tmp_path: Path) -> None:
+        """A declared but absent .djx leaves the module body cached, not re-read."""
+        module_dir = tmp_path / "mod"
+        module_dir.mkdir()
+        module = module_dir / "component.py"
+        module.write_text('component = "<i>from module</i>"\n')
+        info = ComponentInfo(
+            "mod", tmp_path, "", module_dir / "component.djx", module, False
+        )
+        loader = CountingCachedLoader(ModuleLoader())
+        renderer = SimpleComponentRenderer(loader)
+        assert renderer.render(info, {}, None) == "<i>from module</i>"
+        assert renderer.render(info, {}, None) == "<i>from module</i>"
+        assert loader.reads == 1
+        assert loader._compiled[_key(info)].source_path == module
+
+    def test_module_as_template_path_keys_the_cache_by_the_module(
+        self, tmp_path: Path
+    ) -> None:
+        """A component.py standing in for the template still keys on itself."""
+        module_dir = tmp_path / "mod"
+        module_dir.mkdir()
+        module = module_dir / "component.py"
+        module.write_text('component = "<i>x</i>"\n')
+        info = ComponentInfo("mod", tmp_path, "", module, module, False)
+        loader = CachedComponentTemplateLoader(ModuleLoader())
+        assert loader.load_template(info) is not None
+        assert loader._compiled[_key(info)].source_path == module
+
+    @pytest.mark.usefixtures("watched_template_edits")
+    def test_deleted_file_renders_empty_and_drops_the_entry(
+        self, tmp_path: Path
+    ) -> None:
+        """A template removed between renders falls back to an empty render."""
+        path = tmp_path / "card.djx"
+        path.write_text("<h3>one</h3>")
+        info = ComponentInfo("card", tmp_path, "", path, None, True)
+        loader = CachedComponentTemplateLoader(ModuleLoader())
+        renderer = SimpleComponentRenderer(loader)
+        assert renderer.render(info, {}, None) == "<h3>one</h3>"
+        path.unlink()
+        assert renderer.render(info, {}, None) == ""
+        assert loader._compiled == {}
+
+    @pytest.mark.usefixtures("watched_template_edits")
+    def test_unreadable_source_drops_a_stale_entry(self, tmp_path: Path) -> None:
+        """A body that stops decoding invalidates the compiled template."""
+        path = tmp_path / "card.djx"
+        path.write_text("<h3>one</h3>")
+        info = ComponentInfo("card", tmp_path, "", path, None, True)
+        loader = CachedComponentTemplateLoader(ModuleLoader())
+        assert loader.load_template(info) is not None
+        path.write_bytes(b"\xff\xfe broken")
+        _bump_mtime(path)
+        assert loader.load_template(info) is None
+        assert loader._compiled == {}
+
+    def test_component_without_files_caches_nothing(self, tmp_path: Path) -> None:
+        """No source file means no mtime to key on, so nothing is stored."""
+        info = ComponentInfo("ghost", tmp_path, "", None, None, True)
+        loader = CachedComponentTemplateLoader(ModuleLoader())
+        assert loader.load_template(info) is None
+        assert loader._compiled == {}
+
+    def test_a_source_that_does_not_stat_is_compiled_but_not_cached(
+        self, tmp_path: Path
+    ) -> None:
+        """A body under a path with no mtime has nothing to revalidate against."""
+        info = ComponentInfo("x", tmp_path, "", None, None, True)
+        loader = SyntheticSourceLoader(ModuleLoader())
+        assert _render_body(loader, info) == "<i>synthetic</i>"
+        assert loader._compiled == {}
+
+    def test_a_full_cache_evicts_the_least_recently_used_entry(
+        self, tmp_path: Path
+    ) -> None:
+        """Eviction follows use order and never hands out another component's body."""
+        infos = []
+        for name in ("a", "b", "c"):
+            (tmp_path / f"{name}.djx").write_text(f"<i>{name}</i>")
+            infos.append(
+                ComponentInfo(name, tmp_path, "", tmp_path / f"{name}.djx", None, True)
+            )
+        first, second, third = infos
+        loader = CachedComponentTemplateLoader(ModuleLoader(), maxsize=2)
+        assert _render_body(loader, first) == "<i>a</i>"
+        assert _render_body(loader, second) == "<i>b</i>"
+        assert _render_body(loader, first) == "<i>a</i>"
+        assert _render_body(loader, third) == "<i>c</i>"
+        assert list(loader._compiled) == [_key(first), _key(third)]
+        assert _render_body(loader, second) == "<i>b</i>"
+
+    def test_clear_drops_every_compiled_template(self, tmp_path: Path) -> None:
+        """The seam a test uses after rewriting a component on disk."""
+        path = tmp_path / "card.djx"
+        path.write_text("<i>one</i>")
+        info = ComponentInfo("card", tmp_path, "", path, None, True)
+        loader = CachedComponentTemplateLoader(ModuleLoader())
+        assert _render_body(loader, info) == "<i>one</i>"
+        loader.clear()
+        assert loader._compiled == {}
+        path.write_text("<i>two</i>")
+        assert _render_body(loader, info) == "<i>two</i>"
+
+
+class TestRevalidationFollowsWatchedEdits:
+    """Sources are stat-ed only where an edit can reach a render."""
+
+    @pytest.mark.usefixtures("watched_template_edits")
+    def test_edits_are_picked_up_only_where_they_are_watched(
+        self, tmp_path: Path
+    ) -> None:
+        """An unwatched process reuses the entry, and the watch takes the edit."""
+        path = tmp_path / "card.djx"
+        path.write_text("<h3>one</h3>")
+        info = ComponentInfo("card", tmp_path, "", path, None, True)
+        loader = CountingCachedLoader(ModuleLoader())
+        with override_settings(DEBUG=False):
+            assert _render_body(loader, info) == "<h3>one</h3>"
+            path.write_text("<h3>two</h3>")
+            _bump_mtime(path)
+            assert _render_body(loader, info) == "<h3>one</h3>"
+            assert loader.reads == 1
+        assert _render_body(loader, info) == "<h3>two</h3>"
+        assert loader.reads == 2
+
+
+class TestRenderPipelineCaching:
+    """The pipeline `components_manager` builds caches compilation end to end."""
+
+    @pytest.mark.parametrize("debug", [True, False], ids=["watched", "unwatched"])
+    def test_a_repeated_render_neither_reads_nor_compiles(
+        self, tmp_path: Path, *, debug: bool
+    ) -> None:
+        """A warm render through render_component costs no read and no parse."""
+        path = tmp_path / "card.djx"
+        path.write_text("<h3>{{ title }}</h3>")
+        info = ComponentInfo("card", tmp_path, "", path, None, True)
+        with override_settings(DEBUG=debug):
+            assert render_component(info, {"title": "one"}) == "<h3>one</h3>"
+            with (
+                patch(
+                    "next.components.renderers.Template", side_effect=Template
+                ) as compiles,
+                patch.object(
+                    Path, "read_text", autospec=True, side_effect=Path.read_text
+                ) as reads,
+                patch.object(
+                    Path, "stat", autospec=True, side_effect=Path.stat
+                ) as stats,
+            ):
+                html = render_component(info, {"title": "two"})
+        assert html == "<h3>two</h3>"
+        assert compiles.call_count == 0
+        assert reads.call_count == 0
+        assert stats.call_count == (1 if debug else 0)
+
+    @pytest.mark.usefixtures("watched_template_edits")
+    def test_an_edited_djx_reaches_the_next_render(self, tmp_path: Path) -> None:
+        """The live pipeline picks up a rewritten body while edits are watched."""
+        path = tmp_path / "card.djx"
+        path.write_text("<h3>one</h3>")
+        info = ComponentInfo("card", tmp_path, "", path, None, True)
+        assert render_component(info, {}) == "<h3>one</h3>"
+        path.write_text("<h3>two</h3>")
+        _bump_mtime(path)
+        assert render_component(info, {}) == "<h3>two</h3>"
 
 
 class TestInjectComponentContext:

--- a/tests/components/test_manager.py
+++ b/tests/components/test_manager.py
@@ -27,8 +27,11 @@ from next.components import (
     render_component,
 )
 from next.components.manager import _on_settings_reloaded
+from next.components.registry import _VISIBILITY_CACHE_MAX_SIZE
 from next.components.renderers import (
+    _COMPILED_TEMPLATE_CACHE_MAX_SIZE,
     TemplateSource,
+    _CompiledTemplate,
     _inject_component_context,
     _merge_csrf_context,
 )
@@ -62,7 +65,11 @@ def _render_body(loader: ComponentTemplateLoader, info: ComponentInfo) -> str:
 class CountingCachedLoader(CachedComponentTemplateLoader):
     """Cached loader that records how often it read a source."""
 
-    def __init__(self, module_loader: ModuleLoader, maxsize: int = 128) -> None:
+    def __init__(
+        self,
+        module_loader: ModuleLoader,
+        maxsize: int = _COMPILED_TEMPLATE_CACHE_MAX_SIZE,
+    ) -> None:
         """Start with an empty compiled cache and a zeroed read counter."""
         super().__init__(module_loader, maxsize)
         self.reads = 0
@@ -77,6 +84,44 @@ class SyntheticSourceLoader(CachedComponentTemplateLoader):
 
     def load_source(self, info: ComponentInfo) -> TemplateSource | None:
         return TemplateSource("<i>synthetic</i>", info.scope_root / "nowhere.djx")
+
+
+class RewritingSourceLoader(CachedComponentTemplateLoader):
+    """Cached loader that lets one save land while the first body is being read."""
+
+    def __init__(self, module_loader: ModuleLoader) -> None:
+        """Start with an empty compiled cache and no save queued."""
+        super().__init__(module_loader)
+        self.pending_save: str | None = None
+
+    def load_source(self, info: ComponentInfo) -> TemplateSource | None:
+        source = super().load_source(info)
+        if self.pending_save is not None and info.template_path is not None:
+            info.template_path.write_text(self.pending_save)
+            _bump_mtime(info.template_path)
+            self.pending_save = None
+        return source
+
+
+class EvictingFreshnessLoader(CachedComponentTemplateLoader):
+    """Cached loader whose freshness check drops the entry, as an eviction would."""
+
+    def _is_fresh(self, entry: _CompiledTemplate) -> bool:
+        self._compiled.clear()
+        return True
+
+
+_STRING_IF_INVALID_TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": ["django.template.context_processors.request"],
+            "string_if_invalid": "MISSING",
+        },
+    }
+]
 
 
 class TestComponentsManager:
@@ -914,6 +959,57 @@ class TestCachedComponentTemplateLoader:
         assert loader._compiled == {}
         path.write_text("<i>two</i>")
         assert _render_body(loader, info) == "<i>two</i>"
+
+    def test_the_default_bound_matches_the_other_component_caches(self) -> None:
+        """One bound covers every path-keyed component cache in the process."""
+        loader = CachedComponentTemplateLoader(ModuleLoader())
+        assert loader._maxsize == _VISIBILITY_CACHE_MAX_SIZE
+
+    @pytest.mark.usefixtures("watched_template_edits")
+    def test_a_save_during_the_read_does_not_hide_the_edit(
+        self, tmp_path: Path
+    ) -> None:
+        """A rewrite landing between the stat and the read still expires the entry."""
+        path = tmp_path / "card.djx"
+        path.write_text("<i>one</i>")
+        info = ComponentInfo("card", tmp_path, "", path, None, True)
+        loader = RewritingSourceLoader(ModuleLoader())
+        loader.pending_save = "<i>two</i>"
+        assert _render_body(loader, info) == "<i>one</i>"
+        assert _render_body(loader, info) == "<i>two</i>"
+
+    @pytest.mark.usefixtures("watched_template_edits")
+    def test_an_entry_dropped_while_it_is_checked_still_renders(
+        self, tmp_path: Path
+    ) -> None:
+        """An eviction racing the reorder costs the reorder, never the render."""
+        path = tmp_path / "card.djx"
+        path.write_text("<i>one</i>")
+        info = ComponentInfo("card", tmp_path, "", path, None, True)
+        loader = EvictingFreshnessLoader(ModuleLoader())
+        assert _render_body(loader, info) == "<i>one</i>"
+        assert _render_body(loader, info) == "<i>one</i>"
+        assert loader._compiled == {}
+
+
+class TestTemplatesSettingInvalidation:
+    """A `TEMPLATES` change reaches a component whose template is already compiled."""
+
+    def test_an_engine_change_drops_the_compiled_templates(
+        self, tmp_path: Path
+    ) -> None:
+        """The new engine renders the component the old one had already compiled."""
+        path = tmp_path / "card.djx"
+        path.write_text("<i>{{ missing }}</i>")
+        info = ComponentInfo("card", tmp_path, "", path, None, True)
+        loader = components_manager.template_loader
+        assert SimpleComponentRenderer(loader).render(info, {}, None) == "<i></i>"
+        with override_settings(TEMPLATES=_STRING_IF_INVALID_TEMPLATES):
+            overridden = components_manager.template_loader
+            assert overridden is not loader
+            rendered = SimpleComponentRenderer(overridden).render(info, {}, None)
+            assert rendered == "<i>MISSING</i>"
+        assert components_manager.template_loader is not overridden
 
 
 class TestRevalidationFollowsWatchedEdits:

--- a/tests/components/test_manager.py
+++ b/tests/components/test_manager.py
@@ -982,7 +982,7 @@ class TestCachedComponentTemplateLoader:
     def test_an_entry_dropped_while_it_is_checked_still_renders(
         self, tmp_path: Path
     ) -> None:
-        """An eviction racing the reorder costs the reorder, never the render."""
+        """An eviction racing the freshness check costs no render."""
         path = tmp_path / "card.djx"
         path.write_text("<i>one</i>")
         info = ComponentInfo("card", tmp_path, "", path, None, True)
@@ -990,6 +990,25 @@ class TestCachedComponentTemplateLoader:
         assert _render_body(loader, info) == "<i>one</i>"
         assert _render_body(loader, info) == "<i>one</i>"
         assert loader._compiled == {}
+
+    def test_marking_a_dropped_key_leaves_the_cache_alone(self) -> None:
+        """The reorder a concurrent eviction has already outrun does nothing."""
+        loader = CachedComponentTemplateLoader(ModuleLoader())
+        loader._mark_used((Path("/gone/card.djx"), None))
+        assert loader._compiled == {}
+
+    def test_use_order_is_tracked_only_once_the_cache_is_full(
+        self, tmp_path: Path
+    ) -> None:
+        """A cache with room to spare skips the reorder every hit would pay."""
+        path = tmp_path / "card.djx"
+        path.write_text("<i>one</i>")
+        info = ComponentInfo("card", tmp_path, "", path, None, True)
+        loader = CachedComponentTemplateLoader(ModuleLoader())
+        assert _render_body(loader, info) == "<i>one</i>"
+        with patch.object(loader, "_mark_used") as reorder:
+            assert _render_body(loader, info) == "<i>one</i>"
+        assert reorder.call_count == 0
 
 
 class TestTemplatesSettingInvalidation:

--- a/tests/components/test_renderers.py
+++ b/tests/components/test_renderers.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from django.template import Context, Template
+from django.test import RequestFactory
 
 from next.components import (
     ComponentContextManager,
@@ -10,6 +11,7 @@ from next.components import (
     components_manager,
     render_component,
 )
+from next.components.loading import ModuleLoader
 from next.components.renderers import (
     _RESERVED_CONTEXT_KEYS,
     COMPONENT_PROPS_CONTEXT_KEY,
@@ -265,3 +267,82 @@ class TestComponentTagPropsChannel:
                 info,
                 '{% #component "card" %}{% #slot "body" %}ok{% /slot %}{% /component %}',
             )
+
+
+_RENDER_MODULE = """def render(title):
+    return f"<b>{title}</b>"
+"""
+
+
+class TestCallerContextOwnership:
+    """`render_component` reads the caller's mapping and never writes to it."""
+
+    def test_simple_render_leaves_the_caller_dict_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        """The request and csrf keys land in the render copy, not in the argument."""
+        (tmp_path / "card.djx").write_text("<div>{{ title }} {{ csrf_token }}</div>")
+        info = ComponentInfo(
+            name="card",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=tmp_path / "card.djx",
+            module_path=None,
+            is_simple=True,
+        )
+        context_data = {"title": "Hi"}
+        request = RequestFactory().get("/")
+
+        html = render_component(info, context_data, request=request)
+
+        assert "Hi" in html
+        assert context_data == {"title": "Hi"}
+
+    def test_composite_context_functions_write_to_the_render_copy(
+        self, tmp_path: Path
+    ) -> None:
+        """A `@component.context` merge stays inside the render copy."""
+        mgr, info, module_path = build_composite_component(
+            tmp_path, template="<div>{{ title }} {{ env }}</div>"
+        )
+        mgr._registry.register(module_path, None, lambda: {"env": "prod"})
+        context_data = {"title": "Hi"}
+
+        with patch("next.components.renderers.component", mgr):
+            html = render_component(info, context_data)
+
+        assert "prod" in html
+        assert context_data == {"title": "Hi"}
+
+    def test_composite_render_function_leaves_the_caller_dict_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        """The `render()` branch resolves from the caller's mapping read-only."""
+        mgr, info, module_path = build_composite_component(tmp_path)
+        module_path.write_text(_RENDER_MODULE)
+        context_data = {"title": "Hi"}
+
+        with patch("next.components.renderers.component", mgr):
+            html = render_component(info, context_data)
+
+        assert html == "<b>Hi</b>"
+        assert context_data == {"title": "Hi"}
+
+    def test_fallback_to_template_leaves_the_caller_dict_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        """The unloadable-module fallback stamps the anchor on its own copy."""
+        mgr, info, _module_path = build_composite_component(
+            tmp_path,
+            template="<div>{{ title }}|{{ current_component_module_path }}</div>",
+        )
+        context_data = {"title": "Hi"}
+
+        with (
+            patch("next.components.renderers.component", mgr),
+            patch.object(ModuleLoader, "load", return_value=None),
+        ):
+            html = render_component(info, context_data)
+
+        assert "Hi" in html
+        assert context_data == {"title": "Hi"}

--- a/tests/components/test_tags.py
+++ b/tests/components/test_tags.py
@@ -11,6 +11,9 @@ from django.utils.safestring import SafeString
 
 from next.components import ComponentInfo, components_manager
 from next.static import StaticCollector
+from next.templatetags import components as component_tags
+from next.templatetags.components import ComponentNode, _resolve_template_path
+from tests.support import record_path_calls
 
 
 class TestComponentTag:
@@ -339,6 +342,67 @@ class TestComponentTag:
             )
         assert "slot_image" in result or "<img" in result
         assert "kids" in result
+
+    def _render_box(self, tmp_path: Path, source: str, body: str) -> str:
+        """Render ``box`` with `source` as its template and `body` as the call site."""
+        (tmp_path / "box.djx").write_text(source)
+        info = ComponentInfo(
+            name="box",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=tmp_path / "box.djx",
+            module_path=None,
+            is_simple=True,
+        )
+        with patch.object(components_manager, "get_component", return_value=info):
+            t = Template("{% load components %}" + body)
+            return t.render(
+                Context(
+                    {
+                        "current_template_path": str(tmp_path / "page.djx"),
+                        "hostile": "<script>alert(1)</script>",
+                    }
+                )
+            )
+
+    def test_free_children_splice_markup_while_props_stay_escaped(
+        self, tmp_path: Path
+    ) -> None:
+        """Children arrive as finished HTML while props of the same text do not.
+
+        The caller renders children before the component runs, so autoescaping
+        already happened there and a second pass would print the tags. Props
+        travel their own channel and keep escaping untrusted text.
+        """
+        result = self._render_box(
+            tmp_path,
+            "<div>{{ children }}|{{ note }}</div>",
+            '{% #component "box" note=hostile %}<b>kid</b>{% /component %}',
+        )
+        assert result == "<div><b>kid</b>|&lt;script&gt;alert(1)&lt;/script&gt;</div>"
+
+    def test_variables_inside_children_keep_their_escaping(
+        self, tmp_path: Path
+    ) -> None:
+        """A hostile value interpolated inside children stays escaped."""
+        result = self._render_box(
+            tmp_path,
+            "<div>{{ children }}</div>",
+            '{% #component "box" %}<b>{{ hostile }}</b>{% /component %}',
+        )
+        assert result == "<div><b>&lt;script&gt;alert(1)&lt;/script&gt;</b></div>"
+
+    @pytest.mark.parametrize(
+        "call_site",
+        ['{% component "box" %}', '{% #component "box" %}{% /component %}'],
+        ids=["void", "empty-block"],
+    )
+    def test_component_without_children_renders_nothing_for_them(
+        self, tmp_path: Path, call_site: str
+    ) -> None:
+        """The void form and an empty body both leave ``{{ children }}`` blank."""
+        result = self._render_box(tmp_path, "<div>{{ children }}</div>", call_site)
+        assert result == "<div></div>"
 
     def test_component_tag_with_props(self, tmp_path: Path) -> None:
         """Component tag parses key=val props."""
@@ -944,3 +1008,291 @@ class TestComponentMissReporting:
         assert [r.getMessage() for r in warnings] == [
             "component 'nvbar' skipped, no current_template_path in context"
         ]
+
+
+class TestComponentNodePathCache:
+    """Tests for the process-wide ``current_template_path`` resolve memo."""
+
+    def _node(self) -> ComponentNode:
+        t = Template('{% load components %}{% component "card" %}')
+        return next(n for n in t.nodelist if isinstance(n, ComponentNode))
+
+    def _noncanonical(self, tmp_path: Path, name: str) -> tuple[str, Path]:
+        scope = tmp_path / name
+        scope.mkdir()
+        page = scope / "page.djx"
+        return str(scope / ".." / name / "page.djx"), page.resolve()
+
+    def test_repeated_lookup_resolves_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second lookup with the same raw path reuses the memo."""
+        node = self._node()
+        raw, expected = self._noncanonical(tmp_path, "scope")
+        ctx = Context({"current_template_path": raw})
+        _resolve_template_path.cache_clear()
+        seen = record_path_calls(monkeypatch, "resolve")
+        first = node._template_path_from_context(ctx)
+        second = node._template_path_from_context(ctx)
+        assert first == expected
+        assert second == first
+        assert len(seen) == 1
+
+    def test_changed_path_is_resolved_again(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second raw path resolves on its own instead of reusing the memo."""
+        node = self._node()
+        raw_a, expected_a = self._noncanonical(tmp_path, "scope_a")
+        raw_b, expected_b = self._noncanonical(tmp_path, "scope_b")
+        _resolve_template_path.cache_clear()
+        seen = record_path_calls(monkeypatch, "resolve")
+        first = node._template_path_from_context(
+            Context({"current_template_path": raw_a})
+        )
+        second = node._template_path_from_context(
+            Context({"current_template_path": raw_b})
+        )
+        assert first == expected_a
+        assert second == expected_b
+        assert len(seen) == 2
+
+    def test_rotating_parents_each_resolve_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Twenty rotating parent pages resolve once each, not once per render."""
+        node = self._node()
+        cases = [self._noncanonical(tmp_path, f"scope{i}") for i in range(20)]
+        contexts = [Context({"current_template_path": raw}) for raw, _ in cases]
+        _resolve_template_path.cache_clear()
+        seen = record_path_calls(monkeypatch, "resolve")
+        for _ in range(3):
+            for ctx, (_raw, expected) in zip(contexts, cases, strict=True):
+                assert node._template_path_from_context(ctx) == expected
+        assert len(seen) == len(cases)
+
+    def test_second_node_reuses_the_shared_memo(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A path one node resolved costs a second node nothing."""
+        raw, expected = self._noncanonical(tmp_path, "scope")
+        ctx = Context({"current_template_path": raw})
+        _resolve_template_path.cache_clear()
+        seen = record_path_calls(monkeypatch, "resolve")
+        assert self._node()._template_path_from_context(ctx) == expected
+        assert self._node()._template_path_from_context(ctx) == expected
+        assert len(seen) == 1
+
+    def test_path_value_is_taken_as_resolved(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``Path`` under the key was already resolved by whoever wrote it."""
+        node = self._node()
+        raw = (tmp_path / "t.djx").resolve()
+        seen = record_path_calls(monkeypatch, "resolve")
+        result = node._template_path_from_context(
+            Context({"current_template_path": raw})
+        )
+        assert result is raw
+        assert seen == []
+
+    def test_nested_tag_does_not_resolve_the_parent_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A tag inside a component template reuses the path its parent resolved."""
+        (tmp_path / "outer.djx").write_text(
+            '{% load components %}<b>{% component "inner" %}</b>'
+        )
+        (tmp_path / "inner.djx").write_text("<i>deep</i>")
+        infos = {
+            name: ComponentInfo(
+                name=name,
+                scope_root=tmp_path,
+                scope_relative="",
+                template_path=tmp_path / f"{name}.djx",
+                module_path=None,
+                is_simple=True,
+            )
+            for name in ("outer", "inner")
+        }
+        raw = str(tmp_path / "page.djx")
+        resolved: list[str] = []
+
+        def counting(value: str) -> Path:
+            resolved.append(value)
+            return Path(value).resolve()
+
+        monkeypatch.setattr(component_tags, "_resolve_template_path", counting)
+        with patch.object(
+            components_manager,
+            "get_component",
+            side_effect=lambda name, _p: infos[name],
+        ):
+            result = Template('{% load components %}{% component "outer" %}').render(
+                Context({"current_template_path": raw})
+            )
+        assert result == "<b><i>deep</i></b>"
+        assert resolved == [raw]
+
+    def test_missing_path_resolves_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A context without ``current_template_path`` touches no filesystem."""
+        node = self._node()
+        seen = record_path_calls(monkeypatch, "resolve")
+        assert node._template_path_from_context(Context({})) is None
+        assert seen == []
+
+    def test_unexpected_type_resolves_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A raw value that is neither ``str`` nor ``Path`` touches no filesystem."""
+        node = self._node()
+        ctx = Context({"current_template_path": 42})
+        seen = record_path_calls(monkeypatch, "resolve")
+        assert node._template_path_from_context(ctx) is None
+        assert node._template_path_from_context(ctx) is None
+        assert seen == []
+
+    def test_warm_render_does_not_resolve(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The second render of a simple component resolves no path at all."""
+        (tmp_path / "card.djx").write_text("<div>ok</div>")
+        info = ComponentInfo(
+            name="card",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=tmp_path / "card.djx",
+            module_path=None,
+            is_simple=True,
+        )
+        t = Template('{% load components %}{% component "card" %}')
+        ctx = Context({"current_template_path": str(tmp_path / "t.djx")})
+        with patch.object(components_manager, "get_component", return_value=info):
+            assert "ok" in t.render(ctx)
+            seen = record_path_calls(monkeypatch, "resolve")
+            assert "ok" in t.render(ctx)
+        assert seen == []
+
+
+_GOLDEN_COMPONENT = (
+    '<article data-title="{{ title }}">'
+    '{% #set_slot "header" %}<h2>default header</h2>{% /set_slot %}'
+    '{% #set_slot "description" %}<i>fallback</i>{% /set_slot %}'
+    "<p>{{ site }}</p>"
+    "<div>{{ children }}</div>"
+    "</article>"
+)
+
+_GOLDEN_PAGE = (
+    "{% load components %}"
+    "<main>"
+    '{% #component "card" title="Card title" description="prop value" %}'
+    '{% #slot "header" %}<h1>Injected</h1>{% /slot %}'
+    "<span>{{ title }}</span>"
+    "{% /component %}"
+    "</main>"
+)
+
+_GOLDEN_HTML = (
+    "<main>"
+    '<article data-title="Card title">'
+    "<h1>Injected</h1>"
+    "<i>fallback</i>"
+    "<p>next.dj</p>"
+    "<div><span>Page title</span></div>"
+    "</article>"
+    "</main>"
+)
+
+
+class TestComponentRenderGolden:
+    """The rendered page is pinned character for character."""
+
+    def test_page_with_slots_and_props_renders_the_pinned_html(
+        self, tmp_path: Path
+    ) -> None:
+        """Slots, the set_slot fallback, and prop shadowing produce one fixed string.
+
+        The context the tag hands to the renderer is built in place, so the
+        expectation is spelled out rather than asserted piecewise. Free
+        children and slot bodies both arrive marked safe, because the caller
+        already rendered and escaped them, while the ``title`` prop is the
+        escaping channel and reaches the component as plain text.
+        """
+        (tmp_path / "card.djx").write_text(_GOLDEN_COMPONENT)
+        info = ComponentInfo(
+            name="card",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=tmp_path / "card.djx",
+            module_path=None,
+            is_simple=True,
+        )
+        context = Context(
+            {
+                "current_template_path": str(tmp_path / "page.djx"),
+                "title": "Page title",
+                "site": "next.dj",
+            }
+        )
+        with patch.object(components_manager, "get_component", return_value=info):
+            result = Template(_GOLDEN_PAGE).render(context)
+
+        assert result == _GOLDEN_HTML
+
+
+_ESCAPE_COMPONENT = '<div>{{ children }}{% #set_slot "body" %}{% /set_slot %}</div>'
+
+_FREE_CHILD_BODY = "{{ danger }}"
+_SLOT_CHILD_BODY = '{% #slot "body" %}{{ danger }}{% /slot %}'
+
+
+class TestCallerControlsChildEscaping:
+    """Free children and slot bodies carry whatever the caller rendered."""
+
+    def _render(self, tmp_path: Path, body: str, *, autoescape: bool) -> str:
+        (tmp_path / "card.djx").write_text(_ESCAPE_COMPONENT)
+        info = ComponentInfo(
+            name="card",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=tmp_path / "card.djx",
+            module_path=None,
+            is_simple=True,
+        )
+        call = '{% #component "card" %}' + body + "{% /component %}"
+        if not autoescape:
+            call = "{% autoescape off %}" + call + "{% endautoescape %}"
+        with patch.object(components_manager, "get_component", return_value=info):
+            return Template("{% load components %}" + call).render(
+                Context(
+                    {
+                        "current_template_path": str(tmp_path / "page.djx"),
+                        "danger": "<script>alert(1)</script>",
+                    }
+                )
+            )
+
+    @pytest.mark.parametrize(
+        "body", [_FREE_CHILD_BODY, _SLOT_CHILD_BODY], ids=("children", "slot")
+    )
+    def test_escaping_caller_hands_over_escaped_markup(
+        self, tmp_path: Path, body: str
+    ) -> None:
+        """A caller with autoescaping on escapes the value before the tag sees it."""
+        assert self._render(tmp_path, body, autoescape=True) == (
+            "<div>&lt;script&gt;alert(1)&lt;/script&gt;</div>"
+        )
+
+    @pytest.mark.parametrize(
+        "body", [_FREE_CHILD_BODY, _SLOT_CHILD_BODY], ids=("children", "slot")
+    )
+    def test_autoescape_off_caller_hands_over_raw_markup(
+        self, tmp_path: Path, body: str
+    ) -> None:
+        """Under ``{% autoescape off %}`` the raw value reaches the component."""
+        assert self._render(tmp_path, body, autoescape=False) == (
+            "<div><script>alert(1)</script></div>"
+        )

--- a/tests/conf/test_checks.py
+++ b/tests/conf/test_checks.py
@@ -31,7 +31,7 @@ VALID_TYPED_VALUES: dict[str, object] = {
 class TestValueTypeErrors:
     """`check_next_framework_value_types` reports mistyped keys as next.E076."""
 
-    def test_key_types_map_covers_exactly_seven_keys(self) -> None:
+    def test_key_types_map_covers_exactly_the_typed_keys(self) -> None:
         assert set(_KEY_TYPES) == set(VALID_TYPED_VALUES)
 
     @pytest.mark.parametrize(
@@ -61,7 +61,7 @@ class TestValueTypeErrors:
         assert [m.id for m in messages] == ["next.E076"]
         assert f"NEXT_FRAMEWORK[{key!r}]" in messages[0].msg
 
-    def test_silent_on_valid_map_of_all_seven_keys(self) -> None:
+    def test_silent_on_valid_map_of_every_typed_key(self) -> None:
         with override_settings(NEXT_FRAMEWORK=dict(VALID_TYPED_VALUES)):
             assert check_next_framework_value_types() == []
 

--- a/tests/forms/test_dispatch.py
+++ b/tests/forms/test_dispatch.py
@@ -149,7 +149,7 @@ def _run_component_context(tmp_path: Path, request: object) -> object:
         _inject_component_context(info, context_data, request)
         return context_data["out"]
     finally:
-        component_ctx._registry._registry.pop(module_path.resolve(), None)
+        component_ctx._registry.unregister(module_path)
 
 
 def _run_page_context(tmp_path: Path, request: object) -> object:

--- a/tests/pages/test_manager_render_path.py
+++ b/tests/pages/test_manager_render_path.py
@@ -9,7 +9,6 @@ from django.test import override_settings
 
 from next.pages import Page
 from next.pages.loaders import _load_python_module_memo
-from next.pages.manager import template_edits_watched
 from next.testing import envelope_of
 from tests.support import (
     build_nested_page,
@@ -573,12 +572,6 @@ class TestZoneTickOnTheResolvingBranch:
 
 class TestTemplateStalenessGate:
     """Source staleness is stat-checked only where template edits are watched."""
-
-    def test_the_gate_follows_the_debug_setting(self, watched_template_edits) -> None:
-        """The predicate is read per call, so an override takes effect at once."""
-        assert template_edits_watched() is True
-        with override_settings(DEBUG=False):
-            assert template_edits_watched() is False
 
     def test_a_production_process_still_records_a_snapshot(
         self, page_instance, tmp_path

--- a/tests/partial/conftest.py
+++ b/tests/partial/conftest.py
@@ -35,11 +35,10 @@ _PARTIAL_MODULES = (
 def _partial_form_registries():
     """Register the partial-suite forms and restore the clean baseline after.
 
-    The snapshot is taken before the partial modules load, so the teardown
-    drops every action and provider they registered. A later forms suite
-    then sees the registry exactly as it was, not the partial fixtures.
-    Re-execution each test is idempotent because registration keys on the
-    file path.
+    The snapshot is taken before the partial modules load, so the teardown drops every
+    action and provider they registered. A later forms suite then sees the registry
+    exactly as it was, not the partial fixtures. Re-execution each test is idempotent
+    because registration keys on the file path.
     """
     with isolated_form_registries():
         for module_path in _PARTIAL_MODULES:

--- a/tests/partial/regression_forms.py
+++ b/tests/partial/regression_forms.py
@@ -61,11 +61,10 @@ class GuardedValidateForm(Form):
 class ViewGuardValidateForm(Form):
     """Form guarded by a view-level hook, with no action guard at all.
 
-    The denial must land in the view-permission layer before the form
-    binds, so the second authorization layer is proven independent of the
-    action guard. The unique-email validator only ever runs behind that
-    hook, so an authenticated blur can surface its error and an anonymous
-    blur cannot reach it.
+    The denial must land in the view-permission layer before the form binds, so the
+    second authorization layer is proven independent of the action guard. The
+    unique-email validator only ever runs behind that hook, so an authenticated blur can
+    surface its error and an anonymous blur cannot reach it.
     """
 
     email = forms.EmailField()

--- a/tests/partial/test_golden.py
+++ b/tests/partial/test_golden.py
@@ -332,10 +332,9 @@ GOLDEN_CASES = [
 class TestGoldenFixturesArePinned:
     """The committed fixtures match a fresh serialisation, no silent drift.
 
-    The Python serialiser writes these bytes and vitest reads them back, so
-    a drift between the two toolchains would otherwise pass unnoticed. Run
-    `GOLDEN_UPDATE=1` to regenerate the committed fixtures after a
-    deliberate wire change.
+    The Python serialiser writes these bytes and vitest reads them back, so a drift
+    between the two toolchains would otherwise pass unnoticed. Run `GOLDEN_UPDATE=1` to
+    regenerate the committed fixtures after a deliberate wire change.
     """
 
     @pytest.mark.skipif(_UPDATE_GOLDEN, reason="GOLDEN_UPDATE regenerates instead")

--- a/tests/partial/test_wizard_advance.py
+++ b/tests/partial/test_wizard_advance.py
@@ -93,9 +93,8 @@ class TestWizardAdvanceRendersZoneNotPageView:
     """The advance renders only the next step zone, never the step page view.
 
     The advance builds the next wizard and renders its master zone through
-    `render_zone`, so the step page view never runs and authorization stays
-    in the action guard. The zone render fires exactly once, for the next
-    step's page and zone.
+    `render_zone`, so the step page view never runs and authorization stays in the
+    action guard. The zone render fires exactly once, for the next step's page and zone.
     """
 
     def test_advance_renders_one_zone_and_no_page_view(

--- a/tests/support/forms.py
+++ b/tests/support/forms.py
@@ -18,10 +18,9 @@ from next.forms.wizard import wizard_backend_manager
 def isolated_form_registries() -> Generator[None, None, None]:
     """Snapshot the form registries on entry and put the baseline back on exit.
 
-    Actions registered inside the block are dropped, so a later suite sees
-    the registry exactly as import time left it. The manager API is what
-    moves `version` on restore, which reaching into the backend maps by
-    hand does not.
+    Actions registered inside the block are dropped, so a later suite sees the registry
+    exactly as import time left it. The manager API is what moves `version` on restore,
+    which reaching into the backend maps by hand does not.
     """
     actions = form_action_manager.snapshot_actions()
     diagnostics = registration_diagnostics.snapshot()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -142,8 +142,8 @@ class TestLoadBackends:
         [("type", TypeError), ("value", ValueError), ("import", ImportError)],
     )
     def test_other_errors_from_construction_escape(self, kind, error) -> None:
-        # a constructor failing for anything but its own config is a bug
-        # rather than an entry to skip
+        # a constructor failing for anything but its own
+        # config is a bug rather than an entry to skip
         with pytest.raises(error, match="boom"):
             load_backends(
                 [{"BACKEND": RAISING, "ERROR": kind}, {"BACKEND": ALPHA}],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,10 +5,26 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from django.test import override_settings
 
 from next.pages.loaders import _load_python_module
-from next.utils import callable_name, defining_file, resolve_base_dir
+from next.utils import (
+    callable_name,
+    defining_file,
+    resolve_base_dir,
+    template_edits_watched,
+)
 from tests.support import attribution, unwrapped_decorator, wraps_decorator
+
+
+class TestTemplateEditsWatched:
+    """Tests for ``template_edits_watched``."""
+
+    def test_the_gate_follows_the_debug_setting(self, watched_template_edits) -> None:
+        """The predicate is read per call, so an override takes effect at once."""
+        assert template_edits_watched() is True
+        with override_settings(DEBUG=False):
+            assert template_edits_watched() is False
 
 
 class TestResolveBaseDir:

--- a/tests/testing/test_isolation.py
+++ b/tests/testing/test_isolation.py
@@ -3,6 +3,11 @@ from pathlib import Path
 from django.http import HttpRequest, HttpResponse
 from django.template import Template
 
+from next.components import (
+    CachedComponentTemplateLoader,
+    ComponentInfo,
+    render_component,
+)
 from next.components.manager import components_manager
 from next.forms import ActionRegistration, RegistryFormActionBackend
 from next.forms.backends import FormActionBackend
@@ -10,6 +15,7 @@ from next.forms.diagnostics import registration_diagnostics
 from next.forms.manager import form_action_manager
 from next.pages.manager import page
 from next.testing import (
+    reset_component_templates,
     reset_components,
     reset_form_actions,
     reset_form_registration_state,
@@ -136,6 +142,25 @@ class TestResetFormRegistrationState:
         assert backend._name_index == {}
         assert registration_diagnostics.outside_base_dir == []
         assert registration_diagnostics.action_applied_to_class == []
+
+
+class TestResetComponentTemplates:
+    """reset_component_templates drops the compiled templates of the pipeline."""
+
+    def test_clears_the_compiled_templates(self, tmp_path: Path) -> None:
+        path = tmp_path / "card.djx"
+        path.write_text("<i>one</i>")
+        info = ComponentInfo("card", tmp_path, "", path, None, True)
+        assert render_component(info, {}) == "<i>one</i>"
+        loader = components_manager.template_loader
+        assert isinstance(loader, CachedComponentTemplateLoader)
+        assert loader._compiled
+
+        reset_component_templates()
+
+        assert loader._compiled == {}
+        path.write_text("<i>two</i>")
+        assert render_component(info, {}) == "<i>two</i>"
 
 
 class TestResetPageCache:


### PR DESCRIPTION
## Description

Component rendering: compiled templates are cached and the lookups every render repeated are memoised.

- A component template is compiled once and reused until the file it was read from changes. A warm render pays one `stat` under `DEBUG` and nothing in production, instead of a disk read plus a full parse on every call.
- `component.get_functions` is memoised per registry version and the `current_template_path` resolution per path string. Both ran again on every render of every component.
- The source mtime is taken before the body is read, so a save landing between the two expires the entry instead of hiding behind a fresh mtime.
- A Django `TEMPLATES` change drops the render pipeline, because a compiled `Template` pins the engine that built it and `settings_reloaded` fires for `NEXT_FRAMEWORK` alone.
- The compiled cache is bounded at the 2048 entries the other path-keyed component caches share, up from 128, where a project with more components than that would thrash. Its mutations are guarded by a lock, so an eviction racing the LRU reorder costs the reorder rather than raising from a render. Use order is tracked only once the cache is full, which leaves the warm render path faster than it was before the cache existed.
- `template_edits_watched` moved to `next/utils.py`, since the page, component, and static caches all read that predicate.
- Component children are joined as a `SafeString`. They are already rendered and escaped by the caller, and top-level `{% component %}` output was always spliced raw.
- Fixed `cache or ...` in `ModuleLoader` and `ComponentScanner`: `ModuleCache.__len__` makes an empty shared cache falsy, so it was silently replaced with a fresh one.

A separate commit rewraps docstrings and comments across `next/` to fill the line limit, with no narrow columns and no orphan tail lines. No code changes.

## How to test

`make test` — 3892 passed, 19 skipped, coverage 100.00%. `make lint`, `make type-check` and `make docs` (`-W`) are clean.

`make bench` was run paired, three alternating pairs over the renderer benchmark file. The hardening costs nothing on warm renders: `simple_render` 0.977x, `composite_template_render` 0.968x, `composite_render_with_context_function` 0.988x, `render_end_to_end` 0.992x against the previous commit.

## Related issues

—

## Checklist

- [x] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [ ] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable
