### PR TITLE
perf(static): plan asset discovery and hold the watcher routers

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,7 +45,7 @@ jobs:
                && !contains(github.event.pull_request.title, '[skip bench]')))
           && !contains(github.event.head_commit.message, '[skip bench]') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 20
     steps:
       - name: Checkout HEAD with full history
         uses: actions/checkout@v6

--- a/docs/content/howto/reload-routes-from-code.rst
+++ b/docs/content/howto/reload-routes-from-code.rst
@@ -50,6 +50,7 @@ Import the receivers module from ``AppConfig.ready`` so the decorators run at st
            from notes import receivers  # imported for its receiver registrations
 
 Each call rebuilds the backend list from the current ``NEXT_FRAMEWORK`` configuration, clears Django's URL caches, and emits ``router_reloaded``.
+The framework listens to that signal itself, so the routers the development watcher and the staticfiles finder read are rebuilt with the ones the URL resolver serves.
 Receivers should tolerate being invoked more than once when several writes batch into one task.
 
 Observe the reload

--- a/docs/content/internals/autoreload.rst
+++ b/docs/content/internals/autoreload.rst
@@ -120,6 +120,12 @@ Route set change.
 The route set diff is taken by ``NextStatReloader`` from the configured page roots.
 A custom router that builds routes from another source rebuilds them through ``router_manager.reload``, which is the public API covered in :doc:`/content/howto/reload-routes-from-code`.
 
+The routers behind that list are built once per configuration rather than once per tick, and a settings reload or a change of ``BASE_DIR`` builds them again.
+A build that dropped an entry is held by nothing, so a router that failed to build while the apps were still loading is tried again on the next read rather than staying out of the watch list for good.
+Each tick observes the trees the built routers reported, and the resolution of those trees is held with them.
+A page root created under a live server, or a root symlink re-pointed at another release, therefore reaches the watcher only after a restart.
+A page created inside a tree that is already watched needs no restart, because the reloader rescans the watched trees on every tick and notices the new route.
+
 A ``.djx`` edit triggers neither path.
 Templates are re-read on render, and under ``DEBUG`` the page and component layers invalidate their cached compilation against the source mtime.
 A saved edit shows up on the next request without a process restart, while with ``DEBUG`` off it takes one.

--- a/docs/content/internals/autoreload.rst
+++ b/docs/content/internals/autoreload.rst
@@ -90,7 +90,7 @@ A ``pages`` directory beside the working directory that no router routes is neit
 Every read of a router here is guarded, and the guard drops a value of the wrong type instead of passing it on.
 ``runserver`` boots, ``collectstatic`` runs, and the staticfiles finder answers even when a backend raises from ``page_roots`` or ``components_folder_name``, and equally when it answers the wrong shape.
 The failure costs that backend its trees and nothing else.
-It is logged once per backend and subject rather than per tick, and again after a settings reload.
+It is logged once per backend and subject rather than per tick, and again once the framework is reconfigured.
 
 - Each page root contributes a ``**/page.py`` spec.
 - Each page root paired with the name its router returns from ``components_folder_name`` contributes a ``**/<components-folder>/**/component.py`` spec, ``_components`` by default.
@@ -120,11 +120,20 @@ Route set change.
 The route set diff is taken by ``NextStatReloader`` from the configured page roots.
 A custom router that builds routes from another source rebuilds them through ``router_manager.reload``, which is the public API covered in :doc:`/content/howto/reload-routes-from-code`.
 
-The routers behind that list are built once per configuration rather than once per tick, and a settings reload or a change of ``BASE_DIR`` builds them again.
-A build that dropped an entry is held by nothing, so a router that failed to build while the apps were still loading is tried again on the next read rather than staying out of the watch list for good.
-Each tick observes the trees the built routers reported, and the resolution of those trees is held with them.
-A page root created under a live server, or a root symlink re-pointed at another release, therefore reaches the watcher only after a restart.
-A page created inside a tree that is already watched needs no restart, because the reloader rescans the watched trees on every tick and notices the new route.
+Router lifetime
+~~~~~~~~~~~~~~~
+
+Reading that list builds one router per ``PAGE_BACKENDS`` entry, and a router answers about the disk it probed while it was built.
+With ``DEBUG`` off the routers are held until the configuration behind them changes, so a static lookup and a reloader tick stop paying for a build per read.
+A settings reload, a change of ``BASE_DIR``, and ``router_manager.reload`` each build them again.
+A build that dropped an entry is held by nothing, so a router that failed while the apps were still loading is tried again on the next read rather than staying out of the watch list for good.
+
+With ``DEBUG`` on nothing is held.
+Every read builds the routers again, which is what makes a page tree created, moved, or removed under the development server reach the very next tick, whether it comes from ``DIRS``, from an application, or from ``BASE_DIR``.
+A page created inside a tree that is already watched needs no rebuild at all, because the reloader rescans the watched trees on every tick and notices the new route.
+
+What is held whatever ``DEBUG`` is set to is the resolution of the trees the routers report.
+A root symlink re-pointed at another release therefore reaches the watcher only after a restart or a reconfigure.
 
 A ``.djx`` edit triggers neither path.
 Templates are re-read on render, and under ``DEBUG`` the page and component layers invalidate their cached compilation against the source mtime.

--- a/docs/content/internals/static-pipeline.rst
+++ b/docs/content/internals/static-pipeline.rst
@@ -22,25 +22,30 @@ Asset plans
 An asset plan is what ``AssetDiscovery`` remembers about one page path or one component.
 It holds the co-located files the walk found, the assets built from the ``styles`` and ``scripts`` lists of the owning module, and the directories the walk read.
 A plan caches the disk, not the URLs.
-The stem probes, the layout walk, and the module import happen once, and every file the plan holds still goes to ``register_file`` on every render, so a backend whose answer changes is seen by the next request.
-The default backend answers those calls from its own ``(logical_name, suffix)`` memo, so the repeat costs a dictionary lookup.
+
+The stem probes, the layout walk, and the module import happen once, and every file the plan holds still goes to ``register_file`` on every render, so a backend free to resolve the same file to a different URL per request is asked every time.
+The default backend answers those calls from its own ``(logical_name, suffix)`` memo, which lives as long as the backend does.
+The repeat therefore costs it a dictionary lookup, and its answer changes only when ``StaticManager.reload`` builds a new backend.
 Module-level URLs are literals the backend is never asked about, so the plan keeps them as finished ``StaticAsset`` records, and the same frozen instance rides every render and every collector.
 
 The page plan is keyed by the page file path.
-The component plan is keyed by the component's ``template_path``, ``module_path``, and ``name``, which is everything the plan depends on, so a rescan that produces an equal ``ComponentInfo`` reuses the entry and a renamed or moved component gets its own.
+The component plan is keyed by the component's ``template_path``, ``module_path``, and ``name``, which is what identifies the component the plan was built for, so a rescan that produces an equal ``ComponentInfo`` reuses the entry and a renamed or moved component gets its own.
 A simple component owns no folder and reaches no plan at all, which keeps the entries the cache holds to the components that read the disk.
 Both caches are bounded and evict the least recently used entry.
 
-Two things invalidate a plan.
+Three things invalidate a plan.
 
 - A settings reload drops the whole static manager, and the discovery instance with its plans goes with it.
+- A registration in the stem, kind, or placeholder registry changes which filenames count as an asset without moving any file, so every plan carries the generation of those three registries and is rebuilt when it no longer matches.
+  This check runs whatever ``DEBUG`` is set to, because it costs three integer reads and no syscall.
 - Under ``DEBUG`` each render re-stats the directories the plan was read from and rebuilds when one of them has moved, appeared, or gone away.
+  The mtimes are read in nanoseconds and compared for inequality, so a directory restored from an archive with an older timestamp counts as changed too, and one that does not stat at all is recorded as absent rather than as a timestamp.
   For a page those directories are the whole walk from the page directory up to the page root, not only the ones that already hold a ``layout.djx``, so a layout added in between is visible on the next request.
   For a component they are the component folder and the folder holding its module.
 
 A backend that rejects a file needs no invalidation, because the next render offers the file to it again, the warning repeats, and a fixed backend takes effect at once.
 Outside ``DEBUG`` a warm render issues no ``stat`` call at all, because a production process does not mutate co-located files under a running server.
-The ``asset_registered`` signal fires once per file asset per render.
+The ``asset_registered`` signal follows the collector rather than the render, so a component mounted several times on one page announces each of its assets once.
 
 Discovery and injection
 -----------------------
@@ -145,7 +150,7 @@ Signals
 
 The pipeline fires four signals.
 
-- ``asset_registered`` fires once per co-located file registered through a backend.
+- ``asset_registered`` fires once per co-located file the collector accepts from a backend registration.
   Module-level ``styles`` and ``scripts`` lists, every ``{% use_style %}`` and ``{% use_script %}`` form, void or block, and the ``{% use_module %}`` tag call ``collector.add`` directly and do not emit it.
 - ``collector_finalized`` once per request after the collector closes its set.
 - ``html_injected`` once per request after the manager replaces the placeholder slots.

--- a/docs/content/internals/static-pipeline.rst
+++ b/docs/content/internals/static-pipeline.rst
@@ -13,7 +13,34 @@ Overview
 --------
 
 The static pipeline runs entirely per request.
-``AssetDiscovery`` walks the page and component trees on each render, builds ``StaticAsset`` records, and feeds them to the request ``StaticCollector``.
+``AssetDiscovery`` walks the page and component trees, builds ``StaticAsset`` records, and feeds them to the request ``StaticCollector``.
+The walk itself happens once per page and once per component, and later renders reuse what it found on disk.
+
+Asset plans
+-----------
+
+An asset plan is what ``AssetDiscovery`` remembers about one page path or one component.
+It holds the co-located files the walk found, the assets built from the ``styles`` and ``scripts`` lists of the owning module, and the directories the walk read.
+A plan caches the disk, not the URLs.
+The stem probes, the layout walk, and the module import happen once, and every file the plan holds still goes to ``register_file`` on every render, so a backend whose answer changes is seen by the next request.
+The default backend answers those calls from its own ``(logical_name, suffix)`` memo, so the repeat costs a dictionary lookup.
+Module-level URLs are literals the backend is never asked about, so the plan keeps them as finished ``StaticAsset`` records, and the same frozen instance rides every render and every collector.
+
+The page plan is keyed by the page file path.
+The component plan is keyed by the component's ``template_path``, ``module_path``, and ``name``, which is everything the plan depends on, so a rescan that produces an equal ``ComponentInfo`` reuses the entry and a renamed or moved component gets its own.
+A simple component owns no folder and reaches no plan at all, which keeps the entries the cache holds to the components that read the disk.
+Both caches are bounded and evict the least recently used entry.
+
+Two things invalidate a plan.
+
+- A settings reload drops the whole static manager, and the discovery instance with its plans goes with it.
+- Under ``DEBUG`` each render re-stats the directories the plan was read from and rebuilds when one of them has moved, appeared, or gone away.
+  For a page those directories are the whole walk from the page directory up to the page root, not only the ones that already hold a ``layout.djx``, so a layout added in between is visible on the next request.
+  For a component they are the component folder and the folder holding its module.
+
+A backend that rejects a file needs no invalidation, because the next render offers the file to it again, the warning repeats, and a fixed backend takes effect at once.
+Outside ``DEBUG`` a warm render issues no ``stat`` call at all, because a production process does not mutate co-located files under a running server.
+The ``asset_registered`` signal fires once per file asset per render.
 
 Discovery and injection
 -----------------------

--- a/docs/content/ref/utils.rst
+++ b/docs/content/ref/utils.rst
@@ -12,7 +12,6 @@ It backs decorator registration, attributing a decorated object to the file wher
 It also holds ``walk_page_tree``, the depth-first page-tree walk the file router and the system checks both run, and ``page_roots_shape_error``, the shared shape probe a check runs over what a router reports.
 Both live here for the same reason ``PageRoot`` does.
 The ``DEBUG`` predicate ``template_edits_watched``, which the page, component, and static caches read before they stat anything, is here for the same reason.
-So are ``store_bounded``, the bounded write every per-path memo shares, and ``MAX_ANCESTOR_WALK_DEPTH``, the depth every ancestor walk stops at.
 
 ``resolve_base_dir`` returns ``settings.BASE_DIR`` coerced to ``pathlib.Path``, or ``None`` when it is unset, for backends that resolve project-relative paths.
 ``classify_dirs_entries`` splits a backend ``DIRS`` list into existing directory roots and plain skip-name segments, the same split the file router applies.
@@ -24,7 +23,7 @@ Public API
 
 .. automodule:: next.utils
    :members:
-   :exclude-members: callable_name, defining_file, walk_page_tree, page_roots_shape_error, template_edits_watched, store_bounded, MisattributedContext, MisattributionLog
+   :exclude-members: callable_name, defining_file, walk_page_tree, page_roots_shape_error, template_edits_watched, store_bounded, stat_mtime_ns, resolved_tree, forget_resolved_trees, MAX_ANCESTOR_WALK_DEPTH, MisattributedContext, MisattributionLog
 
 See also
 --------

--- a/docs/content/ref/utils.rst
+++ b/docs/content/ref/utils.rst
@@ -12,6 +12,7 @@ It backs decorator registration, attributing a decorated object to the file wher
 It also holds ``walk_page_tree``, the depth-first page-tree walk the file router and the system checks both run, and ``page_roots_shape_error``, the shared shape probe a check runs over what a router reports.
 Both live here for the same reason ``PageRoot`` does.
 The ``DEBUG`` predicate ``template_edits_watched``, which the page, component, and static caches read before they stat anything, is here for the same reason.
+So are ``store_bounded``, the bounded write every per-path memo shares, and ``MAX_ANCESTOR_WALK_DEPTH``, the depth every ancestor walk stops at.
 
 ``resolve_base_dir`` returns ``settings.BASE_DIR`` coerced to ``pathlib.Path``, or ``None`` when it is unset, for backends that resolve project-relative paths.
 ``classify_dirs_entries`` splits a backend ``DIRS`` list into existing directory roots and plain skip-name segments, the same split the file router applies.
@@ -23,7 +24,7 @@ Public API
 
 .. automodule:: next.utils
    :members:
-   :exclude-members: _classify_one_dir_entry, callable_name, defining_file, walk_page_tree, page_roots_shape_error, template_edits_watched, MisattributedContext, MisattributionLog
+   :exclude-members: callable_name, defining_file, walk_page_tree, page_roots_shape_error, template_edits_watched, store_bounded, MisattributedContext, MisattributionLog
 
 See also
 --------

--- a/docs/content/topics/static-assets/co-located-files.rst
+++ b/docs/content/topics/static-assets/co-located-files.rst
@@ -91,9 +91,13 @@ Under ``DEBUG`` it re-checks the directories it read on every render, so an edit
 - Deleting one of those files removes it from the next request.
 - A ``layout.djx`` created in a directory between the page and the page root starts wrapping the page, and its co-located assets join on the same request.
 
-Module-level ``styles`` and ``scripts`` lists live in ``page.py`` and ``component.py``, so editing them restarts the dev server and the new list is read on the way back up.
+- A stem or a kind registered after the first render joins the probe on the next one, because every plan carries the generation of the registries it read.
 
-With ``DEBUG`` off none of these checks run.
+Module-level ``styles`` and ``scripts`` lists live in ``page.py`` and ``component.py``.
+Editing one under a watched tree restarts the dev server, and the new list is read on the way back up.
+Where no watch covers the module, the edit is read the next time the plan rebuilds.
+
+With ``DEBUG`` off the directory checks do not run, and only a registration still invalidates a plan.
 A production process is expected to publish assets with ``collectstatic`` and restart, so a file changed under a running server stays invisible until the next start.
 
 Asset ownership

--- a/docs/content/topics/static-assets/co-located-files.rst
+++ b/docs/content/topics/static-assets/co-located-files.rst
@@ -81,6 +81,21 @@ A file is recognised only when its stem matches a registered stem for the owner'
 A file that does not match a registered stem and kind pair is ignored.
 Discovery does not warn on unknown files because the folder may hold documentation or fixtures.
 
+Editing during development
+--------------------------
+
+Discovery walks a page or a component folder once and reuses what it found there on later renders.
+Under ``DEBUG`` it re-checks the directories it read on every render, so an edit under the dev server takes effect the way it did before the plan existed.
+
+- A ``template.css``, ``layout.js``, or ``component.css`` added next to its owner is picked up by the next request.
+- Deleting one of those files removes it from the next request.
+- A ``layout.djx`` created in a directory between the page and the page root starts wrapping the page, and its co-located assets join on the same request.
+
+Module-level ``styles`` and ``scripts`` lists live in ``page.py`` and ``component.py``, so editing them restarts the dev server and the new list is read on the way back up.
+
+With ``DEBUG`` off none of these checks run.
+A production process is expected to publish assets with ``collectstatic`` and restart, so a file changed under a running server stays invisible until the next start.
+
 Asset ownership
 ---------------
 

--- a/docs/content/topics/static-assets/signals.rst
+++ b/docs/content/topics/static-assets/signals.rst
@@ -18,12 +18,13 @@ Signals and payloads
 asset_registered
 ~~~~~~~~~~~~~~~~
 
-Fires after a file asset is added to the collector, on every render that adds it.
+Fires after a file asset lands in the collector, once per asset per collector.
+An asset the collector deduplicates away, such as the second mount of the same component on one page, emits no signal.
 The sender is the asset instance.
 The payload carries ``collector`` and ``backend``.
 
 Registration with the backend is per render.
-Discovery asks ``register_file`` for the URL of every discovered file on every render, so a backend that resolves a URL differently is seen by the next request, and ``asset_registered`` carries the asset that registration produced.
+Discovery asks ``register_file`` for the URL of every discovered file on every render, so a backend free to resolve the same file to a different URL per request is asked every time, and ``asset_registered`` carries the asset that registration produced.
 
 .. note::
 

--- a/docs/content/topics/static-assets/signals.rst
+++ b/docs/content/topics/static-assets/signals.rst
@@ -18,9 +18,12 @@ Signals and payloads
 asset_registered
 ~~~~~~~~~~~~~~~~
 
-Fires after a file is registered with a backend and added to the collector.
+Fires after a file asset is added to the collector, on every render that adds it.
 The sender is the asset instance.
 The payload carries ``collector`` and ``backend``.
+
+Registration with the backend is per render.
+Discovery asks ``register_file`` for the URL of every discovered file on every render, so a backend that resolves a URL differently is seen by the next request, and ``asset_registered`` carries the asset that registration produced.
 
 .. note::
 

--- a/next/apps/config.py
+++ b/next/apps/config.py
@@ -8,7 +8,11 @@ from django.apps import AppConfig
 
 from next.checks import register_all as _register_checks
 from next.forms.autodiscover import autodiscover_forms
+from next.pages.loaders import forget_page_roots
+from next.pages.watch import forget_watch_state
 from next.ports import partial_shaper_slot
+from next.static.manager import forget_manager_page_roots
+from next.urls.signals import router_reloaded
 
 from . import autoreload, components, staticfiles, templates
 
@@ -23,6 +27,12 @@ class NextFrameworkConfig(AppConfig):
     def ready(self) -> None:
         """Register checks, install every startup hook, and compose the ports."""
         _register_checks()
+        # A reload from code replaces the routers the URL resolver serves
+        # without touching settings, and every memo of what those routers
+        # report has to go with them or the layers answer for two generations.
+        router_reloaded.connect(forget_watch_state)
+        router_reloaded.connect(forget_page_roots)
+        router_reloaded.connect(forget_manager_page_roots)
         autoreload.install()
         templates.install()
         staticfiles.install()

--- a/next/components/loading.py
+++ b/next/components/loading.py
@@ -13,6 +13,8 @@ import logging
 from collections import OrderedDict
 from typing import TYPE_CHECKING, cast
 
+from next.utils import store_bounded
+
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -41,10 +43,7 @@ class ModuleCache:
 
     def set(self, path: Path, module: ModuleType | None) -> None:
         """Store the module (or `None` on failure) under `path`, evicting when full."""
-        if path not in self._order and len(self._order) >= self._maxsize:
-            self._order.popitem(last=False)
-        self._order[path] = module
-        self._order.move_to_end(path)
+        store_bounded(self._order, path, module, self._maxsize)
 
     def clear(self) -> None:
         """Drop every entry from the cache."""

--- a/next/components/registry.py
+++ b/next/components/registry.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 from collections import OrderedDict
 from typing import TYPE_CHECKING
 
+from next.utils import store_bounded
+
 from .signals import component_registered, components_registered
 
 
@@ -198,9 +200,9 @@ class ComponentVisibilityResolver:
                 result[name] = info
                 seen.add(name)
 
-        self._result_cache[template_path] = result
-        if len(self._result_cache) > _VISIBILITY_CACHE_MAX_SIZE:
-            self._result_cache.popitem(last=False)
+        store_bounded(
+            self._result_cache, template_path, result, _VISIBILITY_CACHE_MAX_SIZE
+        )
         return result
 
     def _calculate_visibility_score(
@@ -226,9 +228,7 @@ class ComponentVisibilityResolver:
             self._path_cache.move_to_end(cache_key)
             return self._path_cache[cache_key]
         value = self._compute_relative_parts(template_path, scope_root)
-        self._path_cache[cache_key] = value
-        if len(self._path_cache) > _VISIBILITY_CACHE_MAX_SIZE:
-            self._path_cache.popitem(last=False)
+        store_bounded(self._path_cache, cache_key, value, _VISIBILITY_CACHE_MAX_SIZE)
         return value
 
     def _compute_relative_parts(

--- a/next/components/renderers.py
+++ b/next/components/renderers.py
@@ -21,7 +21,7 @@ from django.utils.functional import SimpleLazyObject
 
 from next.deps import get_request_dep_cache, resolver
 from next.deps.cache import DependencyCache
-from next.utils import template_edits_watched
+from next.utils import store_bounded, template_edits_watched
 
 from .context import component
 
@@ -231,10 +231,7 @@ class CachedComponentTemplateLoader(ComponentTemplateLoader):
 
     def _store(self, key: _SourceKey, entry: _CompiledTemplate) -> None:
         with self._lock:
-            if key not in self._compiled and len(self._compiled) >= self._maxsize:
-                self._compiled.popitem(last=False)
-            self._compiled[key] = entry
-            self._compiled.move_to_end(key)
+            store_bounded(self._compiled, key, entry, self._maxsize)
 
 
 def _stamp_component_anchor(info: ComponentInfo, context_dict: dict[str, Any]) -> None:

--- a/next/pages/loaders.py
+++ b/next/pages/loaders.py
@@ -20,6 +20,7 @@ import contextlib
 import importlib.util
 import logging
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 from typing import TYPE_CHECKING, ClassVar, override
 
 from django.core.signals import setting_changed
@@ -27,7 +28,13 @@ from django.core.signals import setting_changed
 from next.conf import next_framework_settings
 from next.conf.imports import import_class_cached
 from next.conf.signals import settings_reloaded
-from next.utils import MAX_ANCESTOR_WALK_DEPTH, classify_dirs_entries, resolve_base_dir
+from next.utils import (
+    MAX_ANCESTOR_WALK_DEPTH,
+    classify_dirs_entries,
+    resolve_base_dir,
+    stat_mtime_ns,
+    store_bounded,
+)
 
 from .watch import get_pages_directories_for_watch
 
@@ -147,7 +154,8 @@ def _load_python_module(file_path: Path) -> types.ModuleType | None:
         return module
 
 
-_MODULE_MEMO: dict[Path, tuple[float, types.ModuleType | None]] = {}
+_MODULE_MEMO: OrderedDict[Path, tuple[int, types.ModuleType | None]] = OrderedDict()
+_MODULE_MEMO_MAX_SIZE = 2048
 
 
 def _load_python_module_memo(file_path: Path) -> types.ModuleType | None:
@@ -155,21 +163,24 @@ def _load_python_module_memo(file_path: Path) -> types.ModuleType | None:
 
     Different call sites (`PythonTemplateLoader.can_load`, `load_template`,
     and `Page._create_regular_page_pattern`) previously executed the
-    module up to three times per URL dispatch. The memo keys by mtime so
-    that autoreload and template-stale detection still pick up edits.
+    module up to three times per URL dispatch. The memo keys by nanosecond
+    mtime so that autoreload and template-stale detection still pick up an
+    edit a coarser timestamp would round away, and it is bounded because
+    every entry holds a whole executed module alive.
     """
-    try:
-        mtime = file_path.stat().st_mtime
-    except OSError:
+    mtime = stat_mtime_ns(file_path)
+    if mtime is None:
         _MODULE_MEMO.pop(file_path, None)
         return _load_python_module(file_path)
 
     cached = _MODULE_MEMO.get(file_path)
     if cached is not None and cached[0] == mtime:
+        # Left where it sits, because this answers up to three times per URL
+        # dispatch and the bound is there to cap memory, not to rank pages.
         return cached[1]
 
     module = _load_python_module(file_path)
-    _MODULE_MEMO[file_path] = (mtime, module)
+    store_bounded(_MODULE_MEMO, file_path, (mtime, module), _MODULE_MEMO_MAX_SIZE)
     return module
 
 
@@ -212,7 +223,7 @@ def _page_roots() -> tuple[Path, ...]:
     return cached
 
 
-def _reset_page_roots_cache(**kwargs) -> None:
+def forget_page_roots(**kwargs) -> None:
     """Drop the memoised page trees so the next walk asks the routers again."""
     _PAGE_ROOTS_CACHE["value"] = None
 
@@ -224,10 +235,10 @@ def _on_setting_changed(*, setting: str, **kwargs) -> None:
     of a router with `APP_DIRS` move with `INSTALLED_APPS`.
     """
     if setting == "INSTALLED_APPS":
-        _reset_page_roots_cache()
+        forget_page_roots()
 
 
-settings_reloaded.connect(_reset_page_roots_cache)
+settings_reloaded.connect(forget_page_roots)
 setting_changed.connect(_on_setting_changed)
 
 
@@ -248,8 +259,10 @@ def read_module_string_lists(
     absent or broken module apart from one that declares none of the names.
     Anything but a list or tuple of non-empty strings reads as an empty list,
     so a caller never has to type-check what a user module bound to the name.
+    Read through the mtime memo, so an edit is picked up while a re-read of the
+    same file executes no module body a second time.
     """
-    module = _load_python_module(file_path)
+    module = _load_python_module_memo(file_path)
     if module is None:
         return None
     return {attr: _read_string_list(module, attr) for attr in attrs}

--- a/next/pages/loaders.py
+++ b/next/pages/loaders.py
@@ -27,9 +27,8 @@ from django.core.signals import setting_changed
 from next.conf import next_framework_settings
 from next.conf.imports import import_class_cached
 from next.conf.signals import settings_reloaded
-from next.utils import classify_dirs_entries, resolve_base_dir
+from next.utils import MAX_ANCESTOR_WALK_DEPTH, classify_dirs_entries, resolve_base_dir
 
-from .paths import _MAX_ANCESTOR_WALK_DEPTH
 from .watch import get_pages_directories_for_watch
 
 
@@ -204,7 +203,7 @@ _PAGE_ROOTS_CACHE: dict[str, tuple[Path, ...] | None] = {"value": None}
 def _page_roots() -> tuple[Path, ...]:
     """Return the resolved page trees the routers report, memoised.
 
-    Reading them builds every router backend, too much work to repeat per walk.
+    Reading them probes the trees of every router, too much work per walk.
     """
     cached = _PAGE_ROOTS_CACHE["value"]
     if cached is None:
@@ -398,7 +397,7 @@ class LayoutTemplateLoader(TemplateLoader):
         watched_dirs: list[Path] = []
         current_dir = file_path.parent
 
-        for depth in range(_MAX_ANCESTOR_WALK_DEPTH):
+        for depth in range(MAX_ANCESTOR_WALK_DEPTH):
             if current_dir == current_dir.parent:
                 break
             if depth < watched_depth:
@@ -427,8 +426,8 @@ class LayoutTemplateLoader(TemplateLoader):
             if resolved.is_relative_to(root)
         ]
         if not depths:
-            return _MAX_ANCESTOR_WALK_DEPTH
-        return min(*depths, _MAX_ANCESTOR_WALK_DEPTH)
+            return MAX_ANCESTOR_WALK_DEPTH
+        return min(*depths, MAX_ANCESTOR_WALK_DEPTH)
 
     def _find_layout_files(self, file_path: Path) -> list[Path]:
         """Return `layout.djx` paths from near to far plus global layouts.

--- a/next/pages/paths.py
+++ b/next/pages/paths.py
@@ -9,13 +9,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from next.utils import MAX_ANCESTOR_WALK_DEPTH
+
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-# The bound every ancestor walk shares, so none reaches the filesystem root.
-_MAX_ANCESTOR_WALK_DEPTH = 64
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,7 +45,7 @@ def _build_page_path_info(file_path: Path) -> PagePathInfo:
     """Read every path fact of `file_path` in one pass over the disk."""
     ancestors: list[Path] = []
     current_dir = file_path.parent
-    for _ in range(_MAX_ANCESTOR_WALK_DEPTH):
+    for _ in range(MAX_ANCESTOR_WALK_DEPTH):
         if current_dir == current_dir.parent:
             break
         ancestors.append(current_dir / "page.py")

--- a/next/pages/watch.py
+++ b/next/pages/watch.py
@@ -8,11 +8,12 @@ backend from the answer rather than passing on a value of the wrong shape.
 from __future__ import annotations
 
 import logging
+from collections import OrderedDict
 from typing import TYPE_CHECKING
 
 from next.backends import backend_entries
 from next.conf.signals import settings_reloaded
-from next.utils import page_roots_shape_error
+from next.utils import page_roots_shape_error, resolve_base_dir, store_bounded
 
 
 if TYPE_CHECKING:
@@ -41,9 +42,21 @@ _MALFORMED = (
     "watcher. The same failure is not logged again until the settings reload."
 )
 
-# The backends are rebuilt on every tick, so a per-instance flag cannot stop a
-# broken one from logging forever. One key per source and subject bounds the set.
+# A router that keeps raising is read once a second, so a report of the same
+# failure is kept to one per settings generation. One key per source and
+# subject bounds the set.
 _reported_failures: set[tuple[str, str]] = set()
+
+# The base directory rides along, because a router reads it while it is built
+# and a change to it alone emits no reload.
+_backends_memo: dict[str, tuple[Path | None, list[RouterBackend] | None] | None] = {
+    "value": None
+}
+
+# Held with the routers, so a re-pointed root symlink reaches the watcher only
+# after a restart.
+_resolved_roots: OrderedDict[Path, Path] = OrderedDict()
+_RESOLVED_ROOTS_MAX_SIZE = 2048
 
 
 def _first_failure(source: str, subject: str) -> bool:
@@ -55,33 +68,82 @@ def _first_failure(source: str, subject: str) -> bool:
     return True
 
 
-def _forget_reported_failures(**kwargs) -> None:
-    """Diagnose a failing backend again after the configuration changed."""
+def _forget_watch_state(**kwargs) -> None:
+    """Rebuild the routers and diagnose a failing one again after a reconfigure."""
     _reported_failures.clear()
+    _backends_memo["value"] = None
+    _resolved_roots.clear()
 
 
-settings_reloaded.connect(_forget_reported_failures)
+settings_reloaded.connect(_forget_watch_state)
 
 
-def iter_page_backends_for_watch() -> Iterator[RouterBackend]:
-    """Yield one router per `PAGE_BACKENDS` entry, skipping the ones that fail.
-
-    A backend that cannot be built costs its own trees and nothing else, so
-    the watcher keeps observing every tree the other entries report.
-    """
+def _build_page_backends_for_watch() -> tuple[list[RouterBackend], bool]:
+    """Build one router per `PAGE_BACKENDS` entry, telling whether all were built."""
     # next.urls imports next.pages, so the router import is deferred here to
     # break the next.pages <-> next.urls cycle.
     from next.urls import RouterFactory  # noqa: PLC0415
 
+    backends: list[RouterBackend] = []
+    complete = True
     for position, config in enumerate(backend_entries("PAGE_BACKENDS"), start=1):
         try:
             backend = RouterFactory.create_backend(config)
         except Exception:
+            complete = False
             # Keyed by position, because entries naming no BACKEND share a key.
             if _first_failure(str(position), "construction"):
                 logger.exception(_NOT_BUILT, position, config.get("BACKEND"))
             continue
-        yield backend
+        backends.append(backend)
+    return backends, complete
+
+
+def _page_backends_for_watch() -> list[RouterBackend]:
+    """Return the routers the watcher reads, building them when it has to.
+
+    A complete build is held until the configuration behind it changes, while
+    one that dropped an entry is tried again, because the entry can fail for a
+    reason the next read no longer has, such as an app that had yet to load.
+    """
+    base_dir = resolve_base_dir()
+    memo = _backends_memo["value"]
+    if memo is not None:
+        if memo[0] != base_dir:
+            # A change of BASE_DIR alone emits no reload, so the routers built
+            # against the previous one go, and their diagnostics with them.
+            _forget_watch_state()
+        elif memo[1] is not None:
+            return memo[1]
+    backends, complete = _build_page_backends_for_watch()
+    _backends_memo["value"] = (base_dir, backends if complete else None)
+    return backends
+
+
+def iter_page_backends_for_watch() -> Iterator[RouterBackend]:
+    """Return one router per `PAGE_BACKENDS` entry, skipping the ones that fail.
+
+    A backend that cannot be built costs its own trees and nothing else, so
+    the watcher keeps observing every tree the other entries report. The
+    routers are built before the iterator is handed back, because an abandoned
+    iterator would otherwise leave the held ones half a configuration behind.
+    """
+    return iter(_page_backends_for_watch())
+
+
+def _resolved_root_for_watch(path: Path) -> Path:
+    """Return the resolved form of a reported tree, memoised until a reload.
+
+    A router reports the same handful of trees every tick, and resolving one
+    costs more than everything else the tick pays for it.
+    """
+    resolved = _resolved_roots.get(path)
+    if resolved is None:
+        resolved = path.resolve()
+        # A router free to report a new tree per tick would otherwise grow the
+        # memo without bound, and dropping the stalest keeps the steady set.
+        store_bounded(_resolved_roots, path, resolved, _RESOLVED_ROOTS_MAX_SIZE)
+    return resolved
 
 
 def page_root_paths_for_watch(backend: RouterBackend) -> list[Path]:
@@ -104,7 +166,7 @@ def page_root_paths_for_watch(backend: RouterBackend) -> list[Path]:
         if _first_failure(source, subject):
             logger.error(_MALFORMED, source, subject)
         return []
-    return [root.path.resolve() for root in roots]
+    return [_resolved_root_for_watch(root.path) for root in roots]
 
 
 def components_folder_name_for_watch(backend: RouterBackend) -> str | None:

--- a/next/pages/watch.py
+++ b/next/pages/watch.py
@@ -8,12 +8,17 @@ backend from the answer rather than passing on a value of the wrong shape.
 from __future__ import annotations
 
 import logging
-from collections import OrderedDict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from next.backends import backend_entries
 from next.conf.signals import settings_reloaded
-from next.utils import page_roots_shape_error, resolve_base_dir, store_bounded
+from next.utils import (
+    forget_resolved_trees,
+    page_roots_shape_error,
+    resolve_base_dir,
+    resolved_tree,
+    template_edits_watched,
+)
 
 
 if TYPE_CHECKING:
@@ -28,35 +33,39 @@ logger = logging.getLogger(__name__)
 
 _FAILED = (
     "%s failed to report its %s, so it contributes nothing to the watcher. "
-    "The same failure is not logged again until the settings reload."
+    "The same failure is not logged again until the framework is reconfigured."
 )
 
 _NOT_BUILT = (
     "PAGE_BACKENDS entry number %s (%s) could not be built, so it contributes "
     "nothing to the watcher. The same failure is not logged again until the "
-    "settings reload."
+    "framework is reconfigured."
 )
 
 _MALFORMED = (
     "%s reported a %s of the wrong type, so it contributes nothing to the "
-    "watcher. The same failure is not logged again until the settings reload."
+    "watcher. The same failure is not logged again until the framework is "
+    "reconfigured."
 )
 
 # A router that keeps raising is read once a second, so a report of the same
-# failure is kept to one per settings generation. One key per source and
-# subject bounds the set.
+# failure is kept to one per configuration, keyed by source and subject.
 _reported_failures: set[tuple[str, str]] = set()
 
-# The base directory rides along, because a router reads it while it is built
-# and a change to it alone emits no reload.
-_backends_memo: dict[str, tuple[Path | None, list[RouterBackend] | None] | None] = {
-    "value": None
-}
 
-# Held with the routers, so a re-pointed root symlink reaches the watcher only
-# after a restart.
-_resolved_roots: OrderedDict[Path, Path] = OrderedDict()
-_RESOLVED_ROOTS_MAX_SIZE = 2048
+class _BackendsMemo(NamedTuple):
+    """The held routers, and the base directory they were built against.
+
+    The base directory rides along because a router reads it while it is built
+    and a change to it alone emits no reload. An incomplete build holds no
+    routers, which is what makes the next read try the failing entry again.
+    """
+
+    base_dir: Path | None
+    backends: list[RouterBackend] | None
+
+
+_BACKENDS_MEMO: dict[str, _BackendsMemo | None] = {"value": None}
 
 
 def _first_failure(source: str, subject: str) -> bool:
@@ -68,14 +77,19 @@ def _first_failure(source: str, subject: str) -> bool:
     return True
 
 
-def _forget_watch_state(**kwargs) -> None:
-    """Rebuild the routers and diagnose a failing one again after a reconfigure."""
+def _forget_backends() -> None:
+    """Drop the held routers and re-arm the diagnostics of the ones that failed."""
     _reported_failures.clear()
-    _backends_memo["value"] = None
-    _resolved_roots.clear()
+    _BACKENDS_MEMO["value"] = None
 
 
-settings_reloaded.connect(_forget_watch_state)
+def forget_watch_state(**kwargs) -> None:
+    """Drop everything the watch layer holds, so a reconfigure is read afresh."""
+    _forget_backends()
+    forget_resolved_trees()
+
+
+settings_reloaded.connect(forget_watch_state)
 
 
 def _build_page_backends_for_watch() -> tuple[list[RouterBackend], bool]:
@@ -102,48 +116,41 @@ def _build_page_backends_for_watch() -> tuple[list[RouterBackend], bool]:
 def _page_backends_for_watch() -> list[RouterBackend]:
     """Return the routers the watcher reads, building them when it has to.
 
-    A complete build is held until the configuration behind it changes, while
-    one that dropped an entry is tried again, because the entry can fail for a
+    A complete build is held until the configuration behind it changes, which
+    is what keeps a static lookup and a reloader tick from building one per
+    read. An incomplete one is built again, because an entry can fail for a
     reason the next read no longer has, such as an app that had yet to load.
+
+    A process watching the disk holds nothing at all, so every read builds the
+    routers again. A router answers about the trees it probed while it was
+    built, and that is what makes a page tree created, moved, or removed under
+    the development server reach the very next read.
     """
+    if template_edits_watched():
+        return _build_page_backends_for_watch()[0]
     base_dir = resolve_base_dir()
-    memo = _backends_memo["value"]
+    memo = _BACKENDS_MEMO["value"]
     if memo is not None:
-        if memo[0] != base_dir:
+        if memo.base_dir != base_dir:
             # A change of BASE_DIR alone emits no reload, so the routers built
             # against the previous one go, and their diagnostics with them.
-            _forget_watch_state()
-        elif memo[1] is not None:
-            return memo[1]
+            _forget_backends()
+        elif memo.backends is not None:
+            return memo.backends
     backends, complete = _build_page_backends_for_watch()
-    _backends_memo["value"] = (base_dir, backends if complete else None)
+    _BACKENDS_MEMO["value"] = _BackendsMemo(base_dir, backends if complete else None)
     return backends
 
 
 def iter_page_backends_for_watch() -> Iterator[RouterBackend]:
     """Return one router per `PAGE_BACKENDS` entry, skipping the ones that fail.
 
-    A backend that cannot be built costs its own trees and nothing else, so
-    the watcher keeps observing every tree the other entries report. The
-    routers are built before the iterator is handed back, because an abandoned
-    iterator would otherwise leave the held ones half a configuration behind.
+    A backend that cannot be built costs its own trees and nothing else, so the
+    watcher keeps observing every tree the other entries report. Every router
+    is built before the iterator is handed back, so abandoning it half way
+    leaves nothing half built behind.
     """
     return iter(_page_backends_for_watch())
-
-
-def _resolved_root_for_watch(path: Path) -> Path:
-    """Return the resolved form of a reported tree, memoised until a reload.
-
-    A router reports the same handful of trees every tick, and resolving one
-    costs more than everything else the tick pays for it.
-    """
-    resolved = _resolved_roots.get(path)
-    if resolved is None:
-        resolved = path.resolve()
-        # A router free to report a new tree per tick would otherwise grow the
-        # memo without bound, and dropping the stalest keeps the steady set.
-        store_bounded(_resolved_roots, path, resolved, _RESOLVED_ROOTS_MAX_SIZE)
-    return resolved
 
 
 def page_root_paths_for_watch(backend: RouterBackend) -> list[Path]:
@@ -166,7 +173,7 @@ def page_root_paths_for_watch(backend: RouterBackend) -> list[Path]:
         if _first_failure(source, subject):
             logger.error(_MALFORMED, source, subject)
         return []
-    return [_resolved_root_for_watch(root.path) for root in roots]
+    return [resolved_tree(root.path) for root in roots]
 
 
 def components_folder_name_for_watch(backend: RouterBackend) -> str | None:

--- a/next/server/roots.py
+++ b/next/server/roots.py
@@ -19,8 +19,11 @@ if TYPE_CHECKING:
 
 
 def get_framework_filesystem_roots_for_linking() -> list[Path]:
-    """Return sorted unique roots from page trees and component `DIRS`."""
-    roots: set[Path] = {p.resolve() for p in get_pages_directories_for_watch()}
+    """Return sorted unique roots from page trees and component `DIRS`.
+
+    The page trees arrive resolved, so only the component roots are normalised.
+    """
+    roots: set[Path] = set(get_pages_directories_for_watch())
     for config in backend_entries("COMPONENT_BACKENDS"):
         roots.update(p.resolve() for p in component_extra_roots_from_config(config))
     return sorted(roots)

--- a/next/static/assets.py
+++ b/next/static/assets.py
@@ -77,6 +77,12 @@ class KindRegistry:
         self._slots: dict[str, str] = {}
         self._renderers: dict[str, str] = {}
         self._inline_tags: dict[str, str] = {}
+        self._version = 0
+
+    @property
+    def version(self) -> int:
+        """Return a counter every registration bumps, so a cached answer can tell."""
+        return self._version
 
     def register(
         self,
@@ -133,6 +139,7 @@ class KindRegistry:
         self._renderers[kind] = renderer
         if inline_tag is not None:
             self._inline_tags[kind] = inline_tag
+        self._version += 1
 
     def extension(self, kind: str) -> str:
         """Return the file extension registered for the given kind.

--- a/next/static/backends.py
+++ b/next/static/backends.py
@@ -64,6 +64,8 @@ class StaticBackend(ABC):
         for example `"about"` or `"components/card"`. The `kind` argument
         must be a kind registered in the default kind registry. The method
         raises `RuntimeError` when the asset cannot be resolved to a URL.
+        Discovery calls it once per discovered file per render, so a backend
+        whose answer changes takes effect without a restart.
         """
 
 

--- a/next/static/backends.py
+++ b/next/static/backends.py
@@ -64,8 +64,8 @@ class StaticBackend(ABC):
         for example `"about"` or `"components/card"`. The `kind` argument
         must be a kind registered in the default kind registry. The method
         raises `RuntimeError` when the asset cannot be resolved to a URL.
-        Discovery calls it once per discovered file per render, so a backend
-        whose answer changes takes effect without a restart.
+        Discovery asks on every render rather than remembering the answer, so a
+        backend is free to resolve the same file to a different URL per request.
         """
 
 
@@ -106,10 +106,12 @@ class StaticFilesBackend(StaticBackend):
 
         The suffix is taken from `source_path.suffix`, so a single kind
         can serve multiple file extensions if a custom backend wishes to.
-        Result is cached per `(logical_name, suffix)`. Missing entries
-        in the staticfiles manifest are reported as `RuntimeError` with
-        a hint about running `collectstatic`. The `kind` argument is part
-        of the contract and ignored here, the suffix alone names the file.
+        The answer is memoised per `(logical_name, suffix)` for the life of
+        this backend, which `StaticManager.reload()` ends, because staticfiles
+        itself reads its manifest once per process. Missing entries in that
+        manifest are reported as `RuntimeError` with a hint about running
+        `collectstatic`. The `kind` argument is part of the contract and
+        ignored here, the suffix alone names the file.
         """
         del kind
         suffix = source_path.suffix

--- a/next/static/collector.py
+++ b/next/static/collector.py
@@ -216,6 +216,12 @@ class PlaceholderRegistry:
     def __init__(self) -> None:
         """Initialise an empty slot registry."""
         self._slots: dict[str, PlaceholderSlot] = {}
+        self._version = 0
+
+    @property
+    def version(self) -> int:
+        """Return a counter every registration bumps, so a cached answer can tell."""
+        return self._version
 
     def register(self, name: str, *, token: str) -> None:
         """Register the slot under its name with the given placeholder token.
@@ -239,6 +245,7 @@ class PlaceholderRegistry:
             )
             raise ValueError(msg)
         self._slots[name] = PlaceholderSlot(name=name, token=token)
+        self._version += 1
 
     def get(self, name: str) -> PlaceholderSlot | None:
         """Return the slot registered under the given name or None."""
@@ -293,8 +300,8 @@ class StaticCollector:
         self._js_context_serializers: dict[str, JsContextSerializer] = {}
         self._js_context_encoded: dict[str, str] = {}
 
-    def add(self, asset: StaticAsset, *, prepend: bool = False) -> None:
-        """Add the asset unless its dedup key was already recorded.
+    def add(self, asset: StaticAsset, *, prepend: bool = False) -> bool:
+        """Add the asset unless its dedup key was already recorded, and report which.
 
         Inline assets always append because their dedup key derives from the body.
         URL-form assets with `prepend=True` are inserted before existing append entries
@@ -302,10 +309,11 @@ class StaticCollector:
 
         The asset routes to the bucket named by `KindRegistry.slot(asset.kind)`.
         Unregistered kinds raise `KeyError` so misconfiguration surfaces immediately.
+        The answer is what keeps a caller from announcing an asset that never landed.
         """
         key = self._dedup.key(asset)
         if key in self._seen_keys:
-            return
+            return False
         self._seen_keys.add(key)
         slot = default_kinds.slot(asset.kind)
         bucket = self._buckets.setdefault(slot, [])
@@ -317,6 +325,7 @@ class StaticCollector:
             self._prepend_idx[slot] = idx + 1
         else:
             bucket.append(asset)
+        return True
 
     def assets_in_slot(self, name: str) -> list[StaticAsset]:
         """Return collected assets for the named slot in insertion order.

--- a/next/static/discovery.py
+++ b/next/static/discovery.py
@@ -19,6 +19,10 @@ The provider contract requires that `page_roots` returns already
 resolved absolute paths. Both the static manager and the co-located
 finder satisfy this contract, which lets the discovery layer skip a
 round of resolution on every logical-name lookup.
+
+Both entry points answer from an asset plan. A plan remembers what the
+disk held, not what the backend answered, so every co-located file is
+registered again on every render.
 """
 
 from __future__ import annotations
@@ -29,7 +33,7 @@ from collections import OrderedDict
 from typing import TYPE_CHECKING, NamedTuple, Protocol, runtime_checkable
 
 from next.pages import loaders as pages_loaders
-from next.utils import template_edits_watched
+from next.utils import MAX_ANCESTOR_WALK_DEPTH, store_bounded, template_edits_watched
 
 from .assets import StaticAsset, default_kinds
 from .collector import default_placeholders
@@ -37,7 +41,7 @@ from .signals import asset_registered
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
     from pathlib import Path
 
     from next.components import ComponentInfo
@@ -50,8 +54,16 @@ logger = logging.getLogger(__name__)
 
 
 _MODULE_LIST_CACHE_MAX_SIZE = 2048
-_LAYOUT_DIR_CACHE_MAX_SIZE = 2048
 _PAGE_PLAN_CACHE_MAX_SIZE = 2048
+_COMPONENT_PLAN_CACHE_MAX_SIZE = 2048
+
+# The mtime a directory that does not stat is remembered under. Any later stat
+# beats it, so a plan read over a missing directory rebuilds once it is back.
+_MISSING_DIRECTORY_MTIME = -1.0
+
+# Everything a component plan depends on. The folder it reads comes from one of
+# the two paths, and the logical name comes from the component name.
+type _ComponentKey = tuple[Path | None, Path | None, str]
 
 
 class _FoundAsset(NamedTuple):
@@ -62,16 +74,24 @@ class _FoundAsset(NamedTuple):
     kind: str
 
 
-class _PageAssetPlan(NamedTuple):
-    """What one page path contributes, and the directories it was read from.
+class _AssetPlan(NamedTuple):
+    """What one page or component contributes, and where it was read from.
 
-    A warm render registers the files named here instead of probing every
-    stem again. `module_path` is the page itself, or `None` where it is gone.
+    A warm render skips the stem probes and the module import, and still
+    hands every found file to the backend. Module URLs are literals the
+    backend never sees, so they ride the plan as finished assets.
     """
 
     files: tuple[_FoundAsset, ...]
-    module_path: Path | None
+    module_assets: tuple[StaticAsset, ...]
     directory_mtimes: tuple[tuple[Path, float], ...]
+
+
+class _LayoutWalk(NamedTuple):
+    """The directories holding a layout, and the mtimes of the watched ones."""
+
+    layouts: tuple[Path, ...]
+    mtimes: tuple[tuple[Path, float], ...]
 
 
 def _url_suffix(url: str) -> str:
@@ -103,19 +123,21 @@ def _rel_path_str(child: Path, root: Path) -> str | None:
     return rel
 
 
-def _directory_mtimes(directories: list[Path]) -> tuple[tuple[Path, float], ...]:
-    """Snapshot the mtime of each directory, dropping the ones that do not stat.
+def _directory_mtime(directory: Path) -> float:
+    """Return the mtime of a directory, or the sentinel when it does not stat.
 
     Taken whether or not the process watches asset edits, so a plan built
     with `DEBUG` off still has something to compare against once it comes on.
     """
-    snapshot: list[tuple[Path, float]] = []
-    for directory in directories:
-        try:
-            snapshot.append((directory, directory.stat().st_mtime))
-        except OSError:
-            continue
-    return tuple(snapshot)
+    try:
+        return directory.stat().st_mtime
+    except OSError:
+        return _MISSING_DIRECTORY_MTIME
+
+
+def _directory_mtimes(directories: Sequence[Path]) -> tuple[tuple[Path, float], ...]:
+    """Snapshot the mtime of every directory a plan is about to read."""
+    return tuple((directory, _directory_mtime(directory)) for directory in directories)
 
 
 @runtime_checkable
@@ -254,8 +276,10 @@ class AssetDiscovery:
         self._resolver = resolver or PathResolver(provider.page_roots)
         self._stems = stems or default_stems
         self._module_list_cache: OrderedDict[Path, dict[str, list[str]]] = OrderedDict()
-        self._layout_dir_cache: OrderedDict[Path, list[Path]] = OrderedDict()
-        self._page_plan_cache: OrderedDict[Path, _PageAssetPlan] = OrderedDict()
+        self._page_plan_cache: OrderedDict[Path, _AssetPlan] = OrderedDict()
+        self._component_plan_cache: OrderedDict[_ComponentKey, _AssetPlan] = (
+            OrderedDict()
+        )
 
     def discover_page_assets(self, file_path: Path, collector: StaticCollector) -> None:
         """Collect layout, template, and module-level assets for a page file.
@@ -264,32 +288,52 @@ class AssetDiscovery:
         the template directory, then from `styles` and `scripts`
         module lists declared in `page.py`.
         """
-        plan = self._page_asset_plan(file_path)
+        self._plan_for(
+            self._page_plan_cache,
+            file_path,
+            self._build_page_asset_plan,
+            file_path,
+            collector,
+            _PAGE_PLAN_CACHE_MAX_SIZE,
+        )
+
+    def _plan_for[K, S](
+        self,
+        cache: OrderedDict[K, _AssetPlan],
+        key: K,
+        build: Callable[[S], _AssetPlan],
+        subject: S,
+        collector: StaticCollector,
+        size: int,
+    ) -> None:
+        """Feed `collector` from the plan under `key`, rebuilding a stale one.
+
+        An entry the render left alone is only worth rewriting once the cache is
+        full enough to evict, because that is when order decides.
+        """
+        cached = cache.get(key)
+        if cached is None or self._plan_stale(cached):
+            plan = build(subject)
+            store_bounded(cache, key, plan, size)
+        else:
+            plan = cached
+            if len(cache) >= size:
+                store_bounded(cache, key, plan, size)
         for found in plan.files:
             self._register_file(found, collector)
-        if plan.module_path is not None:
-            self._collect_module_lists(plan.module_path, collector)
+        for asset in plan.module_assets:
+            collector.add(asset)
 
-    def _page_asset_plan(self, file_path: Path) -> _PageAssetPlan:
-        """Return the memoised plan of `file_path`, walking the disk on a miss."""
-        plan = self._page_plan_cache.get(file_path)
-        if plan is not None and not self._plan_stale(plan):
-            self._page_plan_cache.move_to_end(file_path)
-            return plan
-        plan = self._build_page_asset_plan(file_path)
-        self._page_plan_cache[file_path] = plan
-        if len(self._page_plan_cache) > _PAGE_PLAN_CACHE_MAX_SIZE:
-            self._page_plan_cache.popitem(last=False)
-        return plan
-
-    def _build_page_asset_plan(self, file_path: Path) -> _PageAssetPlan:
+    def _build_page_asset_plan(self, file_path: Path) -> _AssetPlan:
         """Probe every role directory behind `file_path` in one pass."""
         resolved = file_path.resolve()
         page_root = self._resolver.find_page_root(resolved)
+        # Before the walk stats anything, because the import writes
+        # `__pycache__` into the very directory the walk is about to snapshot.
+        lists = self._module_lists(resolved) if resolved.exists() else {}
+        walk = self._walk_layouts(resolved, page_root)
         files: list[_FoundAsset] = []
-        directories: list[Path] = []
-        for layout_dir in self._find_layout_directories(resolved, page_root):
-            directories.append(layout_dir)
+        for layout_dir in walk.layouts:
             files += self._find_role_files(
                 layout_dir,
                 logical_name=self._resolver.logical_name_for_layout(
@@ -298,7 +342,6 @@ class AssetDiscovery:
                 role="layout",
             )
         template_dir = resolved.parent
-        directories.append(template_dir)
         files += self._find_role_files(
             template_dir,
             logical_name=self._resolver.logical_name_for_template(
@@ -306,60 +349,79 @@ class AssetDiscovery:
             ),
             role="template",
         )
-        return _PageAssetPlan(
+        return _AssetPlan(
             files=tuple(files),
-            module_path=resolved if resolved.exists() else None,
-            directory_mtimes=_directory_mtimes(directories),
+            module_assets=self._module_assets(lists),
+            directory_mtimes=walk.mtimes,
         )
 
-    def _plan_stale(self, plan: _PageAssetPlan) -> bool:
+    def _plan_stale(self, plan: _AssetPlan) -> bool:
         """Whether a directory the plan was read from has moved since.
 
         Only a process watching template edits pays the stats. An asset created or
-        deleted moves the mtime of the directory holding it.
+        deleted moves the mtime of the directory holding it, and a directory
+        that appears or goes away counts the same. One that was already missing
+        when the plan was built has nothing to rebuild for.
         """
         if not template_edits_watched():
             return False
         for directory, mtime in plan.directory_mtimes:
-            try:
-                current = directory.stat().st_mtime
-            except OSError:
-                return True
-            if current > mtime:
+            current = _directory_mtime(directory)
+            if current == mtime:
+                continue
+            if current == _MISSING_DIRECTORY_MTIME or current > mtime:
                 return True
         return False
 
     def discover_component_assets(
         self, info: ComponentInfo, collector: StaticCollector
     ) -> None:
-        """Collect co-located CSS, JS, and module asset lists for a component."""
-        component_dir = self._component_directory(info)
-        if component_dir is None:
-            return
-        logical_name = f"components/{info.name}"
-        self._collect_role_directory(
-            component_dir,
-            logical_name=logical_name,
-            role="component",
-            collector=collector,
-        )
-        module_path = info.module_path
-        if module_path is not None and module_path.exists():
-            self._collect_module_lists(module_path, collector)
+        """Collect co-located CSS, JS, and module asset lists for a component.
 
-    def _collect_role_directory(
-        self,
-        directory: Path,
-        *,
-        logical_name: str,
-        role: str,
-        collector: StaticCollector,
-    ) -> None:
-        """Register every `{stem}{ext}` file the directory holds for the role."""
-        for found in self._find_role_files(
-            directory, logical_name=logical_name, role=role
-        ):
-            self._register_file(found, collector)
+        Every instance of a component on a page arrives here, so the plan is
+        what keeps the second instance from walking the folder again.
+        """
+        if info.is_simple:
+            # A simple component owns no folder, so it has nothing to plan and
+            # an entry per instance would only crowd out the plans that do.
+            return
+        key: _ComponentKey = (info.template_path, info.module_path, info.name)
+        self._plan_for(
+            self._component_plan_cache,
+            key,
+            self._build_component_asset_plan,
+            info,
+            collector,
+            _COMPONENT_PLAN_CACHE_MAX_SIZE,
+        )
+
+    def _build_component_asset_plan(self, info: ComponentInfo) -> _AssetPlan:
+        """Probe the component folder once and note what it was read from."""
+        component_dir = self._component_directory(info)
+        if component_dir is None:  # pragma: no cover
+            return _AssetPlan(files=(), module_assets=(), directory_mtimes=())
+        module_path = info.module_path
+        # Before the mtimes are taken, for the reason the page builder names.
+        lists = (
+            self._module_lists(module_path)
+            if module_path is not None and module_path.exists()
+            else {}
+        )
+        directories = [component_dir]
+        module_dir = None if module_path is None else module_path.parent.resolve()
+        if module_dir is not None and module_dir != component_dir:
+            directories.append(module_dir)
+        mtimes = _directory_mtimes(directories)
+        files = tuple(
+            self._find_role_files(
+                component_dir, logical_name=f"components/{info.name}", role="component"
+            )
+        )
+        return _AssetPlan(
+            files=files,
+            module_assets=self._module_assets(lists),
+            directory_mtimes=mtimes,
+        )
 
     def _find_role_files(
         self, directory: Path, *, logical_name: str, role: str
@@ -368,7 +430,8 @@ class AssetDiscovery:
 
         The set of extensions probed comes from `KindRegistry.kinds()`, so registering a
         new kind during `AppConfig.ready` is enough to teach discovery about it. Each
-        hit carries its resolved path, because the collector dedups on it.
+        hit is built from `directory`, so a caller that resolved it once hands out
+        canonical paths without paying a resolve per file.
         """
         found: list[_FoundAsset] = []
         for stem in self._stems.stems(role):
@@ -376,49 +439,45 @@ class AssetDiscovery:
                 suffix = default_kinds.extension(kind)
                 candidate = directory / f"{stem}{suffix}"
                 if candidate.exists():
-                    found.append(_FoundAsset(candidate.resolve(), logical_name, kind))
+                    found.append(_FoundAsset(candidate, logical_name, kind))
         return found
 
-    def _collect_module_lists(
-        self, module_path: Path, collector: StaticCollector
-    ) -> None:
-        """Read URL list variables matching every registered placeholder slot.
+    def _module_lists(self, module_path: Path) -> dict[str, list[str]]:
+        """Read the URL list variable named after every registered slot.
 
-        The discovery layer iterates over registered slots in
-        `default_placeholders` and reads the variable named after each
-        slot. Each URL gets a `kind` derived from its file extension via
-        `KindRegistry.kind_for_extension`. URLs whose suffix is not in
-        the registry are dropped with a debug log.
-
-        The caller in `discover_page_assets` passes a resolved module
-        path. The component entry point still calls with the raw path,
-        so the key is normalised here as a safety net.
+        Read while the plan is built rather than while it is applied, because
+        importing the module writes `__pycache__` beside it and that would
+        move a directory mtime the plan had already taken. The component entry
+        point calls with a raw path, so the key is normalised as a safety net.
         """
         cache_key = module_path if module_path.is_absolute() else module_path.resolve()
-        if cache_key in self._module_list_cache:
-            self._module_list_cache.move_to_end(cache_key)
-            cached = self._module_list_cache[cache_key]
-        else:
+        cached = self._module_list_cache.get(cache_key)
+        if cached is None:
             lists = pages_loaders.read_module_string_lists(
                 module_path, [slot.name for slot in default_placeholders]
             )
-            if lists is None:
-                self._module_list_cache[cache_key] = {}
-                if len(self._module_list_cache) > _MODULE_LIST_CACHE_MAX_SIZE:
-                    self._module_list_cache.popitem(last=False)
-                return
-            cached = lists
-            self._module_list_cache[cache_key] = cached
-            if len(self._module_list_cache) > _MODULE_LIST_CACHE_MAX_SIZE:
-                self._module_list_cache.popitem(last=False)
-        for slot_name, urls in cached.items():
-            for url in urls:
-                self._register_module_url(url, slot_name, collector)
+            cached = lists if lists is not None else {}
+        store_bounded(
+            self._module_list_cache, cache_key, cached, _MODULE_LIST_CACHE_MAX_SIZE
+        )
+        return cached
 
-    def _register_module_url(
-        self, url: str, slot_name: str, collector: StaticCollector
-    ) -> None:
-        """Resolve a module-level URL to a kind and add it to the collector.
+    def _module_assets(self, lists: dict[str, list[str]]) -> tuple[StaticAsset, ...]:
+        """Turn every URL the module lists name into an asset.
+
+        Built with the plan rather than on every render, because these URLs
+        are literals the backend is never asked about.
+        """
+        assets: list[StaticAsset] = []
+        for slot_name, urls in lists.items():
+            for url in urls:
+                asset = self._module_asset(url, slot_name)
+                if asset is not None:
+                    assets.append(asset)
+        return tuple(assets)
+
+    def _module_asset(self, url: str, slot_name: str) -> StaticAsset | None:
+        """Resolve a module-level URL to an asset of the kind its suffix names.
 
         The kind comes from `KindRegistry.kind_for_extension(suffix)`
         where suffix is the lowercase trailing dot-extension of the
@@ -428,11 +487,11 @@ class AssetDiscovery:
         suffix = _url_suffix(url)
         if not suffix:
             logger.debug("Module URL %r has no recognised extension", url)
-            return
+            return None
         kind = default_kinds.kind_for_extension(suffix)
         if kind is None:
             logger.debug("Module URL %r has unregistered extension %r", url, suffix)
-            return
+            return None
         kind_slot = default_kinds.slot(kind)
         if kind_slot != slot_name:
             logger.debug(
@@ -442,14 +501,16 @@ class AssetDiscovery:
                 kind_slot,
                 slot_name,
             )
-            return
-        collector.add(StaticAsset(url=url, kind=kind))
+            return None
+        return StaticAsset(url=url, kind=kind)
 
     def _register_file(self, found: _FoundAsset, collector: StaticCollector) -> None:
         """Register a file with the backend and add the result to the collector.
 
-        Warnings are logged for `OSError` and `ValueError`. All other exception types
-        propagate so bugs in custom backends surface loudly.
+        Asked of the backend on every render, so a backend that resolves a URL
+        differently once a build lands is seen without a restart. Warnings are
+        logged for `OSError` and `ValueError` and drop that one asset. All other
+        exception types propagate so bugs in custom backends surface loudly.
         """
         backend = self._provider.default_backend
         try:
@@ -470,41 +531,39 @@ class AssetDiscovery:
         asset_registered.send(sender=asset, collector=collector, backend=backend)
 
     def _component_directory(self, info: ComponentInfo) -> Path | None:
-        """Return the directory that holds a composite component, or None."""
-        if info.is_simple:
-            return None
-        if info.template_path is not None:
-            return info.template_path.parent
-        if info.module_path is not None:  # pragma: no cover
-            return info.module_path.parent
-        return None  # pragma: no cover
+        """Return the resolved directory holding a composite component, or None.
 
-    def _find_layout_directories(
-        self, file_path: Path, page_root: Path | None
-    ) -> list[Path]:
-        """Walk up from the page directory and return layout dirs outermost first.
-
-        The caller is expected to pass a resolved absolute `file_path`.
-        The resolver contract also guarantees that `page_root` is
-        resolved, which lets this loop compare paths with `==` without
-        issuing another filesystem call per iteration.
+        Resolving the folder once here spells every asset the plan hands out
+        the way the staticfiles finder spells it, at no per-file cost.
         """
-        if file_path in self._layout_dir_cache:
-            self._layout_dir_cache.move_to_end(file_path)
-            return self._layout_dir_cache[file_path]
-        directories: list[Path] = []
-        current_dir = file_path.parent
-        while True:
-            if (current_dir / "layout.djx").exists():
-                directories.append(current_dir)
-            if page_root is not None and current_dir == page_root:
+        source = info.template_path or info.module_path
+        return None if source is None else source.parent.resolve()
+
+    def _walk_layouts(self, file_path: Path, page_root: Path | None) -> _LayoutWalk:
+        """Walk up from the page directory, outermost first, and stat as it goes.
+
+        Inside a page tree every directory is watched, because a layout dropped
+        into an empty one has to invalidate the plan that walked past it.
+        Outside one there is no boundary between project and system
+        directories, so the walk only watches what it read.
+        """
+        layouts: list[Path] = []
+        watched: list[tuple[Path, float]] = []
+        page_dir = file_path.parent
+        current_dir = page_dir
+        for _ in range(MAX_ANCESTOR_WALK_DEPTH):
+            # Stat first so a file landing between the two reads leaves the
+            # plan stale rather than invisible until a restart.
+            mtime = _directory_mtime(current_dir)
+            holds_layout = (current_dir / "layout.djx").exists()
+            if holds_layout:
+                layouts.append(current_dir)
+            if page_root is not None or holds_layout or current_dir == page_dir:
+                watched.append((current_dir, mtime))
+            if current_dir == page_root:
                 break
             parent = current_dir.parent
             if parent == current_dir:
                 break
             current_dir = parent
-        result = list(reversed(directories))
-        self._layout_dir_cache[file_path] = result
-        if len(self._layout_dir_cache) > _LAYOUT_DIR_CACHE_MAX_SIZE:
-            self._layout_dir_cache.popitem(last=False)
-        return result
+        return _LayoutWalk(tuple(reversed(layouts)), tuple(reversed(watched)))

--- a/next/static/discovery.py
+++ b/next/static/discovery.py
@@ -1,28 +1,9 @@
-"""Discover co-located CSS/JS files and page and component module asset lists.
+"""Discover co-located CSS and JS files and the asset lists a module declares.
 
-This module owns the filesystem side of the static pipeline. It walks
-layout chains, reads `styles` and `scripts` module lists, and pushes
-results onto a collector via the active backend.
-
-The path-to-logical-name conversion lives on the `PathResolver` so both
-discovery and the staticfiles finder share the exact same mapping. The
-`StemRegistry` controls which filenames are auto-picked-up per role. It
-lets users teach the framework about new stems like `page.css` or
-`panel.js` without patching the core.
-
-The `BackendProvider` protocol inverts the dependency direction. The
-discovery layer does not import the static manager directly. Any object
-exposing `default_backend` and `page_roots` satisfies the protocol,
-which makes unit-testing without a full manager trivial.
-
-The provider contract requires that `page_roots` returns already
-resolved absolute paths. Both the static manager and the co-located
-finder satisfy this contract, which lets the discovery layer skip a
-round of resolution on every logical-name lookup.
-
-Both entry points answer from an asset plan. A plan remembers what the
-disk held, not what the backend answered, so every co-located file is
-registered again on every render.
+This module owns the filesystem side of the static pipeline. It walks layout
+chains, reads `styles` and `scripts` module lists, and feeds a collector
+through the active backend. Both entry points answer from an asset plan, which
+remembers what the disk held rather than what the backend answered.
 """
 
 from __future__ import annotations
@@ -33,7 +14,13 @@ from collections import OrderedDict
 from typing import TYPE_CHECKING, NamedTuple, Protocol, runtime_checkable
 
 from next.pages import loaders as pages_loaders
-from next.utils import MAX_ANCESTOR_WALK_DEPTH, store_bounded, template_edits_watched
+from next.utils import (
+    MAX_ANCESTOR_WALK_DEPTH,
+    resolved_tree,
+    stat_mtime_ns,
+    store_bounded,
+    template_edits_watched,
+)
 
 from .assets import StaticAsset, default_kinds
 from .collector import default_placeholders
@@ -53,16 +40,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-_MODULE_LIST_CACHE_MAX_SIZE = 2048
 _PAGE_PLAN_CACHE_MAX_SIZE = 2048
 _COMPONENT_PLAN_CACHE_MAX_SIZE = 2048
 
-# The mtime a directory that does not stat is remembered under. Any later stat
-# beats it, so a plan read over a missing directory rebuilds once it is back.
-_MISSING_DIRECTORY_MTIME = -1.0
-
-# Everything a component plan depends on. The folder it reads comes from one of
-# the two paths, and the logical name comes from the component name.
+# What identifies the component a plan was built for. The folder it reads comes
+# from one of the two paths, and the logical name comes from the component name.
 type _ComponentKey = tuple[Path | None, Path | None, str]
 
 
@@ -79,19 +61,22 @@ class _AssetPlan(NamedTuple):
 
     A warm render skips the stem probes and the module import, and still
     hands every found file to the backend. Module URLs are literals the
-    backend never sees, so they ride the plan as finished assets.
+    backend never sees, so they ride the plan as finished assets. The
+    registry generation rides along too, because which filenames count as
+    assets is answered from registries no directory mtime moves with.
     """
 
     files: tuple[_FoundAsset, ...]
     module_assets: tuple[StaticAsset, ...]
-    directory_mtimes: tuple[tuple[Path, float], ...]
+    directory_mtimes: tuple[tuple[Path, int | None], ...]
+    registries: tuple[int, int, int]
 
 
 class _LayoutWalk(NamedTuple):
     """The directories holding a layout, and the mtimes of the watched ones."""
 
     layouts: tuple[Path, ...]
-    mtimes: tuple[tuple[Path, float], ...]
+    mtimes: tuple[tuple[Path, int | None], ...]
 
 
 def _url_suffix(url: str) -> str:
@@ -123,21 +108,31 @@ def _rel_path_str(child: Path, root: Path) -> str | None:
     return rel
 
 
-def _directory_mtime(directory: Path) -> float:
-    """Return the mtime of a directory, or the sentinel when it does not stat.
+def _directory_mtimes(
+    directories: Sequence[Path],
+) -> tuple[tuple[Path, int | None], ...]:
+    """Snapshot the mtime of every directory a plan is about to read.
 
-    Taken whether or not the process watches asset edits, so a plan built
-    with `DEBUG` off still has something to compare against once it comes on.
+    Taken whether or not the process watches asset edits, so a plan built with
+    `DEBUG` off still has something to compare against once it comes on. A
+    directory that does not stat is recorded as `None`, which no real mtime
+    equals, so one that appears later rebuilds the plan that walked past it.
     """
+    return tuple((directory, stat_mtime_ns(directory)) for directory in directories)
+
+
+def _resolved_parent(path: Path) -> Path:
+    """Return the resolved directory holding `path`, or its own spelling.
+
+    A relative path resolves through the working directory, which an atomic
+    deploy removes out from under a live worker, and a render is no place to
+    raise over the name of a folder.
+    """
+    parent = path.parent
     try:
-        return directory.stat().st_mtime
+        return resolved_tree(parent)
     except OSError:
-        return _MISSING_DIRECTORY_MTIME
-
-
-def _directory_mtimes(directories: Sequence[Path]) -> tuple[tuple[Path, float], ...]:
-    """Snapshot the mtime of every directory a plan is about to read."""
-    return tuple((directory, _directory_mtime(directory)) for directory in directories)
+        return parent
 
 
 @runtime_checkable
@@ -175,12 +170,19 @@ class StemRegistry:
             "layout": ["layout"],
             "component": ["component"],
         }
+        self._version = 0
+
+    @property
+    def version(self) -> int:
+        """Return a counter every registration bumps, so a cached answer can tell."""
+        return self._version
 
     def register(self, role: str, stem: str) -> None:
         """Add a stem under the given role, creating the role when missing."""
         stems = self._roles.setdefault(role, [])
         if stem not in stems:
             stems.append(stem)
+            self._version += 1
 
     def stems(self, role: str) -> tuple[str, ...]:
         """Return registered stems for the role in registration order."""
@@ -275,7 +277,6 @@ class AssetDiscovery:
         self._provider = provider
         self._resolver = resolver or PathResolver(provider.page_roots)
         self._stems = stems or default_stems
-        self._module_list_cache: OrderedDict[Path, dict[str, list[str]]] = OrderedDict()
         self._page_plan_cache: OrderedDict[Path, _AssetPlan] = OrderedDict()
         self._component_plan_cache: OrderedDict[_ComponentKey, _AssetPlan] = (
             OrderedDict()
@@ -288,37 +289,28 @@ class AssetDiscovery:
         the template directory, then from `styles` and `scripts`
         module lists declared in `page.py`.
         """
-        self._plan_for(
-            self._page_plan_cache,
-            file_path,
-            self._build_page_asset_plan,
-            file_path,
-            collector,
-            _PAGE_PLAN_CACHE_MAX_SIZE,
+        plan = self._page_plan_cache.get(file_path)
+        if plan is None or self._plan_stale(plan):
+            plan = self._build_page_asset_plan(file_path)
+        store_bounded(self._page_plan_cache, file_path, plan, _PAGE_PLAN_CACHE_MAX_SIZE)
+        self._apply_plan(plan, collector)
+
+    def _registry_generation(self) -> tuple[int, int, int]:
+        """Return the generation of every registry a plan reads while it is built.
+
+        Read before a plan probes anything, so a registration landing while the
+        probe runs leaves the plan stale rather than stamped as up to date. The
+        stem registry is this instance's own, because a caller is free to hand
+        `AssetDiscovery` one and the probe reads that one.
+        """
+        return (
+            self._stems.version,
+            default_kinds.version,
+            default_placeholders.version,
         )
 
-    def _plan_for[K, S](
-        self,
-        cache: OrderedDict[K, _AssetPlan],
-        key: K,
-        build: Callable[[S], _AssetPlan],
-        subject: S,
-        collector: StaticCollector,
-        size: int,
-    ) -> None:
-        """Feed `collector` from the plan under `key`, rebuilding a stale one.
-
-        An entry the render left alone is only worth rewriting once the cache is
-        full enough to evict, because that is when order decides.
-        """
-        cached = cache.get(key)
-        if cached is None or self._plan_stale(cached):
-            plan = build(subject)
-            store_bounded(cache, key, plan, size)
-        else:
-            plan = cached
-            if len(cache) >= size:
-                store_bounded(cache, key, plan, size)
+    def _apply_plan(self, plan: _AssetPlan, collector: StaticCollector) -> None:
+        """Hand every file the plan found to the backend, then its module URLs."""
         for found in plan.files:
             self._register_file(found, collector)
         for asset in plan.module_assets:
@@ -327,8 +319,9 @@ class AssetDiscovery:
     def _build_page_asset_plan(self, file_path: Path) -> _AssetPlan:
         """Probe every role directory behind `file_path` in one pass."""
         resolved = file_path.resolve()
+        registries = self._registry_generation()
         page_root = self._resolver.find_page_root(resolved)
-        # Before the walk stats anything, because the import writes
+        # Imported before the walk stats anything, because the import writes
         # `__pycache__` into the very directory the walk is about to snapshot.
         lists = self._module_lists(resolved) if resolved.exists() else {}
         walk = self._walk_layouts(resolved, page_root)
@@ -353,25 +346,25 @@ class AssetDiscovery:
             files=tuple(files),
             module_assets=self._module_assets(lists),
             directory_mtimes=walk.mtimes,
+            registries=registries,
         )
 
     def _plan_stale(self, plan: _AssetPlan) -> bool:
-        """Whether a directory the plan was read from has moved since.
+        """Whether anything the plan was read from has changed since.
 
-        Only a process watching template edits pays the stats. An asset created or
-        deleted moves the mtime of the directory holding it, and a directory
-        that appears or goes away counts the same. One that was already missing
-        when the plan was built has nothing to rebuild for.
+        A registration moves no file, so the registry generation is compared
+        whatever the process watches. Only a process watching template edits
+        pays the stats, and there an asset created or deleted moves the mtime
+        of the directory holding it, as does a directory that comes or goes.
         """
+        if plan.registries != self._registry_generation():
+            return True
         if not template_edits_watched():
             return False
-        for directory, mtime in plan.directory_mtimes:
-            current = _directory_mtime(directory)
-            if current == mtime:
-                continue
-            if current == _MISSING_DIRECTORY_MTIME or current > mtime:
-                return True
-        return False
+        return any(
+            stat_mtime_ns(directory) != mtime
+            for directory, mtime in plan.directory_mtimes
+        )
 
     def discover_component_assets(
         self, info: ComponentInfo, collector: StaticCollector
@@ -381,36 +374,39 @@ class AssetDiscovery:
         Every instance of a component on a page arrives here, so the plan is
         what keeps the second instance from walking the folder again.
         """
-        if info.is_simple:
+        source = info.template_path or info.module_path
+        if info.is_simple or source is None:
             # A simple component owns no folder, so it has nothing to plan and
             # an entry per instance would only crowd out the plans that do.
             return
         key: _ComponentKey = (info.template_path, info.module_path, info.name)
-        self._plan_for(
-            self._component_plan_cache,
-            key,
-            self._build_component_asset_plan,
-            info,
-            collector,
-            _COMPONENT_PLAN_CACHE_MAX_SIZE,
+        plan = self._component_plan_cache.get(key)
+        if plan is None or self._plan_stale(plan):
+            plan = self._build_component_asset_plan(info, _resolved_parent(source))
+        store_bounded(
+            self._component_plan_cache, key, plan, _COMPONENT_PLAN_CACHE_MAX_SIZE
         )
+        self._apply_plan(plan, collector)
 
-    def _build_component_asset_plan(self, info: ComponentInfo) -> _AssetPlan:
+    def _build_component_asset_plan(
+        self, info: ComponentInfo, component_dir: Path
+    ) -> _AssetPlan:
         """Probe the component folder once and note what it was read from."""
-        component_dir = self._component_directory(info)
-        if component_dir is None:  # pragma: no cover
-            return _AssetPlan(files=(), module_assets=(), directory_mtimes=())
         module_path = info.module_path
-        # Before the mtimes are taken, for the reason the page builder names.
+        registries = self._registry_generation()
+        # Imported before the mtimes are taken, because the import writes
+        # `__pycache__` into the folder the snapshot is about to read.
         lists = (
             self._module_lists(module_path)
             if module_path is not None and module_path.exists()
             else {}
         )
         directories = [component_dir]
-        module_dir = None if module_path is None else module_path.parent.resolve()
+        module_dir = None if module_path is None else _resolved_parent(module_path)
         if module_dir is not None and module_dir != component_dir:
             directories.append(module_dir)
+        # Stat before the probe, so a file landing between the two reads leaves
+        # the plan stale rather than invisible until a restart.
         mtimes = _directory_mtimes(directories)
         files = tuple(
             self._find_role_files(
@@ -421,6 +417,7 @@ class AssetDiscovery:
             files=files,
             module_assets=self._module_assets(lists),
             directory_mtimes=mtimes,
+            registries=registries,
         )
 
     def _find_role_files(
@@ -430,8 +427,8 @@ class AssetDiscovery:
 
         The set of extensions probed comes from `KindRegistry.kinds()`, so registering a
         new kind during `AppConfig.ready` is enough to teach discovery about it. Each
-        hit is built from `directory`, so a caller that resolved it once hands out
-        canonical paths without paying a resolve per file.
+        hit carries its resolved path, because the staticfiles finder spells it that way
+        and the two layers have to agree on which file a logical name means.
         """
         found: list[_FoundAsset] = []
         for stem in self._stems.stems(role):
@@ -439,7 +436,7 @@ class AssetDiscovery:
                 suffix = default_kinds.extension(kind)
                 candidate = directory / f"{stem}{suffix}"
                 if candidate.exists():
-                    found.append(_FoundAsset(candidate, logical_name, kind))
+                    found.append(_FoundAsset(candidate.resolve(), logical_name, kind))
         return found
 
     def _module_lists(self, module_path: Path) -> dict[str, list[str]]:
@@ -447,20 +444,12 @@ class AssetDiscovery:
 
         Read while the plan is built rather than while it is applied, because
         importing the module writes `__pycache__` beside it and that would
-        move a directory mtime the plan had already taken. The component entry
-        point calls with a raw path, so the key is normalised as a safety net.
+        move a directory mtime the plan had already taken.
         """
-        cache_key = module_path if module_path.is_absolute() else module_path.resolve()
-        cached = self._module_list_cache.get(cache_key)
-        if cached is None:
-            lists = pages_loaders.read_module_string_lists(
-                module_path, [slot.name for slot in default_placeholders]
-            )
-            cached = lists if lists is not None else {}
-        store_bounded(
-            self._module_list_cache, cache_key, cached, _MODULE_LIST_CACHE_MAX_SIZE
+        lists = pages_loaders.read_module_string_lists(
+            module_path, [slot.name for slot in default_placeholders]
         )
-        return cached
+        return lists if lists is not None else {}
 
     def _module_assets(self, lists: dict[str, list[str]]) -> tuple[StaticAsset, ...]:
         """Turn every URL the module lists name into an asset.
@@ -507,10 +496,10 @@ class AssetDiscovery:
     def _register_file(self, found: _FoundAsset, collector: StaticCollector) -> None:
         """Register a file with the backend and add the result to the collector.
 
-        Asked of the backend on every render, so a backend that resolves a URL
-        differently once a build lands is seen without a restart. Warnings are
-        logged for `OSError` and `ValueError` and drop that one asset. All other
-        exception types propagate so bugs in custom backends surface loudly.
+        The signal follows the collector, so a component mounted many times on
+        one page announces each of its assets once. Warnings are logged for
+        `OSError` and `ValueError` and drop that one asset. All other exception
+        types propagate so bugs in custom backends surface loudly.
         """
         backend = self._provider.default_backend
         try:
@@ -527,43 +516,33 @@ class AssetDiscovery:
             )
             return
         asset = StaticAsset(url=url, kind=found.kind, source_path=found.source_path)
-        collector.add(asset)
-        asset_registered.send(sender=asset, collector=collector, backend=backend)
-
-    def _component_directory(self, info: ComponentInfo) -> Path | None:
-        """Return the resolved directory holding a composite component, or None.
-
-        Resolving the folder once here spells every asset the plan hands out
-        the way the staticfiles finder spells it, at no per-file cost.
-        """
-        source = info.template_path or info.module_path
-        return None if source is None else source.parent.resolve()
+        if collector.add(asset):
+            asset_registered.send(sender=asset, collector=collector, backend=backend)
 
     def _walk_layouts(self, file_path: Path, page_root: Path | None) -> _LayoutWalk:
         """Walk up from the page directory, outermost first, and stat as it goes.
 
         Inside a page tree every directory is watched, because a layout dropped
-        into an empty one has to invalidate the plan that walked past it.
-        Outside one there is no boundary between project and system
-        directories, so the walk only watches what it read.
+        into an empty one has to invalidate the plan that walked past it, and
+        the tree root bounds what that costs. Outside one there is no boundary
+        between project and system directories, so the walk watches what it read.
         """
         layouts: list[Path] = []
-        watched: list[tuple[Path, float]] = []
-        page_dir = file_path.parent
-        current_dir = page_dir
-        for _ in range(MAX_ANCESTOR_WALK_DEPTH):
+        watched: list[tuple[Path, int | None]] = []
+        inside_a_tree = page_root is not None
+        current_dir = file_path.parent
+        for depth in range(MAX_ANCESTOR_WALK_DEPTH):
             # Stat first so a file landing between the two reads leaves the
             # plan stale rather than invisible until a restart.
-            mtime = _directory_mtime(current_dir)
+            mtime = stat_mtime_ns(current_dir)
             holds_layout = (current_dir / "layout.djx").exists()
             if holds_layout:
                 layouts.append(current_dir)
-            if page_root is not None or holds_layout or current_dir == page_dir:
+            if inside_a_tree or holds_layout or depth == 0:
                 watched.append((current_dir, mtime))
-            if current_dir == page_root:
-                break
             parent = current_dir.parent
-            if parent == current_dir:
+            # The tree root ends the walk, and so does the filesystem root.
+            if current_dir in (page_root, parent):
                 break
             current_dir = parent
         return _LayoutWalk(tuple(reversed(layouts)), tuple(reversed(watched)))

--- a/next/static/finders.py
+++ b/next/static/finders.py
@@ -66,7 +66,8 @@ def discover_colocated_static_assets() -> dict[str, Path]:
     custom stems registered during `AppConfig.ready` are picked up.
     """
     out: dict[str, Path] = {}
-    page_roots = tuple(root.resolve() for root in get_pages_directories_for_watch())
+    # Resolved already, because that is what the watch layer promises.
+    page_roots = tuple(get_pages_directories_for_watch())
     resolver = PathResolver(lambda: page_roots)
 
     for template_path in get_template_djx_paths_for_watch():

--- a/next/static/manager.py
+++ b/next/static/manager.py
@@ -12,7 +12,6 @@ hook in `next.conf` resets the wrapper when `NEXT_FRAMEWORK` changes.
 
 from __future__ import annotations
 
-import contextlib
 from typing import TYPE_CHECKING, Any, cast
 
 from django.conf import settings
@@ -309,15 +308,19 @@ class StaticManager:
         return StaticCollector(dedup=dedup, js_context_policy=policy)
 
     def page_roots(self) -> tuple[Path, ...]:
-        """Return absolute page-tree roots from configured page backends."""
-        if self._cached_page_roots is not None:
-            return self._cached_page_roots
-        roots: list[Path] = []
-        for root in get_pages_directories_for_watch():
-            with contextlib.suppress(OSError):
-                roots.append(root.resolve())
-        self._cached_page_roots = tuple(roots)
+        """Return absolute page-tree roots from configured page backends.
+
+        Taken as the watch layer spells them, already resolved, so a lookup
+        pays no second resolve per root.
+        """
+        if self._cached_page_roots is None:
+            self._cached_page_roots = tuple(get_pages_directories_for_watch())
         return self._cached_page_roots
+
+    def forget_page_roots(self) -> None:
+        """Read the page trees again, dropping what was derived from the old ones."""
+        self._cached_page_roots = None
+        self._discovery = None
 
 
 class DefaultStaticManager(LazyObject):
@@ -369,6 +372,16 @@ def reset_default_manager() -> None:
     fresh manager on the next access.
     """
     default_manager._wrapped = empty  # type: ignore[assignment]
+
+
+def forget_manager_page_roots(**kwargs) -> None:
+    """Tell the default manager a reload moved what the routers report.
+
+    A manager nothing has built yet reads them fresh anyway, so the lazy
+    handle is left alone rather than woken to be invalidated.
+    """
+    if default_manager._wrapped is not empty:
+        default_manager.forget_page_roots()
 
 
 def _on_settings_reloaded(**kwargs) -> None:

--- a/next/templatetags/components.py
+++ b/next/templatetags/components.py
@@ -33,6 +33,7 @@ from next.components import collect_visible_components, get_component, render_co
 from next.components.renderers import COMPONENT_PROPS_CONTEXT_KEY, SLOT_KEY_PREFIX
 from next.conf import fail_loudly, next_framework_settings
 from next.static import collect_component_assets
+from next.utils import on_forget_resolved_trees
 
 
 # Component tags span several lines, which Django's tag regex refuses by default.
@@ -76,9 +77,14 @@ def _strip_quotes(raw: str) -> str:
 def _resolve_template_path(raw: str) -> Path:
     """Return the resolved file for a raw ``current_template_path`` string.
 
-    One page path reaches every node the page renders, so the memo is process-wide.
+    One page path reaches every node the page renders, so the memo is
+    process-wide and keyed by the string the node carries rather than by a path
+    built per read. It is dropped with the shared page-tree resolutions.
     """
     return Path(raw).resolve()
+
+
+on_forget_resolved_trees(_resolve_template_path.cache_clear)
 
 
 def _comment_safe(text: str) -> str:

--- a/next/urls/backends.py
+++ b/next/urls/backends.py
@@ -12,7 +12,7 @@ from django.core.exceptions import AppRegistryNotReady
 
 from next.conf import import_class_cached, next_framework_settings
 from next.pages import page
-from next.utils import PageRoot, classify_dirs_entries, resolve_base_dir
+from next.utils import PageRoot, classify_dirs_entries, resolve_base_dir, resolved_tree
 
 from .dispatcher import FilesystemTreeDispatcher
 from .parser import default_url_parser
@@ -131,22 +131,23 @@ class FileRouterBackend(RouterBackend):
         )
         if extra_root_paths is None or skip_dir_names is None:
             dirs_list = list(extra_root_paths or [])
+            # Already resolved, because the classification probes what it keeps.
             roots, segment_names = classify_dirs_entries(dirs_list, base_dir)
             skip = frozenset({comp_name, *segment_names})
         else:
-            roots = list(extra_root_paths)
+            # `page_roots` promises resolved absolute trees, and a subclass
+            # passing both keywords bypasses the classification that resolves.
+            roots = [resolved_tree(root) for root in extra_root_paths]
             skip = skip_dir_names
-        # `page_roots` promises resolved absolute trees, and a subclass is free
-        # to pass both keyword arguments and bypass the classification above.
-        self._extra_root_paths = [root.resolve() for root in roots if root.exists()]
+        self._extra_root_paths = roots
         self._skip_dir_names = skip
         self._components_folder_name = comp_name
 
         self.options = _narrow_file_router_options(raw_opts)
         self._patterns_cache: dict[str, list[URLPattern | URLResolver]] = {}
         self._app_pages_path_cache: dict[str, tuple[Path, Path | None]] = {}
-        self._root_pages_paths_cache: list[Path] | None = None
         self._root_patterns_cache: list[URLPattern | URLResolver] | None = None
+        self._root_pages_paths_cache: list[Path] | None = None
         self._url_parser = default_url_parser
 
     @override
@@ -284,7 +285,9 @@ class FileRouterBackend(RouterBackend):
         """Return `<app>/pages_dir` when that directory exists.
 
         The answer is memoised per app directory, so an app that moves is
-        looked at again while a static lookup pays no probe per call.
+        looked at again while a static lookup pays no probe per call. The memo
+        lives as long as this router, which the watch layer rebuilds per read
+        while the process watches the disk.
         """
         app_path = directories.get(app_name)
         if app_path is None:
@@ -295,7 +298,7 @@ class FileRouterBackend(RouterBackend):
         if cached is not None and cached[0] == app_path:
             return cached[1]
         candidate = app_path / self.pages_dir
-        pages_path = candidate if candidate.exists() else None
+        pages_path = resolved_tree(candidate) if candidate.exists() else None
         self._app_pages_path_cache[app_name] = (app_path, pages_path)
         return pages_path
 
@@ -303,18 +306,19 @@ class FileRouterBackend(RouterBackend):
         """Return paths from `DIRS` plus optional `BASE_DIR` / `pages_dir`.
 
         Memoised per instance, because the roots this router serves belong to
-        the configuration it was built for and every reader asks per call.
+        the configuration it was built for and every reader asks per call. A
+        copy goes back, so a caller appending to the answer moves no root.
         """
         if self._root_pages_paths_cache is None:
-            result: list[Path] = list(self._extra_root_paths)
+            result = [p for p in self._extra_root_paths if p.exists()]
             if not self.app_dirs and not result:
                 base_dir = resolve_base_dir()
                 if base_dir is not None:
                     pages_path = base_dir / self.pages_dir
                     if pages_path.exists():
-                        result.append(pages_path)
+                        result.append(resolved_tree(pages_path))
             self._root_pages_paths_cache = result
-        return self._root_pages_paths_cache
+        return list(self._root_pages_paths_cache)
 
     def _generate_urls_for_app(
         self, app_name: str, directories: Mapping[str, Path]

--- a/next/urls/backends.py
+++ b/next/urls/backends.py
@@ -131,21 +131,22 @@ class FileRouterBackend(RouterBackend):
         )
         if extra_root_paths is None or skip_dir_names is None:
             dirs_list = list(extra_root_paths or [])
-            path_roots, segment_names = classify_dirs_entries(dirs_list, base_dir)
-            roots: list[Path] = path_roots
+            roots, segment_names = classify_dirs_entries(dirs_list, base_dir)
             skip = frozenset({comp_name, *segment_names})
         else:
             roots = list(extra_root_paths)
             skip = skip_dir_names
-        self._extra_root_paths = roots
+        # `page_roots` promises resolved absolute trees, and a subclass is free
+        # to pass both keyword arguments and bypass the classification above.
+        self._extra_root_paths = [root.resolve() for root in roots if root.exists()]
         self._skip_dir_names = skip
         self._components_folder_name = comp_name
 
         self.options = _narrow_file_router_options(raw_opts)
         self._patterns_cache: dict[str, list[URLPattern | URLResolver]] = {}
         self._app_pages_path_cache: dict[str, tuple[Path, Path | None]] = {}
-        self._root_patterns_cache: list[URLPattern | URLResolver] | None = None
         self._root_pages_paths_cache: list[Path] | None = None
+        self._root_patterns_cache: list[URLPattern | URLResolver] | None = None
         self._url_parser = default_url_parser
 
     @override
@@ -282,9 +283,8 @@ class FileRouterBackend(RouterBackend):
     ) -> Path | None:
         """Return `<app>/pages_dir` when that directory exists.
 
-        The `exists()` answer is memoised per app directory, so an app that
-        moves is looked at again while a tree created after the first read
-        needs the fresh backend a settings reload builds.
+        The answer is memoised per app directory, so an app that moves is
+        looked at again while a static lookup pays no probe per call.
         """
         app_path = directories.get(app_name)
         if app_path is None:
@@ -294,28 +294,27 @@ class FileRouterBackend(RouterBackend):
         cached = self._app_pages_path_cache.get(app_name)
         if cached is not None and cached[0] == app_path:
             return cached[1]
-        pages_path = app_path / self.pages_dir
-        result = pages_path if pages_path.exists() else None
-        self._app_pages_path_cache[app_name] = (app_path, result)
-        return result
+        candidate = app_path / self.pages_dir
+        pages_path = candidate if candidate.exists() else None
+        self._app_pages_path_cache[app_name] = (app_path, pages_path)
+        return pages_path
 
     def _get_root_pages_paths(self) -> list[Path]:
         """Return paths from `DIRS` plus optional `BASE_DIR` / `pages_dir`.
 
-        Memoised per instance. A settings reload recreates the backend,
-        so the memo never outlives its configuration.
+        Memoised per instance, because the roots this router serves belong to
+        the configuration it was built for and every reader asks per call.
         """
-        if self._root_pages_paths_cache is not None:
-            return self._root_pages_paths_cache
-        result: list[Path] = [p.resolve() for p in self._extra_root_paths if p.exists()]
-        if not self.app_dirs and not result:
-            base_dir = resolve_base_dir()
-            if base_dir is not None:
-                pages_path = base_dir / self.pages_dir
-                if pages_path.exists():
-                    result.append(pages_path)
-        self._root_pages_paths_cache = result
-        return result
+        if self._root_pages_paths_cache is None:
+            result: list[Path] = list(self._extra_root_paths)
+            if not self.app_dirs and not result:
+                base_dir = resolve_base_dir()
+                if base_dir is not None:
+                    pages_path = base_dir / self.pages_dir
+                    if pages_path.exists():
+                        result.append(pages_path)
+            self._root_pages_paths_cache = result
+        return self._root_pages_paths_cache
 
     def _generate_urls_for_app(
         self, app_name: str, directories: Mapping[str, Path]

--- a/next/utils.py
+++ b/next/utils.py
@@ -29,17 +29,66 @@ logger = logging.getLogger(__name__)
 # The bound every ancestor walk shares, so none reaches the filesystem root.
 MAX_ANCESTOR_WALK_DEPTH = 64
 
+_RESOLVED_TREES_MAX_SIZE = 2048
+
+
+@functools.lru_cache(maxsize=_RESOLVED_TREES_MAX_SIZE)
+def resolved_tree(path: Path) -> Path:
+    """Return the resolved form of a page tree, memoised across the process.
+
+    A router reports the same handful of trees on every read, and resolving one
+    costs more than everything else the read pays for it. The bound drops the
+    least recently read, so a router free to name a new tree per read grows the
+    memo no further while the steady set of a project stays in it.
+    """
+    return path.resolve()
+
+
+# Memos of resolved paths that a layer keys its own way, dropped with this one.
+_RESOLUTION_CLEARERS: list[Callable[[], None]] = []
+
+
+def on_forget_resolved_trees(clear: Callable[[], None]) -> None:
+    """Register a memo of resolved paths to drop whenever this module drops its own."""
+    _RESOLUTION_CLEARERS.append(clear)
+
+
+def forget_resolved_trees() -> None:
+    """Drop every memoised resolution, so a re-pointed tree is read again."""
+    resolved_tree.cache_clear()
+    for clear in _RESOLUTION_CLEARERS:
+        clear()
+
 
 def store_bounded[K, V](cache: OrderedDict[K, V], key: K, value: V, size: int) -> None:
     """Make `key` the freshest entry of a bounded cache and evict the stalest.
 
-    The pop before the write is what moves an existing key to the end, and it
-    leaves no window where a concurrent eviction could fail the reorder.
+    The write lands before the reorder, so a key already held never goes
+    missing for a concurrent reader. No caller holds a lock, so the two steps
+    after it tolerate another thread evicting the very key being written, which
+    costs a rebuild rather than an error out of a render.
     """
-    cache.pop(key, None)
     cache[key] = value
-    if len(cache) > size:
-        cache.popitem(last=False)
+    try:
+        cache.move_to_end(key)
+        if len(cache) > size:
+            cache.popitem(last=False)
+    except KeyError:
+        # The key is gone, so there is nothing left to reorder and the eviction
+        # that took it already brought the cache back inside the bound.
+        return
+
+
+def stat_mtime_ns(path: Path) -> int | None:
+    """Return the nanosecond mtime of `path`, or `None` when it does not stat.
+
+    Nanoseconds rather than a float, because a float timestamp rounds two
+    writes a filesystem told apart back into one value.
+    """
+    try:
+        return path.stat().st_mtime_ns
+    except OSError:
+        return None
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,52 +133,50 @@ def resolve_base_dir() -> Path | None:
 
 
 def template_edits_watched() -> bool:
-    """Whether the composition caches stat their sources to notice an edit.
+    """Whether the caches re-read the disk to notice a change under way.
 
-    Autoreload leaves `.djx` alone, so under `DEBUG` the stat is the only
-    thing making an edit visible. Read per call, so an override takes effect.
+    Autoreload leaves `.djx` alone and restarts for no directory that appears,
+    so under `DEBUG` reading again is the only thing making either visible.
+    Read per call, so an override takes effect.
     """
     return bool(settings.DEBUG)
 
 
 def _dir_entry_candidate(item: Path, base_dir: Path | None) -> Path | None:
-    """Return the directory a ``DIRS`` entry could name, before any probe.
+    """Return the path a ``DIRS`` entry could name, before it is resolved.
 
-    A relative entry names one only against ``BASE_DIR``, so without one it
-    can only be a URL segment.
+    A relative entry names one only against ``BASE_DIR``, so without one the
+    entry can only be a URL segment.
     """
     if item.is_absolute():
         return item
-    if base_dir is None:
-        return None
-    return base_dir / item
+    return None if base_dir is None else base_dir / item
 
 
-def _dir_entry_segment_name(item: Path, text: str) -> str:
+def _dir_entry_segment_name(item: Path) -> str:
     """Return the URL segment name a ``DIRS`` entry that names no tree carries.
 
-    A Windows-style entry read on POSIX carries no separator of its own, so
-    the last component comes from the normalised text rather than the path.
+    A relative Windows-style entry read on POSIX carries no separator of its
+    own, so its last component comes from the forward-slashed text instead. An
+    absolute entry already separates, and a backslash in it is part of a name.
     """
+    if item.is_absolute():
+        return item.name
+    text = str(item).replace("\\", "/")
     return Path(text).name if "/" in text else item.name
 
 
 def _iter_dir_entries(
     entries: list[Any] | tuple[Any, ...] | None,
-) -> Generator[tuple[Path, str], None, None]:
-    """Yield every ``DIRS`` entry that names anything, as a path and its text.
-
-    The text is forward-slashed once here, because both readers below would
-    otherwise normalise the same entry again.
-    """
+) -> Generator[Path, None, None]:
+    """Yield every ``DIRS`` entry that names anything, as a path."""
     for raw in entries or ():
         if raw is None:
             continue
         item = Path(raw) if not isinstance(raw, Path) else raw
-        text = str(item).replace("\\", "/")
-        if not text or text == ".":
-            continue
-        yield item, text
+        # `Path("")` spells itself ".", so the one test covers the empty entry.
+        if str(item) != ".":
+            yield item
 
 
 def classify_dirs_entries(
@@ -138,12 +185,15 @@ def classify_dirs_entries(
     """Split ``DIRS`` into directory roots and URL segment names (file router)."""
     path_roots: list[Path] = []
     segments: set[str] = set()
-    for item, text in _iter_dir_entries(entries):
+    for item in _iter_dir_entries(entries):
         candidate = _dir_entry_candidate(item, base_dir)
-        if candidate is not None and candidate.is_dir():
-            path_roots.append(candidate.resolve())
+        # Resolved before the probe, so a `..` reaching past a directory that
+        # does not exist still names the tree the entry means.
+        resolved = None if candidate is None else resolved_tree(candidate)
+        if resolved is not None and resolved.is_dir():
+            path_roots.append(resolved)
         else:
-            name = _dir_entry_segment_name(item, text)
+            name = _dir_entry_segment_name(item)
             # An entry that is nothing but separators names no segment, and an
             # empty name would reach `skip_dir_names` as a directory to refuse.
             if name:

--- a/next/utils.py
+++ b/next/utils.py
@@ -19,10 +19,27 @@ from django.conf import settings
 
 
 if TYPE_CHECKING:
+    from collections import OrderedDict
     from collections.abc import Callable, Generator, Iterable
 
 
 logger = logging.getLogger(__name__)
+
+
+# The bound every ancestor walk shares, so none reaches the filesystem root.
+MAX_ANCESTOR_WALK_DEPTH = 64
+
+
+def store_bounded[K, V](cache: OrderedDict[K, V], key: K, value: V, size: int) -> None:
+    """Make `key` the freshest entry of a bounded cache and evict the stalest.
+
+    The pop before the write is what moves an existing key to the end, and it
+    leaves no window where a concurrent eviction could fail the reorder.
+    """
+    cache.pop(key, None)
+    cache[key] = value
+    if len(cache) > size:
+        cache.popitem(last=False)
 
 
 @dataclass(frozen=True, slots=True)
@@ -75,28 +92,44 @@ def template_edits_watched() -> bool:
     return bool(settings.DEBUG)
 
 
-def _classify_one_dir_entry(
-    item: Path, base_dir: Path | None
-) -> tuple[str, Path | str | None]:
+def _dir_entry_candidate(item: Path, base_dir: Path | None) -> Path | None:
+    """Return the directory a ``DIRS`` entry could name, before any probe.
+
+    A relative entry names one only against ``BASE_DIR``, so without one it
+    can only be a URL segment.
+    """
     if item.is_absolute():
-        if item.exists() and item.is_dir():
-            return "path", item
-        return "segment", item.name
+        return item
+    if base_dir is None:
+        return None
+    return base_dir / item
 
-    s = str(item).replace("\\", "/")
-    if "/" in s:
-        if base_dir is not None:
-            cand = (base_dir / item).resolve()
-            if cand.exists() and cand.is_dir():
-                return "path", cand
-        return "segment", Path(s).name or None
 
-    if base_dir is not None:
-        cand = base_dir / item
-        if cand.exists() and cand.is_dir():
-            return "path", cand.resolve()
+def _dir_entry_segment_name(item: Path, text: str) -> str:
+    """Return the URL segment name a ``DIRS`` entry that names no tree carries.
 
-    return "segment", item.name
+    A Windows-style entry read on POSIX carries no separator of its own, so
+    the last component comes from the normalised text rather than the path.
+    """
+    return Path(text).name if "/" in text else item.name
+
+
+def _iter_dir_entries(
+    entries: list[Any] | tuple[Any, ...] | None,
+) -> Generator[tuple[Path, str], None, None]:
+    """Yield every ``DIRS`` entry that names anything, as a path and its text.
+
+    The text is forward-slashed once here, because both readers below would
+    otherwise normalise the same entry again.
+    """
+    for raw in entries or ():
+        if raw is None:
+            continue
+        item = Path(raw) if not isinstance(raw, Path) else raw
+        text = str(item).replace("\\", "/")
+        if not text or text == ".":
+            continue
+        yield item, text
 
 
 def classify_dirs_entries(
@@ -105,22 +138,16 @@ def classify_dirs_entries(
     """Split ``DIRS`` into directory roots and URL segment names (file router)."""
     path_roots: list[Path] = []
     segments: set[str] = set()
-    if not entries:
-        return path_roots, frozenset()
-
-    for raw in entries:
-        if raw is None:
-            continue
-        item = Path(raw) if not isinstance(raw, Path) else raw
-        s = str(item)
-        if not s or s == ".":
-            continue
-
-        kind, value = _classify_one_dir_entry(item, base_dir)
-        if kind == "path" and isinstance(value, Path):
-            path_roots.append(value.resolve())
-        elif kind == "segment" and isinstance(value, str) and value:
-            segments.add(value)
+    for item, text in _iter_dir_entries(entries):
+        candidate = _dir_entry_candidate(item, base_dir)
+        if candidate is not None and candidate.is_dir():
+            path_roots.append(candidate.resolve())
+        else:
+            name = _dir_entry_segment_name(item, text)
+            # An entry that is nothing but separators names no segment, and an
+            # empty name would reach `skip_dir_names` as a directory to refuse.
+            if name:
+                segments.add(name)
 
     return path_roots, frozenset(segments)
 

--- a/tests/apps/test_config.py
+++ b/tests/apps/test_config.py
@@ -13,8 +13,11 @@ from django.utils.autoreload import (
 
 from next.apps import autoreload as next_autoreload, components as next_components
 from next.components import DummyBackend, FileComponentsBackend, components_manager
+from next.pages import loaders as pages_loaders
+from next.pages.watch import get_pages_directories_for_watch
 from next.server import NextStatReloader
-from next.urls import RouterFactory
+from next.static import get_static_manager
+from next.urls import RouterFactory, router_manager
 from tests.support import MalformedRootsRouter, RaisingRootsRouter, importable_dir
 
 
@@ -172,6 +175,34 @@ class TestNextFrameworkConfig:
         autoreload_started.send(sender=mock_autoreload_sender)
         for _path, glob in mock_autoreload_sender.watch_calls:
             assert ".djx" not in glob, f"unexpected djx glob: {glob!r}"
+
+
+class TestARouterReloadDropsThePageRootMemos:
+    """Three layers memoise what the routers report, and a reload moves all three."""
+
+    def test_every_page_root_memo_reads_the_tree_that_appeared(self, tmp_path) -> None:
+        """A reload from code touches no setting, so each memo needs the signal.
+
+        The watch layer holds the routers off `DEBUG`, and the loaders and the
+        static manager hold what those routers reported.
+        """
+        with override_settings(
+            BASE_DIR=tmp_path,
+            DEBUG=False,
+            NEXT_FRAMEWORK={"PAGE_BACKENDS": [_page_backend_entry()]},
+        ):
+            manager = get_static_manager()
+            assert get_pages_directories_for_watch() == []
+            assert pages_loaders._page_roots() == ()
+            assert manager.page_roots() == ()
+
+            (tmp_path / "pages").mkdir()
+            router_manager.reload()
+            tree = (tmp_path / "pages").resolve()
+
+            assert get_pages_directories_for_watch() == [tree]
+            assert pages_loaders._page_roots() == (tree,)
+            assert manager.page_roots() == (tree,)
 
 
 class TestAutoreloadInstallIdempotent:

--- a/tests/benchmarks/server/test_bench_autoreload.py
+++ b/tests/benchmarks/server/test_bench_autoreload.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from django.test import override_settings
 
+from next.pages.watch import get_pages_directories_for_watch
 from next.server.autoreload import NextStatReloader, _tree_dir_signature
 from tests.benchmarks.factories import build_pages_tree
+from tests.support import file_router_config_entry
 
 
 if TYPE_CHECKING:
@@ -49,3 +52,18 @@ class TestBenchCollectRoutes:
             reloader._collect_routes()
 
         benchmark(run)
+
+
+class TestBenchWatchDirectories:
+    """The reloader asks for the watched page trees once a second."""
+
+    @pytest.mark.benchmark(group="server.autoreload")
+    def test_pages_directories_warm(self, tmp_path: Path, benchmark) -> None:
+        """The routers are held, so a tick pays the tree probes and nothing else."""
+        root = tmp_path / "shell"
+        root.mkdir()
+        with override_settings(
+            NEXT_FRAMEWORK={"PAGE_BACKENDS": [file_router_config_entry(pages_dir=root)]}
+        ):
+            get_pages_directories_for_watch()
+            benchmark(get_pages_directories_for_watch)

--- a/tests/benchmarks/static/test_bench_discovery.py
+++ b/tests/benchmarks/static/test_bench_discovery.py
@@ -8,7 +8,7 @@ from django.test import override_settings
 from next.static import AssetDiscovery, StaticCollector
 from next.static.discovery import PathResolver
 from tests.benchmarks.factories import build_layout_page
-from tests.support import RecordingStaticBackend, StaticAssetProvider, component_info
+from tests.support import PlainStaticBackend, StaticAssetProvider, component_info
 
 
 if TYPE_CHECKING:
@@ -25,7 +25,7 @@ def _discovery_for(tmp_path: Path, *, assets: bool) -> tuple[AssetDiscovery, Pat
         (page_file.parent / "template.js").write_text("/* js */")
         (tmp_path / "layout.css").write_text("body{}")
     discovery = AssetDiscovery(
-        StaticAssetProvider(RecordingStaticBackend(), (tmp_path.resolve(),))
+        StaticAssetProvider(PlainStaticBackend(), (tmp_path.resolve(),))
     )
     discovery.discover_page_assets(page_file, StaticCollector())
     return discovery, page_file
@@ -62,7 +62,7 @@ def _component_for(tmp_path: Path) -> tuple[AssetDiscovery, ComponentInfo]:
     (comp_dir / "component.js").write_text("/* widget */")
     info = component_info(comp_dir, template="<div>widget</div>")
     discovery = AssetDiscovery(
-        StaticAssetProvider(RecordingStaticBackend(), (tmp_path.resolve(),))
+        StaticAssetProvider(PlainStaticBackend(), (tmp_path.resolve(),))
     )
     discovery.discover_component_assets(info, StaticCollector())
     return discovery, info

--- a/tests/benchmarks/static/test_bench_discovery.py
+++ b/tests/benchmarks/static/test_bench_discovery.py
@@ -5,42 +5,16 @@ from typing import TYPE_CHECKING
 import pytest
 from django.test import override_settings
 
-from next.static import AssetDiscovery, StaticCollector, StaticFilesBackend
-from next.static.assets import default_kinds
+from next.static import AssetDiscovery, StaticCollector
 from next.static.discovery import PathResolver
 from tests.benchmarks.factories import build_layout_page
+from tests.support import RecordingStaticBackend, StaticAssetProvider, component_info
 
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from next.static import StaticBackend
-
-
-class _StubBackend(StaticFilesBackend):
-    """Backend with deterministic URLs, so a run times discovery and nothing else."""
-
-    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
-        """Return the URL the logical name and kind spell out."""
-        del source_path
-        return f"/static/next/{logical_name}{default_kinds.extension(kind)}"
-
-
-class _Provider:
-    """The narrow provider `AssetDiscovery` reads, holding resolved roots."""
-
-    def __init__(self, backend: StaticBackend, roots: tuple[Path, ...]) -> None:
-        self._backend = backend
-        self._roots = roots
-
-    @property
-    def default_backend(self) -> StaticBackend:
-        """Return the backend every registration goes through."""
-        return self._backend
-
-    def page_roots(self) -> tuple[Path, ...]:
-        """Return the resolved page trees the discovery walks within."""
-        return self._roots
+    from next.components import ComponentInfo
 
 
 def _discovery_for(tmp_path: Path, *, assets: bool) -> tuple[AssetDiscovery, Path]:
@@ -50,7 +24,9 @@ def _discovery_for(tmp_path: Path, *, assets: bool) -> tuple[AssetDiscovery, Pat
         (page_file.parent / "template.css").write_text("body{}")
         (page_file.parent / "template.js").write_text("/* js */")
         (tmp_path / "layout.css").write_text("body{}")
-    discovery = AssetDiscovery(_Provider(_StubBackend(), (tmp_path.resolve(),)))
+    discovery = AssetDiscovery(
+        StaticAssetProvider(RecordingStaticBackend(), (tmp_path.resolve(),))
+    )
     discovery.discover_page_assets(page_file, StaticCollector())
     return discovery, page_file
 
@@ -76,6 +52,47 @@ class TestBenchPageAssetDiscovery:
         with override_settings(DEBUG=True):
             discovery.discover_page_assets(page_file, StaticCollector())
             benchmark(discovery.discover_page_assets, page_file, StaticCollector())
+
+
+def _component_for(tmp_path: Path) -> tuple[AssetDiscovery, ComponentInfo]:
+    """Build a warm discovery over a composite component with both asset kinds."""
+    comp_dir = tmp_path / "_components" / "widget"
+    comp_dir.mkdir(parents=True)
+    (comp_dir / "component.css").write_text(".widget{}")
+    (comp_dir / "component.js").write_text("/* widget */")
+    info = component_info(comp_dir, template="<div>widget</div>")
+    discovery = AssetDiscovery(
+        StaticAssetProvider(RecordingStaticBackend(), (tmp_path.resolve(),))
+    )
+    discovery.discover_component_assets(info, StaticCollector())
+    return discovery, info
+
+
+class TestBenchComponentAssetDiscovery:
+    """Per-instance cost of `discover_component_assets`, paid by every tag render."""
+
+    @pytest.mark.benchmark(group="static.discovery")
+    def test_component_assets_warm(self, tmp_path: Path, benchmark) -> None:
+        discovery, info = _component_for(tmp_path)
+        benchmark(discovery.discover_component_assets, info, StaticCollector())
+
+    @pytest.mark.benchmark(group="static.discovery")
+    def test_component_assets_repeated_instance(
+        self, tmp_path: Path, benchmark
+    ) -> None:
+        """A second instance on the same page, sharing the request collector."""
+        discovery, info = _component_for(tmp_path)
+        collector = StaticCollector()
+        discovery.discover_component_assets(info, collector)
+        benchmark(discovery.discover_component_assets, info, collector)
+
+    @pytest.mark.benchmark(group="static.discovery")
+    def test_component_assets_warm_debug(self, tmp_path: Path, benchmark) -> None:
+        """The same component under `DEBUG`, where the plan stats its folder."""
+        discovery, info = _component_for(tmp_path)
+        with override_settings(DEBUG=True):
+            discovery.discover_component_assets(info, StaticCollector())
+            benchmark(discovery.discover_component_assets, info, StaticCollector())
 
 
 class TestBenchPathResolver:

--- a/tests/benchmarks/static/test_bench_pipeline.py
+++ b/tests/benchmarks/static/test_bench_pipeline.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from django.template import Context, Template
+from django.test import override_settings
+
+from next.static.collector import default_placeholders
+from next.static.manager import StaticManager
+from tests.benchmarks.factories import build_layout_page
+from tests.support import component_info, file_router_config_entry
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from next.components import ComponentInfo
+    from next.static.collector import StaticCollector
+
+
+_ASSET_COUNTS = (5, 20)
+_COLOCATED_ASSETS = 4
+_COMPONENT_INSTANCES = 50
+
+
+def _page_html() -> str:
+    tokens = {slot.name: slot.token for slot in default_placeholders}
+    return (
+        f"<html><head><title>Bench</title>{tokens['styles']}</head>"
+        f"<body><main>row</main>{tokens['scripts']}</body></html>"
+    )
+
+
+def _module_lists(count: int) -> str:
+    """Return the `styles` and `scripts` declarations sharing `count` module URLs."""
+    styles = [f"/static/bench_{i}.css" for i in range((count + 1) // 2)]
+    scripts = [f"/static/bench_{i}.js" for i in range(count // 2)]
+    return f"styles = {styles!r}\nscripts = {scripts!r}\n"
+
+
+def _write_role_files(directory: Path, stem: str) -> None:
+    (directory / f"{stem}.css").write_text("body{}")
+    (directory / f"{stem}.js").write_text("/* js */")
+
+
+def _build_pipeline_page(root: Path, assets: int) -> Path:
+    """Write a page under one layout carrying `assets` assets in total."""
+    page_file = build_layout_page(
+        root,
+        layouts=1,
+        template="<h1>x</h1>",
+        page_body=_module_lists(assets - _COLOCATED_ASSETS),
+    )
+    _write_role_files(root, "layout")
+    _write_role_files(page_file.parent, "template")
+    return page_file
+
+
+def _build_pipeline_component(root: Path) -> ComponentInfo:
+    """Write a composite component with both co-located asset kinds."""
+    component_dir = root / "_components" / "widget"
+    component_dir.mkdir(parents=True)
+    _write_role_files(component_dir, "component")
+    return component_info(component_dir, template="<div>widget</div>")
+
+
+def _vanilla_template(assets: int) -> Template:
+    """Return a vanilla Django template naming `assets` files through `static`."""
+    tags = "".join(
+        f'<link rel="stylesheet" href="{{% static \'bench_{i}.css\' %}}">'
+        for i in range(assets)
+    )
+    return Template("{% load static %}" + tags)
+
+
+class TestBenchStaticPipeline:
+    """The whole per-request static path, from discovery to the injected HTML."""
+
+    @pytest.mark.parametrize("assets", _ASSET_COUNTS, ids=["n5", "n20"])
+    @pytest.mark.benchmark(group="static.pipeline")
+    def test_page_pipeline(self, tmp_path: Path, assets: int, benchmark) -> None:
+        """Collector, page discovery and injection, the shape a page GET walks."""
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "PAGE_BACKENDS": [file_router_config_entry(pages_dir=tmp_path)]
+            }
+        ):
+            page_file = _build_pipeline_page(tmp_path, assets)
+            manager = StaticManager()
+            html = _page_html()
+
+            def run() -> str:
+                collector = manager.create_collector()
+                manager.discover_page_assets(page_file, collector)
+                return manager.inject(html, collector)
+
+            run()
+            benchmark(run)
+
+    @pytest.mark.benchmark(group="static.pipeline")
+    def test_page_pipeline_with_component_instances(
+        self, tmp_path: Path, benchmark
+    ) -> None:
+        """One page mounting the same component fifty times, on one collector."""
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "PAGE_BACKENDS": [file_router_config_entry(pages_dir=tmp_path)]
+            }
+        ):
+            page_file = _build_pipeline_page(tmp_path, _ASSET_COUNTS[0])
+            info = _build_pipeline_component(tmp_path)
+            manager = StaticManager()
+            html = _page_html()
+
+            def run() -> str:
+                collector: StaticCollector = manager.create_collector()
+                manager.discover_page_assets(page_file, collector)
+                for _instance in range(_COMPONENT_INSTANCES):
+                    manager.discover_component_assets(info, collector)
+                return manager.inject(html, collector)
+
+            run()
+            benchmark(run)
+
+    @pytest.mark.parametrize("assets", _ASSET_COUNTS, ids=["n5", "n20"])
+    @pytest.mark.benchmark(group="static.pipeline")
+    def test_vanilla_static_tags(self, assets: int, benchmark) -> None:
+        """Reference line, a vanilla template naming the same number of files."""
+        template = _vanilla_template(assets)
+        context = Context()
+        template.render(context)
+        benchmark(template.render, context)

--- a/tests/components/test_tags.py
+++ b/tests/components/test_tags.py
@@ -12,7 +12,8 @@ from django.utils.safestring import SafeString
 from next.components import ComponentInfo, components_manager
 from next.static import StaticCollector
 from next.templatetags import components as component_tags
-from next.templatetags.components import ComponentNode, _resolve_template_path
+from next.templatetags.components import ComponentNode
+from next.utils import forget_resolved_trees
 from tests.support import record_path_calls
 
 
@@ -1011,7 +1012,7 @@ class TestComponentMissReporting:
 
 
 class TestComponentNodePathCache:
-    """Tests for the process-wide ``current_template_path`` resolve memo."""
+    """Tests for the shared page-tree memo the tag resolves its path through."""
 
     def _node(self) -> ComponentNode:
         t = Template('{% load components %}{% component "card" %}')
@@ -1030,7 +1031,7 @@ class TestComponentNodePathCache:
         node = self._node()
         raw, expected = self._noncanonical(tmp_path, "scope")
         ctx = Context({"current_template_path": raw})
-        _resolve_template_path.cache_clear()
+        forget_resolved_trees()
         seen = record_path_calls(monkeypatch, "resolve")
         first = node._template_path_from_context(ctx)
         second = node._template_path_from_context(ctx)
@@ -1045,7 +1046,7 @@ class TestComponentNodePathCache:
         node = self._node()
         raw_a, expected_a = self._noncanonical(tmp_path, "scope_a")
         raw_b, expected_b = self._noncanonical(tmp_path, "scope_b")
-        _resolve_template_path.cache_clear()
+        forget_resolved_trees()
         seen = record_path_calls(monkeypatch, "resolve")
         first = node._template_path_from_context(
             Context({"current_template_path": raw_a})
@@ -1064,7 +1065,7 @@ class TestComponentNodePathCache:
         node = self._node()
         cases = [self._noncanonical(tmp_path, f"scope{i}") for i in range(20)]
         contexts = [Context({"current_template_path": raw}) for raw, _ in cases]
-        _resolve_template_path.cache_clear()
+        forget_resolved_trees()
         seen = record_path_calls(monkeypatch, "resolve")
         for _ in range(3):
             for ctx, (_raw, expected) in zip(contexts, cases, strict=True):
@@ -1077,11 +1078,39 @@ class TestComponentNodePathCache:
         """A path one node resolved costs a second node nothing."""
         raw, expected = self._noncanonical(tmp_path, "scope")
         ctx = Context({"current_template_path": raw})
-        _resolve_template_path.cache_clear()
+        forget_resolved_trees()
         seen = record_path_calls(monkeypatch, "resolve")
         assert self._node()._template_path_from_context(ctx) == expected
         assert self._node()._template_path_from_context(ctx) == expected
         assert len(seen) == 1
+
+    def test_the_tag_keeps_its_memo_keyed_by_the_raw_string(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The node carries a string, so building a path per read is what the memo saves."""
+        node = self._node()
+        raw, expected = self._noncanonical(tmp_path, "shared")
+        ctx = Context({"current_template_path": raw})
+        forget_resolved_trees()
+        assert node._template_path_from_context(ctx) == expected
+        seen = record_path_calls(monkeypatch, "resolve")
+
+        assert node._template_path_from_context(ctx) == expected
+        assert seen == []
+
+    def test_forgetting_the_trees_makes_the_tag_resolve_again(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A reconfigure invalidates this resolution along with every other."""
+        node = self._node()
+        raw, expected = self._noncanonical(tmp_path, "scope")
+        ctx = Context({"current_template_path": raw})
+        forget_resolved_trees()
+        seen = record_path_calls(monkeypatch, "resolve")
+        assert node._template_path_from_context(ctx) == expected
+        forget_resolved_trees()
+        assert node._template_path_from_context(ctx) == expected
+        assert len(seen) == 2
 
     def test_path_value_is_taken_as_resolved(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/pages/test_loaders.py
+++ b/tests/pages/test_loaders.py
@@ -21,6 +21,7 @@ from next.pages.loaders import (
     _load_python_module_memo,
     _page_roots,
     build_registered_loaders,
+    forget_page_roots,
     has_load_errors,
     last_load_error,
     read_module_string_lists,
@@ -710,6 +711,28 @@ class TestLayoutTemplateLoader:
 
         with override_settings(INSTALLED_APPS=["django.contrib.contenttypes"]):
             assert loaders_module._PAGE_ROOTS_CACHE["value"] is None
+
+    def test_forgetting_the_page_roots_asks_the_routers_again(self, tmp_path) -> None:
+        """A reload from code moves what the routers report, memo and all."""
+        first = tmp_path / "one"
+        second = tmp_path / "two"
+        forget_page_roots()
+        try:
+            with patch.object(
+                loaders_module, "get_pages_directories_for_watch", return_value=[first]
+            ):
+                assert _page_roots() == (first,)
+            with patch.object(
+                loaders_module,
+                "get_pages_directories_for_watch",
+                return_value=[first, second],
+            ):
+                assert _page_roots() == (first,)
+                forget_page_roots()
+
+                assert _page_roots() == (first, second)
+        finally:
+            forget_page_roots()
 
     @pytest.mark.parametrize(
         "layouts",
@@ -1496,3 +1519,64 @@ class TestPageModuleImportErrors:
         assert isinstance(second, PageModuleImportError)
         assert first is not second
         assert first.__cause__ is second.__cause__
+
+
+class TestTheModuleMemoIsBounded:
+    """Every entry holds a whole executed module alive, so the memo has a bound."""
+
+    def _write_pages(self, tmp_path: Path, names: tuple[str, ...]) -> list[Path]:
+        """Write one importable `page.py` per name and return their paths."""
+        pages: list[Path] = []
+        for name in names:
+            page_dir = tmp_path / name
+            page_dir.mkdir()
+            page_file = page_dir / "page.py"
+            page_file.write_text(f'template = "{name}"\n')
+            pages.append(page_file)
+        return pages
+
+    def test_a_new_page_past_the_bound_drops_the_stalest(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A project with more pages than the bound holds the ones it just read."""
+        monkeypatch.setattr(loaders_module, "_MODULE_MEMO_MAX_SIZE", 2)
+        reset_module_memo()
+        pages = self._write_pages(tmp_path, ("first", "second", "third"))
+
+        for page_file in pages:
+            assert _load_python_module_memo(page_file) is not None
+
+        assert list(loaders_module._MODULE_MEMO) == pages[1:]
+
+    def test_a_warm_read_neither_executes_nor_writes(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A hit answers from the memo, so the entries keep the order they landed in."""
+        monkeypatch.setattr(loaders_module, "_MODULE_MEMO_MAX_SIZE", 2)
+        reset_module_memo()
+        first, second = self._write_pages(tmp_path, ("first", "second"))
+        _load_python_module_memo(first)
+        _load_python_module_memo(second)
+        executed: list[Path] = []
+        loaded = loaders_module._load_python_module
+
+        def counting(file_path: Path):
+            executed.append(file_path)
+            return loaded(file_path)
+
+        monkeypatch.setattr(loaders_module, "_load_python_module", counting)
+
+        assert _load_python_module_memo(first) is not None
+        assert executed == []
+        assert list(loaders_module._MODULE_MEMO) == [first, second]
+
+    def test_a_file_that_does_not_stat_leaves_no_entry(self, tmp_path) -> None:
+        """A page that vanished is loaded from disk again rather than memoised."""
+        reset_module_memo()
+        page_file = tmp_path / "page.py"
+        page_file.write_text('template = "gone soon"\n')
+        assert _load_python_module_memo(page_file) is not None
+        page_file.unlink()
+
+        assert _load_python_module_memo(page_file) is None
+        assert page_file not in loaders_module._MODULE_MEMO

--- a/tests/pages/test_paths.py
+++ b/tests/pages/test_paths.py
@@ -1,11 +1,7 @@
 from pathlib import Path
 
-from next.pages.paths import (
-    _MAX_ANCESTOR_WALK_DEPTH,
-    clear_page_path_info,
-    forget_page_path_info,
-    page_path_info,
-)
+from next.pages.paths import clear_page_path_info, forget_page_path_info, page_path_info
+from next.utils import MAX_ANCESTOR_WALK_DEPTH
 
 
 class TestPagePathInfo:
@@ -60,12 +56,12 @@ class TestPagePathInfo:
     def test_the_chain_is_bounded_by_the_walk_depth(self, tmp_path) -> None:
         """A tree deeper than the cap contributes no more than the cap."""
         deep = tmp_path
-        for i in range(_MAX_ANCESTOR_WALK_DEPTH + 6):
+        for i in range(MAX_ANCESTOR_WALK_DEPTH + 6):
             deep = deep / f"d{i}"
             deep.mkdir()
 
         assert (
-            len(page_path_info(deep / "page.py").ancestors) == _MAX_ANCESTOR_WALK_DEPTH
+            len(page_path_info(deep / "page.py").ancestors) == MAX_ANCESTOR_WALK_DEPTH
         )
 
 

--- a/tests/pages/test_registry.py
+++ b/tests/pages/test_registry.py
@@ -175,7 +175,7 @@ class TestPageContextRegistry:
     def test_collect_inherited_context_bounded_depth(
         self, context_manager, tmp_path
     ) -> None:
-        """The ancestor walk is bounded by `_MAX_ANCESTOR_WALK_DEPTH`.
+        """The ancestor walk is bounded by `MAX_ANCESTOR_WALK_DEPTH`.
 
         This test fabricates a 70-level deep tree, past the 64 cap,
         and asserts the call returns in bounded time with an empty

--- a/tests/pages/test_watch.py
+++ b/tests/pages/test_watch.py
@@ -7,7 +7,6 @@ import pytest
 from django.test import override_settings
 
 from next.checks.common import get_page_roots
-from next.pages import watch
 from next.pages.registry import (
     get_layout_djx_paths_for_watch,
     get_template_djx_paths_for_watch,
@@ -17,7 +16,8 @@ from next.pages.watch import (
     iter_page_backends_for_watch,
     iter_pages_roots_with_components_folder_names,
 )
-from next.urls import RouterFactory
+from next.urls import RouterFactory, router_manager
+from next.utils import _RESOLVED_TREES_MAX_SIZE, resolved_tree
 from tests.support import (
     MalformedRootsRouter,
     OddComponentsNameRouter,
@@ -28,6 +28,10 @@ from tests.support import (
     importable_dir,
 )
 from tests.support.cases import WATCHED_BACKENDS_CASES, WatchedBackendsCase
+
+
+# The promise every watcher diagnostic ends on, which a reload then keeps.
+_RECONFIGURE_PROMISE = "until the framework is reconfigured."
 
 
 def _write_app(root: Path, name: str) -> Path:
@@ -171,6 +175,8 @@ class TestIterPageBackendsForWatch:
             assert list(iter_page_backends_for_watch()) == []
 
         assert len(_watch_tracebacks(caplog)) == 2
+        for record in _watch_tracebacks(caplog):
+            assert record.getMessage().endswith(_RECONFIGURE_PROMISE)
 
 
 class TestWatchedRootsFollowThePageRoots:
@@ -330,6 +336,7 @@ class TestRouterFailuresNeverReachTheWatcher:
         # type rather than as a raise, and carries no traceback.
         assert _watch_tracebacks(caplog) == []
         assert "of the wrong type" in caplog.records[0].getMessage()
+        assert caplog.records[0].getMessage().endswith(_RECONFIGURE_PROMISE)
 
     def test_a_malformed_components_folder_name_costs_only_its_pairs(
         self, tmp_path, caplog
@@ -372,6 +379,7 @@ class TestRouterFailuresNeverReachTheWatcher:
                 get_pages_directories_for_watch()
 
         assert len(_watch_tracebacks(caplog)) == 1
+        assert _watch_tracebacks(caplog)[0].getMessage().endswith(_RECONFIGURE_PROMISE)
 
     def test_a_settings_reload_lets_the_failure_be_reported_again(
         self, tmp_path, caplog
@@ -473,7 +481,7 @@ def _watched_backends(case: WatchedBackendsCase, tmp_path: Path) -> list[object]
 
 
 class TestTheRoutersOutliveOneTick:
-    """The reloader reads this once a second, so the routers are built rarely."""
+    """Off `DEBUG` the reloader reads held routers, so they are built rarely."""
 
     def test_a_second_read_builds_no_router_again(self, tmp_path) -> None:
         """Two reads of one configuration go through one construction."""
@@ -481,7 +489,7 @@ class TestTheRoutersOutliveOneTick:
         root.mkdir()
         entry = file_router_config_entry(pages_dir=root)
         with (
-            override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}),
+            override_settings(DEBUG=False, NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}),
             patch.object(
                 RouterFactory, "create_backend", wraps=RouterFactory.create_backend
             ) as build,
@@ -515,38 +523,35 @@ class TestTheRoutersOutliveOneTick:
         assert first == [first_root.resolve()]
         assert second == [second_root.resolve()]
 
-    def test_the_resolution_memo_stays_bounded(self, tmp_path, monkeypatch) -> None:
+    def test_the_resolution_memo_stays_bounded(self, tmp_path) -> None:
         """A router free to report a new tree per tick cannot grow the memo."""
         first_root = tmp_path / "one"
         first_root.mkdir()
         second_root = tmp_path / "two"
         second_root.mkdir()
-        monkeypatch.setattr(watch, "_RESOLVED_ROOTS_MAX_SIZE", 1)
         entry = file_router_config_entry(pages_dir=first_root, dirs=[second_root])
 
         with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}):
             watched = get_pages_directories_for_watch()
+            info = resolved_tree.cache_info()
 
-            assert watched == [first_root.resolve(), second_root.resolve()]
-            assert len(watch._resolved_roots) == 1
+        assert watched == [first_root.resolve(), second_root.resolve()]
+        assert info.maxsize == _RESOLVED_TREES_MAX_SIZE
+        assert info.currsize == 2
 
-    def test_the_resolution_memo_evicts_only_the_stalest_tree(
-        self, tmp_path, monkeypatch
-    ) -> None:
-        """Overflowing the memo costs one resolution, not every held one."""
-        roots = []
-        for name in ("one", "two", "three"):
-            root = tmp_path / name
-            root.mkdir()
-            roots.append(root)
-        monkeypatch.setattr(watch, "_RESOLVED_ROOTS_MAX_SIZE", 2)
-        entry = file_router_config_entry(pages_dir=roots[0], dirs=roots[1:])
+    def test_a_repeated_tree_costs_one_resolution(self, tmp_path) -> None:
+        """The steady set of a project is resolved once, however often it is read."""
+        root = tmp_path / "one"
+        root.mkdir()
+        entry = file_router_config_entry(pages_dir=root)
 
-        with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}):
-            watched = get_pages_directories_for_watch()
+        with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry, dict(entry)]}):
+            get_pages_directories_for_watch()
+            get_pages_directories_for_watch()
+            info = resolved_tree.cache_info()
 
-            assert len(watched) == 3
-            assert list(watch._resolved_roots.values()) == watched[1:]
+        assert info.misses == 1
+        assert info.currsize == 1
 
     def test_a_new_base_dir_is_read_without_a_settings_reload(self, tmp_path) -> None:
         """A relative `DIRS` entry follows `BASE_DIR`, whose change reloads nothing.
@@ -560,17 +565,40 @@ class TestTheRoutersOutliveOneTick:
         (second_base / "site").mkdir(parents=True)
 
         with override_settings(
-            NEXT_FRAMEWORK={"PAGE_BACKENDS": [file_router_config_entry(dirs=["site"])]}
+            DEBUG=False,
+            NEXT_FRAMEWORK={"PAGE_BACKENDS": [file_router_config_entry(dirs=["site"])]},
         ):
             with override_settings(BASE_DIR=first_base):
                 first = get_pages_directories_for_watch()
             with override_settings(BASE_DIR=second_base):
                 second = get_pages_directories_for_watch()
-                resolutions = list(watch._resolved_roots.values())
+                # The resolutions outlive the routers, because only a
+                # reconfigure can re-point a tree one of them names.
+                held = resolved_tree.cache_info().currsize
 
         assert first == [(first_base / "site").resolve()]
         assert second == [(second_base / "site").resolve()]
-        assert resolutions == second
+        assert held == 2
+
+    def test_a_router_reload_rebuilds_the_held_routers(self, tmp_path) -> None:
+        """A reload from code replaces the routers the URL resolver serves."""
+        root = tmp_path / "shell"
+        root.mkdir()
+        entry = file_router_config_entry(pages_dir=root)
+
+        with (
+            override_settings(DEBUG=False, NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}),
+            patch.object(
+                RouterFactory, "create_backend", wraps=RouterFactory.create_backend
+            ) as build,
+        ):
+            get_pages_directories_for_watch()
+            router_manager.reload()
+            reloaded = build.call_count
+            watched = get_pages_directories_for_watch()
+
+            assert build.call_count == reloaded + 1
+        assert watched == [root.resolve()]
 
     @pytest.mark.parametrize("case", WATCHED_BACKENDS_CASES, ids=lambda case: case.id)
     def test_the_memo_answers_what_a_rebuild_answers(self, tmp_path, case) -> None:
@@ -582,14 +610,109 @@ class TestTheRoutersOutliveOneTick:
         backends = _watched_backends(case, tmp_path)
         settings_value = {"PAGE_BACKENDS": backends}
 
-        with override_settings(BASE_DIR=tmp_path, NEXT_FRAMEWORK=settings_value):
+        with override_settings(
+            BASE_DIR=tmp_path, DEBUG=False, NEXT_FRAMEWORK=settings_value
+        ):
             held = get_pages_directories_for_watch()
             held_again = get_pages_directories_for_watch()
-        with override_settings(BASE_DIR=tmp_path, NEXT_FRAMEWORK=settings_value):
+        with override_settings(
+            BASE_DIR=tmp_path, DEBUG=False, NEXT_FRAMEWORK=settings_value
+        ):
             rebuilt = get_pages_directories_for_watch()
 
         assert held == held_again
         assert held == rebuilt
+
+
+class TestAWatchingProcessHoldsNoRouter:
+    """Under `DEBUG` a router answers about trees it probed once, so none is held.
+
+    A page tree created, moved, or removed under the development server has to
+    reach the very next read, whichever of the three shapes names it.
+    """
+
+    def test_every_read_builds_the_routers_again(self, tmp_path) -> None:
+        """Two reads of one configuration go through two constructions."""
+        root = tmp_path / "shell"
+        root.mkdir()
+        entry = file_router_config_entry(pages_dir=root)
+        with (
+            override_settings(DEBUG=True, NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}),
+            patch.object(
+                RouterFactory, "create_backend", wraps=RouterFactory.create_backend
+            ) as build,
+        ):
+            first = get_pages_directories_for_watch()
+            second = get_pages_directories_for_watch()
+
+            assert build.call_count == 2
+        assert first == second == [root.resolve()]
+
+    def test_a_dirs_root_created_later_reaches_the_watcher(self, tmp_path) -> None:
+        """A `DIRS` entry that named a URL segment names a tree once one is there.
+
+        Nothing but a fresh classification can tell the two apart, so this is
+        the shape a router held across the change could never report.
+        """
+        entry = file_router_config_entry(dirs=["site"])
+
+        with override_settings(
+            BASE_DIR=tmp_path, DEBUG=True, NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}
+        ):
+            assert get_pages_directories_for_watch() == []
+
+            (tmp_path / "site").mkdir()
+            watched = get_pages_directories_for_watch()
+
+        assert watched == [(tmp_path / "site").resolve()]
+
+    def test_an_app_tree_created_later_reaches_the_watcher(self, tmp_path) -> None:
+        """A page tree an app grows under the dev server reaches the next read."""
+        app_dir = tmp_path / "shop"
+        app_dir.mkdir()
+        entry = file_router_config_entry(app_dirs=True)
+
+        with (
+            patch(
+                "next.urls.backends._installed_app_directories",
+                return_value={"shop": app_dir},
+            ),
+            override_settings(DEBUG=True, NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}),
+        ):
+            assert get_pages_directories_for_watch() == []
+
+            (app_dir / "pages").mkdir()
+            watched = get_pages_directories_for_watch()
+
+        assert watched == [(app_dir / "pages").resolve()]
+
+    def test_a_base_dir_tree_created_later_reaches_the_watcher(self, tmp_path) -> None:
+        """The `BASE_DIR` fallback is probed per read while the disk is watched."""
+        entry = file_router_config_entry(app_dirs=False)
+
+        with override_settings(
+            BASE_DIR=tmp_path, DEBUG=True, NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}
+        ):
+            assert get_pages_directories_for_watch() == []
+
+            (tmp_path / "pages").mkdir()
+            watched = get_pages_directories_for_watch()
+
+        assert watched == [(tmp_path / "pages").resolve()]
+
+    def test_a_tree_that_goes_away_leaves_the_watcher(self, tmp_path) -> None:
+        """A tree removed under the dev server stops being watched at once."""
+        root = tmp_path / "shell"
+        root.mkdir()
+        entry = file_router_config_entry(pages_dir=root)
+
+        with override_settings(DEBUG=True, NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}):
+            assert get_pages_directories_for_watch() == [root.resolve()]
+
+            root.rmdir()
+            watched = get_pages_directories_for_watch()
+
+        assert watched == []
 
 
 class TestABrokenEntryIsBuiltAgain:
@@ -612,7 +735,7 @@ class TestABrokenEntryIsBuiltAgain:
             return build(config)
 
         with (
-            override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}),
+            override_settings(DEBUG=False, NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}),
             patch.object(RouterFactory, "create_backend", side_effect=failing_first),
             caplog.at_level(logging.ERROR, logger="next.pages.watch"),
         ):
@@ -629,7 +752,8 @@ class TestABrokenEntryIsBuiltAgain:
         """The rebuild a new base directory forces reports what it drops again."""
         with (
             override_settings(
-                NEXT_FRAMEWORK={"PAGE_BACKENDS": [{"BACKEND": "nonexistent.Backend"}]}
+                DEBUG=False,
+                NEXT_FRAMEWORK={"PAGE_BACKENDS": [{"BACKEND": "nonexistent.Backend"}]},
             ),
             caplog.at_level(logging.ERROR, logger="next.pages.watch"),
         ):

--- a/tests/pages/test_watch.py
+++ b/tests/pages/test_watch.py
@@ -3,9 +3,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import pytest
 from django.test import override_settings
 
 from next.checks.common import get_page_roots
+from next.pages import watch
 from next.pages.registry import (
     get_layout_djx_paths_for_watch,
     get_template_djx_paths_for_watch,
@@ -25,6 +27,7 @@ from tests.support import (
     file_router_config_entry,
     importable_dir,
 )
+from tests.support.cases import WATCHED_BACKENDS_CASES, WatchedBackendsCase
 
 
 def _write_app(root: Path, name: str) -> Path:
@@ -450,3 +453,190 @@ class TestIterPagesRootsWithComponentsFolderNames:
         """Non-dict entries name no backend and produce no pair."""
         with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": ["not a dict"]}):
             assert iter_pages_roots_with_components_folder_names() == []
+
+
+def _watched_backends(case: WatchedBackendsCase, tmp_path: Path) -> list[object]:
+    """Return the `PAGE_BACKENDS` value one case spells out under `tmp_path`."""
+    existing = tmp_path / "existing"
+    existing.mkdir(exist_ok=True)
+    (tmp_path / "shop").mkdir(exist_ok=True)
+    entries: dict[str, object] = {
+        "not_a_dict": "not a dict",
+        "unimportable": {"BACKEND": "nonexistent.Backend"},
+        "existing": file_router_config_entry(pages_dir=existing),
+        "missing": file_router_config_entry(pages_dir=tmp_path / "missing"),
+        "app_dirs": file_router_config_entry(app_dirs=True),
+        "skipping": file_router_config_entry(pages_dir=existing, dirs=["_drafts"]),
+        "extra_root": file_router_config_entry(pages_dir=existing, dirs=["shop"]),
+    }
+    return [entries[name] for name in case.entries]
+
+
+class TestTheRoutersOutliveOneTick:
+    """The reloader reads this once a second, so the routers are built rarely."""
+
+    def test_a_second_read_builds_no_router_again(self, tmp_path) -> None:
+        """Two reads of one configuration go through one construction."""
+        root = tmp_path / "shell"
+        root.mkdir()
+        entry = file_router_config_entry(pages_dir=root)
+        with (
+            override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}),
+            patch.object(
+                RouterFactory, "create_backend", wraps=RouterFactory.create_backend
+            ) as build,
+        ):
+            first = get_pages_directories_for_watch()
+            second = get_pages_directories_for_watch()
+
+            assert build.call_count == 1
+        assert first == second == [root.resolve()]
+
+    def test_a_settings_reload_builds_the_routers_again(self, tmp_path) -> None:
+        """A reconfigured project is read from its new routers, not the old ones."""
+        first_root = tmp_path / "one"
+        first_root.mkdir()
+        second_root = tmp_path / "two"
+        second_root.mkdir()
+
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "PAGE_BACKENDS": [file_router_config_entry(pages_dir=first_root)]
+            }
+        ):
+            first = get_pages_directories_for_watch()
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "PAGE_BACKENDS": [file_router_config_entry(pages_dir=second_root)]
+            }
+        ):
+            second = get_pages_directories_for_watch()
+
+        assert first == [first_root.resolve()]
+        assert second == [second_root.resolve()]
+
+    def test_the_resolution_memo_stays_bounded(self, tmp_path, monkeypatch) -> None:
+        """A router free to report a new tree per tick cannot grow the memo."""
+        first_root = tmp_path / "one"
+        first_root.mkdir()
+        second_root = tmp_path / "two"
+        second_root.mkdir()
+        monkeypatch.setattr(watch, "_RESOLVED_ROOTS_MAX_SIZE", 1)
+        entry = file_router_config_entry(pages_dir=first_root, dirs=[second_root])
+
+        with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}):
+            watched = get_pages_directories_for_watch()
+
+            assert watched == [first_root.resolve(), second_root.resolve()]
+            assert len(watch._resolved_roots) == 1
+
+    def test_the_resolution_memo_evicts_only_the_stalest_tree(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Overflowing the memo costs one resolution, not every held one."""
+        roots = []
+        for name in ("one", "two", "three"):
+            root = tmp_path / name
+            root.mkdir()
+            roots.append(root)
+        monkeypatch.setattr(watch, "_RESOLVED_ROOTS_MAX_SIZE", 2)
+        entry = file_router_config_entry(pages_dir=roots[0], dirs=roots[1:])
+
+        with override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}):
+            watched = get_pages_directories_for_watch()
+
+            assert len(watched) == 3
+            assert list(watch._resolved_roots.values()) == watched[1:]
+
+    def test_a_new_base_dir_is_read_without_a_settings_reload(self, tmp_path) -> None:
+        """A relative `DIRS` entry follows `BASE_DIR`, whose change reloads nothing.
+
+        The routers read the base directory while they are built, so holding them
+        across a change to it alone would answer for the previous project root.
+        """
+        first_base = tmp_path / "a"
+        (first_base / "site").mkdir(parents=True)
+        second_base = tmp_path / "b"
+        (second_base / "site").mkdir(parents=True)
+
+        with override_settings(
+            NEXT_FRAMEWORK={"PAGE_BACKENDS": [file_router_config_entry(dirs=["site"])]}
+        ):
+            with override_settings(BASE_DIR=first_base):
+                first = get_pages_directories_for_watch()
+            with override_settings(BASE_DIR=second_base):
+                second = get_pages_directories_for_watch()
+                resolutions = list(watch._resolved_roots.values())
+
+        assert first == [(first_base / "site").resolve()]
+        assert second == [(second_base / "site").resolve()]
+        assert resolutions == second
+
+    @pytest.mark.parametrize("case", WATCHED_BACKENDS_CASES, ids=lambda case: case.id)
+    def test_the_memo_answers_what_a_rebuild_answers(self, tmp_path, case) -> None:
+        """Across the configured shapes, held routers read like rebuilt ones.
+
+        A settings reload is what drops the held routers, so the comparison is
+        against the answer routers built for a fresh generation give.
+        """
+        backends = _watched_backends(case, tmp_path)
+        settings_value = {"PAGE_BACKENDS": backends}
+
+        with override_settings(BASE_DIR=tmp_path, NEXT_FRAMEWORK=settings_value):
+            held = get_pages_directories_for_watch()
+            held_again = get_pages_directories_for_watch()
+        with override_settings(BASE_DIR=tmp_path, NEXT_FRAMEWORK=settings_value):
+            rebuilt = get_pages_directories_for_watch()
+
+        assert held == held_again
+        assert held == rebuilt
+
+
+class TestABrokenEntryIsBuiltAgain:
+    """A construction that failed once is no permanent hole in the watch list."""
+
+    def test_a_failed_build_is_tried_again_and_a_healthy_one_is_not(
+        self, tmp_path, caplog
+    ) -> None:
+        """These helpers run before every app is loaded, so a failure can pass."""
+        root = tmp_path / "shell"
+        root.mkdir()
+        entry = file_router_config_entry(pages_dir=root)
+        build = RouterFactory.create_backend
+        attempts: list[dict] = []
+
+        def failing_first(config: dict) -> object:
+            attempts.append(config)
+            if len(attempts) == 1:
+                raise ImportError(config["BACKEND"])
+            return build(config)
+
+        with (
+            override_settings(NEXT_FRAMEWORK={"PAGE_BACKENDS": [entry]}),
+            patch.object(RouterFactory, "create_backend", side_effect=failing_first),
+            caplog.at_level(logging.ERROR, logger="next.pages.watch"),
+        ):
+            first = get_pages_directories_for_watch()
+            second = get_pages_directories_for_watch()
+            third = get_pages_directories_for_watch()
+
+        assert first == []
+        assert second == third == [root.resolve()]
+        assert len(attempts) == 2
+        assert len(_watch_tracebacks(caplog)) == 1
+
+    def test_a_new_base_dir_diagnoses_the_failure_again(self, tmp_path, caplog) -> None:
+        """The rebuild a new base directory forces reports what it drops again."""
+        with (
+            override_settings(
+                NEXT_FRAMEWORK={"PAGE_BACKENDS": [{"BACKEND": "nonexistent.Backend"}]}
+            ),
+            caplog.at_level(logging.ERROR, logger="next.pages.watch"),
+        ):
+            with override_settings(BASE_DIR=tmp_path / "a"):
+                get_pages_directories_for_watch()
+                get_pages_directories_for_watch()
+            with override_settings(BASE_DIR=tmp_path / "b"):
+                get_pages_directories_for_watch()
+
+        assert len(_watch_tracebacks(caplog)) == 2

--- a/tests/server/test_autoreload.py
+++ b/tests/server/test_autoreload.py
@@ -4,10 +4,12 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.test import override_settings
 from django.utils.autoreload import StatReloader
 
 from next.server import NextStatReloader
 from next.server.autoreload import _tree_dir_signature
+from tests.support import file_router_config_entry
 
 
 def _paths_matched_by_reloader_globs(reloader: StatReloader) -> set[Path]:
@@ -180,3 +182,35 @@ class TestDjxNotInStatReloaderGlobMatches:
             next(gen)
 
         assert notified == []
+
+
+class TestTickReadsTheWatchedTrees:
+    """A real tick over the real watch helpers, whose routers outlive one tick."""
+
+    def test_a_page_created_between_ticks_notifies(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A page written under a watched tree restarts the server on the next tick."""
+        root = tmp_path / "shell"
+        root.mkdir()
+        reloader = NextStatReloader()
+        notified: list[Path] = []
+        monkeypatch.setattr(
+            reloader, "notify_file_changed", lambda p: notified.append(Path(p))
+        )
+
+        with (
+            override_settings(
+                NEXT_FRAMEWORK={
+                    "PAGE_BACKENDS": [file_router_config_entry(pages_dir=root)]
+                }
+            ),
+            patch.object(reloader, "snapshot_files", return_value=iter([])),
+        ):
+            gen = reloader.tick()
+            next(gen)
+            (root / "hello").mkdir()
+            (root / "hello" / "page.py").write_text("#")
+            next(gen)
+
+        assert notified == [(root / "hello" / "page.py").resolve()]

--- a/tests/server/test_roots.py
+++ b/tests/server/test_roots.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
 
 from next.server import get_framework_filesystem_roots_for_linking
 from tests.support.backends import file_components_entry
@@ -28,3 +29,14 @@ class TestFrameworkFilesystemRoots:
         assert get_framework_filesystem_roots_for_linking() == sorted(
             {first.resolve(), second.resolve()}
         )
+
+    def test_a_page_tree_is_taken_as_the_watch_layer_spells_it(
+        self, tmp_path: Path, apply_component_backends: Callable[[list[Any]], None]
+    ) -> None:
+        """The watch layer answers resolved, so a link root pays no second resolve."""
+        apply_component_backends([])
+        spelling = tmp_path / "site" / ".." / "site"
+        with patch(
+            "next.server.roots.get_pages_directories_for_watch", return_value=[spelling]
+        ):
+            assert get_framework_filesystem_roots_for_linking() == [spelling]

--- a/tests/static/conftest.py
+++ b/tests/static/conftest.py
@@ -6,7 +6,6 @@ import pytest
 
 from next.components import ComponentInfo
 from next.static import (
-    AssetDiscovery,
     StaticBackend,
     StaticCollector,
     StaticManager,
@@ -16,7 +15,7 @@ from tests.support import RecordingStaticBackend, component_info
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator
+    from collections.abc import Generator
     from pathlib import Path
 
 
@@ -71,19 +70,3 @@ def composite_component(tmp_path: Path) -> ComponentInfo:
     (comp_dir / "component.css").write_text(".widget {}")
     (comp_dir / "component.js").write_text("/* widget */")
     return component_info(comp_dir, module=module_path, template="<div>widget</div>")
-
-
-@pytest.fixture()
-def make_discovery() -> Callable[..., tuple[AssetDiscovery, StaticManager]]:
-    """Build an ``AssetDiscovery`` wired to a given backend and page roots."""
-
-    def _factory(
-        backend: StaticBackend, page_roots: tuple[Path, ...] = ()
-    ) -> tuple[AssetDiscovery, StaticManager]:
-        manager = StaticManager()
-        manager._backends = [backend]
-        manager._loaded = True
-        manager._cached_page_roots = page_roots
-        return AssetDiscovery(manager), manager
-
-    return _factory

--- a/tests/static/conftest.py
+++ b/tests/static/conftest.py
@@ -9,11 +9,10 @@ from next.static import (
     AssetDiscovery,
     StaticBackend,
     StaticCollector,
-    StaticFilesBackend,
     StaticManager,
-    default_kinds,
     reset_default_manager,
 )
+from tests.support import RecordingStaticBackend, component_info
 
 
 if TYPE_CHECKING:
@@ -23,13 +22,6 @@ if TYPE_CHECKING:
 
 CSS_URL = "https://example.com/a.css"
 JS_URL = "https://example.com/a.js"
-
-
-class DeterministicBackend(StaticFilesBackend):
-    """Backend with stable deterministic URLs for discovery-order tests."""
-
-    def register_file(self, _source_path: Path, logical_name: str, kind: str) -> str:
-        return f"/static/next/{logical_name}{default_kinds.extension(kind)}"
 
 
 @pytest.fixture()
@@ -44,7 +36,7 @@ def collector() -> StaticCollector:
 
 @pytest.fixture()
 def file_backend() -> StaticBackend:
-    return DeterministicBackend()
+    return RecordingStaticBackend()
 
 
 @pytest.fixture()
@@ -71,8 +63,6 @@ def simple_component(tmp_path: Path) -> ComponentInfo:
 def composite_component(tmp_path: Path) -> ComponentInfo:
     comp_dir = tmp_path / "_components" / "widget"
     comp_dir.mkdir(parents=True)
-    template_path = comp_dir / "component.djx"
-    template_path.write_text("<div>widget</div>")
     module_path = comp_dir / "component.py"
     module_path.write_text(
         'styles = ["https://cdn.example.com/extra.css"]\n'
@@ -80,14 +70,7 @@ def composite_component(tmp_path: Path) -> ComponentInfo:
     )
     (comp_dir / "component.css").write_text(".widget {}")
     (comp_dir / "component.js").write_text("/* widget */")
-    return ComponentInfo(
-        name="widget",
-        scope_root=tmp_path,
-        scope_relative="",
-        template_path=template_path,
-        module_path=module_path,
-        is_simple=False,
-    )
+    return component_info(comp_dir, module=module_path, template="<div>widget</div>")
 
 
 @pytest.fixture()

--- a/tests/static/test_collector.py
+++ b/tests/static/test_collector.py
@@ -69,6 +69,23 @@ class TestStaticCollectorDedup:
         collector.add(StaticAsset(url=CSS_URL, kind="css", source_path=Path("/a.css")))
         assert len(collector.assets_in_slot("styles")) == 1
 
+    def test_add_reports_whether_the_asset_landed(
+        self, collector: StaticCollector
+    ) -> None:
+        """A caller announcing an asset announces the one the collector kept."""
+        asset = StaticAsset(url=CSS_URL, kind="css")
+        assert collector.add(asset) is True
+        assert collector.add(asset) is False
+
+    def test_a_prepended_duplicate_reports_no_landing_either(
+        self, collector: StaticCollector
+    ) -> None:
+        """The dedup key decides before the bucket does, prepend or not."""
+        collector.add(StaticAsset(url=CSS_URL, kind="css"))
+        assert (
+            collector.add(StaticAsset(url=CSS_URL, kind="css"), prepend=True) is False
+        )
+
     def test_unregistered_kind_raises(self, collector: StaticCollector) -> None:
         with pytest.raises(KeyError, match="Unsupported asset kind"):
             collector.add(StaticAsset(url="weird://x", kind="weird"))

--- a/tests/static/test_discovery.py
+++ b/tests/static/test_discovery.py
@@ -2,55 +2,46 @@ from __future__ import annotations
 
 import os
 import shutil
+from collections import OrderedDict
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from django.test import override_settings
 
+from next.components import ComponentInfo
 from next.static import (
     AssetDiscovery,
     StaticCollector,
     StaticFilesBackend,
+    default_kinds,
     discovery as discovery_mod,
 )
+from next.static.collector import HashContentDedup
 from next.static.discovery import (
     BackendProvider,
     PathResolver,
     StemRegistry,
     default_stems,
 )
+from next.static.signals import asset_registered
 from next.urls import FileRouterBackend
+from tests.support import RecordingStaticBackend, StaticAssetProvider, component_info
 
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
     import pytest
 
-    from next.components import ComponentInfo
     from next.static import StaticBackend
-
-
-class _Provider:
-    """Concrete BackendProvider for tests."""
-
-    def __init__(self, backend: StaticBackend, roots: tuple[Path, ...]) -> None:
-        self._backend = backend
-        self._roots = roots
-
-    @property
-    def default_backend(self) -> StaticBackend:
-        return self._backend
-
-    def page_roots(self) -> tuple[Path, ...]:
-        return self._roots
+    from next.static.discovery import _AssetPlan
 
 
 class TestBackendProviderProtocol:
     """Any object with default_backend + page_roots satisfies the protocol."""
 
     def test_runtime_checkable(self, file_backend: StaticBackend) -> None:
-        provider = _Provider(file_backend, ())
+        provider = StaticAssetProvider(file_backend, ())
         assert isinstance(provider, BackendProvider)
 
     def test_non_conforming_object_fails(self) -> None:
@@ -168,7 +159,7 @@ class TestAssetDiscoveryPageTemplate:
         (tmp_path / "template.js").write_text("/* js */")
         page_path = tmp_path / "page.djx"
         page_path.write_text("")
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
 
         collector = StaticCollector()
@@ -184,7 +175,7 @@ class TestAssetDiscoveryPageTemplate:
     ) -> None:
         page_path = tmp_path / "page.djx"
         page_path.write_text("")
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
 
         collector = StaticCollector()
@@ -211,7 +202,7 @@ class TestAssetDiscoveryLayoutChain:
         page_path = page_dir / "page.djx"
         page_path.write_text("")
 
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
 
         collector = StaticCollector()
@@ -238,7 +229,7 @@ class TestAssetDiscoveryModuleLists:
             'scripts = ["https://cdn.example.com/x.js"]\n'
         )
 
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
 
         collector = StaticCollector()
@@ -258,7 +249,7 @@ class TestAssetDiscoveryModuleLists:
         page_path = page_dir / "page.py"
         page_path.write_text('styles = ["https://c.example/a.css"]\n')
 
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
 
         collector = StaticCollector()
@@ -272,14 +263,13 @@ class TestAssetDiscoveryModuleLists:
             "https://c.example/a.css"
         ]
 
-    def test_module_list_and_layout_caches_evict_oldest(
+    def test_module_list_cache_evicts_oldest(
         self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
     ) -> None:
-        """Both module-list and layout-dir caches drop the oldest key past the limit."""
+        """The module-list cache drops the oldest key past the limit."""
         monkeypatch.setattr(discovery_mod, "_MODULE_LIST_CACHE_MAX_SIZE", 1)
-        monkeypatch.setattr(discovery_mod, "_LAYOUT_DIR_CACHE_MAX_SIZE", 1)
 
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
         collector = StaticCollector()
 
@@ -301,16 +291,6 @@ class TestAssetDiscoveryModuleLists:
         # Oldest module-list key evicted after exceeding max size.
         assert len(discovery._module_list_cache) <= 1
 
-        # Layout-dir cache eviction runs once per page with layouts above it.
-        for i in range(3):
-            sub = tmp_path / f"layout_case_{i}"
-            sub.mkdir()
-            (sub / "layout.djx").write_text("<x/>")
-            page = sub / "page.py"
-            page.write_text("")
-            discovery._find_layout_directories(page.resolve(), tmp_path.resolve())
-        assert len(discovery._layout_dir_cache) <= 1
-
 
 class TestAssetDiscoveryPagePlanCache:
     """The per-page plan is walked once and re-probed only under `DEBUG`."""
@@ -328,7 +308,7 @@ class TestAssetDiscoveryPagePlanCache:
         self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
         page_path = self._page_with_layout(tmp_path)
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
         discovery.discover_page_assets(page_path, StaticCollector())
 
@@ -342,7 +322,7 @@ class TestAssetDiscoveryPagePlanCache:
         self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
         page_path = self._page_with_layout(tmp_path)
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
         with override_settings(DEBUG=True):
             discovery.discover_page_assets(page_path, StaticCollector())
@@ -362,7 +342,7 @@ class TestAssetDiscoveryPagePlanCache:
     ) -> None:
         page_path = self._page_with_layout(tmp_path)
         (page_path.parent / "template.css").write_text("body{}")
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
         with override_settings(DEBUG=True):
             discovery.discover_page_assets(page_path, StaticCollector())
@@ -377,7 +357,7 @@ class TestAssetDiscoveryPagePlanCache:
     ) -> None:
         page_path = self._page_with_layout(tmp_path)
         (page_path.parent / "template.css").write_text("body{}")
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
         with override_settings(DEBUG=True):
             discovery.discover_page_assets(page_path, StaticCollector())
@@ -395,7 +375,7 @@ class TestAssetDiscoveryPagePlanCache:
         self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
     ) -> None:
         monkeypatch.setattr(discovery_mod, "_PAGE_PLAN_CACHE_MAX_SIZE", 1)
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
         for i in range(2):
             page_dir = tmp_path / f"p_{i}"
@@ -404,6 +384,703 @@ class TestAssetDiscoveryPagePlanCache:
             page_path.write_text("")
             discovery.discover_page_assets(page_path, StaticCollector())
         assert len(discovery._page_plan_cache) <= 1
+
+    def test_a_warm_render_does_not_walk_the_disk_again(
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    ) -> None:
+        page_path = self._page_with_layout(tmp_path)
+        (page_path.parent / "template.css").write_text("body{}")
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+        discovery.discover_page_assets(page_path, StaticCollector())
+
+        builds: list[Path] = []
+        walk_disk = discovery._build_page_asset_plan
+
+        def _record(file_path: Path) -> _AssetPlan:
+            builds.append(file_path)
+            return walk_disk(file_path)
+
+        monkeypatch.setattr(discovery, "_build_page_asset_plan", _record)
+        collector = StaticCollector()
+        discovery.discover_page_assets(page_path, collector)
+        assert builds == []
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/section.css"
+        ]
+
+    def test_a_rebuilt_plan_becomes_the_freshest_entry(
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(discovery_mod, "_PAGE_PLAN_CACHE_MAX_SIZE", 2)
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+        pages: list[Path] = []
+        for name in ("first", "second", "third"):
+            page_dir = tmp_path / name
+            page_dir.mkdir()
+            page_path = page_dir / "page.djx"
+            page_path.write_text("")
+            pages.append(page_path)
+
+        with override_settings(DEBUG=True):
+            discovery.discover_page_assets(pages[0], StaticCollector())
+            discovery.discover_page_assets(pages[1], StaticCollector())
+            _bump(pages[0].parent)
+            discovery.discover_page_assets(pages[0], StaticCollector())
+            discovery.discover_page_assets(pages[2], StaticCollector())
+
+        assert list(discovery._page_plan_cache) == [pages[0], pages[2]]
+
+    def test_a_warm_hit_keeps_a_full_cache_in_use_order(
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(discovery_mod, "_PAGE_PLAN_CACHE_MAX_SIZE", 2)
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+        pages: list[Path] = []
+        for name in ("first", "second", "third"):
+            page_dir = tmp_path / name
+            page_dir.mkdir()
+            page_path = page_dir / "page.djx"
+            page_path.write_text("")
+            pages.append(page_path)
+
+        discovery.discover_page_assets(pages[0], StaticCollector())
+        discovery.discover_page_assets(pages[1], StaticCollector())
+        discovery.discover_page_assets(pages[0], StaticCollector())
+        discovery.discover_page_assets(pages[2], StaticCollector())
+
+        assert list(discovery._page_plan_cache) == [pages[0], pages[2]]
+
+    def test_a_nested_render_cannot_push_the_cache_past_its_limit(
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(discovery_mod, "_PAGE_PLAN_CACHE_MAX_SIZE", 1)
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+        pages: list[Path] = []
+        for name in ("outer", "inner"):
+            page_dir = tmp_path / name
+            page_dir.mkdir()
+            (page_dir / "template.css").write_text("body{}")
+            page_path = page_dir / "page.djx"
+            page_path.write_text("")
+            pages.append(page_path)
+        nested: list[int] = []
+
+        def render_the_other_page(sender, **kwargs) -> None:
+            if not nested:
+                nested.append(1)
+                discovery.discover_page_assets(pages[1], StaticCollector())
+
+        asset_registered.connect(render_the_other_page)
+        try:
+            discovery.discover_page_assets(pages[0], StaticCollector())
+        finally:
+            asset_registered.disconnect(render_the_other_page)
+
+        assert nested == [1]
+        assert len(discovery._page_plan_cache) == 1
+
+
+class TestAssetDiscoveryWatchedDirectories:
+    """A plan watches the directories it read, and stats them before reading."""
+
+    @staticmethod
+    def _watched(discovery: AssetDiscovery, page_path: Path) -> list[Path]:
+        plan = discovery._page_plan_cache[page_path]
+        return [directory for directory, _ in plan.directory_mtimes]
+
+    def test_a_page_outside_every_tree_watches_only_its_own_directory(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        page_dir = tmp_path / "a" / "b" / "c"
+        page_dir.mkdir(parents=True)
+        page_path = page_dir / "page.djx"
+        page_path.write_text("")
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        discovery.discover_page_assets(page_path, StaticCollector())
+        assert self._watched(discovery, page_path) == [page_dir]
+
+    def test_a_layout_above_an_untracked_page_is_watched(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        holder = tmp_path / "holder"
+        page_dir = holder / "empty" / "leaf"
+        page_dir.mkdir(parents=True)
+        (holder / "layout.djx").write_text("")
+        page_path = page_dir / "page.djx"
+        page_path.write_text("")
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        discovery.discover_page_assets(page_path, StaticCollector())
+        assert self._watched(discovery, page_path) == [holder, page_dir]
+
+    def test_the_walk_stops_at_the_shared_ancestor_bound(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        current = tmp_path
+        levels: list[Path] = []
+        for depth in range(70):
+            current = current / f"d{depth}"
+            current.mkdir()
+            levels.append(current)
+        for depth in (5, 6):
+            (levels[depth] / "layout.djx").write_text("")
+            (levels[depth] / "layout.css").write_text("body{}")
+        page_path = levels[-1] / "page.djx"
+        page_path.write_text("")
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        collector = StaticCollector()
+        discovery.discover_page_assets(page_path, collector)
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/d6/layout.css"
+        ]
+
+    def test_a_file_written_during_the_walk_shows_up_on_the_next_render(
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    ) -> None:
+        page_dir = tmp_path / "section"
+        page_dir.mkdir()
+        page_path = page_dir / "page.djx"
+        page_path.write_text("")
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+        probe = discovery._find_role_files
+
+        def _write_while_reading(
+            directory: Path, *, logical_name: str, role: str
+        ) -> list[object]:
+            found = probe(directory, logical_name=logical_name, role=role)
+            (page_dir / "template.css").write_text("body{}")
+            return found
+
+        with override_settings(DEBUG=True):
+            monkeypatch.setattr(discovery, "_find_role_files", _write_while_reading)
+            discovery.discover_page_assets(page_path, StaticCollector())
+            monkeypatch.setattr(discovery, "_find_role_files", probe)
+            collector = StaticCollector()
+            discovery.discover_page_assets(page_path, collector)
+
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/section.css"
+        ]
+
+
+class _FailingBackend(StaticFilesBackend):
+    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
+        msg = "cannot resolve"
+        raise ValueError(msg)
+
+
+class _ManifestBackend(RecordingStaticBackend):
+    """Serves built URLs once a manifest lands, and the default URL until then.
+
+    Models the manifest-driven backend the how-to guide walks through, whose
+    answer changes the moment an asset build finishes under a running process.
+    """
+
+    def __init__(self, manifest: Path) -> None:
+        """Bind the manifest path re-checked on every registration."""
+        super().__init__()
+        self._manifest = manifest
+
+    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
+        """Return the built URL when the manifest exists, else the default one."""
+        if not self._manifest.exists():
+            return super().register_file(source_path, logical_name, kind)
+        self.calls.append((logical_name, kind))
+        return f"/build/{logical_name}{default_kinds.extension(kind)}"
+
+
+class _CssOnlyFailingBackend(RecordingStaticBackend):
+    """Rejects `css` and serves everything else, for the partial-failure case."""
+
+    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
+        if kind == "css":
+            msg = "cannot resolve"
+            raise ValueError(msg)
+        return super().register_file(source_path, logical_name, kind)
+
+
+def _probe_counter(discovery: AssetDiscovery, monkeypatch) -> list[Path]:
+    """Record every directory the stem probe reads."""
+    probes: list[Path] = []
+    walk_disk = discovery._find_role_files
+
+    def _record(directory: Path, *, logical_name: str, role: str) -> list[object]:
+        probes.append(directory)
+        return walk_disk(directory, logical_name=logical_name, role=role)
+
+    monkeypatch.setattr(discovery, "_find_role_files", _record)
+    return probes
+
+
+def _module_list_counter(discovery: AssetDiscovery, monkeypatch) -> list[Path]:
+    """Record every module the `styles` and `scripts` reader is pointed at."""
+    reads: list[Path] = []
+    read_lists = discovery._module_lists
+
+    def _record(module_path: Path) -> dict[str, list[str]]:
+        reads.append(module_path)
+        return read_lists(module_path)
+
+    monkeypatch.setattr(discovery, "_module_lists", _record)
+    return reads
+
+
+def _asset_fields(collector: StaticCollector) -> list[tuple[str, str, str, str | None]]:
+    """Return every collected asset as a comparable tuple, in slot order."""
+    return [
+        (slot, a.url, a.kind, str(a.source_path) if a.source_path else None)
+        for slot in ("styles", "scripts")
+        for a in collector.assets_in_slot(slot)
+    ]
+
+
+def _tree_with_every_asset_shape(tmp_path: Path) -> Path:
+    """Build two layout levels, a template pair, and a page with module lists."""
+    (tmp_path / "layout.djx").write_text("")
+    (tmp_path / "layout.css").write_text("body{}")
+    middle = tmp_path / "middle"
+    middle.mkdir()
+    (middle / "layout.djx").write_text("")
+    (middle / "layout.js").write_text("/* js */")
+    page_dir = middle / "post"
+    page_dir.mkdir()
+    (page_dir / "template.css").write_text("body{}")
+    (page_dir / "template.js").write_text("/* js */")
+    page_path = page_dir / "page.py"
+    page_path.write_text(
+        'styles = ["https://cdn.example.com/x.css"]\n'
+        'scripts = ["https://cdn.example.com/x.js"]\n'
+    )
+    return page_path
+
+
+def _bump(directory: Path) -> None:
+    """Push a directory's mtime forward so a plan built from it goes stale."""
+    moved = directory.stat().st_mtime + 10
+    os.utime(directory, (moved, moved))
+
+
+class TestAssetDiscoveryPagePlanWarmRender:
+    """A warm page render keeps the disk facts and asks the backend again."""
+
+    def test_a_warm_render_matches_the_first_pass_asset_for_asset(
+        self, tmp_path: Path
+    ) -> None:
+        page_path = _tree_with_every_asset_shape(tmp_path)
+        discovery = AssetDiscovery(
+            StaticAssetProvider(RecordingStaticBackend(), (tmp_path.resolve(),))
+        )
+
+        cold = StaticCollector()
+        discovery.discover_page_assets(page_path, cold)
+        warm = StaticCollector()
+        discovery.discover_page_assets(page_path, warm)
+
+        assert _asset_fields(warm) == _asset_fields(cold)
+        assert _asset_fields(cold) != []
+
+    def test_a_warm_render_reuses_the_module_url_assets(self, tmp_path: Path) -> None:
+        page_path = _tree_with_every_asset_shape(tmp_path)
+        discovery = AssetDiscovery(
+            StaticAssetProvider(RecordingStaticBackend(), (tmp_path.resolve(),))
+        )
+
+        cold = StaticCollector()
+        discovery.discover_page_assets(page_path, cold)
+        warm = StaticCollector()
+        discovery.discover_page_assets(page_path, warm)
+
+        cold_urls = [a for a in cold.assets_in_slot("styles") if not a.source_path]
+        warm_urls = [a for a in warm.assets_in_slot("styles") if not a.source_path]
+        assert [id(a) for a in warm_urls] == [id(a) for a in cold_urls]
+        assert cold_urls != []
+
+    def test_a_warm_render_registers_every_found_file_again(
+        self, tmp_path: Path
+    ) -> None:
+        page_path = _tree_with_every_asset_shape(tmp_path)
+        backend = RecordingStaticBackend()
+        discovery = AssetDiscovery(StaticAssetProvider(backend, (tmp_path.resolve(),)))
+        discovery.discover_page_assets(page_path, StaticCollector())
+        cold_calls = list(backend.calls)
+
+        backend.calls.clear()
+        discovery.discover_page_assets(page_path, StaticCollector())
+        assert len(cold_calls) == 4
+        assert backend.calls == cold_calls
+
+    def test_a_backend_answering_differently_is_seen_next_render(
+        self, tmp_path: Path
+    ) -> None:
+        """The manifest recipe from the docs, where a build lands mid-process."""
+        page_path = _tree_with_every_asset_shape(tmp_path)
+        manifest = tmp_path / "manifest.json"
+        backend = _ManifestBackend(manifest)
+        discovery = AssetDiscovery(StaticAssetProvider(backend, (tmp_path.resolve(),)))
+
+        fallback = StaticCollector()
+        discovery.discover_page_assets(page_path, fallback)
+        manifest.write_text("{}")
+        built = StaticCollector()
+        discovery.discover_page_assets(page_path, built)
+
+        assert [a.url for a in fallback.assets_in_slot("styles")] == [
+            "/static/next/layout.css",
+            "/static/next/middle/post.css",
+            "https://cdn.example.com/x.css",
+        ]
+        assert [a.url for a in built.assets_in_slot("styles")] == [
+            "/build/layout.css",
+            "/build/middle/post.css",
+            "https://cdn.example.com/x.css",
+        ]
+
+    def test_a_warm_render_reads_neither_the_folders_nor_the_module(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        page_path = _tree_with_every_asset_shape(tmp_path)
+        discovery = AssetDiscovery(
+            StaticAssetProvider(RecordingStaticBackend(), (tmp_path.resolve(),))
+        )
+        probes = _probe_counter(discovery, monkeypatch)
+        reads = _module_list_counter(discovery, monkeypatch)
+
+        discovery.discover_page_assets(page_path, StaticCollector())
+        cold_probes, cold_reads = list(probes), list(reads)
+        discovery.discover_page_assets(page_path, StaticCollector())
+
+        assert len(cold_probes) == 3
+        assert len(cold_reads) == 1
+        assert probes == cold_probes
+        assert reads == cold_reads
+
+    def test_off_debug_a_warm_render_stats_nothing(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        page_path = _tree_with_every_asset_shape(tmp_path)
+        discovery = AssetDiscovery(
+            StaticAssetProvider(RecordingStaticBackend(), (tmp_path.resolve(),))
+        )
+        discovery.discover_page_assets(page_path, StaticCollector())
+
+        stats: list[Path] = []
+        probes: list[Path] = []
+        real_stat = Path.stat
+        real_exists = Path.exists
+
+        def _record(self: Path, **kwargs) -> os.stat_result:
+            stats.append(self)
+            return real_stat(self, **kwargs)
+
+        def _record_exists(self: Path, **kwargs) -> bool:
+            probes.append(self)
+            return real_exists(self, **kwargs)
+
+        monkeypatch.setattr(Path, "stat", _record)
+        monkeypatch.setattr(Path, "exists", _record_exists)
+        with override_settings(DEBUG=False):
+            collector = StaticCollector()
+            discovery.discover_page_assets(page_path, collector)
+        assert stats == []
+        assert probes == []
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/layout.css",
+            "/static/next/middle/post.css",
+            "https://cdn.example.com/x.css",
+        ]
+
+    def test_debug_picks_up_a_layout_added_in_a_walked_directory(
+        self, tmp_path: Path
+    ) -> None:
+        """A `layout.djx` created between root and page is visible next request."""
+        page_path = _tree_with_every_asset_shape(tmp_path)
+        (tmp_path / "middle" / "layout.djx").unlink()
+        (tmp_path / "middle" / "layout.js").unlink()
+        discovery = AssetDiscovery(
+            StaticAssetProvider(RecordingStaticBackend(), (tmp_path.resolve(),))
+        )
+        with override_settings(DEBUG=True):
+            discovery.discover_page_assets(page_path, StaticCollector())
+
+            (tmp_path / "middle" / "layout.djx").write_text("")
+            (tmp_path / "middle" / "layout.css").write_text("body{}")
+            _bump(tmp_path / "middle")
+
+            collector = StaticCollector()
+            discovery.discover_page_assets(page_path, collector)
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/layout.css",
+            "/static/next/middle/layout.css",
+            "/static/next/middle/post.css",
+            "https://cdn.example.com/x.css",
+        ]
+
+    def test_debug_drops_an_asset_deleted_between_renders(self, tmp_path: Path) -> None:
+        page_path = _tree_with_every_asset_shape(tmp_path)
+        discovery = AssetDiscovery(
+            StaticAssetProvider(RecordingStaticBackend(), (tmp_path.resolve(),))
+        )
+        with override_settings(DEBUG=True):
+            discovery.discover_page_assets(page_path, StaticCollector())
+
+            (page_path.parent / "template.css").unlink()
+            _bump(page_path.parent)
+
+            collector = StaticCollector()
+            discovery.discover_page_assets(page_path, collector)
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/layout.css",
+            "https://cdn.example.com/x.css",
+        ]
+
+
+class _EvictingCache(OrderedDict[Path, dict[str, list[str]]]):
+    """A cache that drops a key the moment a reader looks it up.
+
+    Stands in for the eviction a concurrent render performs between two reads
+    of the same key.
+    """
+
+    def __contains__(self, key: object) -> bool:
+        """Report the key as present and evict it on the way out."""
+        present = super().__contains__(key)
+        self.pop(key, None)  # type: ignore[arg-type]
+        return present
+
+
+class TestAssetDiscoveryModuleListCache:
+    """The module list memo is read the way it is written, in one call."""
+
+    def test_a_concurrent_eviction_costs_a_reread_and_nothing_else(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        page_path = tmp_path / "page.py"
+        page_path.write_text('styles = ["https://cdn.example.com/x.css"]\n')
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+        discovery.discover_page_assets(page_path, StaticCollector())
+        discovery._module_list_cache = _EvictingCache(discovery._module_list_cache)
+
+        assert discovery._module_lists(page_path) == {
+            "styles": ["https://cdn.example.com/x.css"],
+            "scripts": [],
+        }
+
+
+class TestAssetDiscoveryPlanFreshness:
+    """A plan is born describing the disk the pass that built it left behind."""
+
+    def test_importing_the_page_module_does_not_age_its_own_plan(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        """The bytecode the import writes lands before the plan takes an mtime."""
+        page_dir = tmp_path / "section"
+        page_dir.mkdir()
+        (page_dir / "template.css").write_text("body{}")
+        page_path = page_dir / "page.py"
+        page_path.write_text('styles = ["https://cdn.example.com/x.css"]\n')
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+
+        with override_settings(DEBUG=True):
+            discovery.discover_page_assets(page_path, StaticCollector())
+            plan = discovery._page_plan_cache[page_path]
+
+        assert (page_dir / "__pycache__").exists()
+        assert plan.module_assets != ()
+        with override_settings(DEBUG=True):
+            assert discovery._plan_stale(plan) is False
+
+    def test_importing_a_component_module_does_not_age_its_own_plan(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        module_path = directory / "component.py"
+        module_path.write_text('styles = ["https://cdn.example.com/w.css"]\n')
+        info = _component_at(directory, "widget", module=module_path)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        with override_settings(DEBUG=True):
+            discovery.discover_component_assets(info, StaticCollector())
+            plan = discovery._component_plan_cache[_component_key(info)]
+
+            assert (directory / "__pycache__").exists()
+            assert discovery._plan_stale(plan) is False
+
+
+class TestAssetDiscoveryPagePlanFailures:
+    """A file the backend rejects is offered to it again on the next render."""
+
+    def test_the_warning_repeats_on_every_render(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        (tmp_path / "template.css").write_text("")
+        page_path = tmp_path / "page.djx"
+        page_path.write_text("")
+        discovery = AssetDiscovery(
+            StaticAssetProvider(_FailingBackend(), (tmp_path.resolve(),))
+        )
+
+        with caplog.at_level("WARNING", logger="next.static.discovery"):
+            discovery.discover_page_assets(page_path, StaticCollector())
+            discovery.discover_page_assets(page_path, StaticCollector())
+
+        failures = [r for r in caplog.records if "Failed to register" in r.getMessage()]
+        assert len(failures) == 2
+
+    def test_a_partial_failure_still_collects_what_registered(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "template.css").write_text("")
+        (tmp_path / "template.js").write_text("")
+        page_path = tmp_path / "page.djx"
+        page_path.write_text("")
+        discovery = AssetDiscovery(
+            StaticAssetProvider(_CssOnlyFailingBackend(), (tmp_path.resolve(),))
+        )
+
+        collector = StaticCollector()
+        discovery.discover_page_assets(page_path, collector)
+        assert collector.assets_in_slot("styles") == []
+        assert [a.url for a in collector.assets_in_slot("scripts")] == [
+            "/static/next/index.js"
+        ]
+
+
+class TestAssetDiscoverySourcePaths:
+    """Collected assets carry an absolute on-disk path with no extra resolution."""
+
+    def test_page_asset_carries_an_absolute_existing_path(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        css = tmp_path / "template.css"
+        css.write_text("body{}")
+        page_path = tmp_path / "page.djx"
+        page_path.write_text("")
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+
+        collector = StaticCollector()
+        discovery.discover_page_assets(page_path, collector)
+        (asset,) = collector.assets_in_slot("styles")
+        assert asset.source_path is not None
+        assert asset.source_path.is_absolute()
+        assert asset.source_path.exists()
+        assert asset.source_path == css.resolve()
+
+    def test_component_asset_carries_an_absolute_existing_path(
+        self, file_backend: StaticBackend, composite_component: ComponentInfo
+    ) -> None:
+        provider = StaticAssetProvider(file_backend, ())
+        discovery = AssetDiscovery(provider)
+
+        collector = StaticCollector()
+        discovery.discover_component_assets(composite_component, collector)
+        assert composite_component.template_path is not None
+        component_dir = composite_component.template_path.parent
+        sources = [
+            a.source_path
+            for a in collector.assets_in_slot("styles")
+            if a.source_path is not None
+        ]
+        assert sources == [component_dir / "component.css"]
+        assert sources[0].is_absolute()
+        assert sources[0].exists()
+
+    def test_component_asset_resolves_the_folder_it_was_reached_through(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        real_dir = tmp_path / "widget"
+        real_dir.mkdir()
+        (real_dir / "component.djx").write_text("<div/>")
+        (real_dir / "component.css").write_text(".w{}")
+        linked_dir = tmp_path / "linked"
+        linked_dir.symlink_to(real_dir, target_is_directory=True)
+        info = ComponentInfo(
+            name="widget",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=linked_dir / "component.djx",
+            module_path=None,
+            is_simple=False,
+        )
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        collector = StaticCollector()
+        discovery.discover_component_assets(info, collector)
+        assert [a.source_path for a in collector.assets_in_slot("styles")] == [
+            real_dir / "component.css"
+        ]
+
+    def test_a_symlinked_page_tree_yields_the_same_urls_and_sources(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        real_root = tmp_path / "real"
+        page_dir = real_root / "section"
+        page_dir.mkdir(parents=True)
+        (real_root / "layout.djx").write_text("")
+        (real_root / "layout.css").write_text("")
+        (page_dir / "template.css").write_text("body{}")
+        (page_dir / "page.djx").write_text("")
+        linked_root = tmp_path / "link"
+        linked_root.symlink_to(real_root, target_is_directory=True)
+
+        provider = StaticAssetProvider(file_backend, (real_root.resolve(),))
+        discovery = AssetDiscovery(provider)
+
+        direct = StaticCollector()
+        discovery.discover_page_assets(page_dir / "page.djx", direct)
+        through_link = StaticCollector()
+        discovery.discover_page_assets(
+            linked_root / "section" / "page.djx", through_link
+        )
+
+        assert [a.url for a in through_link.assets_in_slot("styles")] == [
+            a.url for a in direct.assets_in_slot("styles")
+        ]
+        assert [a.source_path for a in through_link.assets_in_slot("styles")] == [
+            a.source_path for a in direct.assets_in_slot("styles")
+        ]
+
+    def test_content_dedup_holds_across_path_spellings(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        real_dir = tmp_path / "widget"
+        real_dir.mkdir()
+        (real_dir / "component.djx").write_text("<div/>")
+        (real_dir / "component.css").write_text(".shared {}")
+        linked_dir = tmp_path / "linked"
+        linked_dir.symlink_to(real_dir, target_is_directory=True)
+
+        provider = StaticAssetProvider(file_backend, ())
+        discovery = AssetDiscovery(provider)
+        dedup = HashContentDedup()
+        collector = StaticCollector(dedup=dedup)
+        for name, directory in (("widget", real_dir), ("mirror", linked_dir)):
+            discovery.discover_component_assets(
+                ComponentInfo(
+                    name=name,
+                    scope_root=tmp_path,
+                    scope_relative="",
+                    template_path=directory / "component.djx",
+                    module_path=None,
+                    is_simple=False,
+                ),
+                collector,
+            )
+
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/components/widget.css"
+        ]
+        assert len(dedup._cache) == 1
 
 
 class TestAssetDiscoveryModuleListUrlRouting:
@@ -417,7 +1094,7 @@ class TestAssetDiscoveryModuleListUrlRouting:
         page_path = page_dir / "page.py"
         page_path.write_text('scripts = ["https://cdn.example.com/loader"]\n')
 
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
 
         collector = StaticCollector()
@@ -432,7 +1109,7 @@ class TestAssetDiscoveryModuleListUrlRouting:
         page_path = page_dir / "page.py"
         page_path.write_text('scripts = ["https://cdn.example.com/asset.zzz"]\n')
 
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
 
         collector = StaticCollector()
@@ -450,7 +1127,7 @@ class TestAssetDiscoveryModuleListUrlRouting:
         page_path = page_dir / "page.py"
         page_path.write_text('scripts = ["https://cdn.example.com/styling.css"]\n')
 
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
 
         collector = StaticCollector()
@@ -472,7 +1149,7 @@ class TestAssetDiscoveryComponents:
     def test_simple_component_yields_nothing(
         self, file_backend: StaticBackend, simple_component: ComponentInfo
     ) -> None:
-        provider = _Provider(file_backend, ())
+        provider = StaticAssetProvider(file_backend, ())
         discovery = AssetDiscovery(provider)
 
         collector = StaticCollector()
@@ -483,7 +1160,7 @@ class TestAssetDiscoveryComponents:
     def test_composite_component_picks_up_css_js_and_module_lists(
         self, file_backend: StaticBackend, composite_component: ComponentInfo
     ) -> None:
-        provider = _Provider(file_backend, ())
+        provider = StaticAssetProvider(file_backend, ())
         discovery = AssetDiscovery(provider)
 
         collector = StaticCollector()
@@ -497,10 +1174,308 @@ class TestAssetDiscoveryComponents:
         assert "https://cdn.example.com/extra.js" in script_urls
 
 
-class _FailingBackend(StaticFilesBackend):
-    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
-        msg = "cannot resolve"
-        raise ValueError(msg)
+def _component_key(info: ComponentInfo) -> tuple[Path | None, Path | None, str]:
+    """Return the cache key the discovery layer files a component plan under."""
+    return (info.template_path, info.module_path, info.name)
+
+
+def _component_at(directory: Path, name: str, *, module: Path | None) -> ComponentInfo:
+    """Return a composite component whose folder holds a written template."""
+    return component_info(
+        directory, name=name, module=module, template=f"<div>{name}</div>"
+    )
+
+
+class TestAssetDiscoveryComponentPlanCache:
+    """Every extra instance of a component reuses the folder walk of the first."""
+
+    def test_fifty_instances_probe_the_folder_once(
+        self,
+        file_backend: StaticBackend,
+        composite_component: ComponentInfo,
+        monkeypatch,
+    ) -> None:
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+        probes = _probe_counter(discovery, monkeypatch)
+
+        collector = StaticCollector()
+        for _ in range(50):
+            discovery.discover_component_assets(composite_component, collector)
+
+        assert len(probes) == 1
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/components/widget.css",
+            "https://cdn.example.com/extra.css",
+        ]
+
+    def test_a_warm_instance_registers_every_found_file_again(
+        self, composite_component: ComponentInfo
+    ) -> None:
+        backend = RecordingStaticBackend()
+        discovery = AssetDiscovery(StaticAssetProvider(backend, ()))
+        discovery.discover_component_assets(composite_component, StaticCollector())
+        cold_calls = list(backend.calls)
+
+        backend.calls.clear()
+        discovery.discover_component_assets(composite_component, StaticCollector())
+        assert len(cold_calls) == 2
+        assert backend.calls == cold_calls
+
+    def test_fifty_instances_register_every_found_file_each_time(
+        self, composite_component: ComponentInfo
+    ) -> None:
+        backend = RecordingStaticBackend()
+        discovery = AssetDiscovery(StaticAssetProvider(backend, ()))
+
+        collector = StaticCollector()
+        for _ in range(50):
+            discovery.discover_component_assets(composite_component, collector)
+
+        assert len(backend.calls) == 100
+
+    def test_an_equal_info_from_a_rescan_hits_the_same_entry(
+        self, composite_component: ComponentInfo, monkeypatch
+    ) -> None:
+        """A rescan rebuilding the same component reuses the plan it keyed."""
+        discovery = AssetDiscovery(StaticAssetProvider(RecordingStaticBackend(), ()))
+        discovery.discover_component_assets(composite_component, StaticCollector())
+        probes = _probe_counter(discovery, monkeypatch)
+
+        rescanned = ComponentInfo(
+            name=composite_component.name,
+            scope_root=composite_component.scope_root,
+            scope_relative=composite_component.scope_relative,
+            template_path=composite_component.template_path,
+            module_path=composite_component.module_path,
+            is_simple=False,
+        )
+        collector = StaticCollector()
+        discovery.discover_component_assets(rescanned, collector)
+
+        assert probes == []
+        assert len(discovery._component_plan_cache) == 1
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/components/widget.css",
+            "https://cdn.example.com/extra.css",
+        ]
+
+    def test_a_renamed_component_keys_its_own_entry(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        (directory / "component.css").write_text(".w{}")
+        first = _component_at(directory, "widget", module=None)
+        renamed = ComponentInfo(
+            name="gadget",
+            scope_root=first.scope_root,
+            scope_relative="",
+            template_path=first.template_path,
+            module_path=None,
+            is_simple=False,
+        )
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        collector = StaticCollector()
+        discovery.discover_component_assets(first, collector)
+        discovery.discover_component_assets(renamed, collector)
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/components/widget.css",
+            "/static/next/components/gadget.css",
+        ]
+
+    def test_debug_notices_a_stylesheet_added_next_to_the_component(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        info = _component_at(directory, "widget", module=None)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+        with override_settings(DEBUG=True):
+            discovery.discover_component_assets(info, StaticCollector())
+
+            (directory / "component.css").write_text(".w{}")
+            _bump(directory)
+
+            collector = StaticCollector()
+            discovery.discover_component_assets(info, collector)
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/components/widget.css"
+        ]
+
+    def test_off_debug_a_stylesheet_added_later_stays_invisible(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        info = _component_at(directory, "widget", module=None)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+        discovery.discover_component_assets(info, StaticCollector())
+
+        (directory / "component.css").write_text(".w{}")
+        _bump(directory)
+
+        collector = StaticCollector()
+        discovery.discover_component_assets(info, collector)
+        assert collector.assets_in_slot("styles") == []
+
+    def test_a_module_outside_the_component_folder_is_watched_too(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        elsewhere = tmp_path / "lists"
+        elsewhere.mkdir()
+        module_path = elsewhere / "component.py"
+        module_path.write_text('styles = ["https://cdn.example.com/from-away.css"]\n')
+        info = _component_at(directory, "widget", module=module_path)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        collector = StaticCollector()
+        discovery.discover_component_assets(info, collector)
+        plan = discovery._component_plan_cache[_component_key(info)]
+        assert [d for d, _ in plan.directory_mtimes] == [directory, elsewhere]
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "https://cdn.example.com/from-away.css"
+        ]
+
+    def test_a_module_that_is_not_on_disk_is_skipped(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        info = _component_at(directory, "widget", module=directory / "component.py")
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        collector = StaticCollector()
+        discovery.discover_component_assets(info, collector)
+        assert collector.assets_in_slot("styles") == []
+        key = _component_key(info)
+        assert discovery._component_plan_cache[key].module_assets == ()
+
+    def test_a_folder_that_never_existed_leaves_the_plan_alone(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        """A module folder that was missing at build time is no reason to rebuild."""
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        info = _component_at(directory, "widget", module=tmp_path / "gone" / "lists.py")
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        with override_settings(DEBUG=True):
+            discovery.discover_component_assets(info, StaticCollector())
+            plan = discovery._component_plan_cache[_component_key(info)]
+            assert discovery._plan_stale(plan) is False
+
+            (tmp_path / "gone").mkdir()
+            assert discovery._plan_stale(plan) is True
+
+    def test_a_folder_that_goes_away_makes_the_plan_stale(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        """A directory the plan read and can no longer stat rebuilds it."""
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        info = _component_at(directory, "widget", module=None)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        with override_settings(DEBUG=True):
+            discovery.discover_component_assets(info, StaticCollector())
+            plan = discovery._component_plan_cache[_component_key(info)]
+            shutil.rmtree(directory)
+            assert discovery._plan_stale(plan) is True
+
+    def test_the_plan_cache_evicts_the_oldest_key(
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(discovery_mod, "_COMPONENT_PLAN_CACHE_MAX_SIZE", 1)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+        for i in range(2):
+            directory = tmp_path / f"widget_{i}"
+            directory.mkdir()
+            info = _component_at(directory, f"widget_{i}", module=None)
+            discovery.discover_component_assets(info, StaticCollector())
+        assert len(discovery._component_plan_cache) <= 1
+
+    def test_a_simple_component_is_never_planned(
+        self, file_backend: StaticBackend, simple_component: ComponentInfo
+    ) -> None:
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+        collector = StaticCollector()
+        discovery.discover_component_assets(simple_component, collector)
+        discovery.discover_component_assets(simple_component, collector)
+        assert collector.assets_in_slot("styles") == []
+        assert discovery._component_plan_cache == {}
+
+
+class TestAssetDiscoveryComponentPlanFolders:
+    """A component plan tracks the folder it read, however it spells it."""
+
+    def test_a_plan_read_over_a_missing_folder_rebuilds_when_it_appears(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        directory = tmp_path / "widget"
+        info = component_info(directory)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+        with override_settings(DEBUG=True):
+            discovery.discover_component_assets(info, StaticCollector())
+
+            directory.mkdir()
+            (directory / "component.css").write_text(".w{}")
+
+            collector = StaticCollector()
+            discovery.discover_component_assets(info, collector)
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/components/widget.css"
+        ]
+
+    def test_a_file_written_during_the_probe_shows_up_on_the_next_render(
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    ) -> None:
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        info = _component_at(directory, "widget", module=None)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+        probe = discovery._find_role_files
+
+        def _write_while_reading(
+            probed: Path, *, logical_name: str, role: str
+        ) -> list[object]:
+            found = probe(probed, logical_name=logical_name, role=role)
+            (directory / "component.css").write_text(".w{}")
+            return found
+
+        with override_settings(DEBUG=True):
+            monkeypatch.setattr(discovery, "_find_role_files", _write_while_reading)
+            discovery.discover_component_assets(info, StaticCollector())
+            monkeypatch.setattr(discovery, "_find_role_files", probe)
+            collector = StaticCollector()
+            discovery.discover_component_assets(info, collector)
+
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/components/widget.css"
+        ]
+
+    def test_a_simple_info_does_not_read_the_composite_plan(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        (directory / "component.css").write_text(".w{}")
+        composite = _component_at(directory, "widget", module=None)
+        simple = component_info(directory, is_simple=True)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        composite_collector = StaticCollector()
+        discovery.discover_component_assets(composite, composite_collector)
+        simple_collector = StaticCollector()
+        discovery.discover_component_assets(simple, simple_collector)
+
+        assert [a.url for a in composite_collector.assets_in_slot("styles")] == [
+            "/static/next/components/widget.css"
+        ]
+        assert simple_collector.assets_in_slot("styles") == []
+        assert list(discovery._component_plan_cache) == [_component_key(composite)]
 
 
 class TestAssetDiscoveryErrorHandling:
@@ -511,7 +1486,7 @@ class TestAssetDiscoveryErrorHandling:
         page_path = tmp_path / "page.djx"
         page_path.write_text("")
 
-        provider = _Provider(_FailingBackend(), (tmp_path.resolve(),))
+        provider = StaticAssetProvider(_FailingBackend(), (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
 
         collector = StaticCollector()
@@ -534,7 +1509,7 @@ class TestAssetDiscoveryCustomStems:
         page_path = tmp_path / "page.djx"
         page_path.write_text("")
 
-        provider = _Provider(file_backend, (tmp_path.resolve(),))
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider, stems=stems)
 
         collector = StaticCollector()

--- a/tests/static/test_discovery.py
+++ b/tests/static/test_discovery.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import shutil
-from collections import OrderedDict
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -16,7 +15,7 @@ from next.static import (
     default_kinds,
     discovery as discovery_mod,
 )
-from next.static.collector import HashContentDedup
+from next.static.collector import HashContentDedup, default_placeholders
 from next.static.discovery import (
     BackendProvider,
     PathResolver,
@@ -25,12 +24,16 @@ from next.static.discovery import (
 )
 from next.static.signals import asset_registered
 from next.urls import FileRouterBackend
-from tests.support import RecordingStaticBackend, StaticAssetProvider, component_info
+from tests.support import (
+    RecordingStaticBackend,
+    StaticAssetProvider,
+    component_info,
+    record_path_calls,
+    restored_static_registries,
+)
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     import pytest
 
     from next.static import StaticBackend
@@ -241,9 +244,10 @@ class TestAssetDiscoveryModuleLists:
             "https://cdn.example.com/x.js"
         ]
 
-    def test_module_list_cache_skips_reparse(
+    def test_off_debug_an_edited_module_list_stays_invisible(
         self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
+        """The plan holding the module URLs is what freezes them, not a reader."""
         page_dir = tmp_path / "cached"
         page_dir.mkdir()
         page_path = page_dir / "page.py"
@@ -263,33 +267,49 @@ class TestAssetDiscoveryModuleLists:
             "https://c.example/a.css"
         ]
 
-    def test_module_list_cache_evicts_oldest(
-        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    def test_debug_reads_an_edited_module_list_on_the_rebuild(
+        self, tmp_path: Path, file_backend: StaticBackend
     ) -> None:
-        """The module-list cache drops the oldest key past the limit."""
-        monkeypatch.setattr(discovery_mod, "_MODULE_LIST_CACHE_MAX_SIZE", 1)
+        """A `styles` list edited under a live server is read with the new plan."""
+        page_dir = tmp_path / "edited"
+        page_dir.mkdir()
+        page_path = page_dir / "page.py"
+        page_path.write_text('styles = ["https://c.example/a.css"]\n')
 
         provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         discovery = AssetDiscovery(provider)
-        collector = StaticCollector()
 
-        # Two parseable pages exercise the happy-path eviction, a third broken
-        # one exercises the "module is None" branch.
-        for i in range(2):
-            ok_dir = tmp_path / f"ok_{i}"
-            ok_dir.mkdir()
-            ok_page = ok_dir / "page.py"
-            ok_page.write_text(f'styles = ["https://c.example/a{i}.css"]\n')
-            discovery.discover_page_assets(ok_page, collector)
+        with override_settings(DEBUG=True):
+            discovery.discover_page_assets(page_path, StaticCollector())
 
+            page_path.write_text('styles = ["https://c.example/changed.css"]\n')
+            # Rewriting a file moves neither its own directory's mtime past the
+            # snapshot nor the file past the mtime the module memo keyed on.
+            _bump(page_path)
+            _bump(page_dir)
+
+            collector = StaticCollector()
+            discovery.discover_page_assets(page_path, collector)
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "https://c.example/changed.css"
+        ]
+
+    def test_a_module_that_does_not_execute_contributes_nothing(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        """A `page.py` that fails to import leaves the page with no module URLs."""
         broken_dir = tmp_path / "broken"
         broken_dir.mkdir()
         broken_page = broken_dir / "page.py"
         broken_page.write_text("this is not valid python =====\n")
-        discovery.discover_page_assets(broken_page, collector)
 
-        # Oldest module-list key evicted after exceeding max size.
-        assert len(discovery._module_list_cache) <= 1
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+
+        collector = StaticCollector()
+        discovery.discover_page_assets(broken_page, collector)
+        assert collector.assets_in_slot("styles") == []
+        assert discovery._page_plan_cache[broken_page].module_assets == ()
 
 
 class TestAssetDiscoveryPagePlanCache:
@@ -346,6 +366,25 @@ class TestAssetDiscoveryPagePlanCache:
         discovery = AssetDiscovery(provider)
         with override_settings(DEBUG=True):
             discovery.discover_page_assets(page_path, StaticCollector())
+            collector = StaticCollector()
+            discovery.discover_page_assets(page_path, collector)
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/section.css"
+        ]
+
+    def test_debug_rebuilds_when_a_directory_mtime_moves_backwards(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        """A tree restored from a backup carries older mtimes than the plan holds."""
+        page_path = self._page_with_layout(tmp_path)
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+        with override_settings(DEBUG=True):
+            discovery.discover_page_assets(page_path, StaticCollector())
+
+            (page_path.parent / "template.css").write_text("body{}")
+            _rewind(page_path.parent)
+
             collector = StaticCollector()
             discovery.discover_page_assets(page_path, collector)
         assert [a.url for a in collector.assets_in_slot("styles")] == [
@@ -661,10 +700,16 @@ def _tree_with_every_asset_shape(tmp_path: Path) -> Path:
     return page_path
 
 
-def _bump(directory: Path) -> None:
-    """Push a directory's mtime forward so a plan built from it goes stale."""
-    moved = directory.stat().st_mtime + 10
-    os.utime(directory, (moved, moved))
+def _bump(path: Path) -> None:
+    """Push a path's mtime forward so a plan built from it goes stale."""
+    moved = path.stat().st_mtime + 10
+    os.utime(path, (moved, moved))
+
+
+def _rewind(path: Path) -> None:
+    """Pull a path's mtime back, the way restoring a backup over it would."""
+    moved = path.stat().st_mtime - 10
+    os.utime(path, (moved, moved))
 
 
 class TestAssetDiscoveryPagePlanWarmRender:
@@ -841,39 +886,6 @@ class TestAssetDiscoveryPagePlanWarmRender:
         ]
 
 
-class _EvictingCache(OrderedDict[Path, dict[str, list[str]]]):
-    """A cache that drops a key the moment a reader looks it up.
-
-    Stands in for the eviction a concurrent render performs between two reads
-    of the same key.
-    """
-
-    def __contains__(self, key: object) -> bool:
-        """Report the key as present and evict it on the way out."""
-        present = super().__contains__(key)
-        self.pop(key, None)  # type: ignore[arg-type]
-        return present
-
-
-class TestAssetDiscoveryModuleListCache:
-    """The module list memo is read the way it is written, in one call."""
-
-    def test_a_concurrent_eviction_costs_a_reread_and_nothing_else(
-        self, tmp_path: Path, file_backend: StaticBackend
-    ) -> None:
-        page_path = tmp_path / "page.py"
-        page_path.write_text('styles = ["https://cdn.example.com/x.css"]\n')
-        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
-        discovery = AssetDiscovery(provider)
-        discovery.discover_page_assets(page_path, StaticCollector())
-        discovery._module_list_cache = _EvictingCache(discovery._module_list_cache)
-
-        assert discovery._module_lists(page_path) == {
-            "styles": ["https://cdn.example.com/x.css"],
-            "scripts": [],
-        }
-
-
 class TestAssetDiscoveryPlanFreshness:
     """A plan is born describing the disk the pass that built it left behind."""
 
@@ -914,6 +926,184 @@ class TestAssetDiscoveryPlanFreshness:
 
             assert (directory / "__pycache__").exists()
             assert discovery._plan_stale(plan) is False
+
+
+class TestAssetDiscoveryRegistryGeneration:
+    """A registration moves no file, so a plan tracks the registries it read."""
+
+    def test_a_stem_registered_later_reaches_a_planned_page(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        """Teaching discovery a new stem takes effect with `DEBUG` off too."""
+        page_path = tmp_path / "page.djx"
+        page_path.write_text("")
+        (tmp_path / "hero.css").write_text("body{}")
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+
+        cold = StaticCollector()
+        discovery.discover_page_assets(page_path, cold)
+        with restored_static_registries():
+            default_stems.register("template", "hero")
+            warm = StaticCollector()
+            discovery.discover_page_assets(page_path, warm)
+
+        assert cold.assets_in_slot("styles") == []
+        assert [a.url for a in warm.assets_in_slot("styles")] == [
+            "/static/next/index.css"
+        ]
+
+    def test_a_kind_registered_later_reaches_a_planned_component(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        """A folder file of an unknown extension is no asset until the kind is."""
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        (directory / "component.ts").write_text("export default 1")
+        info = _component_at(directory, "widget", module=None)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        cold = StaticCollector()
+        discovery.discover_component_assets(info, cold)
+        with restored_static_registries():
+            default_kinds.register(
+                "ts", extension=".ts", slot="scripts", renderer="render_module_tag"
+            )
+            warm = StaticCollector()
+            discovery.discover_component_assets(info, warm)
+
+        assert cold.assets_in_slot("scripts") == []
+        assert [a.url for a in warm.assets_in_slot("scripts")] == [
+            "/static/next/components/widget.ts"
+        ]
+
+    def test_a_slot_registered_later_reaches_a_planned_page(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        """A module list is named after a slot, so a new one opens a new list."""
+        page_dir = tmp_path / "hero"
+        page_dir.mkdir()
+        page_path = page_dir / "page.py"
+        page_path.write_text('preloads = ["https://cdn.example.com/hero.avif"]\n')
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+
+        cold = StaticCollector()
+        discovery.discover_page_assets(page_path, cold)
+        with restored_static_registries():
+            default_placeholders.register("preloads", token="<!-- next:preloads -->")
+            default_kinds.register(
+                "avif", extension=".avif", slot="preloads", renderer="render_link_tag"
+            )
+            warm = StaticCollector()
+            discovery.discover_page_assets(page_path, warm)
+
+        assert cold.assets_in_slot("preloads") == []
+        assert [a.url for a in warm.assets_in_slot("preloads")] == [
+            "https://cdn.example.com/hero.avif"
+        ]
+
+    def test_the_generation_reads_the_stem_registry_it_was_handed(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        """A caller handing over a stem registry gets plans that track that one."""
+        page_path = tmp_path / "page.djx"
+        page_path.write_text("")
+        (tmp_path / "hero.css").write_text("body{}")
+        stems = StemRegistry()
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider, stems=stems)
+
+        cold = StaticCollector()
+        discovery.discover_page_assets(page_path, cold)
+        stems.register("template", "hero")
+        warm = StaticCollector()
+        discovery.discover_page_assets(page_path, warm)
+
+        assert cold.assets_in_slot("styles") == []
+        assert [a.url for a in warm.assets_in_slot("styles")] == [
+            "/static/next/index.css"
+        ]
+
+    def test_a_stem_registered_during_the_page_probe_is_read_next_render(
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    ) -> None:
+        """The generation is read before the probe, as the mtime snapshot is.
+
+        A registration landing while the plan is built would otherwise be baked
+        into it as already seen, and the file it names would stay invisible.
+        """
+        page_path = tmp_path / "page.djx"
+        page_path.write_text("")
+        (tmp_path / "hero.css").write_text("body{}")
+        stems = StemRegistry()
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider, stems=stems)
+        probe = discovery._find_role_files
+
+        def _register_while_reading(
+            directory: Path, *, logical_name: str, role: str
+        ) -> list[object]:
+            found = probe(directory, logical_name=logical_name, role=role)
+            stems.register("template", "hero")
+            return found
+
+        monkeypatch.setattr(discovery, "_find_role_files", _register_while_reading)
+        discovery.discover_page_assets(page_path, StaticCollector())
+
+        collector = StaticCollector()
+        discovery.discover_page_assets(page_path, collector)
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/index.css"
+        ]
+
+    def test_a_stem_registered_during_the_component_probe_is_read_next_render(
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    ) -> None:
+        """The component builder reads the generation before the probe too."""
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        (directory / "hero.css").write_text(".w{}")
+        info = _component_at(directory, "widget", module=None)
+        stems = StemRegistry()
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()), stems=stems)
+        probe = discovery._find_role_files
+
+        def _register_while_reading(
+            folder: Path, *, logical_name: str, role: str
+        ) -> list[object]:
+            found = probe(folder, logical_name=logical_name, role=role)
+            stems.register("component", "hero")
+            return found
+
+        monkeypatch.setattr(discovery, "_find_role_files", _register_while_reading)
+        discovery.discover_component_assets(info, StaticCollector())
+
+        collector = StaticCollector()
+        discovery.discover_component_assets(info, collector)
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/components/widget.css"
+        ]
+
+
+class TestRestoredStaticRegistries:
+    """The scaffolding puts the state back without putting the counter back."""
+
+    def test_two_blocks_never_share_a_generation(
+        self, file_backend: StaticBackend
+    ) -> None:
+        """A version rolled backwards would let a genuinely stale plan read fresh."""
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        with restored_static_registries():
+            default_stems.register("template", "hero")
+            first = discovery._registry_generation()
+        with restored_static_registries():
+            default_stems.register("template", "gallery")
+            second = discovery._registry_generation()
+
+        assert first != second
+        assert default_stems.stems("template") == ("template",)
 
 
 class TestAssetDiscoveryPagePlanFailures:
@@ -1019,6 +1209,24 @@ class TestAssetDiscoverySourcePaths:
         assert [a.source_path for a in collector.assets_in_slot("styles")] == [
             real_dir / "component.css"
         ]
+
+    def test_a_symlinked_asset_file_reports_its_target(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        """The staticfiles finder spells a hit resolved, and the two have to agree."""
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        target = shared / "theme.css"
+        target.write_text(".shared{}")
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        (directory / "component.css").symlink_to(target)
+        info = _component_at(directory, "widget", module=None)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        collector = StaticCollector()
+        discovery.discover_component_assets(info, collector)
+        assert [a.source_path for a in collector.assets_in_slot("styles")] == [target]
 
     def test_a_symlinked_page_tree_yields_the_same_urls_and_sources(
         self, tmp_path: Path, file_backend: StaticBackend
@@ -1397,6 +1605,28 @@ class TestAssetDiscoveryComponentPlanCache:
             discovery.discover_component_assets(info, StaticCollector())
         assert len(discovery._component_plan_cache) <= 1
 
+    def test_a_warm_hit_keeps_a_full_cache_in_use_order(
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    ) -> None:
+        """A component mounted again is the freshest entry, not the next evicted."""
+        monkeypatch.setattr(discovery_mod, "_COMPONENT_PLAN_CACHE_MAX_SIZE", 2)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+        infos = []
+        for name in ("first", "second", "third"):
+            directory = tmp_path / name
+            directory.mkdir()
+            infos.append(_component_at(directory, name, module=None))
+
+        discovery.discover_component_assets(infos[0], StaticCollector())
+        discovery.discover_component_assets(infos[1], StaticCollector())
+        discovery.discover_component_assets(infos[0], StaticCollector())
+        discovery.discover_component_assets(infos[2], StaticCollector())
+
+        assert list(discovery._component_plan_cache) == [
+            _component_key(infos[0]),
+            _component_key(infos[2]),
+        ]
+
     def test_a_simple_component_is_never_planned(
         self, file_backend: StaticBackend, simple_component: ComponentInfo
     ) -> None:
@@ -1410,6 +1640,50 @@ class TestAssetDiscoveryComponentPlanCache:
 
 class TestAssetDiscoveryComponentPlanFolders:
     """A component plan tracks the folder it read, however it spells it."""
+
+    def test_a_folder_that_does_not_stat_is_recorded_as_nothing(
+        self, tmp_path: Path, file_backend: StaticBackend
+    ) -> None:
+        """Nothing rather than a sentinel a pre-epoch mtime could collide with."""
+        directory = tmp_path / "widget"
+        info = component_info(directory)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+
+        discovery.discover_component_assets(info, StaticCollector())
+
+        plan = discovery._component_plan_cache[_component_key(info)]
+        assert plan.directory_mtimes == ((directory.resolve(), None),)
+
+    def test_a_component_without_a_template_resolves_its_folder_once(
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    ) -> None:
+        """With no template the folder comes from the module path, derived once."""
+        directory = tmp_path / "widget"
+        directory.mkdir()
+        module_path = directory / "component.py"
+        module_path.write_text("")
+        (directory / "component.css").write_text(".w{}")
+        info = ComponentInfo(
+            name="widget",
+            scope_root=tmp_path,
+            scope_relative="",
+            template_path=None,
+            module_path=module_path,
+            is_simple=False,
+        )
+        resolved = directory.resolve()
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+        seen = record_path_calls(monkeypatch, "resolve", keep=lambda p: p == directory)
+
+        collector = StaticCollector()
+        discovery.discover_component_assets(info, collector)
+
+        plan = discovery._component_plan_cache[_component_key(info)]
+        assert seen == [directory]
+        assert [folder for folder, _ in plan.directory_mtimes] == [resolved]
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/components/widget.css"
+        ]
 
     def test_a_plan_read_over_a_missing_folder_rebuilds_when_it_appears(
         self, tmp_path: Path, file_backend: StaticBackend
@@ -1429,6 +1703,38 @@ class TestAssetDiscoveryComponentPlanFolders:
             "/static/next/components/widget.css"
         ]
 
+    def test_a_folder_that_will_not_resolve_keeps_its_own_spelling(
+        self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
+    ) -> None:
+        """A folder that will not resolve is read under the name it was reached by.
+
+        A render is no place to raise over the spelling of a directory.
+        """
+        real_dir = tmp_path / "widget"
+        real_dir.mkdir()
+        (real_dir / "component.css").write_text(".w{}")
+        linked_dir = tmp_path / "linked"
+        linked_dir.symlink_to(real_dir, target_is_directory=True)
+        info = _component_at(linked_dir, "widget", module=None)
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend, ()))
+        resolve = Path.resolve
+
+        def _refuse_the_folder(self: Path, **kwargs) -> Path:
+            if self == linked_dir:
+                msg = "the working directory is gone"
+                raise OSError(msg)
+            return resolve(self, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", _refuse_the_folder)
+        collector = StaticCollector()
+        discovery.discover_component_assets(info, collector)
+
+        plan = discovery._component_plan_cache[_component_key(info)]
+        assert [directory for directory, _ in plan.directory_mtimes] == [linked_dir]
+        assert [a.url for a in collector.assets_in_slot("styles")] == [
+            "/static/next/components/widget.css"
+        ]
+
     def test_a_file_written_during_the_probe_shows_up_on_the_next_render(
         self, tmp_path: Path, file_backend: StaticBackend, monkeypatch
     ) -> None:
@@ -1439,9 +1745,9 @@ class TestAssetDiscoveryComponentPlanFolders:
         probe = discovery._find_role_files
 
         def _write_while_reading(
-            probed: Path, *, logical_name: str, role: str
+            folder: Path, *, logical_name: str, role: str
         ) -> list[object]:
-            found = probe(probed, logical_name=logical_name, role=role)
+            found = probe(folder, logical_name=logical_name, role=role)
             (directory / "component.css").write_text(".w{}")
             return found
 
@@ -1517,14 +1823,3 @@ class TestAssetDiscoveryCustomStems:
         assert [a.url for a in collector.assets_in_slot("styles")] == [
             "/static/next/index.css"
         ]
-
-
-class TestMakeDiscoveryFixture:
-    """Ensure the conftest helper builds a wired-up AssetDiscovery."""
-
-    def test_factory_produces_usable_pair(
-        self, file_backend: StaticBackend, make_discovery: Callable[..., object]
-    ) -> None:
-        discovery, manager = make_discovery(file_backend)  # type: ignore[misc]
-        assert isinstance(discovery, AssetDiscovery)
-        assert manager.default_backend is file_backend

--- a/tests/static/test_manager.py
+++ b/tests/static/test_manager.py
@@ -19,7 +19,7 @@ from next.static import (
     reset_default_manager,
 )
 from next.static.collector import HEAD_CLOSE
-from next.static.manager import DefaultStaticManager
+from next.static.manager import DefaultStaticManager, forget_manager_page_roots
 from next.static.scripts import CSRF_PAYLOAD_KEY, DEV_PAYLOAD_KEY, NextScriptBuilder
 
 
@@ -50,6 +50,74 @@ class TestEnsureBackends:
         roots1 = fresh_manager.page_roots()
         roots2 = fresh_manager.page_roots()
         assert roots1 is roots2
+
+
+class TestPageRootsFollowTheRouters:
+    """The trees the manager serves come from the watch layer and go with it."""
+
+    def test_page_roots_are_taken_as_the_watch_layer_spells_them(
+        self, fresh_manager: StaticManager, tmp_path: Path
+    ) -> None:
+        """The watch layer answers resolved, so a lookup pays no second resolve."""
+        spelling = tmp_path / "site" / ".." / "site"
+        with mock.patch(
+            "next.static.manager.get_pages_directories_for_watch",
+            return_value=[spelling],
+        ):
+            assert fresh_manager.page_roots() == (spelling,)
+
+    def test_forgetting_the_page_roots_reads_them_again(
+        self, fresh_manager: StaticManager, tmp_path: Path
+    ) -> None:
+        """A tree that appeared reaches the manager, resolver memo and all."""
+        first = tmp_path / "one"
+        second = tmp_path / "two"
+        with mock.patch(
+            "next.static.manager.get_pages_directories_for_watch", return_value=[first]
+        ):
+            assert fresh_manager.page_roots() == (first,)
+            stale_discovery = fresh_manager.discovery
+        with mock.patch(
+            "next.static.manager.get_pages_directories_for_watch",
+            return_value=[first, second],
+        ):
+            assert fresh_manager.page_roots() == (first,)
+            fresh_manager.forget_page_roots()
+
+            assert fresh_manager.page_roots() == (first, second)
+        assert fresh_manager.discovery is not stale_discovery
+
+
+class TestForgetManagerPageRoots:
+    """The module-level hook a router reload sends the manager."""
+
+    def test_an_unbuilt_handle_is_left_alone(self, reset_default: None) -> None:
+        """A manager nothing has built yet reads the trees fresh anyway."""
+        reset_default_manager()
+
+        forget_manager_page_roots()
+
+        assert default_manager._wrapped is empty
+
+    def test_a_built_manager_reads_the_trees_again(
+        self, reset_default: None, tmp_path: Path
+    ) -> None:
+        """The live manager drops what it held without being replaced."""
+        reset_default_manager()
+        manager = get_static_manager()
+        with mock.patch(
+            "next.static.manager.get_pages_directories_for_watch", return_value=[]
+        ):
+            assert manager.page_roots() == ()
+
+        with mock.patch(
+            "next.static.manager.get_pages_directories_for_watch",
+            return_value=[tmp_path],
+        ):
+            forget_manager_page_roots()
+
+            assert manager.page_roots() == (tmp_path,)
+        assert get_static_manager() is manager
 
 
 class TestReloadConfig:

--- a/tests/static/test_manager.py
+++ b/tests/static/test_manager.py
@@ -692,3 +692,28 @@ class TestSettingChangedReload:
             # override_settings fires setting_changed, which calls reload.
             # The first attribute access rebuilds the manager.
             assert isinstance(default_manager.default_backend, StaticFilesBackend)
+
+    def test_override_settings_drops_the_cached_asset_plans(
+        self, tmp_path: Path, reset_default: None
+    ) -> None:
+        """Asset plans die with the manager, so reloaded settings re-walk the disk."""
+        (tmp_path / "template.css").write_text("")
+        page_path = tmp_path / "page.djx"
+        page_path.write_text("")
+        manager = get_static_manager()
+        manager._cached_page_roots = (tmp_path.resolve(),)
+        with mock.patch(
+            "next.static.backends.staticfiles_storage.url",
+            return_value="/static/next/index.css",
+        ):
+            manager.discover_page_assets(page_path, StaticCollector())
+        assert manager.discovery._page_plan_cache
+
+        with override_settings(
+            NEXT_FRAMEWORK={
+                "STATIC_BACKENDS": [{"BACKEND": "next.static.StaticFilesBackend"}]
+            }
+        ):
+            reloaded = get_static_manager()
+            assert reloaded is not manager
+            assert not reloaded.discovery._page_plan_cache

--- a/tests/static/test_signals.py
+++ b/tests/static/test_signals.py
@@ -19,11 +19,14 @@ from next.static.signals import (
     html_injected,
 )
 from next.testing import SignalRecorder, capture_signals
+from tests.support import StaticAssetProvider
 
 
 if TYPE_CHECKING:
     from collections.abc import Generator
     from pathlib import Path
+
+    from next.components import ComponentInfo
 
 
 STYLES_PLACEHOLDER = "<!-- next:styles -->"
@@ -66,26 +69,60 @@ class TestAssetRegisteredSignal:
         capture_asset_registered: SignalRecorder,
     ) -> None:
 
-        class _P:
-            @property
-            def default_backend(self) -> StaticFilesBackend:
-                return file_backend
-
-            def page_roots(self) -> tuple[Path, ...]:
-                return (tmp_path.resolve(),)
-
         (tmp_path / "template.css").write_text("")
         page_path = tmp_path / "page.djx"
         page_path.write_text("")
 
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
         collector = StaticCollector()
-        AssetDiscovery(_P()).discover_page_assets(page_path, collector)
+        AssetDiscovery(provider).discover_page_assets(page_path, collector)
 
         assert len(capture_asset_registered) == 1
         event = capture_asset_registered.events[0]
         assert isinstance(event.sender, StaticAsset)
         assert event.kwargs["collector"] is collector
         assert event.kwargs["backend"] is file_backend
+
+    def test_a_warm_page_render_fires_the_same_set_again(
+        self,
+        tmp_path: Path,
+        file_backend: StaticFilesBackend,
+        capture_asset_registered: SignalRecorder,
+    ) -> None:
+        """A warm render re-emits per file asset, and never for a module URL."""
+        (tmp_path / "template.css").write_text("")
+        page_path = tmp_path / "page.py"
+        page_path.write_text('scripts = ["https://cdn.example.com/x.js"]\n')
+
+        provider = StaticAssetProvider(file_backend, (tmp_path.resolve(),))
+        discovery = AssetDiscovery(provider)
+        discovery.discover_page_assets(page_path, StaticCollector())
+        warm = StaticCollector()
+        discovery.discover_page_assets(page_path, warm)
+
+        assert len(capture_asset_registered) == 2
+        cold_event, warm_event = capture_asset_registered.events
+        assert warm_event.sender == cold_event.sender
+        assert warm_event.kwargs["collector"] is warm
+        assert warm_event.kwargs["backend"] is file_backend
+
+    def test_a_warm_component_render_fires_the_same_set_again(
+        self,
+        file_backend: StaticFilesBackend,
+        composite_component: ComponentInfo,
+        capture_asset_registered: SignalRecorder,
+    ) -> None:
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend))
+        discovery.discover_component_assets(composite_component, StaticCollector())
+        warm = StaticCollector()
+        discovery.discover_component_assets(composite_component, warm)
+
+        assert len(capture_asset_registered) == 4
+        warmed = capture_asset_registered.events[2:]
+        assert [e.kwargs["collector"] for e in warmed] == [warm, warm]
+        assert [e.sender for e in warmed] == [
+            e.sender for e in capture_asset_registered.events[:2]
+        ]
 
 
 class TestCollectorFinalizedSignal:

--- a/tests/static/test_signals.py
+++ b/tests/static/test_signals.py
@@ -106,6 +106,24 @@ class TestAssetRegisteredSignal:
         assert warm_event.kwargs["collector"] is warm
         assert warm_event.kwargs["backend"] is file_backend
 
+    def test_a_component_mounted_twice_announces_each_asset_once(
+        self,
+        file_backend: StaticFilesBackend,
+        composite_component: ComponentInfo,
+        capture_asset_registered: SignalRecorder,
+    ) -> None:
+        """The signal follows the collector, which keeps the second instance out."""
+        discovery = AssetDiscovery(StaticAssetProvider(file_backend))
+        collector = StaticCollector()
+        discovery.discover_component_assets(composite_component, collector)
+        discovery.discover_component_assets(composite_component, collector)
+
+        assert len(capture_asset_registered) == 2
+        assert [e.kwargs["collector"] for e in capture_asset_registered.events] == [
+            collector,
+            collector,
+        ]
+
     def test_a_warm_component_render_fires_the_same_set_again(
         self,
         file_backend: StaticFilesBackend,

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -5,7 +5,11 @@ from tests.support.attribution import (
     unwrapped_decorator,
     wraps_decorator,
 )
-from tests.support.backends import MockAutoreloadSender
+from tests.support.backends import (
+    MockAutoreloadSender,
+    RecordingStaticBackend,
+    StaticAssetProvider,
+)
 from tests.support.cases import (
     COERCE_URL_VALUE_CASES,
     URL_BY_ANNOTATION_RESOLVE_CASES,
@@ -14,6 +18,7 @@ from tests.support.cases import (
     UrlByAnnotationResolveCase,
     UrlKwargsResolveCase,
 )
+from tests.support.components import build_composite_component, component_info
 from tests.support.forms import (
     GuardedTenantForm,
     build_post_request,
@@ -84,8 +89,10 @@ __all__ = [
     "RaisingComponentsRouter",
     "RaisingRootsRouter",
     "RaisingSkipNamesRouter",
+    "RecordingStaticBackend",
     "RootPagesRouter",
     "SkippingRouter",
+    "StaticAssetProvider",
     "UrlByAnnotationResolveCase",
     "UrlKwargsResolveCase",
     "_ctx",

--- a/tests/support/__init__.py
+++ b/tests/support/__init__.py
@@ -7,6 +7,7 @@ from tests.support.attribution import (
 )
 from tests.support.backends import (
     MockAutoreloadSender,
+    PlainStaticBackend,
     RecordingStaticBackend,
     StaticAssetProvider,
 )
@@ -58,6 +59,7 @@ from tests.support.patches import (
     patch_checks_components_manager,
     patch_checks_router_manager,
     patch_checks_router_manager_with_routers,
+    restored_static_registries,
 )
 from tests.support.ports import IntentOnlyShaper
 from tests.support.routers import (
@@ -86,6 +88,7 @@ __all__ = [
     "MockAutoreloadSender",
     "OddComponentsNameRouter",
     "OddSkipNamesRouter",
+    "PlainStaticBackend",
     "RaisingComponentsRouter",
     "RaisingRootsRouter",
     "RaisingSkipNamesRouter",
@@ -124,6 +127,7 @@ __all__ = [
     "plain_get",
     "plain_request",
     "record_path_calls",
+    "restored_static_registries",
     "tick_scenario",
     "unified_view",
     "unwrapped_decorator",

--- a/tests/support/backends.py
+++ b/tests/support/backends.py
@@ -118,6 +118,19 @@ class MockAutoreloadSender:
         self.watch_calls.append((path, glob))
 
 
+class PlainStaticBackend(StaticFilesBackend):
+    """Static backend with deterministic URLs and no bookkeeping of its own.
+
+    The counterpart of `RecordingStaticBackend` for a benchmark, where a list
+    growing inside the timed loop would be measured along with the framework.
+    """
+
+    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
+        """Return the URL the logical name and kind spell."""
+        del source_path
+        return f"/static/next/{logical_name}{default_kinds.extension(kind)}"
+
+
 class RecordingStaticBackend(StaticFilesBackend):
     """Static backend with deterministic URLs that logs what it registered.
 

--- a/tests/support/backends.py
+++ b/tests/support/backends.py
@@ -5,6 +5,8 @@ from typing import Any, ClassVar
 
 from django.core.exceptions import ImproperlyConfigured
 
+from next.static import StaticBackend, StaticFilesBackend, default_kinds
+
 
 class FakeBackend:
     """Base of the fake backend family the loader builds in these tests."""
@@ -114,3 +116,44 @@ class MockAutoreloadSender:
     def watch_dir(self, path: object, glob: str) -> None:
         """Record the directory and glob the framework asked to watch."""
         self.watch_calls.append((path, glob))
+
+
+class RecordingStaticBackend(StaticFilesBackend):
+    """Static backend with deterministic URLs that logs what it registered.
+
+    The URLs keep discovery-order assertions readable, and the log is what
+    tells a warm render that registered nothing from a cold one that did.
+    """
+
+    def __init__(self) -> None:
+        """Start with no recorded registration."""
+        super().__init__()
+        self.calls: list[tuple[str, str]] = []
+
+    def register_file(self, source_path: Path, logical_name: str, kind: str) -> str:
+        """Record the registration and return the URL the logical name spells."""
+        del source_path
+        self.calls.append((logical_name, kind))
+        return f"/static/next/{logical_name}{default_kinds.extension(kind)}"
+
+
+class StaticAssetProvider:
+    """The narrow ``BackendProvider`` the asset discovery layer reads.
+
+    Holds a backend and already resolved page roots, so a test wires discovery
+    up without standing a whole static manager behind it.
+    """
+
+    def __init__(self, backend: StaticBackend, roots: tuple[Path, ...] = ()) -> None:
+        """Keep the backend and the resolved page trees to report."""
+        self._backend = backend
+        self._roots = roots
+
+    @property
+    def default_backend(self) -> StaticBackend:
+        """Return the backend every registration goes through."""
+        return self._backend
+
+    def page_roots(self) -> tuple[Path, ...]:
+        """Return the resolved page trees discovery walks within."""
+        return self._roots

--- a/tests/support/cases.py
+++ b/tests/support/cases.py
@@ -164,3 +164,28 @@ PERMISSION_OUTCOME_CASES: tuple[PermissionHookCase, ...] = (
         raises_type_error=True,
     ),
 )
+
+
+@dataclass(frozen=True, slots=True)
+class WatchedBackendsCase:
+    """One ``PAGE_BACKENDS`` shape the watcher reads its page trees from.
+
+    ``entries`` names the entry shapes a test builds under its own ``tmp_path``,
+    because a configured tree only exists once a test has a directory to make.
+    """
+
+    id: str
+    entries: tuple[str, ...]
+
+
+WATCHED_BACKENDS_CASES: tuple[WatchedBackendsCase, ...] = (
+    WatchedBackendsCase("no_entry", ()),
+    WatchedBackendsCase("not_a_dict", ("not_a_dict",)),
+    WatchedBackendsCase("unimportable", ("unimportable",)),
+    WatchedBackendsCase("existing_root", ("existing",)),
+    WatchedBackendsCase("missing_root", ("missing",)),
+    WatchedBackendsCase("app_trees", ("app_dirs",)),
+    WatchedBackendsCase("skip_name_entry", ("skipping",)),
+    WatchedBackendsCase("existing_and_missing", ("existing", "missing")),
+    WatchedBackendsCase("unimportable_and_extra_root", ("unimportable", "extra_root")),
+)

--- a/tests/support/components.py
+++ b/tests/support/components.py
@@ -3,6 +3,32 @@ from pathlib import Path
 from next.components import ComponentContextManager, ComponentInfo
 
 
+def component_info(
+    directory: Path,
+    *,
+    name: str = "widget",
+    module: Path | None = None,
+    template: str | None = None,
+    is_simple: bool = False,
+) -> ComponentInfo:
+    """Return the `ComponentInfo` a component living in `directory` scans as.
+
+    A `template` writes the `component.djx`, which a test holding the folder
+    off disk leaves out.
+    """
+    template_path = directory / "component.djx"
+    if template is not None:
+        template_path.write_text(template)
+    return ComponentInfo(
+        name=name,
+        scope_root=directory.parent,
+        scope_relative="",
+        template_path=template_path,
+        module_path=module,
+        is_simple=is_simple,
+    )
+
+
 def build_composite_component(
     root: Path, *, name: str = "card", template: str = "<div>{{ title }}</div>"
 ) -> tuple[ComponentContextManager, ComponentInfo, Path]:
@@ -13,14 +39,5 @@ def build_composite_component(
     root.mkdir(parents=True, exist_ok=True)
     module_path = (root / "component.py").resolve()
     module_path.write_text("# empty\n")
-    template_path = root / "component.djx"
-    template_path.write_text(template)
-    info = ComponentInfo(
-        name=name,
-        scope_root=root,
-        scope_relative="",
-        template_path=template_path,
-        module_path=module_path,
-        is_simple=False,
-    )
+    info = component_info(root, name=name, module=module_path, template=template)
     return ComponentContextManager(), info, module_path

--- a/tests/support/components.py
+++ b/tests/support/components.py
@@ -13,8 +13,7 @@ def component_info(
 ) -> ComponentInfo:
     """Return the `ComponentInfo` a component living in `directory` scans as.
 
-    A `template` writes the `component.djx`, which a test holding the folder
-    off disk leaves out.
+    A `template` writes the `component.djx` a test with no folder on disk leaves out.
     """
     template_path = directory / "component.djx"
     if template is not None:

--- a/tests/support/patches.py
+++ b/tests/support/patches.py
@@ -1,16 +1,51 @@
 from __future__ import annotations
 
+import copy
 import sys
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+from next.static import default_kinds, default_placeholders
+from next.static.discovery import default_stems
 from tests.support.helpers import next_framework_settings_for_checks
 
 
 if TYPE_CHECKING:
     from collections.abc import Generator
     from pathlib import Path
+
+
+# The highest `_version` each registry has carried, so a restore can roll the
+# state back without rolling the counter every asset plan compares back with it.
+_REGISTRY_VERSION_HIGH_WATER: dict[int, int] = {}
+
+
+@contextmanager
+def restored_static_registries() -> Generator[None, None, None]:
+    """Put the stem, kind, and slot registries back the way the body found them.
+
+    All three are process globals whose generation every asset plan compares
+    against, so a test teaching the framework a new shape puts them back. The
+    state goes back but `_version` only moves forward, because two registry
+    states sharing a generation would make a genuinely stale plan read fresh.
+    """
+    registries = (default_stems, default_kinds, default_placeholders)
+    saved = [copy.deepcopy(registry.__dict__) for registry in registries]
+    try:
+        yield
+    finally:
+        for registry, state in zip(registries, saved, strict=True):
+            key = id(registry)
+            reached = max(
+                _REGISTRY_VERSION_HIGH_WATER.get(key, 0),
+                registry.version,
+                state["_version"],
+            )
+            registry.__dict__.clear()
+            registry.__dict__.update(state)
+            registry._version = reached + 1
+            _REGISTRY_VERSION_HIGH_WATER[key] = reached + 1
 
 
 @contextmanager

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import functools
+from collections import OrderedDict
 from pathlib import Path
+from typing import override
 from unittest.mock import patch
 
 import pytest
@@ -10,11 +12,156 @@ from django.test import override_settings
 from next.pages.loaders import _load_python_module
 from next.utils import (
     callable_name,
+    classify_dirs_entries,
     defining_file,
     resolve_base_dir,
+    stat_mtime_ns,
+    store_bounded,
     template_edits_watched,
 )
 from tests.support import attribution, unwrapped_decorator, wraps_decorator
+
+
+class _EmptiedCache(OrderedDict[str, int]):
+    """A cache another thread emptied between the write and the eviction."""
+
+    @override
+    def popitem(self, last: bool = True) -> tuple[str, int]:
+        """Report the cache as empty, whatever it holds."""
+        raise KeyError(last)
+
+
+class _UnreorderableCache(OrderedDict[str, int]):
+    """A cache another thread evicted the written key from before the reorder."""
+
+    @override
+    def move_to_end(self, key: str, last: bool = True) -> None:
+        """Report the key as gone, whatever the cache holds."""
+        raise KeyError(key)
+
+
+class TestStoreBounded:
+    """Tests for ``store_bounded``."""
+
+    def test_a_rewrite_keeps_the_key_and_makes_it_the_freshest(self) -> None:
+        """A key already held stays readable while it moves to the end."""
+        cache: OrderedDict[str, int] = OrderedDict(first=1, second=2)
+        store_bounded(cache, "first", 10, 2)
+        assert list(cache.items()) == [("second", 2), ("first", 10)]
+
+    def test_a_new_key_past_the_bound_drops_the_stalest(self) -> None:
+        """The bound is what a cache of one-off keys never grows past."""
+        cache: OrderedDict[str, int] = OrderedDict(first=1, second=2)
+        store_bounded(cache, "third", 3, 2)
+        assert list(cache.items()) == [("second", 2), ("third", 3)]
+
+    def test_a_cache_emptied_in_between_costs_no_error(self) -> None:
+        """A concurrent eviction leaves the write standing rather than raising."""
+        cache = _EmptiedCache()
+        store_bounded(cache, "only", 1, 0)
+        assert cache["only"] == 1
+
+    def test_a_key_evicted_before_the_reorder_costs_no_error(self) -> None:
+        """The reorder is no place to raise, because the write already landed."""
+        cache = _UnreorderableCache()
+        store_bounded(cache, "only", 1, 8)
+        assert cache["only"] == 1
+
+    def test_the_write_lands_before_anything_can_go_wrong(self) -> None:
+        """A key already held never goes missing for a reader without the lock."""
+        cache = _UnreorderableCache(first=1, second=2)
+        store_bounded(cache, "first", 10, 1)
+        assert cache["first"] == 10
+        assert len(cache) == 2
+
+
+class TestStatMtimeNs:
+    """Tests for ``stat_mtime_ns``."""
+
+    def test_a_file_reports_the_nanoseconds_its_stat_carries(self, tmp_path) -> None:
+        """The value is the one a caller comparing snapshots would take itself."""
+        target = tmp_path / "page.py"
+        target.write_text("")
+        assert stat_mtime_ns(target) == target.stat().st_mtime_ns
+
+    def test_a_path_that_does_not_stat_reports_nothing(self, tmp_path) -> None:
+        """Nothing rather than a sentinel, because no real mtime equals nothing."""
+        assert stat_mtime_ns(tmp_path / "never-written") is None
+
+
+class TestClassifyDirsEntries:
+    """Tests for ``classify_dirs_entries``."""
+
+    def test_segment_when_relative_name_only(self) -> None:
+        """A bare name becomes a segment when it is not a path under base_dir."""
+        roots, segs = classify_dirs_entries(["extras"], Path("/nonexistent"))
+        assert roots == []
+        assert "extras" in segs
+
+    def test_resolves_existing_dir_under_base(self, tmp_path: Path) -> None:
+        """A relative path that exists under base_dir is classified as a path root."""
+        sub = tmp_path / "nest"
+        sub.mkdir()
+        roots, _segs = classify_dirs_entries([Path("nest")], tmp_path)
+        assert roots == [sub.resolve()]
+
+    def test_resolves_nested_relative_path(self, tmp_path: Path) -> None:
+        """A path string with a slash can resolve under base_dir when it exists."""
+        nested = tmp_path / "x" / "y"
+        nested.mkdir(parents=True)
+        roots, _segs = classify_dirs_entries([Path("x/y")], tmp_path)
+        assert roots == [nested.resolve()]
+
+    def test_a_relative_entry_is_resolved_before_it_is_probed(
+        self, tmp_path: Path
+    ) -> None:
+        """A `..` reaching past a missing directory still names the tree it means."""
+        pages = tmp_path / "pages"
+        pages.mkdir()
+        roots, segs = classify_dirs_entries(["missing/../pages"], tmp_path)
+        assert roots == [pages.resolve()]
+        assert segs == frozenset()
+
+    def test_slash_path_that_is_file_becomes_segment(self, tmp_path: Path) -> None:
+        """When a path with a slash exists but is a file, it is treated as a segment name."""
+        f = tmp_path / "a" / "b"
+        f.parent.mkdir(parents=True)
+        f.write_text("x")
+        roots, segs = classify_dirs_entries([Path("a/b")], tmp_path)
+        assert roots == []
+        assert "b" in segs
+
+    def test_a_relative_windows_entry_reads_its_last_component(
+        self, tmp_path: Path
+    ) -> None:
+        """A backslashed relative entry read on POSIX carries no separator of its own."""
+        roots, segs = classify_dirs_entries(["drafts\\hidden"], tmp_path)
+        assert roots == []
+        assert segs == frozenset({"hidden"})
+
+    def test_an_absolute_entry_keeps_a_backslash_as_part_of_its_name(self) -> None:
+        """On POSIX an absolute entry already separates, so a backslash is a name."""
+        roots, segs = classify_dirs_entries(["/srv/app\\pages"], None)
+        assert roots == []
+        assert segs == frozenset({"app\\pages"})
+
+    def test_a_relative_entry_without_a_base_dir_becomes_a_segment(self) -> None:
+        """Without a base dir a relative entry can only name a URL segment."""
+        roots, segs = classify_dirs_entries(["shop"], None)
+        assert roots == []
+        assert segs == frozenset({"shop"})
+
+    def test_skips_empty_and_dot_entries(self) -> None:
+        """Empty strings and dot entries are ignored."""
+        roots, segs = classify_dirs_entries(["", ".", None], Path("/tmp"))
+        assert roots == []
+        assert segs == frozenset()
+
+    def test_an_entry_of_separators_alone_names_no_segment(self, tmp_path) -> None:
+        """A separator-only entry reaches `skip_dir_names` as nothing at all."""
+        roots, segs = classify_dirs_entries(["\\", "./"], tmp_path)
+        assert roots == []
+        assert segs == frozenset()
 
 
 class TestTemplateEditsWatched:

--- a/tests/urls/conftest.py
+++ b/tests/urls/conftest.py
@@ -27,8 +27,13 @@ def router():
 
 @pytest.fixture()
 def mock_settings():
-    """Patch the ``settings`` object ``resolve_base_dir`` reads."""
+    """Patch the ``settings`` object ``resolve_base_dir`` reads.
+
+    ``DEBUG`` starts off, because a bare ``Mock`` attribute reads as truthy and
+    would put every router that consults it on the disk-watching path.
+    """
     mock = Mock()
+    mock.DEBUG = False
     with patch("next.utils.settings", mock):
         yield mock
 

--- a/tests/urls/test_backends.py
+++ b/tests/urls/test_backends.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from django.core.exceptions import AppRegistryNotReady
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 
 from next.pages import page
 from next.testing import override_next_settings
@@ -138,9 +138,7 @@ class TestFileRouterBackend:
             urls = router.generate_urls()
             assert urls == expected_urls
 
-    def test_get_app_pages_path_returns_cached_entry_without_a_lookup(
-        self, router
-    ) -> None:
+    def test_get_app_pages_path_answers_from_the_memo(self, router) -> None:
         """A second lookup answers from the memo without touching the disk."""
         app_dir = Path("/sentinel")
         sentinel = app_dir / "pages"
@@ -148,6 +146,18 @@ class TestFileRouterBackend:
         with patch.object(Path, "exists") as looked:
             result = router._get_app_pages_path("cached_app", {"cached_app": app_dir})
         assert result is sentinel
+        looked.assert_not_called()
+
+    def test_get_app_pages_path_memoises_a_missing_tree(self, tmp_path) -> None:
+        """An app without a pages tree is answered from the memo too."""
+        app_dir = tmp_path / "shop"
+        app_dir.mkdir()
+        router = FileRouterBackend()
+        directories = {"shop": app_dir}
+
+        assert router._get_app_pages_path("shop", directories) is None
+        with patch.object(Path, "exists") as looked:
+            assert router._get_app_pages_path("shop", directories) is None
         looked.assert_not_called()
 
     def test_get_app_pages_path_looks_again_when_the_app_moves(self, router) -> None:
@@ -211,6 +221,25 @@ class TestFileRouterBackend:
         result = router._get_root_pages_paths()
         assert result == []
 
+    def test_both_keywords_still_normalise_the_roots(self, tmp_path) -> None:
+        """A caller spelling out both keywords skips no part of the contract.
+
+        `page_roots` promises resolved absolute trees, and passing
+        `skip_dir_names` takes the classification that normally does it away.
+        """
+        tree = tmp_path / "tree"
+        tree.mkdir()
+        router = FileRouterBackend(
+            app_dirs=False,
+            extra_root_paths=[
+                tree / ".." / "tree",
+                Path("relative/pages"),
+                Path("/nope/does/not/exist"),
+            ],
+            skip_dir_names=frozenset(),
+        )
+        assert [root.path for root in router.page_roots()] == [tree.resolve()]
+
     def test_get_root_pages_paths_fallback_when_app_dirs_false(
         self, mock_settings, tmp_path
     ) -> None:
@@ -263,18 +292,15 @@ class TestFileRouterBackend:
         assert first == ["p1", "extra"]
         assert second == ["p1", "extra"]
 
-    def test_get_root_pages_paths_memoised_per_instance(self, tmp_path) -> None:
-        """Repeated calls return the cached list without touching the filesystem."""
+    def test_get_root_pages_paths_answers_from_the_memo(self, tmp_path) -> None:
+        """A second call answers the held list without touching the disk."""
         router = FileRouterBackend(extra_root_paths=[tmp_path])
         first = router._get_root_pages_paths()
-        with (
-            patch.object(Path, "resolve") as mock_resolve,
-            patch.object(Path, "exists") as mock_exists,
-        ):
+        with patch.object(Path, "exists") as looked:
             second = router._get_root_pages_paths()
+        assert first == [tmp_path.resolve()]
         assert second is first
-        mock_resolve.assert_not_called()
-        mock_exists.assert_not_called()
+        looked.assert_not_called()
 
     def test_generate_urls_includes_root_when_app_dirs_and_extra_roots(
         self, tmp_path
@@ -529,6 +555,28 @@ class TestSkipDirNames:
             router = RouterFactory.create_backend(entry)
 
             assert router.skip_dir_names() == frozenset({"_components", "_drafts"})
+
+    def test_a_skip_name_is_no_root_once_a_directory_of_that_name_appears(
+        self, tmp_path
+    ) -> None:
+        """One classification answers both, so a skip name never becomes a tree."""
+        (tmp_path / "pages").mkdir()
+        (tmp_path / "pages" / "page.py").write_text('template = "hi"\n')
+        entry = file_router_config_entry(dirs=["_drafts"])
+
+        with (
+            override_settings(BASE_DIR=tmp_path),
+            override_next_settings(PAGE_BACKENDS=[entry]),
+        ):
+            router = RouterFactory.create_backend(entry)
+            before = [root.path for root in router.page_roots()]
+            (tmp_path / "_drafts").mkdir()
+            after = [root.path for root in router.page_roots()]
+            urls = router.generate_urls()
+
+        assert router.skip_dir_names() == frozenset({"_components", "_drafts"})
+        assert before == after == [tmp_path / "pages"]
+        assert len(urls) == 1
 
 
 class TestInstalledAppSpellings:

--- a/tests/urls/test_backends.py
+++ b/tests/urls/test_backends.py
@@ -10,10 +10,12 @@ from next.pages import page
 from next.testing import override_next_settings
 from next.urls import FileRouterBackend, PageRoot, RouterBackend, RouterFactory
 from next.urls.backends import _installed_app_directories, _is_framework_app
+from next.utils import forget_resolved_trees
 from tests.support import (
     file_router_backend_from_params,
     file_router_config_entry,
     importable_dir,
+    record_path_calls,
 )
 
 
@@ -149,15 +151,35 @@ class TestFileRouterBackend:
         looked.assert_not_called()
 
     def test_get_app_pages_path_memoises_a_missing_tree(self, tmp_path) -> None:
-        """An app without a pages tree is answered from the memo too."""
+        """An app without a pages tree is answered from the memo too.
+
+        The memo lives as long as this router, and a tree an app grows under
+        the development server reaches the watcher through a router built
+        after it, not through this one probing again.
+        """
         app_dir = tmp_path / "shop"
         app_dir.mkdir()
         router = FileRouterBackend()
         directories = {"shop": app_dir}
 
-        assert router._get_app_pages_path("shop", directories) is None
-        with patch.object(Path, "exists") as looked:
+        with override_settings(DEBUG=True):
             assert router._get_app_pages_path("shop", directories) is None
+            (app_dir / "pages").mkdir()
+
+            assert router._get_app_pages_path("shop", directories) is None
+
+    def test_get_app_pages_path_memoises_a_tree_it_found(self, tmp_path) -> None:
+        """A tree that is there is looked up once and answered from the memo."""
+        app_dir = tmp_path / "shop"
+        (app_dir / "pages").mkdir(parents=True)
+        router = FileRouterBackend()
+        directories = {"shop": app_dir}
+
+        first = router._get_app_pages_path("shop", directories)
+        with patch.object(Path, "exists") as looked:
+            second = router._get_app_pages_path("shop", directories)
+        assert first == (app_dir / "pages").resolve()
+        assert second is first
         looked.assert_not_called()
 
     def test_get_app_pages_path_looks_again_when_the_app_moves(self, router) -> None:
@@ -202,7 +224,7 @@ class TestFileRouterBackend:
                 result = root_router._get_root_pages_paths()
             if exists:
                 assert len(result) == 1
-                assert result[0] is mock_pages_path
+                assert result[0] is mock_pages_path.resolve()
             else:
                 assert result == []
 
@@ -224,8 +246,10 @@ class TestFileRouterBackend:
     def test_both_keywords_still_normalise_the_roots(self, tmp_path) -> None:
         """A caller spelling out both keywords skips no part of the contract.
 
-        `page_roots` promises resolved absolute trees, and passing
-        `skip_dir_names` takes the classification that normally does it away.
+        `page_roots` promises resolved absolute trees, and passing `skip_dir_names`
+        takes away the classification that normally does it. What the router keeps
+        is resolved once, and the trees that are not there drop out of the report
+        the same way a classified entry does.
         """
         tree = tmp_path / "tree"
         tree.mkdir()
@@ -238,7 +262,42 @@ class TestFileRouterBackend:
             ],
             skip_dir_names=frozenset(),
         )
+        assert router._extra_root_paths == [
+            tree.resolve(),
+            Path("relative/pages").resolve(),
+            Path("/nope/does/not/exist"),
+        ]
         assert [root.path for root in router.page_roots()] == [tree.resolve()]
+
+    def test_a_classified_dirs_entry_is_resolved_once(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """The classification resolves what it keeps, so the constructor need not."""
+        (tmp_path / "site").mkdir()
+        expected = (tmp_path / "site").resolve()
+        forget_resolved_trees()
+
+        with override_settings(BASE_DIR=tmp_path):
+            seen = record_path_calls(monkeypatch, "resolve")
+            router = FileRouterBackend(app_dirs=False, extra_root_paths=["site"])
+            held = list(router._extra_root_paths)
+
+        assert held == [expected]
+        assert seen == [tmp_path / "site"]
+
+    def test_a_root_created_later_leaves_two_routers_equal(self, tmp_path) -> None:
+        """Identical configuration compares equal whether or not the tree is there."""
+        tree = tmp_path / "late"
+        before = FileRouterBackend(
+            app_dirs=False, extra_root_paths=[tree], skip_dir_names=frozenset()
+        )
+        tree.mkdir()
+        after = FileRouterBackend(
+            app_dirs=False, extra_root_paths=[tree], skip_dir_names=frozenset()
+        )
+
+        assert before == after
+        assert hash(before) == hash(after)
 
     def test_get_root_pages_paths_fallback_when_app_dirs_false(
         self, mock_settings, tmp_path
@@ -299,8 +358,34 @@ class TestFileRouterBackend:
         with patch.object(Path, "exists") as looked:
             second = router._get_root_pages_paths()
         assert first == [tmp_path.resolve()]
-        assert second is first
+        assert second == first
         looked.assert_not_called()
+
+    def test_get_root_pages_paths_hands_back_a_copy(self, tmp_path) -> None:
+        """A caller appending to the answer moves no root this router serves."""
+        router = FileRouterBackend(extra_root_paths=[tmp_path])
+        first = router._get_root_pages_paths()
+        first.append(Path("/appended"))
+
+        assert first is not router._extra_root_paths
+        assert router._get_root_pages_paths() == [tmp_path.resolve()]
+
+    def test_get_root_pages_paths_memoises_the_base_dir(
+        self, mock_settings, tmp_path
+    ) -> None:
+        """The `BASE_DIR` fallback is probed once and answered from the memo.
+
+        A project growing its first page tree under the development server
+        reaches the watcher through the router built for the next read.
+        """
+        mock_settings.BASE_DIR = tmp_path
+        mock_settings.DEBUG = True
+        router = FileRouterBackend(app_dirs=False)
+
+        assert router._get_root_pages_paths() == []
+        (tmp_path / "pages").mkdir()
+
+        assert router._get_root_pages_paths() == []
 
     def test_generate_urls_includes_root_when_app_dirs_and_extra_roots(
         self, tmp_path

--- a/tests/urls/test_dispatcher.py
+++ b/tests/urls/test_dispatcher.py
@@ -107,8 +107,20 @@ class TestClassifyDirsEntries:
         assert roots == []
         assert "b" in segs
 
+    def test_a_relative_entry_without_a_base_dir_becomes_a_segment(self) -> None:
+        """Without a base dir a relative entry can only name a URL segment."""
+        roots, segs = classify_dirs_entries(["shop"], None)
+        assert roots == []
+        assert segs == frozenset({"shop"})
+
     def test_skips_empty_and_dot_entries(self) -> None:
         """Empty strings and dot entries are ignored."""
         roots, segs = classify_dirs_entries(["", ".", None], Path("/tmp"))
+        assert roots == []
+        assert segs == frozenset()
+
+    def test_an_entry_of_separators_alone_names_no_segment(self, tmp_path) -> None:
+        """A separator-only entry reaches `skip_dir_names` as nothing at all."""
+        roots, segs = classify_dirs_entries(["\\", "./"], tmp_path)
         assert roots == []
         assert segs == frozenset()

--- a/tests/urls/test_dispatcher.py
+++ b/tests/urls/test_dispatcher.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 from next.urls.dispatcher import scan_pages_tree
-from next.utils import classify_dirs_entries
 
 
 class TestScanPagesDirectory:
@@ -73,54 +72,3 @@ class TestScanPagesDirectory:
             )
         assert len(calls) == 1
         assert calls[0][0].name == "_components"
-
-
-class TestClassifyDirsEntries:
-    """Branch coverage for ``next.urls.classify_dirs_entries``."""
-
-    def test_segment_when_relative_name_only(self) -> None:
-        """A bare name becomes a segment when it is not a path under base_dir."""
-        roots, segs = classify_dirs_entries(["extras"], Path("/nonexistent"))
-        assert roots == []
-        assert "extras" in segs
-
-    def test_resolves_existing_dir_under_base(self, tmp_path: Path) -> None:
-        """A relative path that exists under base_dir is classified as a path root."""
-        sub = tmp_path / "nest"
-        sub.mkdir()
-        roots, _segs = classify_dirs_entries([Path("nest")], tmp_path)
-        assert roots == [sub.resolve()]
-
-    def test_resolves_nested_relative_path(self, tmp_path: Path) -> None:
-        """A path string with a slash can resolve under base_dir when it exists."""
-        nested = tmp_path / "x" / "y"
-        nested.mkdir(parents=True)
-        roots, _segs = classify_dirs_entries([Path("x/y")], tmp_path)
-        assert roots == [nested.resolve()]
-
-    def test_slash_path_that_is_file_becomes_segment(self, tmp_path: Path) -> None:
-        """When a path with a slash exists but is a file, it is treated as a segment name."""
-        f = tmp_path / "a" / "b"
-        f.parent.mkdir(parents=True)
-        f.write_text("x")
-        roots, segs = classify_dirs_entries([Path("a/b")], tmp_path)
-        assert roots == []
-        assert "b" in segs
-
-    def test_a_relative_entry_without_a_base_dir_becomes_a_segment(self) -> None:
-        """Without a base dir a relative entry can only name a URL segment."""
-        roots, segs = classify_dirs_entries(["shop"], None)
-        assert roots == []
-        assert segs == frozenset({"shop"})
-
-    def test_skips_empty_and_dot_entries(self) -> None:
-        """Empty strings and dot entries are ignored."""
-        roots, segs = classify_dirs_entries(["", ".", None], Path("/tmp"))
-        assert roots == []
-        assert segs == frozenset()
-
-    def test_an_entry_of_separators_alone_names_no_segment(self, tmp_path) -> None:
-        """A separator-only entry reaches `skip_dir_names` as nothing at all."""
-        roots, segs = classify_dirs_entries(["\\", "./"], tmp_path)
-        assert roots == []
-        assert segs == frozenset()


### PR DESCRIPTION
## Description

`AssetDiscovery` re-walked the disk on every render: it probed every registered stem against every registered kind for the page directory and each layout directory above it, and it re-read the `styles` and `scripts` lists of the owning module. This PR gives both entry points an **asset plan** — what one page path or one component contributes, and where it was read from. A plan caches the disk, not the URLs, so the stem probes, the layout walk, and the module import happen once while every file still goes to `register_file` on each render and a backend stays free to answer differently per request.

The watch layer got the same treatment one level down. `iter_page_backends_for_watch` used to build one router per `PAGE_BACKENDS` entry on every read, and that read sits on the staticfiles finder, the page registry, and the reloader tick. The routers are now held for the configuration they were built for.

Holding a router means holding every filesystem probe it made, and that is where the second half of this PR lives. A router answers about the disk it saw while it was built, so a page tree created, moved, or removed under the development server would never have reached the next tick. The freshness therefore hangs off the **holding decision** rather than off each individual probe: a process watching the disk holds no router and builds them per read, which is the only thing that lets a `DIRS` entry be classified again — an entry naming a directory that does not exist yet is a URL skip-segment, not a root, and no per-probe gate can undo that. With `DEBUG` off the routers are held as before, so the request path keeps the win.

Plans have the same class of problem from a different direction. Which filenames count as an asset comes from the stem, kind, and placeholder registries, and no directory mtime moves when one of them gains an entry. Every plan now carries the generation of all three, compares it before the `DEBUG` gate, and reads it *before* it probes, so a registration landing while the probe runs leaves the plan stale rather than stamped as current. The generation comes from the discovery instance, because a caller may hand it a stem registry of its own.

`router_manager.reload()` — the documented way to rebuild routes from code — reached only the watch layer, leaving `next.pages.loaders` and `StaticManager` answering from the previous generation and spelling co-located assets under fallback logical names. All three page-root memos now drop together on `router_reloaded`.

Smaller correctness work that came out of reviewing the above: directory mtimes are read in nanoseconds and compared for inequality, so an mtime moving backwards invalidates a plan and a directory that does not stat is recorded as absent rather than colliding with a pre-epoch timestamp. A symlinked co-located file reports its resolved target again, so discovery and the staticfiles finder agree on which file a logical name means. `asset_registered` follows the collector rather than the render, so a component mounted several times on one page announces each of its assets once instead of once per mount.

Shared machinery: `next.utils.store_bounded` is the bounded write every per-path memo makes, and it writes before it reorders so a live key is never transiently invisible and a concurrent eviction cannot raise out of a render. The four open-coded bounded caches in `next/components` call it now, the page-module memo is bounded and keyed on a nanosecond mtime, and one process-wide memo holds every page-tree resolution behind a single invalidation point.

### Behaviour worth knowing about

`StaticCollector.add` now returns `bool` instead of `None` — whether the asset landed, which is what keeps a caller from announcing one the collector deduplicated away. Existing callers that ignore the result are unaffected, but a subclass that overrides `add` and returns `None` will stop `asset_registered` from firing for co-located files.

`FileRouterBackend.page_roots()` now reports resolved absolute trees on every branch, where the `BASE_DIR` and application branches previously reported the raw spelling. `page_roots` already documented this contract and both readers already dereferenced the result as a resolved path.

Under `DEBUG` a page render re-stats the whole ancestor chain up to the page root rather than only the directories that already hold a `layout.djx`, which is what makes a `layout.djx` dropped into an empty intermediate directory visible on the next request. The cost is proportional to tree depth and is paid only under `DEBUG`. Removing that term means sharing one ancestor pass with `next/pages/manager.py`, which already stats the same chain per render — worth doing, but as its own change.

## How to test

`make ci` passes locally: ruff, mypy strict, 4007 tests at 100% coverage on `next/`, the JS suite, every example at 100%, and the compat group. `make docs` builds clean with `-W`.

Hot paths changed, so `make bench` was run as the CI paired comparison does it — base and head from separate clean checkouts of the same machine, comparing against a `main` run:

```
0.72x  test_page_assets_warm_bare
0.79x  test_page_assets_warm_with_assets
0.90x  test_page_assets_warm_debug
1.04x  test_reload_cycle
1.11x  test_app_dirs_page_roots
```

`test_app_dirs_page_roots` builds a fresh router per round, so it pays the resolve that `page_roots` now promises without ever reaching the memo that amortises it. Everything else is inside the noise floor, and the `median:99%` gate passes.

One measurement caveat for anyone re-running this: benchmarking head from the working directory rather than a clean checkout inflates every import-heavy case by ~40%, because a failing `import` scans `sys.path` and the repo root accumulates `htmlcov`, `.benchmarks`, and `docs/_build`.

## Related issues

None.

## Checklist

- [x] `make ci` passes locally
- [x] New or changed `next/` code covered by tests (100% for package)
- [ ] Example + tests when adding public API or behavior users copy from `examples/`
- [x] Docs updated when behavior or usage changes
- [ ] Link issues with `Fixes #123` / `Closes #123` when applicable
